### PR TITLE
feat: display gemini thinking events

### DIFF
--- a/client/src/components/chat/ChatMessage.jsx
+++ b/client/src/components/chat/ChatMessage.jsx
@@ -42,6 +42,7 @@ const ChatMessage = ({
   const [feedbackSubmitted, setFeedbackSubmitted] = useState(false);
   const [submittingFeedback, setSubmittingFeedback] = useState(false);
   const [activeFeedback, setActiveFeedback] = useState(null); // Track active feedback button
+  const [showThoughts, setShowThoughts] = useState(false);
 
   // Configure marked renderer and copy buttons
   useEffect(() => {
@@ -300,6 +301,23 @@ const ChatMessage = ({
       >
         {renderContent()}
         {isUser && hasVariables && <MessageVariables variables={message.variables} />}
+        {!isUser && message.thoughts && message.thoughts.length > 0 && (
+          <div className="mt-1 text-xs text-gray-600">
+            <button
+              onClick={() => setShowThoughts(!showThoughts)}
+              className="underline"
+            >
+              {showThoughts ? t('pages.appChat.hideThoughts') : t('pages.appChat.showThoughts')}
+            </button>
+            {showThoughts && (
+              <ul className="list-disc pl-4 mt-1 space-y-1">
+                {message.thoughts.map((th, idx) => (
+                  <li key={idx}>{typeof th === 'string' ? th : JSON.stringify(th)}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
       </div>
       
       {/* Info about finish reason and retry options */}

--- a/client/src/components/widget/ChatWidget.jsx
+++ b/client/src/components/widget/ChatWidget.jsx
@@ -61,6 +61,7 @@ const ChatWidget = ({
     addUserMessage,
     addAssistantMessage,
     updateAssistantMessage,
+    addMessageThought,
     setMessageError,
     deleteMessage,
     editMessage,
@@ -134,6 +135,11 @@ const ChatWidget = ({
       }
       setProcessing(false);
       setUseMaxTokens(false);
+    },
+    onThinking: (data) => {
+      if (window.lastMessageId) {
+        addMessageThought(window.lastMessageId, data.thought || data);
+      }
     },
     onConnected: async (event) => {
       try {

--- a/client/src/hooks/useChatMessages.js
+++ b/client/src/hooks/useChatMessages.js
@@ -147,6 +147,24 @@ function useChatMessages(chatId = 'default') {
   }, []);
 
   /**
+   * Append a thought entry to an assistant message
+   * @param {string} id - The ID of the message to update
+   * @param {string|Object} thought - The thought data
+   */
+  const addMessageThought = useCallback((id, thought) => {
+    setMessages(prev =>
+      prev.map(msg =>
+        msg.id === id
+          ? {
+              ...msg,
+              thoughts: [...(msg.thoughts || []), thought]
+            }
+          : msg
+      )
+    );
+  }, []);
+
+  /**
    * Set an error on a message
    * @param {string} id - The ID of the message to update
    * @param {string} errorMessage - The error message
@@ -250,6 +268,7 @@ function useChatMessages(chatId = 'default') {
     addUserMessage,
     addAssistantMessage,
     updateAssistantMessage,
+    addMessageThought,
     setMessageError,
     deleteMessage,
     editMessage,

--- a/contents/locales/de.json
+++ b/contents/locales/de.json
@@ -101,6 +101,8 @@
       "shareConversation": "Unterhaltung teilen",
       "copyToClipboard": "In die Zwischenablage kopieren",
       "copied": "In die Zwischenablage kopiert!",
+      "showThoughts": "Denkanalyse anzeigen",
+      "hideThoughts": "Denkanalyse verbergen",
       "configureApp": "Konfigurieren",
       "inputParameters": "Eingabeparameter",
       "parameters": "Parameter",

--- a/contents/locales/en.json
+++ b/contents/locales/en.json
@@ -101,6 +101,8 @@
       "shareConversation": "Share conversation",
       "copyToClipboard": "Copy to clipboard",
       "copied": "Copied to clipboard!",
+      "showThoughts": "Show reasoning",
+      "hideThoughts": "Hide reasoning",
       "configureApp": "Configure",
       "parameters": "Parameters",
       "inputParameters": "Input Parameters",

--- a/server/adapters/google.js
+++ b/server/adapters/google.js
@@ -175,7 +175,8 @@ const GoogleAdapter = {
         complete: false,
         error: false,
         errorMessage: null,
-        finishReason: null
+        finishReason: null,
+        thinking: []
       };
 
       const { events, done } = parseSSEBuffer(buffer);
@@ -191,6 +192,16 @@ const GoogleAdapter = {
                 result.content.push(part.text);
               }
             }
+          }
+
+          if (data.candidates && data.candidates[0]?.safetyRatings) {
+            result.thinking.push({ type: 'safety', info: data.candidates[0].safetyRatings });
+          }
+          if (data.candidates && data.candidates[0]?.citationMetadata) {
+            result.thinking.push({ type: 'citation', info: data.candidates[0].citationMetadata });
+          }
+          if (data.promptFeedback) {
+            result.thinking.push({ type: 'feedback', info: data.promptFeedback });
           }
 
           if (data.candidates && data.candidates[0]?.finishReason) {

--- a/server/services/chatService.js
+++ b/server/services/chatService.js
@@ -223,6 +223,11 @@ export async function executeStreamingResponse({
             fullResponse += textContent;
           }
         }
+        if (result && result.thinking && result.thinking.length > 0) {
+          for (const thought of result.thinking) {
+            sendSSE(clientRes, 'thinking', { thought });
+          }
+        }
         if (result && result.error) {
           await logInteraction('chat_error', buildLogData(true, {
             responseType: 'error',


### PR DESCRIPTION
## Summary
- add `showThoughts`/`hideThoughts` strings
- store reasoning events on messages
- support `thinking` SSE events in the frontend
- display reasoning in chat messages
- parse thinking data from Gemini responses and forward via SSE

## Testing
- `npm run build:client` *(fails: Rollup failed to resolve import)*

------
https://chatgpt.com/codex/tasks/task_e_68677d3030648322a88653b8a3c51ab0