### PR TITLE
Move request body limit setting to platform config

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ The server can be configured through environment variables or by editing the `co
 | `ANTHROPIC_API_KEY` | Anthropic API key | (required) |
 | `GOOGLE_API_KEY` | Google AI API key | (required) |
 
+The maximum JSON request body size is configured via the `requestBodyLimitMB` option in `contents/config/platform.json`.
+
 ### SSL Configuration
 
 For HTTPS support, set these environment variables or define them in `config.env`:

--- a/contents/config/platform.json
+++ b/contents/config/platform.json
@@ -2,6 +2,7 @@
   "features": {
     "usageTracking": true
   },
+  "requestBodyLimitMB": 50,
   "telemetry": {
     "enabled": false,
     "metrics": true,

--- a/docs/file-upload-feature.md
+++ b/docs/file-upload-feature.md
@@ -42,7 +42,7 @@ The file upload feature allows users to upload text files and PDF documents to t
 - File content is processed in `processMessageTemplates()`
 - All AI adapters (OpenAI, Anthropic, Google) handle file content
 - Content is automatically included in AI prompts
-- Server configured with 50MB request body limit to handle file uploads
+- Server configured with the `requestBodyLimitMB` setting in `platform.json` (default 50MB) to handle file uploads
 
 ### Configuration
 Enable file upload for an app by adding to the app configuration:
@@ -83,7 +83,7 @@ Enable file upload for an app by adding to the app configuration:
 **fileUpload.maxFileSizeMB** (number)
 - Maximum file size in megabytes
 - Default: `10`
-- Range: 1-50 (limited by server configuration)
+- Range: 1-50 (limited by the `requestBodyLimitMB` setting)
 
 **fileUpload.supportedTextFormats** (array)
 - List of supported MIME types for text files

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -7,6 +7,7 @@ The optional `platform.json` file controls global platform behaviour. It is loca
   "features": {
     "usageTracking": true
   },
+  "requestBodyLimitMB": 50,
   "telemetry": {
     "enabled": false,
     "metrics": true,
@@ -18,4 +19,5 @@ The optional `platform.json` file controls global platform behaviour. It is loca
 ```
 
 * **features.usageTracking** – enables or disables recording of usage statistics in `contents/data/usage.json`.
+* **requestBodyLimitMB** – maximum size of JSON request bodies in megabytes. Defaults to `50`.
 * **telemetry** – configures OpenTelemetry integration. When enabled, metrics are exported via Prometheus on the configured port and traces/logs can be collected.

--- a/server/server.js
+++ b/server/server.js
@@ -66,9 +66,10 @@ if (cluster.isPrimary && workerCount > 1) {
   const contentsDir = config.CONTENTS_DIR;
   console.log(`Using contents directory: ${contentsDir}`);
 
-  // Initialize telemetry based on platform configuration
+  // Load platform configuration and initialize telemetry
+  let platformConfig = {};
   try {
-    const platformConfig = await loadJson('config/platform.json');
+    platformConfig = await loadJson('config/platform.json');
     await initTelemetry(platformConfig?.telemetry || {});
   } catch (err) {
     console.error('Failed to initialize telemetry:', err);
@@ -114,7 +115,7 @@ if (cluster.isPrimary && workerCount > 1) {
   // Error localization and API key validation implemented in serverHelpers.js
 
   // Middleware
-  setupMiddleware(app);
+  setupMiddleware(app, platformConfig);
 
   // Helper to verify API key exists for a model and provide a meaningful error
   // Implemented in serverHelpers.js


### PR DESCRIPTION
## Summary
- move request body size limit to `platform.json`
- update docs and config examples
- middleware uses platform config for the limit

## Testing
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_6869a99d0df48322a359cd66d26082ad