### PR TITLE
feat: use turndown for html to markdown

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -22,6 +22,7 @@
         "react-i18next": "^15.4.1",
         "react-router-dom": "^6.10.0",
         "tailwindcss": "^3.3.2",
+        "turndown": "^7.2.0",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -886,6 +887,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/@mixmark-io/domino": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mixmark-io/domino/-/domino-2.2.0.tgz",
+      "integrity": "sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4051,6 +4058,15 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/turndown": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/turndown/-/turndown-7.2.0.tgz",
+      "integrity": "sha512-eCZGBN4nNNqM9Owkv9HAtWRYfLA4h909E/WGAWWBpmB275ehNhZyk87/Tpvjbp0jjNl9XwCsbe6bm6CqFsgD+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@mixmark-io/domino": "^2.2.0"
+      }
     },
     "node_modules/unpdf": {
       "version": "0.12.2",

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "i18next": "^24.2.3",
     "i18next-browser-languagedetector": "^8.0.4",
     "marked": "^15.0.8",
+    "turndown": "^7.2.0",
     "microsoft-cognitiveservices-speech-sdk": "^1.44.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/client/src/utils/markdownUtils.js
+++ b/client/src/utils/markdownUtils.js
@@ -1,4 +1,5 @@
 import { marked } from 'marked';
+import TurndownService from 'turndown';
 
 /**
  * Configure marked options for better HTML output
@@ -8,6 +9,8 @@ marked.setOptions({
   gfm: true, // Enable GitHub Flavored Markdown
   sanitize: false, // Allow HTML (ReactQuill will handle sanitization)
 });
+
+const turndownService = new TurndownService();
 
 /**
  * Convert markdown text to HTML suitable for ReactQuill
@@ -28,7 +31,7 @@ export const markdownToHtml = (markdown) => {
 };
 
 /**
- * Simple HTML to markdown conversion (basic implementation)
+ * Convert HTML text to Markdown using turndown
  * @param {string} html - The HTML text to convert
  * @returns {string} Markdown string
  */
@@ -37,30 +40,7 @@ export const htmlToMarkdown = (html) => {
     return '';
   }
 
-  // Basic HTML to markdown conversion
-  return html
-    .replace(/<h1[^>]*>(.*?)<\/h1>/gi, '# $1\n\n')
-    .replace(/<h2[^>]*>(.*?)<\/h2>/gi, '## $1\n\n')
-    .replace(/<h3[^>]*>(.*?)<\/h3>/gi, '### $1\n\n')
-    .replace(/<h4[^>]*>(.*?)<\/h4>/gi, '#### $1\n\n')
-    .replace(/<h5[^>]*>(.*?)<\/h5>/gi, '##### $1\n\n')
-    .replace(/<h6[^>]*>(.*?)<\/h6>/gi, '###### $1\n\n')
-    .replace(/<strong[^>]*>(.*?)<\/strong>/gi, '**$1**')
-    .replace(/<b[^>]*>(.*?)<\/b>/gi, '**$1**')
-    .replace(/<em[^>]*>(.*?)<\/em>/gi, '*$1*')
-    .replace(/<i[^>]*>(.*?)<\/i>/gi, '*$1*')
-    .replace(/<ul[^>]*>(.*?)<\/ul>/gis, '$1\n')
-    .replace(/<ol[^>]*>(.*?)<\/ol>/gis, '$1\n')
-    .replace(/<li[^>]*>(.*?)<\/li>/gi, '- $1\n')
-    .replace(/<blockquote[^>]*>(.*?)<\/blockquote>/gis, '> $1\n\n')
-    .replace(/<code[^>]*>(.*?)<\/code>/gi, '`$1`')
-    .replace(/<pre[^>]*>(.*?)<\/pre>/gis, '```\n$1\n```\n\n')
-    .replace(/<a[^>]*href="([^"]*)"[^>]*>(.*?)<\/a>/gi, '[$2]($1)')
-    .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<p[^>]*>(.*?)<\/p>/gis, '$1\n\n')
-    .replace(/<[^>]*>/g, '') // Remove any remaining HTML tags
-    .replace(/\n{3,}/g, '\n\n') // Clean up excessive line breaks
-    .trim();
+  return turndownService.turndown(html);
 };
 
 /**


### PR DESCRIPTION
## Summary
- use Turndown for HTML → Markdown conversions
- add turndown dependency for the client

## Testing
- `node -e "import('./client/src/utils/markdownUtils.js').then(m=>{const html='<h1>Title</h1><p>Hello <strong>world</strong></p>'; const md=m.htmlToMarkdown(html); console.log('MD:',md); const html2=m.markdownToHtml(md); console.log('HTML:',html2);})"`
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_6869b1bc06d8832281dc56cfc93ad204