### PR TITLE
Add per-model & per-tool request throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ The server can be configured through environment variables or by editing the `co
 | `GOOGLE_API_KEY` | Google AI API key | (required) |
 
 The maximum JSON request body size is configured via the `requestBodyLimitMB` option in `contents/config/platform.json`.
+Outbound request concurrency can also be tuned with the `requestConcurrency` setting in the same file and overridden per model or tool. Values below `1` or an omitted setting result in unlimited concurrency.
 
 ### SSL Configuration
 

--- a/concepts/2025-07-07 Request Throttling.md
+++ b/concepts/2025-07-07 Request Throttling.md
@@ -1,0 +1,13 @@
+# Request Throttling
+
+## Overview
+External LLM providers and web tools enforce rate limits. To avoid hitting those limits when multiple requests are made concurrently, a simple queue based throttling mechanism has been introduced.
+
+## Key Files
+- `server/requestThrottler.js` – implements `throttledFetch` with per-model and per-tool queues.
+- `contents/config/platform.json` – defines the default `requestConcurrency` value.
+- `contents/config/models.json` / `tools.json` – optional `concurrency` values overriding the default.
+- LLM service and tool modules now use `throttledFetch` instead of `fetch`.
+
+## Usage
+Specify `requestConcurrency` in `platform.json` to limit concurrent outbound requests. A value below `1` or an omitted setting means concurrency is unlimited. Individual models or tools can define a `concurrency` property to override the global value with the same rules. All outbound fetch calls from chat services and tools now use `throttledFetch(modelId|toolId, url)`.

--- a/contents/config/models.json
+++ b/contents/config/models.json
@@ -68,7 +68,8 @@
     "url": "https://api.mistral.ai/v1/chat/completions",
     "provider": "mistral",
     "tokenLimit": 32000,
-    "supportsTools": true
+    "supportsTools": true,
+    "concurrency": 1
   },
   {
     "id": "local-mistral",

--- a/contents/config/platform.json
+++ b/contents/config/platform.json
@@ -9,5 +9,6 @@
     "traces": true,
     "logs": true,
     "port": 9464
-  }
+  },
+  "requestConcurrency": 2
 }

--- a/contents/config/tools.json
+++ b/contents/config/tools.json
@@ -4,6 +4,7 @@
     "name": "Brave Web / Internet Search",
     "description": "Search the web / internet using Brave for up-to-date information. Use the 'query' parameter with your search terms.",
     "script": "braveSearch.js",
+    "concurrency": 5,
     "parameters": {
       "type": "object",
       "properties": {
@@ -20,6 +21,7 @@
     "name": "Web Content Extractor",
     "description": "Extract clean, readable content from an URL. This can be content like PDFs or webpages, removing ads, headers, footers, and other non-content elements. Use the 'url' parameter with a valid HTTP/HTTPS URL.",
     "script": "webContentExtractor.js",
+    "concurrency": 3,
     "parameters": {
       "type": "object",
       "properties": {

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -14,10 +14,12 @@ The optional `platform.json` file controls global platform behaviour. It is loca
     "traces": true,
     "logs": true,
     "port": 9464
-  }
+  },
+  "requestConcurrency": 2
 }
 ```
 
 * **features.usageTracking** – enables or disables recording of usage statistics in `contents/data/usage.json`.
 * **requestBodyLimitMB** – maximum size of JSON request bodies in megabytes. Defaults to `50`.
 * **telemetry** – configures OpenTelemetry integration. When enabled, metrics are exported via Prometheus on the configured port and traces/logs can be collected.
+* **requestConcurrency** – default concurrency level for outbound requests when no per-model or per-tool override is specified. If omitted or set to a value below `1`, concurrency is unlimited.

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -26,6 +26,8 @@ The server reads settings from the environment or a `.env` file such as `config.
 | `MAGIC_PROMPT_MODEL` | Default model for the magic prompt feature | `gpt-3.5-turbo` |
 | `MAGIC_PROMPT_PROMPT` | Default prompt used to refine user input | `Improve the following prompt.` |
 
+The concurrency of outbound requests is configured via `requestConcurrency` in `contents/config/platform.json` and can be overridden per model or tool. If this value is omitted or below `1`, requests are not throttled.
+
 ## SSL Configuration
 
 To enable HTTPS you must provide certificate files via environment variables:

--- a/server/requestThrottler.js
+++ b/server/requestThrottler.js
@@ -1,0 +1,64 @@
+/**
+ * Request throttling utility supporting per-model and per-tool limits.
+ * Keeps an in-memory queue for each identifier so provider rate limits are not exceeded.
+ */
+import configCache from './configCache.js';
+
+const queues = new Map(); // id -> array of pending tasks
+const actives = new Map(); // id -> number of active requests
+
+// Any configured value below 1 disables throttling (treated as unlimited)
+
+function normalizeLimit(value) {
+  return typeof value === 'number' && value >= 1 ? value : Infinity;
+}
+
+function getConcurrency(id = 'default') {
+  const platform = configCache.getPlatform() || {};
+  const models = configCache.getModels() || [];
+  const tools = configCache.getTools() || [];
+  const model = models.find(m => m.id === id);
+  if (model && typeof model.concurrency === 'number') return normalizeLimit(model.concurrency);
+  const tool = tools.find(t => t.id === id);
+  if (tool && typeof tool.concurrency === 'number') return normalizeLimit(tool.concurrency);
+  const limit = platform.requestConcurrency;
+  return normalizeLimit(limit);
+}
+
+export function throttledFetch(id, url, options = {}) {
+  if (typeof url === 'undefined') {
+    // called as throttledFetch(url)
+    url = id;
+    id = 'default';
+  }
+  if (!queues.has(id)) {
+    queues.set(id, []);
+    actives.set(id, 0);
+  }
+
+  const queue = queues.get(id);
+
+  return new Promise((resolve, reject) => {
+    const execute = async () => {
+      actives.set(id, actives.get(id) + 1);
+      try {
+        const res = await fetch(url, options);
+        resolve(res);
+      } catch (err) {
+        reject(err);
+      } finally {
+        actives.set(id, actives.get(id) - 1);
+        if (queue.length > 0) {
+          const next = queue.shift();
+          next();
+        }
+      }
+    };
+
+    if (actives.get(id) < getConcurrency(id)) {
+      execute();
+    } else {
+      queue.push(execute);
+    }
+  });
+}

--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -3,6 +3,7 @@ import { createCompletionRequest } from '../../adapters/index.js';
 import { getErrorDetails, logInteraction, trackSession } from '../../utils.js';
 import { clients, activeRequests } from '../../sse.js';
 import { actionTracker } from '../../actionTracker.js';
+import { throttledFetch } from '../../requestThrottler.js';
 
 import {
   prepareChatRequest,
@@ -42,7 +43,7 @@ export default function registerSessionRoutes(app, { verifyApiKey, processMessag
         timeoutId = setTimeout(() => reject(new Error(`Request timed out after ${DEFAULT_TIMEOUT/1000} seconds`)), DEFAULT_TIMEOUT);
       });
       try {
-        const responsePromise = fetch(request.url, {
+        const responsePromise = throttledFetch(model.id, request.url, {
           method: 'POST',
           headers: request.headers,
           body: JSON.stringify(request.body)

--- a/server/routes/magicPromptRoutes.js
+++ b/server/routes/magicPromptRoutes.js
@@ -5,6 +5,7 @@ import { recordMagicPrompt, estimateTokens } from '../usageTracker.js';
 import validate from '../validators/validate.js';
 import { magicPromptSchema } from '../validators/index.js';
 import config from '../config.js';
+import { throttledFetch } from '../requestThrottler.js';
 
 // BIG FAT TODO reuse methods like simpleCompletion and extract the adapter specifics
 export default function registerMagicPromptRoutes(app, { verifyApiKey, DEFAULT_TIMEOUT }) {
@@ -41,7 +42,7 @@ export default function registerMagicPromptRoutes(app, { verifyApiKey, DEFAULT_T
       const timeoutPromise = new Promise((_, reject) => {
         timeoutId = setTimeout(() => reject(new Error(`Request timed out after ${DEFAULT_TIMEOUT/1000} seconds`)), DEFAULT_TIMEOUT);
       });
-      const responsePromise = fetch(request.url, { method: 'POST', headers: request.headers, body: JSON.stringify(request.body) });
+      const responsePromise = throttledFetch(model.id, request.url, { method: 'POST', headers: request.headers, body: JSON.stringify(request.body) });
       const llmResponse = await Promise.race([responsePromise, timeoutPromise]);
       clearTimeout(timeoutId);
       if (!llmResponse.ok) {

--- a/server/services/chatService.js
+++ b/server/services/chatService.js
@@ -8,6 +8,7 @@ import { normalizeName } from '../adapters/toolFormatter.js';
 import { activeRequests } from '../sse.js';
 import { actionTracker } from '../actionTracker.js';
 import { createParser } from 'eventsource-parser';
+import { throttledFetch } from '../requestThrottler.js';
 
 // Prepend file data to message content when present
 export function preprocessMessagesWithFileData(messages) {
@@ -105,7 +106,7 @@ export async function executeNonStreamingResponse({
   });
 
   try {
-    const responsePromise = fetch(request.url, {
+    const responsePromise = throttledFetch(model.id, request.url, {
       method: 'POST',
       headers: request.headers,
       body: JSON.stringify(request.body)
@@ -193,7 +194,7 @@ export async function executeStreamingResponse({
     activeRequests.delete(chatId);
   }, DEFAULT_TIMEOUT);
 
-  fetch(request.url, {
+  throttledFetch(model.id, request.url, {
     method: 'POST',
     headers: request.headers,
     body: JSON.stringify(request.body),
@@ -335,7 +336,7 @@ export function processChatWithTools({
     activeRequests.delete(chatId);
   }, DEFAULT_TIMEOUT);
 
-  fetch(request.url, {
+  throttledFetch(model.id, request.url, {
     method: 'POST',
     headers: request.headers,
     body: JSON.stringify(request.body),

--- a/server/toolLoader.js
+++ b/server/toolLoader.js
@@ -1,6 +1,7 @@
 import { loadJson } from './configLoader.js';
 import config from './config.js';
 import configCache from './configCache.js';
+import { throttledFetch } from './requestThrottler.js';
 
 /**
  * Load tools defined locally in config/tools.json
@@ -23,7 +24,7 @@ export async function discoverMcpTools() {
   if (!mcpUrl) return [];
 
   try {
-    const response = await fetch(`${mcpUrl.replace(/\/$/, '')}/tools`);
+    const response = await throttledFetch('mcp', `${mcpUrl.replace(/\/$/, '')}/tools`);
     if (!response.ok) {
       console.error(`Failed to fetch tools from MCP server: ${response.status}`);
       return [];

--- a/server/tools/braveSearch.js
+++ b/server/tools/braveSearch.js
@@ -1,4 +1,5 @@
 import config from '../config.js';
+import { throttledFetch } from '../requestThrottler.js';
 
 export default async function braveSearch({ query, q }) {
   // Accept both 'query' and 'q' parameters for flexibility
@@ -12,7 +13,7 @@ export default async function braveSearch({ query, q }) {
     throw new Error('BRAVE_SEARCH_API_KEY is not set');
   }
   const endpoint = config.BRAVE_SEARCH_ENDPOINT || 'https://api.search.brave.com/res/v1/web/search';
-  const res = await fetch(`${endpoint}?q=${encodeURIComponent(searchQuery)}`, {
+  const res = await throttledFetch('braveSearch', `${endpoint}?q=${encodeURIComponent(searchQuery)}`, {
     headers: {
       'X-Subscription-Token': apiKey,
       'Accept': 'application/json'

--- a/server/tools/webContentExtractor.js
+++ b/server/tools/webContentExtractor.js
@@ -1,6 +1,7 @@
 import { JSDOM } from 'jsdom';
 import https from 'https';
 import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs';
+import { throttledFetch } from '../requestThrottler.js';
 
 function createError(message, code) {
   const err = new Error(message);
@@ -44,7 +45,7 @@ export default async function webContentExtractor({ url, uri, link, maxLength = 
       console.warn(`Ignoring SSL certificate errors for ${targetUrl}`);
     }
 
-    const response = await fetch(targetUrl, {
+    const response = await throttledFetch('webContentExtractor', targetUrl, {
       headers: {
         'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36',
         'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',

--- a/server/utils.js
+++ b/server/utils.js
@@ -4,6 +4,7 @@ import { createCompletionRequest, processResponseBuffer } from "./adapters/index
 import fs from 'fs/promises';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { throttledFetch } from './requestThrottler.js';
 import configCache from './configCache.js';
 
 /**
@@ -362,7 +363,7 @@ export async function simpleCompletion(prompt, { model: modelId, temperature = 0
     stream: false
   });
 
-  const response = await fetch(request.url, {
+  const response = await throttledFetch(model.id, request.url, {
     method: 'POST',
     headers: request.headers,
     body: JSON.stringify(request.body)


### PR DESCRIPTION
## Summary
- support per-model/per-tool concurrency via new `requestConcurrency` and `concurrency` options
- remove `REQUEST_CONCURRENCY` env variable; use platform configuration
- document throttling configuration and update concept notes
- throttle all LLM and tool fetches with identifier-based queue
- clarify unlimited concurrency default

------
https://chatgpt.com/codex/tasks/task_e_686bb4d479748322ba09ecc6d1c569ba