### PR TITLE
feat(canvas): enhance clipboard and chat

### DIFF
--- a/client/src/components/Icon.jsx
+++ b/client/src/components/Icon.jsx
@@ -46,6 +46,7 @@ import {
   SwatchIcon,
   BriefcaseIcon,
   PaintBrushIcon,
+  ChevronDownIcon,
   Bars3Icon,
   FaceFrownIcon as OutlineFaceFrownIcon
 } from '@heroicons/react/24/outline';
@@ -80,6 +81,7 @@ import {
   SwatchIcon as SolidSwatchIcon,
   BriefcaseIcon as SolidBriefcaseIcon,
   PaintBrushIcon as SolidPaintBrushIcon,
+  ChevronDownIcon as SolidChevronDownIcon,
   FaceFrownIcon as SolidFaceFrownIcon
 } from '@heroicons/react/24/solid';
 
@@ -106,6 +108,7 @@ const iconMap = {
   'information-circle': { outline: OutlineInformationCircleIcon, solid: SolidInformationCircleIcon },
   list: { outline: ListBulletIcon, solid: ListBulletIcon },
   menu: { outline: Bars3Icon, solid: Bars3Icon },
+  'chevron-down': { outline: ChevronDownIcon, solid: SolidChevronDownIcon },
   microphone: { outline: OutlineMicrophoneIcon, solid: SolidMicrophoneIcon },
   'minus-circle': { outline: MinusCircleIcon, solid: SolidMinusCircleIcon },
   'paint-brush': { outline: PaintBrushIcon, solid: SolidPaintBrushIcon },

--- a/client/src/components/canvas/CanvasChatPanel.jsx
+++ b/client/src/components/canvas/CanvasChatPanel.jsx
@@ -21,7 +21,8 @@ const CanvasChatPanel = ({
   onClearSelection,
   width,
   cleanupEventSource,
-  inputRef
+  inputRef,
+  onInsertAnswer
 }) => {
   const { t } = useTranslation();
 
@@ -43,6 +44,7 @@ const CanvasChatPanel = ({
             appId={appId}
             chatId={chatId}
             compact={true}
+            onInsert={onInsertAnswer}
           />
         </div>
       </div>

--- a/client/src/components/chat/ChatMessageList.jsx
+++ b/client/src/components/chat/ChatMessageList.jsx
@@ -19,6 +19,7 @@ const ChatMessageList = ({
   editable = false,
   compact = false,
   onOpenInCanvas,
+  onInsert,
   canvasEnabled = false
 }) => {
   const chatContainerRef = useRef(null);
@@ -72,6 +73,7 @@ const ChatMessageList = ({
               modelId={modelId}
               compact={compact}
               onOpenInCanvas={onOpenInCanvas}
+              onInsert={onInsert}
               canvasEnabled={canvasEnabled}
             />
           </div>

--- a/client/src/hooks/useCanvasEditing.js
+++ b/client/src/hooks/useCanvasEditing.js
@@ -8,6 +8,7 @@ const useCanvasEditing = ({
   selection,
   setSelection,
   setSelectedText,
+  setCursorPosition,
   handlePromptSubmit,
   chatInputRef
 }) => {
@@ -15,6 +16,9 @@ const useCanvasEditing = ({
   // Handle text selection in the editor
   const handleSelectionChange = useCallback((range, source, editor) => {
     try {
+      if (range) {
+        setCursorPosition(range.index);
+      }
       if (range && range.length > 0) {
         const selectedText = editor.getText(range.index, range.length);
         setSelection(range);
@@ -35,7 +39,7 @@ const useCanvasEditing = ({
       setSelection(null);
       setSelectedText('');
     }
-  }, [setSelection, setSelectedText, chatInputRef]);
+  }, [setSelection, setSelectedText, setCursorPosition, chatInputRef]);
 
   // Handle edit toolbar actions - bypass app prompts and use direct AI instructions
   const handleEditAction = useCallback(async (action, description, selectedText, currentLanguage) => {


### PR DESCRIPTION
## Summary
- add chevron-down icon
- implement copy dropdown and insert button in chat messages
- wire insertion action through chat components
- track cursor position in canvas editing hook
- handle inserting chat answers in canvas
- add custom clipboard logic for cut/copy/paste in canvas editor

## Testing
- `npm run build:client`

------
https://chatgpt.com/codex/tasks/task_e_686c28cd57c0832294d5a9d3d36b7b18