### PR TITLE
fix cache bust

### DIFF
--- a/client/src/pages/AdminSystemPage.jsx
+++ b/client/src/pages/AdminSystemPage.jsx
@@ -12,7 +12,7 @@ const AdminSystemPage = () => {
     setForceRefreshMessage('');
 
     try {
-      const response = await fetch('/api/admin/force-refresh', {
+      const response = await fetch('/api/admin/client/_refresh', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/contents/config/platform.json
+++ b/contents/config/platform.json
@@ -13,7 +13,7 @@
   },
   "requestConcurrency": 2,
   "refreshSalt": {
-    "adminTriggered": 7,
-    "lastUpdated": "2025-07-08T16:04:45.821Z"
+    "salt": 9,
+    "lastUpdated": "2025-07-08T17:00:38.743Z"
   }
 }

--- a/server/configCache.js
+++ b/server/configCache.js
@@ -90,7 +90,7 @@ class ConfigCache {
    */
   async refreshCacheEntry(key) {
     try {
-      const data = await loadJson(key);
+      const data = await loadJson(key, { useCache: false });
       if (data !== null) {
         this.setCacheEntry(key, data);
       }

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -58,7 +58,7 @@ export default function registerAdminRoutes(app) {
   });
 
   // Force refresh endpoint - triggers client reload by updating refresh salt
-  app.post('/api/admin/force-refresh', async (req, res) => {
+  app.post('/api/admin/client/_refresh', async (req, res) => {
     try {
       const rootDir = getRootDir();
       const platformConfigPath = join(rootDir, 'contents', 'config', 'platform.json');
@@ -69,13 +69,13 @@ export default function registerAdminRoutes(app) {
       // Initialize refreshSalt if it doesn't exist
       if (!platformConfig.refreshSalt) {
         platformConfig.refreshSalt = {
-          adminTriggered: 0,
+          salt: 0,
           lastUpdated: new Date().toISOString()
         };
       }
       
       // Increment admin-triggered value and update timestamp
-      platformConfig.refreshSalt.adminTriggered += 1;
+      platformConfig.refreshSalt.salt += 1;
       platformConfig.refreshSalt.lastUpdated = new Date().toISOString();
       
       // Write back to file
@@ -87,11 +87,11 @@ export default function registerAdminRoutes(app) {
       // Refresh specifically the platform configuration
       await configCache.refreshCacheEntry('config/platform.json');
       
-      console.log(`🔄 Force refresh triggered. New admin salt: ${platformConfig.refreshSalt.adminTriggered}`);
+      console.log(`🔄 Force refresh triggered. New admin salt: ${platformConfig.refreshSalt.salt}`);
       
       res.json({ 
         message: 'Force refresh triggered successfully',
-        newAdminSalt: platformConfig.refreshSalt.adminTriggered,
+        newAdminSalt: platformConfig.refreshSalt.salt,
         timestamp: platformConfig.refreshSalt.lastUpdated
       });
     } catch (error) {
@@ -100,7 +100,7 @@ export default function registerAdminRoutes(app) {
     }
   });
 
-  app.get('/api/admin/force-refresh', (req, res, next) => {
+  app.get('/api/admin/client/_refresh', (req, res, next) => {
     req.method = 'POST';
     app._router.handle(req, res, next);
   });

--- a/server/routes/chat/dataRoutes.js
+++ b/server/routes/chat/dataRoutes.js
@@ -119,8 +119,8 @@ export default function registerDataRoutes(app) {
       }
       
       // Compute refresh salt combining version and admin-triggered value
-      const refreshSalt = platform.refreshSalt || { adminTriggered: 0, lastUpdated: new Date().toISOString() };
-      const computedSalt = `${appVersion}.${refreshSalt.adminTriggered}`;
+      const refreshSalt = platform.refreshSalt || { salt: 0, lastUpdated: new Date().toISOString() };
+      const computedSalt = `${appVersion}.${refreshSalt.salt}`;
       
       // Add version and computed salt to platform response
       const enhancedPlatform = {


### PR DESCRIPTION
This pull request updates the "force refresh" functionality across the codebase to improve clarity and consistency. The most significant changes include renaming endpoints, replacing the `adminTriggered` property with `salt` in the refresh salt logic, and ensuring the cache refresh mechanism bypasses cached data.

### Endpoint Updates:
* Renamed the "force refresh" endpoint from `/api/admin/force-refresh` to `/api/admin/client/_refresh` for better clarity and alignment with client-related operations. (`client/src/pages/AdminSystemPage.jsx` [[1]](diffhunk://#diff-8d33070d8fc89d6b74677560aced0b244a256b1171dbf6b6a720ec99db424d72L15-R15) `server/routes/adminRoutes.js` [[2]](diffhunk://#diff-23d21f537ae542556434e04b37de7e46c7f51c2582e327bc0ae306b51d373d5dL61-R61) [[3]](diffhunk://#diff-23d21f537ae542556434e04b37de7e46c7f51c2582e327bc0ae306b51d373d5dL103-R103)

### Refresh Salt Logic Updates:
* Replaced the `adminTriggered` property with `salt` in the `refreshSalt` object to simplify naming and improve readability. Updated related logic to increment `salt` instead of `adminTriggered` and adjusted logging and response messages accordingly. (`contents/config/platform.json` [[1]](diffhunk://#diff-8e742665197867891e0b20fafe841175d2db897c9ca0a8f5f0439ab361aae092L16-R17) `server/routes/adminRoutes.js` [[2]](diffhunk://#diff-23d21f537ae542556434e04b37de7e46c7f51c2582e327bc0ae306b51d373d5dL72-R78) [[3]](diffhunk://#diff-23d21f537ae542556434e04b37de7e46c7f51c2582e327bc0ae306b51d373d5dL90-R94)
* Updated the computation of the `refreshSalt` value in the data routes to use the new `salt` property. (`server/routes/chat/dataRoutes.js` [server/routes/chat/dataRoutes.jsL122-R123](diffhunk://#diff-5e90656181f976c12c3249119fff83a68bb7ea088210cbed850f40c79b0943e6L122-R123))

### Cache Refresh Mechanism:
* Modified the `refreshCacheEntry` method to bypass cached data by passing the `useCache: false` option to the `loadJson` function, ensuring fresh data is loaded during cache refresh. (`server/configCache.js` [server/configCache.jsL93-R93](diffhunk://#diff-beaea68fa5ef15a7971b77ff4b61dff71356475ce37ab3d7804be8f9ca79eba9L93-R93))