### PR TITLE
Add server-side app config validation

### DIFF
--- a/server/validators/appConfigSchema.js
+++ b/server/validators/appConfigSchema.js
@@ -1,0 +1,34 @@
+import { z } from 'zod';
+
+export const appConfigSchema = z.object({
+  id: z.string(),
+  order: z.number().optional(),
+  name: z.record(z.string()),
+  description: z.record(z.string()),
+  color: z.string(),
+  icon: z.string(),
+  system: z.record(z.string()),
+  tokenLimit: z.number(),
+  preferredModel: z.string().optional(),
+  preferredOutputFormat: z.string().optional(),
+  preferredStyle: z.string().optional(),
+  preferredTemperature: z.number().optional(),
+  sendChatHistory: z.boolean().optional(),
+  messagePlaceholder: z.record(z.string()).optional(),
+  prompt: z.record(z.string()).optional(),
+  variables: z.array(z.any()).optional(),
+  settings: z.any().optional(),
+  inputMode: z.any().optional(),
+  imageUpload: z.any().optional(),
+  fileUpload: z.any().optional(),
+  features: z.any().optional(),
+  greeting: z.any().optional(),
+  starterPrompts: z.array(z.any()).optional(),
+  sourcePath: z.string().optional(),
+  allowedModels: z.array(z.string()).optional(),
+  disallowModelSelection: z.boolean().optional(),
+  allowEmptyContent: z.boolean().optional(),
+  enabled: z.boolean().optional(),
+}).passthrough();
+
+export const knownAppKeys = Object.keys(appConfigSchema.shape);


### PR DESCRIPTION
## Summary
- warn about invalid and unknown app config keys
- use new Zod schema when loading apps

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686edaa6382c83229d7726f7de3a8a69