### PR TITLE
Fix cache re-initialization after clearing

### DIFF
--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -46,6 +46,9 @@ export default function registerAdminRoutes(app) {
   app.post('/api/admin/cache/_clear', async (req, res) => {
     try {
       configCache.clear();
+      // Immediately reinitialize the cache so subsequent API calls work
+      await configCache.initialize();
+
       res.json({ message: 'Configuration cache cleared successfully' });
     } catch (e) {
       console.error('Error clearing cache:', e);


### PR DESCRIPTION
## Summary
- reinitialize configuration cache after clearing it via admin API

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ef345d89883228f9b9259168857f1