### PR TITLE
Hide empty categories in app and prompt lists

### DIFF
--- a/client/src/pages/AppsList.jsx
+++ b/client/src/pages/AppsList.jsx
@@ -49,6 +49,23 @@ const AppsList = () => {
     return uiConfig?.appsList?.categories || defaultCategoriesConfig;
   }, [uiConfig]);
 
+  // Only display categories that contain at least one app
+  const availableCategories = useMemo(() => {
+    if (!categoriesConfig.enabled) return [];
+    const usedCategories = new Set(apps.map(app => app.category || 'utility'));
+    return categoriesConfig.list.filter(category => {
+      if (category.id === 'all') return categoriesConfig.showAll;
+      return usedCategories.has(category.id);
+    });
+  }, [categoriesConfig, apps]);
+
+  useEffect(() => {
+    if (selectedCategory !== 'all') {
+      const exists = apps.some(app => (app.category || 'utility') === selectedCategory);
+      if (!exists) setSelectedCategory('all');
+    }
+  }, [apps, selectedCategory]);
+
   const [sortMethod, setSortMethod] = useState(sortConfig.default || 'relevance');
 
   useEffect(() => {
@@ -480,7 +497,7 @@ const AppsList = () => {
       {/* Category filter */}
       {categoriesConfig.enabled && (
         <div className="flex flex-wrap gap-2 mb-6 justify-center">
-          {categoriesConfig.list.map(category => (
+          {availableCategories.map(category => (
             <button
               key={category.id}
               onClick={() => handleCategorySelect(category.id)}

--- a/client/src/pages/PromptsList.jsx
+++ b/client/src/pages/PromptsList.jsx
@@ -45,6 +45,23 @@ const PromptsList = () => {
     return uiConfig?.promptsList?.categories || defaultCategoriesConfig;
   }, [uiConfig]);
 
+  // Only display categories that contain at least one prompt
+  const availableCategories = useMemo(() => {
+    if (!categoriesConfig.enabled) return [];
+    const usedCategories = new Set(prompts.map(p => p.category || 'creative'));
+    return categoriesConfig.list.filter(category => {
+      if (category.id === 'all') return categoriesConfig.showAll;
+      return usedCategories.has(category.id);
+    });
+  }, [categoriesConfig, prompts]);
+
+  useEffect(() => {
+    if (selectedCategory !== 'all') {
+      const exists = prompts.some(p => (p.category || 'creative') === selectedCategory);
+      if (!exists) setSelectedCategory('all');
+    }
+  }, [prompts, selectedCategory]);
+
   const [sortMethod, setSortMethod] = useState(sortConfig.default || 'relevance');
 
   useEffect(() => {
@@ -251,7 +268,7 @@ const PromptsList = () => {
       {/* Category filter */}
       {categoriesConfig.enabled && (
         <div className="flex flex-wrap gap-2 mb-6 justify-center">
-          {categoriesConfig.list.map(category => (
+          {availableCategories.map(category => (
             <button
               key={category.id}
               onClick={() => handleCategorySelect(category.id)}


### PR DESCRIPTION
## Summary
- show only categories that contain items in `AppsList` and `PromptsList`
- reset selected category if no items exist for it

## Testing
- `npm run build:client`

------
https://chatgpt.com/codex/tasks/task_e_6870e7278b0c8322a10cd7f0cab9187c