### PR TITLE
Fix app list page initialization error

### DIFF
--- a/client/src/pages/AppsList.jsx
+++ b/client/src/pages/AppsList.jsx
@@ -49,6 +49,8 @@ const AppsList = () => {
     return uiConfig?.appsList?.categories || defaultCategoriesConfig;
   }, [uiConfig]);
 
+  const [apps, setApps] = useState([]);
+
   // Only display categories that contain at least one app
   const availableCategories = useMemo(() => {
     if (!categoriesConfig.enabled) return [];
@@ -72,7 +74,6 @@ const AppsList = () => {
     setSortMethod(sortConfig.default || 'relevance');
   }, [sortConfig]);
   
-  const [apps, setApps] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');


### PR DESCRIPTION
## Summary
- avoid referencing `apps` state before it's defined in `AppsList`

## Testing
- `npm run test:mistral` *(fails: Cannot find module `server/tests/mistralAdapter.test.js`)*

------
https://chatgpt.com/codex/tasks/task_e_6871262151e083228d8d31930f3c418d