### PR TITLE
Add i18n for admin dashboard

### DIFF
--- a/client/src/i18n/core/de.json
+++ b/client/src/i18n/core/de.json
@@ -260,6 +260,77 @@
       "delete": {
         "confirm": "Sind Sie sicher, dass Sie dieses Modell löschen möchten?"
       }
+    },
+    "home": {
+      "title": "Admin-Dashboard",
+      "welcome": "Willkommen im Verwaltungsbereich der AI Hub Apps",
+      "quickActions": "Schnellaktionen",
+      "systemActions": "Systemaktionen",
+      "addNewApp": "Neue App hinzufügen",
+      "addNewModel": "Neues Modell hinzufügen",
+      "addNewPrompt": "Neuen Prompt hinzufügen",
+      "backToApps": "Zurück zu Apps",
+      "refreshCache": "Cache aktualisieren",
+      "clearCache": "Cache leeren",
+      "systemSettings": "Systemeinstellungen",
+      "cacheRefreshSuccess": "Cache erfolgreich aktualisiert",
+      "cacheRefreshError": "Fehler beim Aktualisieren des Caches: {{message}}",
+      "clearCacheConfirm": "Cache wirklich leeren?",
+      "cacheClearSuccess": "Cache erfolgreich geleert",
+      "cacheClearError": "Fehler beim Löschen des Caches: {{message}}",
+      "sections": {
+        "usageDesc": "Anwendungsstatistiken und Analysen anzeigen",
+        "appsDesc": "Apps erstellen, bearbeiten und verwalten",
+        "modelsDesc": "KI-Modelle konfigurieren und verwalten",
+        "promptsDesc": "Prompt-Vorlagen erstellen und verwalten",
+        "systemDesc": "Systemeinstellungen und Wartungstools",
+        "shortlinksDesc": "Kurzlinks der Anwendung verwalten"
+      }
+    },
+    "system": {
+      "title": "Systemadministration",
+      "description": "Systemweite Einstellungen und Wartung verwalten",
+      "forceTitle": "Client-Refresh erzwingen",
+      "forceDesc": "Einen erzwungenen Neuladevorgang für alle Clients auslösen. Dies löscht alle Browser-Caches, LocalStorage und lädt alle Assets ohne Cache neu. Die Disclaimer-Akzeptanz bleibt erhalten.",
+      "warningTitle": "Warnung",
+      "warningDesc": "Diese Aktion zwingt alle verbundenen Clients, beim nächsten Seitenaufruf den Browser neu zu laden. Verwende dies bei kritischen Updates oder wenn Clients zwischengespeicherte Daten löschen müssen.",
+      "trigger": "Force Refresh auslösen",
+      "triggering": "Force Refresh wird ausgelöst...",
+      "triggerSuccess": "Force-Refresh erfolgreich ausgelöst! Neuer Salt: {{salt}}. Alle Clients laden sich beim nächsten Seitenaufruf neu.",
+      "triggerError": "Fehler beim Auslösen des Force Refresh",
+      "cacheTitle": "Server-Cache-Verwaltung",
+      "cacheDesc": "Verwalte den serverseitigen Konfigurationscache. Mit diesen Werkzeugen kannst du den Cache aktualisieren oder leeren.",
+      "refreshCache": "Cache aktualisieren",
+      "clearCache": "Cache leeren"
+    },
+    "usage": {
+      "title": "Admin-Dashboard",
+      "subtitle": "Nutzungsstatistiken und Systemübersicht",
+      "downloadCsv": "CSV herunterladen",
+      "downloadJson": "JSON herunterladen",
+      "lastUpdated": "Zuletzt aktualisiert",
+      "lastReset": "Zuletzt zurückgesetzt",
+      "activeUsers": "Aktive Benutzer",
+      "activeApps": "Aktive Apps",
+      "noDataTitle": "Keine Daten verfügbar",
+      "noDataDesc": "Nutzungsstatistiken konnten nicht geladen werden.",
+      "totalMessages": "Nachrichten insgesamt",
+      "totalTokens": "Token insgesamt",
+      "magicPrompts": "Magic Prompts",
+      "feedbackScore": "Feedback-Score",
+      "tokenDistribution": "Token-Verteilung",
+      "promptTokens": "Prompt-Token",
+      "completionTokens": "Completion-Token",
+      "appUsageDistribution": "App-Nutzungsverteilung",
+      "appTokenUsage": "App-Token-Nutzung",
+      "tabs": {
+        "overview": "Übersicht",
+        "users": "Benutzer",
+        "apps": "Anwendungen",
+        "magic": "Magic Prompt",
+        "feedback": "Feedback",
+        "details": "Details"
+      }
     }
   }
 }

--- a/client/src/i18n/core/en.json
+++ b/client/src/i18n/core/en.json
@@ -260,6 +260,77 @@
       "delete": {
         "confirm": "Are you sure you want to delete this model?"
       }
+    },
+    "home": {
+      "title": "Admin Dashboard",
+      "welcome": "Welcome to the AI Hub Apps administration center",
+      "quickActions": "Quick Actions",
+      "systemActions": "System Actions",
+      "addNewApp": "Add New App",
+      "addNewModel": "Add New Model",
+      "addNewPrompt": "Add New Prompt",
+      "backToApps": "Back to Apps",
+      "refreshCache": "Refresh Cache",
+      "clearCache": "Clear Cache",
+      "systemSettings": "System Settings",
+      "cacheRefreshSuccess": "Cache refreshed successfully",
+      "cacheRefreshError": "Error refreshing cache: {{message}}",
+      "clearCacheConfirm": "Are you sure you want to clear the cache?",
+      "cacheClearSuccess": "Cache cleared successfully",
+      "cacheClearError": "Error clearing cache: {{message}}",
+      "sections": {
+        "usageDesc": "View application usage statistics and analytics",
+        "appsDesc": "Create, edit, and manage applications",
+        "modelsDesc": "Configure and manage AI models",
+        "promptsDesc": "Create and manage prompt templates",
+        "systemDesc": "System settings and maintenance tools",
+        "shortlinksDesc": "Manage application short links"
+      }
+    },
+    "system": {
+      "title": "System Administration",
+      "description": "Manage system-wide settings and maintenance",
+      "forceTitle": "Force Client Refresh",
+      "forceDesc": "Trigger a force refresh for all clients. This will clear all browser caches, localStorage, and force clients to reload all assets (JS, CSS, fonts, configurations) without using browser cache. The disclaimer acceptance will be preserved.",
+      "warningTitle": "Warning",
+      "warningDesc": "This action will force all connected clients to reload their browsers on their next page interaction. Use this when deploying critical updates or when clients need to clear cached data.",
+      "trigger": "Trigger Force Refresh",
+      "triggering": "Triggering Force Refresh...",
+      "triggerSuccess": "Force refresh triggered successfully! New salt: {{salt}}. All clients will refresh on their next page load.",
+      "triggerError": "Failed to trigger force refresh",
+      "cacheTitle": "Server Cache Management",
+      "cacheDesc": "Manage server-side configuration cache. Use these tools to refresh or clear cached configuration files on the server.",
+      "refreshCache": "Refresh Cache",
+      "clearCache": "Clear Cache"
+    },
+    "usage": {
+      "title": "Admin Dashboard",
+      "subtitle": "Usage analytics and system overview",
+      "downloadCsv": "Download CSV",
+      "downloadJson": "Download JSON",
+      "lastUpdated": "Last Updated",
+      "lastReset": "Last Reset",
+      "activeUsers": "Active Users",
+      "activeApps": "Active Apps",
+      "noDataTitle": "No Data Available",
+      "noDataDesc": "Unable to load usage statistics.",
+      "totalMessages": "Total Messages",
+      "totalTokens": "Total Tokens",
+      "magicPrompts": "Magic Prompts",
+      "feedbackScore": "Feedback Score",
+      "tokenDistribution": "Token Distribution",
+      "promptTokens": "Prompt Tokens",
+      "completionTokens": "Completion Tokens",
+      "appUsageDistribution": "App Usage Distribution",
+      "appTokenUsage": "App Token Usage",
+      "tabs": {
+        "overview": "Overview",
+        "users": "Users",
+        "apps": "Applications",
+        "magic": "Magic Prompt",
+        "feedback": "Feedback",
+        "details": "Details"
+      }
     }
   }
 }

--- a/client/src/pages/AdminHome.jsx
+++ b/client/src/pages/AdminHome.jsx
@@ -12,19 +12,27 @@ const AdminHome = () => {
   const handleCacheRefresh = async () => {
     try {
       await makeAdminApiCall('/api/admin/cache/_refresh', { method: 'POST' });
-      alert('Cache refreshed successfully');
+      alert(t('admin.home.cacheRefreshSuccess', 'Cache refreshed successfully'));
     } catch (error) {
-      alert('Error refreshing cache: ' + error.message);
+      alert(
+        t('admin.home.cacheRefreshError', 'Error refreshing cache: {{message}}', {
+          message: error.message
+        })
+      );
     }
   };
 
   const handleCacheClear = async () => {
-    if (confirm('Are you sure you want to clear the cache?')) {
+    if (confirm(t('admin.home.clearCacheConfirm', 'Are you sure you want to clear the cache?'))) {
       try {
         await makeAdminApiCall('/api/admin/cache/_clear', { method: 'POST' });
-        alert('Cache cleared successfully');
+        alert(t('admin.home.cacheClearSuccess', 'Cache cleared successfully'));
       } catch (error) {
-        alert('Error clearing cache: ' + error.message);
+        alert(
+          t('admin.home.cacheClearError', 'Error clearing cache: {{message}}', {
+            message: error.message
+          })
+        );
       }
     }
   };
@@ -32,42 +40,42 @@ const AdminHome = () => {
   const adminSections = [
     {
       title: t('admin.nav.usage', 'Usage Reports'),
-      description: 'View application usage statistics and analytics',
+      description: t('admin.home.sections.usageDesc', 'View application usage statistics and analytics'),
       href: '/admin/usage',
       icon: 'chart-bar',
       color: 'bg-blue-500'
     },
     {
       title: t('admin.nav.apps', 'Apps Management'),
-      description: 'Create, edit, and manage applications',
+      description: t('admin.home.sections.appsDesc', 'Create, edit, and manage applications'),
       href: '/admin/apps',
       icon: 'collection',
       color: 'bg-green-500'
     },
     {
       title: t('admin.nav.models', 'Models Management'),
-      description: 'Configure and manage AI models',
+      description: t('admin.home.sections.modelsDesc', 'Configure and manage AI models'),
       href: '/admin/models',
       icon: 'cpu-chip',
       color: 'bg-purple-500'
     },
     {
       title: t('admin.nav.prompts', 'Prompts Management'),
-      description: 'Create and manage prompt templates',
+      description: t('admin.home.sections.promptsDesc', 'Create and manage prompt templates'),
       href: '/admin/prompts',
       icon: 'clipboard-document-list',
       color: 'bg-indigo-500'
     },
     {
       title: t('admin.nav.system', 'System Administration'),
-      description: 'System settings and maintenance tools',
+      description: t('admin.home.sections.systemDesc', 'System settings and maintenance tools'),
       href: '/admin/system',
       icon: 'cog',
       color: 'bg-orange-500'
     },
     {
       title: t('admin.nav.shortlinks', 'Short Links'),
-      description: 'Manage application short links',
+      description: t('admin.home.sections.shortlinksDesc', 'Manage application short links'),
       href: '/admin/shortlinks',
       icon: 'link',
       color: 'bg-teal-500'
@@ -84,9 +92,11 @@ const AdminHome = () => {
               <div className="mx-auto h-16 w-16 flex items-center justify-center rounded-full bg-indigo-100 mb-4">
                 <Icon name="shield-check" className="h-8 w-8 text-indigo-600" />
               </div>
-              <h1 className="text-4xl font-bold text-gray-900">Admin Dashboard</h1>
+              <h1 className="text-4xl font-bold text-gray-900">
+                {t('admin.home.title', 'Admin Dashboard')}
+              </h1>
               <p className="text-gray-600 mt-2 text-lg">
-                Welcome to the AI Hub Apps administration center
+                {t('admin.home.welcome', 'Welcome to the AI Hub Apps administration center')}
               </p>
             </div>
           </div>
@@ -127,14 +137,16 @@ const AdminHome = () => {
 
           {/* Quick Actions */}
           <div className="mt-12 bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-6">Quick Actions</h2>
+            <h2 className="text-xl font-semibold text-gray-900 mb-6">
+              {t('admin.home.quickActions', 'Quick Actions')}
+            </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
               <button
                 onClick={() => navigate('/admin/apps/new')}
                 className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
               >
                 <Icon name="plus" className="h-4 w-4 mr-2" />
-                Add New App
+                {t('admin.home.addNewApp', 'Add New App')}
               </button>
               
               <button
@@ -142,7 +154,7 @@ const AdminHome = () => {
                 className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-purple-500"
               >
                 <Icon name="plus" className="h-4 w-4 mr-2" />
-                Add New Model
+                {t('admin.home.addNewModel', 'Add New Model')}
               </button>
               
               <button
@@ -150,7 +162,7 @@ const AdminHome = () => {
                 className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
               >
                 <Icon name="plus" className="h-4 w-4 mr-2" />
-                Add New Prompt
+                {t('admin.home.addNewPrompt', 'Add New Prompt')}
               </button>
               
               <Link
@@ -158,21 +170,23 @@ const AdminHome = () => {
                 className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
               >
                 <Icon name="home" className="h-4 w-4 mr-2" />
-                Back to Apps
+                {t('admin.home.backToApps', 'Back to Apps')}
               </Link>
             </div>
           </div>
 
           {/* System Actions */}
           <div className="mt-8 bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-            <h2 className="text-xl font-semibold text-gray-900 mb-6">System Actions</h2>
+            <h2 className="text-xl font-semibold text-gray-900 mb-6">
+              {t('admin.home.systemActions', 'System Actions')}
+            </h2>
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
               <button
                 onClick={handleCacheRefresh}
                 className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
               >
                 <Icon name="refresh" className="h-4 w-4 mr-2" />
-                Refresh Cache
+                {t('admin.home.refreshCache', 'Refresh Cache')}
               </button>
               
               <button
@@ -180,7 +194,7 @@ const AdminHome = () => {
                 className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
               >
                 <Icon name="trash" className="h-4 w-4 mr-2" />
-                Clear Cache
+                {t('admin.home.clearCache', 'Clear Cache')}
               </button>
               
               <Link
@@ -188,7 +202,7 @@ const AdminHome = () => {
                 className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500"
               >
                 <Icon name="cog" className="h-4 w-4 mr-2" />
-                System Settings
+                {t('admin.home.systemSettings', 'System Settings')}
               </Link>
             </div>
           </div>

--- a/client/src/pages/AdminSystemPage.jsx
+++ b/client/src/pages/AdminSystemPage.jsx
@@ -23,12 +23,18 @@ const AdminSystemPage = () => {
 
       setForceRefreshMessage({
         type: 'success',
-        text: `Force refresh triggered successfully! New salt: ${data.newAdminSalt}. All clients will refresh on their next page load.`
+        text: t(
+          'admin.system.triggerSuccess',
+          'Force refresh triggered successfully! New salt: {{salt}}. All clients will refresh on their next page load.',
+          { salt: data.newAdminSalt }
+        )
       });
     } catch (error) {
       setForceRefreshMessage({
         type: 'error',
-        text: error.message || 'Failed to trigger force refresh'
+        text:
+          t('admin.system.triggerError', 'Failed to trigger force refresh') +
+          (error.message ? `: ${error.message}` : '')
       });
     } finally {
       setForceRefreshLoading(false);
@@ -44,8 +50,12 @@ const AdminSystemPage = () => {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
           <div className="flex justify-between items-center">
             <div>
-              <h1 className="text-3xl font-bold text-gray-900">System Administration</h1>
-              <p className="text-gray-600 mt-1">Manage system-wide settings and maintenance</p>
+              <h1 className="text-3xl font-bold text-gray-900">
+                {t('admin.system.title', 'System Administration')}
+              </h1>
+              <p className="text-gray-600 mt-1">
+                {t('admin.system.description', 'Manage system-wide settings and maintenance')}
+              </p>
             </div>
           </div>
         </div>
@@ -64,22 +74,28 @@ const AdminSystemPage = () => {
                 </div>
               </div>
               <div className="flex-1">
-                <h3 className="text-lg font-semibold text-gray-900 mb-2">Force Client Refresh</h3>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                  {t('admin.system.forceTitle', 'Force Client Refresh')}
+                </h3>
                 <p className="text-gray-600 mb-4">
-                  Trigger a force refresh for all clients. This will clear all browser caches, localStorage, 
-                  and force clients to reload all assets (JS, CSS, fonts, configurations) without using 
-                  browser cache. The disclaimer acceptance will be preserved.
+                  {t(
+                    'admin.system.forceDesc',
+                    'Trigger a force refresh for all clients. This will clear all browser caches, localStorage, and force clients to reload all assets (JS, CSS, fonts, configurations) without using browser cache. The disclaimer acceptance will be preserved.'
+                  )}
                 </p>
                 
                 <div className="bg-amber-50 border border-amber-200 rounded-md p-4 mb-4">
                   <div className="flex">
                     <Icon name="warning" size="md" className="text-amber-500 mt-0.5 mr-3" />
                     <div>
-                      <h4 className="text-sm font-medium text-amber-800">Warning</h4>
+                      <h4 className="text-sm font-medium text-amber-800">
+                        {t('admin.system.warningTitle', 'Warning')}
+                      </h4>
                       <p className="text-sm text-amber-700 mt-1">
-                        This action will force all connected clients to reload their browsers on their 
-                        next page interaction. Use this when deploying critical updates or when clients 
-                        need to clear cached data.
+                        {t(
+                          'admin.system.warningDesc',
+                          'This action will force all connected clients to reload their browsers on their next page interaction. Use this when deploying critical updates or when clients need to clear cached data.'
+                        )}
                       </p>
                     </div>
                   </div>
@@ -126,12 +142,12 @@ const AdminSystemPage = () => {
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                       </svg>
-                      Triggering Force Refresh...
+                      {t('admin.system.triggering', 'Triggering Force Refresh...')}
                     </>
                   ) : (
                     <>
                       <Icon name="refresh" size="md" className="mr-2" />
-                      Trigger Force Refresh
+                      {t('admin.system.trigger', 'Trigger Force Refresh')}
                     </>
                   )}
                 </button>
@@ -148,10 +164,14 @@ const AdminSystemPage = () => {
                 </div>
               </div>
               <div className="flex-1">
-                <h3 className="text-lg font-semibold text-gray-900 mb-2">Server Cache Management</h3>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                  {t('admin.system.cacheTitle', 'Server Cache Management')}
+                </h3>
                 <p className="text-gray-600 mb-4">
-                  Manage server-side configuration cache. Use these tools to refresh or clear 
-                  cached configuration files on the server.
+                  {t(
+                    'admin.system.cacheDesc',
+                    'Manage server-side configuration cache. Use these tools to refresh or clear cached configuration files on the server.'
+                  )}
                 </p>
                 
                 <div className="flex space-x-4">
@@ -162,7 +182,7 @@ const AdminSystemPage = () => {
                     className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
                   >
                     <Icon name="refresh" size="md" className="mr-2" />
-                    Refresh Cache
+                    {t('admin.system.refreshCache', 'Refresh Cache')}
                   </a>
                   
                   <a
@@ -172,7 +192,7 @@ const AdminSystemPage = () => {
                     className="inline-flex items-center px-4 py-2 border border-gray-300 text-sm font-medium rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500"
                   >
                     <Icon name="trash" size="md" className="mr-2" />
-                    Clear Cache
+                    {t('admin.system.clearCache', 'Clear Cache')}
                   </a>
                 </div>
               </div>

--- a/client/src/pages/AdminUsageReports.jsx
+++ b/client/src/pages/AdminUsageReports.jsx
@@ -74,7 +74,9 @@ const AppUsageCard = ({ data }) => {
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-      <h3 className="text-lg font-semibold text-gray-900 mb-4">App Usage Distribution</h3>
+      <h3 className="text-lg font-semibold text-gray-900 mb-4">
+        {t('admin.usage.appUsageDistribution', 'App Usage Distribution')}
+      </h3>
       <div className="space-y-4">
         {apps.map(([app, value]) => {
           const displayValue = typeof value === 'object' ? (value.good || 0) + (value.bad || 0) : value;
@@ -220,8 +222,12 @@ const AdminUsageReports = () => {
     <div className="min-h-screen bg-gray-50 flex items-center justify-center">
       <div className="text-center">
         <div className="text-red-500 text-6xl mb-4">⚠️</div>
-        <h2 className="text-2xl font-bold text-gray-900 mb-2">No Data Available</h2>
-        <p className="text-gray-600">Unable to load usage statistics.</p>
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">
+          {t('admin.usage.noDataTitle', 'No Data Available')}
+        </h2>
+        <p className="text-gray-600">
+          {t('admin.usage.noDataDesc', 'Unable to load usage statistics.')}
+        </p>
       </div>
     </div>
   );
@@ -229,12 +235,12 @@ const AdminUsageReports = () => {
   const { messages, tokens, feedback, magicPrompt, lastUpdated, lastReset } = usage;
 
   const tabs = [
-    { id: 'overview', label: 'Overview', icon: <Icon name="chart" size="md" /> },
-    { id: 'users', label: 'Users', icon: <Icon name="users" size="md" /> },
-    { id: 'apps', label: 'Applications', icon: <Icon name="settings" size="md" /> },
-    { id: 'magic', label: 'Magic Prompt', icon: <Icon name="sparkles" size="md" /> },
-    { id: 'feedback', label: 'Feedback', icon: <Icon name="thumbs-up" size="md" /> },
-    { id: 'details', label: 'Details', icon: <Icon name="chat" size="md" /> }
+    { id: 'overview', label: t('admin.usage.tabs.overview', 'Overview'), icon: <Icon name="chart" size="md" /> },
+    { id: 'users', label: t('admin.usage.tabs.users', 'Users'), icon: <Icon name="users" size="md" /> },
+    { id: 'apps', label: t('admin.usage.tabs.apps', 'Applications'), icon: <Icon name="settings" size="md" /> },
+    { id: 'magic', label: t('admin.usage.tabs.magic', 'Magic Prompt'), icon: <Icon name="sparkles" size="md" /> },
+    { id: 'feedback', label: t('admin.usage.tabs.feedback', 'Feedback'), icon: <Icon name="thumbs-up" size="md" /> },
+    { id: 'details', label: t('admin.usage.tabs.details', 'Details'), icon: <Icon name="chat" size="md" /> }
   ];
 
   const renderOverview = () => (
@@ -242,25 +248,25 @@ const AdminUsageReports = () => {
       {/* Main Stats */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <StatCard
-          title="Total Messages"
+          title={t('admin.usage.totalMessages', 'Total Messages')}
           value={messages.total}
           icon={<Icon name="chat" size="lg" className="text-white" />}
           color="bg-blue-500"
         />
         <StatCard
-          title="Total Tokens"
+          title={t('admin.usage.totalTokens', 'Total Tokens')}
           value={tokens.total}
           icon={<Icon name="document-text" size="lg" className="text-white" />}
           color="bg-green-500"
         />
         <StatCard
-          title="Magic Prompts"
+          title={t('admin.usage.magicPrompts', 'Magic Prompts')}
           value={magicPrompt.total}
           icon={<Icon name="sparkles" size="lg" className="text-white" />}
           color="bg-purple-500"
         />
         <StatCard
-          title="Feedback Score"
+          title={t('admin.usage.feedbackScore', 'Feedback Score')}
           value={`${feedback.good}/${feedback.good + feedback.bad}`}
           icon={<Icon name="thumbs-up" size="lg" className="text-white" />}
           color="bg-amber-500"
@@ -270,10 +276,12 @@ const AdminUsageReports = () => {
       {/* Token Breakdown */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-          <h3 className="text-lg font-semibold text-gray-900 mb-4">Token Distribution</h3>
+          <h3 className="text-lg font-semibold text-gray-900 mb-4">
+            {t('admin.usage.tokenDistribution', 'Token Distribution')}
+          </h3>
           <div className="space-y-4">
             <div className="flex justify-between items-center">
-              <span className="text-gray-600">Prompt Tokens</span>
+              <span className="text-gray-600">{t('admin.usage.promptTokens', 'Prompt Tokens')}</span>
               <span className="font-semibold">{new Intl.NumberFormat().format(tokens.prompt.total)}</span>
             </div>
             <div className="w-full bg-gray-200 rounded-full h-3">
@@ -283,7 +291,7 @@ const AdminUsageReports = () => {
               ></div>
             </div>
             <div className="flex justify-between items-center">
-              <span className="text-gray-600">Completion Tokens</span>
+              <span className="text-gray-600">{t('admin.usage.completionTokens', 'Completion Tokens')}</span>
               <span className="font-semibold">{new Intl.NumberFormat().format(tokens.completion.total)}</span>
             </div>
             <div className="w-full bg-gray-200 rounded-full h-3">
@@ -329,7 +337,9 @@ const AdminUsageReports = () => {
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <AppUsageCard data={messages.perApp} />
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
-        <h3 className="text-lg font-semibold text-gray-900 mb-4">App Token Usage</h3>
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          {t('admin.usage.appTokenUsage', 'App Token Usage')}
+        </h3>
         <div className="space-y-4">
           {Object.entries(tokens.perApp || {}).map(([app, tokenCount]) => (
             <div key={app} className="flex justify-between items-center p-3 bg-gray-50 rounded-lg">
@@ -663,21 +673,25 @@ const AdminUsageReports = () => {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex justify-between items-center py-6">
             <div>
-              <h1 className="text-3xl font-bold text-gray-900">Admin Dashboard</h1>
-              <p className="text-gray-600 mt-1">Usage analytics and system overview</p>
+              <h1 className="text-3xl font-bold text-gray-900">
+                {t('admin.usage.title', 'Admin Dashboard')}
+              </h1>
+              <p className="text-gray-600 mt-1">
+                {t('admin.usage.subtitle', 'Usage analytics and system overview')}
+              </p>
             </div>
             <div className="flex space-x-3">
               <button
                 onClick={downloadCsv}
                 className="inline-flex items-center px-4 py-2 bg-white border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
               >
-                Download CSV
+                {t('admin.usage.downloadCsv', 'Download CSV')}
               </button>
               <button
                 onClick={downloadJson}
                 className="inline-flex items-center px-4 py-2 bg-indigo-600 border border-transparent rounded-md shadow-sm text-sm font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
               >
-                Download JSON
+                {t('admin.usage.downloadJson', 'Download JSON')}
               </button>
             </div>
           </div>
@@ -689,19 +703,19 @@ const AdminUsageReports = () => {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-center">
             <div>
-              <div className="text-sm text-gray-600">Last Updated</div>
+              <div className="text-sm text-gray-600">{t('admin.usage.lastUpdated', 'Last Updated')}</div>
               <div className="text-sm font-medium">{new Date(lastUpdated).toLocaleString()}</div>
             </div>
             <div>
-              <div className="text-sm text-gray-600">Last Reset</div>
+              <div className="text-sm text-gray-600">{t('admin.usage.lastReset', 'Last Reset')}</div>
               <div className="text-sm font-medium">{new Date(lastReset).toLocaleString()}</div>
             </div>
             <div>
-              <div className="text-sm text-gray-600">Active Users</div>
+              <div className="text-sm text-gray-600">{t('admin.usage.activeUsers', 'Active Users')}</div>
               <div className="text-sm font-medium">{Object.keys(messages.perUser || {}).length}</div>
             </div>
             <div>
-              <div className="text-sm text-gray-600">Active Apps</div>
+              <div className="text-sm text-gray-600">{t('admin.usage.activeApps', 'Active Apps')}</div>
               <div className="text-sm font-medium">{Object.keys(messages.perApp || {}).length}</div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- localize new Admin sections: dashboard, usage, system
- add translations for English and German locales

## Testing
- `node -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871889762108322b24d5866120bcd3a