### PR TITLE
Remove client cache for apps

### DIFF
--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -184,24 +184,22 @@ const handleApiResponse = async (apiCall, cacheKey = null, ttl = DEFAULT_CACHE_T
 
 // Apps
 export const fetchApps = async (options = {}) => {
-  const { skipCache = false, language = null } = options;
-  const cacheKey = skipCache ? null : buildCacheKey(CACHE_KEYS.APPS_LIST, { language });
-  
+  const { language = null } = options;
+
   return handleApiResponse(
     () => apiClient.get('/apps', { params: { language } }),
-    cacheKey,
-    DEFAULT_CACHE_TTL.MEDIUM
+    null, // no client-side caching for apps list
+    null
   );
 };
 
 export const fetchAppDetails = async (appId, options = {}) => {
-  const { skipCache = false, language = null } = options;
-  const cacheKey = skipCache ? null : buildCacheKey(CACHE_KEYS.APP_DETAILS, { id: appId, language });
-  
+  const { language = null } = options;
+
   return handleApiResponse(
     () => apiClient.get(`/apps/${appId}`, { params: { language } }),
-    cacheKey,
-    DEFAULT_CACHE_TTL.MEDIUM
+    null, // no client-side caching for app details
+    null
   );
 };
 

--- a/client/src/pages/AppChat.jsx
+++ b/client/src/pages/AppChat.jsx
@@ -31,7 +31,6 @@ import NoMessagesView from "../components/chat/NoMessagesView";
 import InputVariables from "../components/chat/InputVariables";
 import SharedAppHeader from "../components/SharedAppHeader";
 import { useUIConfig } from "../components/UIConfigContext";
-import cache, { CACHE_KEYS } from "../utils/cache"; // Import cache for manual clearing
 import { recordAppUsage } from "../utils/recentApps";
 import { isMarkdown } from "../utils/markdownUtils";
 import { saveAppSettings, loadAppSettings } from '../utils/appSettings';
@@ -723,11 +722,9 @@ const AppChat = () => {
     setShowFileUploader(false);
   };
 
-  // Function to clear app cache and reload
+  // Function to reload the current app
   const clearAppCache = useCallback(() => {
-    // Clear all app detail caches
-    cache.invalidateByPattern(CACHE_KEYS.APP_DETAILS);
-    // Reload the current app
+    // Client-side caching for apps was removed; simply reload
     window.location.reload();
   }, []);
 


### PR DESCRIPTION
## Summary
- remove internal caching for `fetchApps` and `fetchAppDetails`
- update AppChat reload handler after removing cache

## Testing
- `npm run build:client`
- `npm run build:server`


------
https://chatgpt.com/codex/tasks/task_e_68718814c61883229e0027feb4eec46a