### PR TITLE
Fix apps list search input style

### DIFF
--- a/client/src/pages/AppsList.jsx
+++ b/client/src/pages/AppsList.jsx
@@ -453,8 +453,8 @@ const AppsList = () => {
           }`}
         >
           <div className="relative flex-grow">
-            <div className="absolute inset-y-0 left-0 pl-4 flex items-center pointer-events-none">
-              <Icon name="search" className="text-gray-400" />
+            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+              <Icon name="search" className="h-5 w-5 text-gray-400" />
             </div>
             <input
               type="text"
@@ -464,7 +464,7 @@ const AppsList = () => {
               }
               value={searchTerm}
               onChange={handleSearchChange}
-              className="w-full pl-12 pr-12 py-3 border rounded-lg text-base focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              className="block w-full pl-10 pr-10 py-2 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
               autoComplete="off"
               data-lpignore="true"
               data-1p-ignore="true"


### PR DESCRIPTION
## Summary
- style the apps list search field the same as admin search boxes

## Testing
- `npm run build:client`


------
https://chatgpt.com/codex/tasks/task_e_68726d2d67dc8322866b9b6508d4e0f1