### PR TITLE
Handle JSON output schema

### DIFF
--- a/client/src/components/AppConfigForm.jsx
+++ b/client/src/components/AppConfigForm.jsx
@@ -32,9 +32,13 @@ const AppConfigForm = ({
   // Available output formats
   const outputFormats = [
     { id: 'markdown', name: t('appConfig.markdown', 'Markdown') },
-    { id: 'text', name: t('appConfig.plainText', 'Plain Text') },
-    { id: 'json', name: t('appConfig.json', 'JSON') }
+    { id: 'text', name: t('appConfig.plainText', 'Plain Text') }
   ];
+
+  // Only show JSON when an outputSchema is configured
+  if (app?.outputSchema) {
+    outputFormats.push({ id: 'json', name: t('appConfig.json', 'JSON') });
+  }
 
   // If settings are completely disabled, don't show the form
   if (app?.settings?.enabled === false) {

--- a/client/src/components/chat/ChatMessage.jsx
+++ b/client/src/components/chat/ChatMessage.jsx
@@ -269,11 +269,15 @@ const ChatMessage = ({
 
     if (message.loading) {
       // console.log('🔄 Rendering loading state for message:', contentToRender);
-      // For loading assistant messages with markdown, still use the StreamingMarkdown component
-      if (outputFormat === 'markdown' && !isUser) {
+      // For loading assistant messages with markdown or JSON, use StreamingMarkdown
+      if (!isUser && (outputFormat === 'markdown' || outputFormat === 'json')) {
+        const mdContent =
+          outputFormat === 'json'
+            ? `\u0060\u0060\u0060json\n${contentToRender}\n\u0060\u0060\u0060`
+            : contentToRender;
         return (
           <div className="flex flex-col">
-            <StreamingMarkdown content={contentToRender} />
+            <StreamingMarkdown content={mdContent} />
             <div className="flex mt-2">
               <span className="inline-block w-2 h-2 bg-gray-500 rounded-full animate-pulse"></span>
               <span className="ml-1 inline-block w-2 h-2 bg-gray-500 rounded-full animate-pulse" style={{ animationDelay: '0.2s' }}></span>
@@ -312,10 +316,13 @@ const ChatMessage = ({
       );
     }
     
-    if (outputFormat === 'markdown' && !isUser) {
-      // console.log('✅ Rendering completed markdown content:', contentToRender?.length || 0, 'chars');
+    if (!isUser && (outputFormat === 'markdown' || outputFormat === 'json')) {
+      const mdContent =
+        outputFormat === 'json'
+          ? `\u0060\u0060\u0060json\n${contentToRender}\n\u0060\u0060\u0060`
+          : contentToRender;
       // Use StreamingMarkdown component for better real-time rendering
-      return <StreamingMarkdown content={contentToRender} />;
+      return <StreamingMarkdown content={mdContent} />;
     }
     
     return <div className="break-words whitespace-normal" style={{boxSizing: 'content-box', display: 'inline-block'}}>{contentToRender}</div>;


### PR DESCRIPTION
## Summary
- show JSON output format only when `outputSchema` is configured for the app
- render JSON responses using the same markdown code styling

## Testing
- `npm run build:client`

------
https://chatgpt.com/codex/tasks/task_e_6874ba2a1cd88322b021a44011d470f3