### PR TITLE
Ensure JSON output in admin app generator

### DIFF
--- a/client/src/components/AppCreationWizard.jsx
+++ b/client/src/components/AppCreationWizard.jsx
@@ -697,10 +697,19 @@ const AIGenerationStep = ({ appData, updateAppData }) => {
 
         // Parse the generated JSON configuration
         try {
-          const jsonMatch = generatedConfig.match(/```json\s*(\{[\s\S]*?\})\s*```/);
-          if (jsonMatch) {
-            const configJson = JSON.parse(jsonMatch[1]);
-            console.log('Generated config:', configJson);
+          let configJson;
+
+          // Prefer direct JSON when structured output is enabled
+          try {
+            configJson = JSON.parse(generatedConfig);
+          } catch {
+            const jsonMatch = generatedConfig.match(/```json\s*(\{[\s\S]*?\})\s*```/);
+            if (jsonMatch) {
+              configJson = JSON.parse(jsonMatch[1]);
+            }
+          }
+
+          if (configJson) {
             
             // Convert to multilingual format and merge with existing app data
             const multilingualConfig = {

--- a/contents/locales/de.json
+++ b/contents/locales/de.json
@@ -288,5 +288,20 @@
     "translate": "Übersetzen",
     "grammar": "Grammatik",
     "format": "Formatieren"
+  },
+  "admin": {
+    "apps": {
+      "wizard": {
+        "ai": {
+          "language": "Sprache",
+          "loadingPrompt": "Lade Prompt-Konfiguration...",
+          "error": {
+            "parse": "Generierte Konfiguration konnte nicht gelesen werden",
+            "generate": "Konfiguration konnte nicht generiert werden",
+            "network": "Netzwerkfehler bei der Generierung der App"
+          }
+        }
+      }
+    }
   }
 }

--- a/contents/locales/en.json
+++ b/contents/locales/en.json
@@ -337,7 +337,14 @@
           "promptPlaceholder": "Example: Create a meeting summarizer app that takes meeting notes and extracts key points, action items, and decisions...",
           "generate": "Generate App",
           "generating": "Generating...",
-          "success": "App configuration generated successfully! You can review and modify it in the next steps."
+          "success": "App configuration generated successfully! You can review and modify it in the next steps.",
+          "language": "Language",
+          "loadingPrompt": "Loading prompt configuration...",
+          "error": {
+            "parse": "Failed to parse generated configuration",
+            "generate": "Failed to generate app configuration",
+            "network": "Network error occurred while generating app"
+          }
         },
         "basic": {
           "title": "Basic Information",
@@ -347,7 +354,6 @@
           "appIdPlaceholder": "e.g., my-awesome-app",
           "name": "App Name",
           "namePlaceholder": "Enter app name",
-          "description": "Description",
           "descriptionPlaceholder": "Enter app description",
           "color": "Color",
           "icon": "Icon",
@@ -404,7 +410,7 @@
         },
         "error": {
           "idRequired": "App ID is required",
-          "nameRequired": "App name is required", 
+          "nameRequired": "App name is required",
           "descriptionRequired": "App description is required",
           "colorRequired": "App color is required",
           "iconRequired": "App icon is required",

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -843,9 +843,16 @@ export default function registerAdminRoutes(app) {
       
       // Use the existing simpleCompletion function
       const { simpleCompletion } = await import('../utils.js');
-      const result = await simpleCompletion(messages, { 
-        modelId: modelId, 
-        temperature: temperature 
+
+      // Retrieve output schema from the app-generator config if available
+      const apps = configCache.getApps(true);
+      const generatorApp = apps.find(a => a.id === 'app-generator');
+
+      const result = await simpleCompletion(messages, {
+        modelId: modelId,
+        temperature: temperature,
+        responseFormat: 'json',
+        responseSchema: generatorApp?.outputSchema
       });
 
       console.log('Completion result:', JSON.stringify(result, null, 2));

--- a/server/utils.js
+++ b/server/utils.js
@@ -338,35 +338,54 @@ export async function logNewSession(chatId, appId, metadata = {}) {
  * Performs a simple, non-streaming completion request to a language model.
  * @param {string} prompt - The prompt to send to the model.
  * @param {object} options - Configuration options.
- * @param {string} options.model - The ID of the model to use.
+ * @param {string} [options.modelId] - The ID of the model to use.
+ * @param {string} [options.model] - Alias for modelId.
  * @param {number} [options.temperature=0.7] - The temperature for the completion.
+ * @param {string} [options.responseFormat] - Desired output format ('json').
+ * @param {object} [options.responseSchema] - Optional JSON schema for structured output.
  * @returns {Promise<string>} The content of the model's response.
  */
-export async function simpleCompletion(messages, { modelId: modelId, temperature = 0.7 }) {
-  console.log('Starting simple completion...', { messages: JSON.stringify(messages, null, 2), modelId, temperature });
+export async function simpleCompletion(
+  messages,
+  {
+    modelId = null,
+    model = null,
+    temperature = 0.7,
+    responseFormat = null,
+    responseSchema = null
+  } = {}
+) {
+  const resolvedModelId = modelId || model;
+
+  console.log('Starting simple completion...', { messages: JSON.stringify(messages, null, 2), modelId: resolvedModelId, temperature });
   // Try to get models from cache first
   let models = configCache.getModels();
   console.log('Available models:', models.map(m => m.id));
-  
-  const model = models.find(m => m.id === modelId);
-  console.log('Using model:', model);
-  if (!model) {
-    throw new Error(`Model ${modelId} not found`);
+
+  const modelConfig = models.find(m => m.id === resolvedModelId);
+  console.log('Using model:', modelConfig);
+  if (!modelConfig) {
+    throw new Error(`Model ${resolvedModelId} not found`);
   }
 
-  const apiKey = config[`${model.provider.toUpperCase()}_API_KEY`];
+  const apiKey = config[`${modelConfig.provider.toUpperCase()}_API_KEY`];
   if (!apiKey) {
-    throw new Error(`API key for ${model.provider} not found in environment variables.`);
+    throw new Error(`API key for ${modelConfig.provider} not found in environment variables.`);
   }
 
-  // const messages = [{ role: 'user', content: prompt }];
-  const request = createCompletionRequest(model, messages, apiKey, {
+  const msgArray = Array.isArray(messages)
+    ? messages
+    : [{ role: 'user', content: messages }];
+
+  const request = createCompletionRequest(modelConfig, msgArray, apiKey, {
     temperature,
     maxTokens: 8192, // Sufficient for internal tasks
-    stream: false
+    stream: false,
+    responseFormat,
+    responseSchema
   });
 
-  const response = await throttledFetch(model.id, request.url, {
+  const response = await throttledFetch(modelConfig.id, request.url, {
     method: 'POST',
     headers: request.headers,
     body: JSON.stringify(request.body)
@@ -380,7 +399,7 @@ export async function simpleCompletion(messages, { modelId: modelId, temperature
   const responseData = await response.json();
 
   // Use the adapter to parse the response
-  const parsed = processResponseBuffer(model.provider, JSON.stringify(responseData));
+  const parsed = processResponseBuffer(modelConfig.provider, JSON.stringify(responseData));
   
   // Return both content and usage data
   return {


### PR DESCRIPTION
## Summary
- add JSON response support to `simpleCompletion`
- use structured response in admin completions endpoint
- parse direct JSON when generating apps
- add internationalization keys for the app generator wizard
- use app-generator schema for structured output

## Testing
- `node server/tests/openaiAdapter.test.js`


------
https://chatgpt.com/codex/tasks/task_e_6874d0abc3fc8322bd2d2493ef169d13