### PR TITLE
Fix missing tool call type

### DIFF
--- a/server/adapters/openai.js
+++ b/server/adapters/openai.js
@@ -154,6 +154,11 @@ const OpenAIAdapter = {
             } else if (tc.delta && tc.delta.function) {
               normalized.function = { ...tc.delta.function };
             }
+            if (tc.type || (tc.delta && tc.delta.type)) {
+              normalized.type = tc.type || tc.delta.type;
+            } else {
+              normalized.type = 'function';
+            }
             result.tool_calls.push(normalized);
           }
         }

--- a/server/services/chatService.js
+++ b/server/services/chatService.js
@@ -402,6 +402,7 @@ export function processChatWithTools({
               collectedToolCalls.push({
                 index: call.index,
                 id: call.id,
+                type: call.type || 'function',
                 function: {
                   name: call.function.name,
                   arguments: call.function.arguments || ''


### PR DESCRIPTION
## Summary
- retain `type` attribute when parsing streaming tool calls
- include tool type when storing tool calls in `chatService`

## Testing
- `npm run test:openai`
- `npm run test:mistral`
- `npm run test:anthropic`
- `npm run test:google` *(fails: ERR_ASSERTION)*

------
https://chatgpt.com/codex/tasks/task_e_68752a1ad93c8322b66321c893c96317