### PR TITLE
Fix multi-tool OpenAI requests

### DIFF
--- a/server/adapters/openai.js
+++ b/server/adapters/openai.js
@@ -21,7 +21,11 @@ const OpenAIAdapter = {
 
       // Handle image data in messages
       if (!message.imageData) {
-        return { ...base, content };
+        const finalContent =
+          base.tool_calls && (content === undefined || content === '')
+            ? null
+            : content;
+        return { ...base, content: finalContent };
       }
 
       // Format messages with image content for vision models

--- a/server/services/chatService.js
+++ b/server/services/chatService.js
@@ -436,7 +436,9 @@ export function processChatWithTools({
     const toolNames = collectedToolCalls.map(c => c.function.name).join(', ');
     actionTracker.trackAction(chatId, { action: 'processing', message: `Using tool(s): ${toolNames}...` });
 
-    llmMessages.push({ role: 'assistant', content: assistantContent, tool_calls: collectedToolCalls });
+    const assistantMessage = { role: 'assistant', tool_calls: collectedToolCalls };
+    assistantMessage.content = assistantContent || null;
+    llmMessages.push(assistantMessage);
 
     for (const call of collectedToolCalls) {
       const toolId = tools.find(t => normalizeName(t.id) === call.function.name)?.id || call.function.name;


### PR DESCRIPTION
## Summary
- ensure OpenAI messages with tool calls use `null` content
- set `content: null` for assistant tool responses

## Testing
- `npm run test:openai`
- `npm run test:mistral`
- `npm run test:anthropic`
- `npm run test:google` *(fails: ERR_ASSERTION)*

------
https://chatgpt.com/codex/tasks/task_e_687536149f1c83229909150bc4d5c66c