### PR TITLE
Enable rich clipboard copy

### DIFF
--- a/client/src/features/canvas/components/ExportMenu.jsx
+++ b/client/src/features/canvas/components/ExportMenu.jsx
@@ -38,8 +38,21 @@ const ExportMenu = ({ content, onClose }) => {
   };
 
   const handleCopyHTML = () => {
-    navigator.clipboard
-      .writeText(content)
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = content;
+    const plain = tempDiv.textContent || tempDiv.innerText || '';
+    const hasClipboardWrite = navigator.clipboard && navigator.clipboard.write;
+
+    const item = new ClipboardItem({
+      'text/html': new Blob([content], { type: 'text/html' }),
+      'text/plain': new Blob([plain], { type: 'text/plain' })
+    });
+
+    const copyPromise = hasClipboardWrite
+      ? navigator.clipboard.write([item])
+      : navigator.clipboard.writeText(content);
+
+    copyPromise
       .then(() => {
         console.log('✅ HTML copied to clipboard');
       })

--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -116,8 +116,20 @@ const ChatMessage = ({
         data = plain;
     }
 
-    navigator.clipboard
-      .writeText(data)
+    const hasClipboardWrite = navigator.clipboard && navigator.clipboard.write;
+    let copyPromise;
+
+    if (format === 'html' && hasClipboardWrite) {
+      const item = new ClipboardItem({
+        'text/html': new Blob([html], { type: 'text/html' }),
+        'text/plain': new Blob([plain], { type: 'text/plain' })
+      });
+      copyPromise = navigator.clipboard.write([item]);
+    } else {
+      copyPromise = navigator.clipboard.writeText(data);
+    }
+
+    copyPromise
       .then(() => {
         setCopied(true);
         setTimeout(() => setCopied(false), 2000);


### PR DESCRIPTION
## Summary
- add ClipboardItem usage in chat message copy
- export HTML from canvas using ClipboardItem

## Testing
- `npx eslint client/src/features/chat/components/ChatMessage.jsx client/src/features/canvas/components/ExportMenu.jsx --fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6876cc66fb4483228550e9ec6a238d00