### PR TITLE
Make prompt details popup scrollable

### DIFF
--- a/client/src/features/prompts/components/PromptDetailsPopup.jsx
+++ b/client/src/features/prompts/components/PromptDetailsPopup.jsx
@@ -74,7 +74,7 @@ const PromptDetailsPopup = ({ prompt, isOpen, onClose }) => {
             <h4 className="text-sm font-medium text-gray-700 mb-2">
               {t('admin.prompts.details.promptContent', 'Prompt Content')}
             </h4>
-            <div className="bg-gray-50 rounded-lg p-3">
+            <div className="bg-gray-50 rounded-lg p-3 max-h-60 overflow-y-auto">
               <p className="text-sm text-gray-600 leading-relaxed whitespace-pre-wrap">
                 {getLocalizedValue(prompt.prompt)}
               </p>


### PR DESCRIPTION
## Summary
- let Prompt Details popup handle really long prompts by making the content area scrollable

## Testing
- `npm run lint:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6877bced85a48322b29d60668879433d