### PR TITLE
Enable ESC key to close prompt views

### DIFF
--- a/client/src/features/prompts/components/PromptDetailsPopup.jsx
+++ b/client/src/features/prompts/components/PromptDetailsPopup.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { getLocalizedContent } from '../../../utils/localizeContent';
@@ -8,6 +8,17 @@ const PromptDetailsPopup = ({ prompt, isOpen, onClose }) => {
   const { t, i18n } = useTranslation();
   const currentLanguage = i18n.language;
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = e => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
 
   if (!isOpen || !prompt) return null;
 

--- a/client/src/features/prompts/components/PromptModal.jsx
+++ b/client/src/features/prompts/components/PromptModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import Icon from '../../../shared/components/Icon';
 import { highlightVariables } from '../../../utils/highlightVariables';
@@ -7,6 +7,16 @@ const PromptModal = ({ prompt, onClose, isFavorite, onToggleFavorite, t }) => {
   const [copyStatus, setCopyStatus] = useState('idle');
   const [shareStatus, setShareStatus] = useState('idle');
   if (!prompt) return null;
+
+  useEffect(() => {
+    const handleKeyDown = e => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
 
   const handleShare = async () => {
     const url = `${window.location.origin}/prompts?id=${encodeURIComponent(prompt.id)}`;

--- a/client/src/shared/components/SearchModal.jsx
+++ b/client/src/shared/components/SearchModal.jsx
@@ -32,6 +32,17 @@ const SearchModal = ({
   }, [isOpen]);
 
   useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = e => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  useEffect(() => {
     if (!isOpen || !query.trim() || !fuseRef.current) {
       setResults([]);
       return;


### PR DESCRIPTION
## Summary
- allow closing SearchModal with the Escape key even when the input isn't focused
- close PromptModal on ESC
- close PromptDetailsPopup on ESC

## Testing
- `npm run lint:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6877bcb962a48322a0b87cab9f0b50a2