### PR TITLE
Refactor adminRoutes to async fs

### DIFF
--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -1,6 +1,6 @@
 import { getUsage } from '../usageTracker.js';
 import configCache from '../configCache.js';
-import { readFileSync, existsSync } from 'fs';
+import { existsSync } from 'fs';
 import { promises as fs } from 'fs';
 import { atomicWriteJSON } from '../utils/atomicWrite.js';
 import { join } from 'path';
@@ -306,10 +306,13 @@ export default function registerAdminRoutes(app) {
       const appFilePath = join(rootDir, 'contents', 'apps', `${newApp.id}.json`);
 
       try {
-        readFileSync(appFilePath, 'utf8');
+        await fs.readFile(appFilePath, 'utf8');
         return res.status(400).json({ error: 'App with this ID already exists' });
       } catch (err) {
         // File doesn't exist, which is what we want
+        if (err.code !== 'ENOENT') {
+          throw err;
+        }
       }
 
       // Save the app to individual file
@@ -366,8 +369,13 @@ export default function registerAdminRoutes(app) {
       const appFilePath = join(rootDir, 'contents', 'apps', `${appId}.json`);
 
       // Check if file exists
-      if (!readFileSync(appFilePath, 'utf8')) {
-        return res.status(404).json({ error: 'App not found' });
+      try {
+        await fs.readFile(appFilePath, 'utf8');
+      } catch (err) {
+        if (err.code === 'ENOENT') {
+          return res.status(404).json({ error: 'App not found' });
+        }
+        throw err;
       }
 
       // Delete the file
@@ -484,10 +492,13 @@ export default function registerAdminRoutes(app) {
       const modelFilePath = join(rootDir, 'contents', 'models', `${newModel.id}.json`);
 
       try {
-        readFileSync(modelFilePath, 'utf8');
+        await fs.readFile(modelFilePath, 'utf8');
         return res.status(400).json({ error: 'Model with this ID already exists' });
       } catch (err) {
         // File doesn't exist, which is what we want
+        if (err.code !== 'ENOENT') {
+          throw err;
+        }
       }
 
       // Handle default model logic - only one model can be default
@@ -798,10 +809,13 @@ export default function registerAdminRoutes(app) {
       const promptFilePath = join(rootDir, 'contents', 'prompts', `${newPrompt.id}.json`);
 
       try {
-        readFileSync(promptFilePath, 'utf8');
+        await fs.readFile(promptFilePath, 'utf8');
         return res.status(400).json({ error: 'Prompt with this ID already exists' });
       } catch (err) {
         // File doesn't exist, which is what we want
+        if (err.code !== 'ENOENT') {
+          throw err;
+        }
       }
 
       // Save the prompt to individual file


### PR DESCRIPTION
## Summary
- replace blocking fs operations in `server/routes/adminRoutes.js`
- remove unused `readFileSync` import

## Testing
- `npm run lint:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6878443cb6288322836b3f36d87e527f