### PR TITLE
Fix missing translations

### DIFF
--- a/client/src/features/admin/pages/AdminAppEditPage.jsx
+++ b/client/src/features/admin/pages/AdminAppEditPage.jsx
@@ -637,9 +637,9 @@ const AdminAppEditPage = () => {
                       onChange={e => handleInputChange('preferredOutputFormat', e.target.value)}
                       className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
                     >
-                      <option value="markdown">Markdown</option>
-                      <option value="text">Plain Text</option>
-                      <option value="json">JSON</option>
+                      <option value="markdown">{t('appConfig.markdown', 'Markdown')}</option>
+                      <option value="text">{t('appConfig.plainText', 'Plain Text')}</option>
+                      <option value="json">{t('appConfig.json', 'JSON')}</option>
                     </select>
                   </div>
 

--- a/client/src/features/admin/pages/AdminAppsPage.jsx
+++ b/client/src/features/admin/pages/AdminAppsPage.jsx
@@ -422,7 +422,9 @@ const AdminAppsPage = () => {
                                 : app.category}
                             </span>
                           ) : (
-                            <span className="text-gray-400 text-sm">N/A</span>
+                            <span className="text-gray-400 text-sm">
+                              {t('common.notAvailable', 'N/A')}
+                            </span>
                           )}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap">
@@ -439,10 +441,10 @@ const AdminAppsPage = () => {
                           </span>
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                          {app.order ?? 'N/A'}
+                          {app.order ?? t('common.notAvailable', 'N/A')}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                          {app.preferredModel || 'N/A'}
+                          {app.preferredModel || t('common.notAvailable', 'N/A')}
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                           <div className="flex justify-end space-x-2">

--- a/client/src/features/admin/pages/AdminPromptsPage.jsx
+++ b/client/src/features/admin/pages/AdminPromptsPage.jsx
@@ -341,7 +341,9 @@ const AdminPromptsPage = () => {
                                   : prompt.category}
                               </span>
                             ) : (
-                              <span className="text-gray-400 text-sm">N/A</span>
+                              <span className="text-gray-400 text-sm">
+                                {t('common.notAvailable', 'N/A')}
+                              </span>
                             )}
                           </td>
                           <td className="px-6 py-4">

--- a/client/src/features/apps/components/AppDetailsPopup.jsx
+++ b/client/src/features/apps/components/AppDetailsPopup.jsx
@@ -92,27 +92,33 @@ const AppDetailsPopup = ({ app, isOpen, onClose }) => {
                 <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
                   {t('admin.apps.details.model', 'Model')}
                 </div>
-                <div className="text-sm text-gray-900 mt-1">{app.preferredModel || 'Default'}</div>
+                <div className="text-sm text-gray-900 mt-1">
+                  {app.preferredModel || t('common.default', 'Default')}
+                </div>
               </div>
               <div className="bg-gray-50 rounded-lg p-3">
                 <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
                   {t('admin.apps.details.tokenLimit', 'Token Limit')}
                 </div>
-                <div className="text-sm text-gray-900 mt-1">{app.tokenLimit || 'Default'}</div>
+                <div className="text-sm text-gray-900 mt-1">
+                  {app.tokenLimit || t('common.default', 'Default')}
+                </div>
               </div>
               <div className="bg-gray-50 rounded-lg p-3">
                 <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
                   {t('admin.apps.details.temperature', 'Temperature')}
                 </div>
                 <div className="text-sm text-gray-900 mt-1">
-                  {app.preferredTemperature || 'Default'}
+                  {app.preferredTemperature || t('common.default', 'Default')}
                 </div>
               </div>
               <div className="bg-gray-50 rounded-lg p-3">
                 <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
                   {t('admin.apps.details.order', 'Order')}
                 </div>
-                <div className="text-sm text-gray-900 mt-1">{app.order || 'Not set'}</div>
+                <div className="text-sm text-gray-900 mt-1">
+                  {app.order || t('common.notSet', 'Not set')}
+                </div>
               </div>
             </div>
           </div>
@@ -133,7 +139,9 @@ const AppDetailsPopup = ({ app, isOpen, onClose }) => {
                         </span>
                         <span className="text-xs text-gray-500">{variable.type}</span>
                         {variable.required && (
-                          <span className="text-xs text-red-500">required</span>
+                          <span className="text-xs text-red-500">
+                            {t('common.required', 'required')}
+                          </span>
                         )}
                       </div>
                     </div>

--- a/client/src/features/prompts/components/PromptDetailsPopup.jsx
+++ b/client/src/features/prompts/components/PromptDetailsPopup.jsx
@@ -103,14 +103,16 @@ const PromptDetailsPopup = ({ prompt, isOpen, onClose }) => {
                   {t('admin.prompts.details.order', 'Order')}
                 </div>
                 <div className="text-sm text-gray-900 mt-1">
-                  {prompt.order !== undefined ? prompt.order : 'Not set'}
+                  {prompt.order !== undefined ? prompt.order : t('common.notSet', 'Not set')}
                 </div>
               </div>
               <div className="bg-gray-50 rounded-lg p-3">
                 <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
                   {t('admin.prompts.details.linkedApp', 'Linked App')}
                 </div>
-                <div className="text-sm text-gray-900 mt-1">{prompt.appId || 'None'}</div>
+                <div className="text-sm text-gray-900 mt-1">
+                  {prompt.appId || t('common.none', 'None')}
+                </div>
               </div>
             </div>
           </div>
@@ -131,7 +133,9 @@ const PromptDetailsPopup = ({ prompt, isOpen, onClose }) => {
                         </span>
                         <span className="text-xs text-gray-500">{variable.type}</span>
                         {variable.required && (
-                          <span className="text-xs text-red-500">required</span>
+                          <span className="text-xs text-red-500">
+                            {t('common.required', 'required')}
+                          </span>
                         )}
                       </div>
                     </div>
@@ -140,7 +144,7 @@ const PromptDetailsPopup = ({ prompt, isOpen, onClose }) => {
                     </div>
                     {variable.defaultValue && (
                       <div className="text-xs text-gray-500 mt-1">
-                        Default: {variable.defaultValue}
+                        {t('common.default', 'Default')}: {variable.defaultValue}
                       </div>
                     )}
                   </div>

--- a/client/src/shared/components/ModelDetailsPopup.jsx
+++ b/client/src/shared/components/ModelDetailsPopup.jsx
@@ -171,14 +171,18 @@ const ModelDetailsPopup = ({ model, isOpen, onClose }) => {
                 <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
                   {t('admin.models.details.modelId', 'Model ID')}
                 </div>
-                <div className="text-sm text-gray-900 mt-1">{model.modelId || 'Not specified'}</div>
+                <div className="text-sm text-gray-900 mt-1">
+                  {model.modelId || t('common.notSpecified', 'Not specified')}
+                </div>
               </div>
               <div className="bg-gray-50 rounded-lg p-3">
                 <div className="text-xs font-medium text-gray-500 uppercase tracking-wide">
                   {t('admin.models.details.tokenLimit', 'Token Limit')}
                 </div>
                 <div className="text-sm text-gray-900 mt-1">
-                  {model.tokenLimit ? model.tokenLimit.toLocaleString() : 'Not set'}
+                  {model.tokenLimit
+                    ? model.tokenLimit.toLocaleString()
+                    : t('common.notSet', 'Not set')}
                 </div>
               </div>
               <div className="bg-gray-50 rounded-lg p-3">
@@ -186,7 +190,7 @@ const ModelDetailsPopup = ({ model, isOpen, onClose }) => {
                   {t('admin.models.details.supportsTools', 'Supports Tools')}
                 </div>
                 <div className="text-sm text-gray-900 mt-1">
-                  {model.supportsTools ? 'Yes' : 'No'}
+                  {model.supportsTools ? t('common.yes', 'Yes') : t('common.no', 'No')}
                 </div>
               </div>
               {model.concurrency && (

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -45,7 +45,14 @@
     "expiresAt": "Ablaufdatum",
     "codeTaken": "Code vergeben",
     "codeAvailable": "Code verfügbar",
-    "codeTooShort": "Code zu kurz"
+    "codeTooShort": "Code zu kurz",
+    "notAvailable": "k.A.",
+    "notSet": "Nicht festgelegt",
+    "notSpecified": "Nicht angegeben",
+    "none": "Keine",
+    "yes": "Ja",
+    "no": "Nein",
+    "required": "erforderlich"
   },
   "pages": {
     "home": {
@@ -182,7 +189,10 @@
     "temperature": "Temperatur",
     "temperatureDescription": "Steuert die Zufälligkeit: Niedrigere Werte sind deterministischer, höhere Werte sind kreativer.",
     "systemPrompt": "System-Prompt",
-    "systemPromptDescription": "Anweisungen für die KI zu Beginn des Gesprächs."
+    "systemPromptDescription": "Anweisungen für die KI zu Beginn des Gesprächs.",
+    "markdown": "Markdown",
+    "plainText": "Klartext",
+    "json": "JSON"
   },
   "chatMessage": {
     "user": "Du",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -43,7 +43,14 @@
     "expiresAt": "Expires At",
     "codeTaken": "Code taken",
     "codeAvailable": "Code available",
-    "codeTooShort": "Code must be at least 5 characters"
+    "codeTooShort": "Code must be at least 5 characters",
+    "notAvailable": "N/A",
+    "notSet": "Not set",
+    "notSpecified": "Not specified",
+    "none": "None",
+    "yes": "Yes",
+    "no": "No",
+    "required": "required"
   },
   "pages": {
     "home": {
@@ -188,7 +195,10 @@
     "temperature": "Temperature",
     "temperatureDescription": "Controls randomness: Lower values are more deterministic, higher values are more creative.",
     "systemPrompt": "System Prompt",
-    "systemPromptDescription": "Instructions for the AI at the beginning of the conversation."
+    "systemPromptDescription": "Instructions for the AI at the beginning of the conversation.",
+    "markdown": "Markdown",
+    "plainText": "Plain Text",
+    "json": "JSON"
   },
   "chatMessage": {
     "user": "You",


### PR DESCRIPTION
## Summary
- add new common translation keys for fallback labels
- localize output format options in admin app edit
- use translated fallback values in admin apps list
- localize missing strings in admin prompts list
- fix untranslated defaults in app and prompt detail popups
- localize model details popup info

## Testing
- `npm run format`
- `npm run lint:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_6877dac94eb88322873f2ff60d8e431a