### PR TITLE
Fix ESLint space-before-function-paren rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,7 +38,7 @@ export default [
       'comma-dangle': ['error', 'never'],
       'object-curly-spacing': ['error', 'always'],
       'array-bracket-spacing': ['error', 'never'],
-      'space-before-function-paren': ['error', 'never'],
+      'space-before-function-paren': ['error', 'always'],
       'keyword-spacing': 'error',
       'space-infix-ops': 'error',
       'no-trailing-spaces': 'error'


### PR DESCRIPTION
## Summary
- update ESLint config to use `space-before-function-paren: ['error', 'always']`

## Testing
- `npx eslint eslint.config.js`
- `npx prettier --check eslint.config.js`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68784558e2448322b5f90f5e8bf1fef1