### PR TITLE
Handle missing preferred model

### DIFF
--- a/client/src/shared/hooks/useAppSettings.js
+++ b/client/src/shared/hooks/useAppSettings.js
@@ -58,9 +58,14 @@ const useAppSettings = (appId, app) => {
 
     const defaultModel = models.find(m => m.default);
 
+    let initialModel = app.preferredModel;
+    if (!models.some(m => m.id === initialModel)) {
+      initialModel = defaultModel ? defaultModel.id : models[0]?.id || null;
+    }
+
     // Initialize with app defaults
     const initialState = {
-      selectedModel: app.preferredModel || (defaultModel ? defaultModel.id : null),
+      selectedModel: initialModel,
       selectedStyle: app.preferredStyle || 'normal',
       temperature: app.preferredTemperature || 0.7,
       selectedOutputFormat: app.preferredOutputFormat || 'markdown',
@@ -77,7 +82,11 @@ const useAppSettings = (appId, app) => {
     // Load saved settings and override defaults if available
     const savedSettings = loadAppSettings(appId);
     if (savedSettings) {
-      if (savedSettings.selectedModel) setSelectedModel(savedSettings.selectedModel);
+      if (
+        savedSettings.selectedModel &&
+        models.some(m => m.id === savedSettings.selectedModel)
+      )
+        setSelectedModel(savedSettings.selectedModel);
       if (savedSettings.selectedStyle) setSelectedStyle(savedSettings.selectedStyle);
       if (savedSettings.selectedOutputFormat)
         setSelectedOutputFormat(savedSettings.selectedOutputFormat);

--- a/docs/models.md
+++ b/docs/models.md
@@ -98,7 +98,7 @@ The AI Hub provides a flexible system for selecting which AI model an app uses. 
     }
     ```
 
-    If a default model is set, the app's model dropdown in the user interface will pre-select this model if the app has no `preferredModel`. Only one model should be marked as the default.
+    If a default model is set, the app's model dropdown in the user interface will pre-select this model if the app has no `preferredModel`. If an app's preferred model cannot be found, the default model is used instead. Only one model should be marked as the default.
 
 4.  **First Available Model**: If none of the above are set, the app will simply use the first model from the list of available models.
 

--- a/server/services/chat/RequestBuilder.js
+++ b/server/services/chat/RequestBuilder.js
@@ -57,11 +57,15 @@ class RequestBuilder {
       }
 
       const defaultModel = models.find(m => m.default)?.id;
-      const model = models.find(m => m.id === (modelId || app.preferredModel || defaultModel));
+      let resolvedModelId = modelId || app.preferredModel || defaultModel;
+      if (!models.some(m => m.id === resolvedModelId)) {
+        resolvedModelId = defaultModel;
+      }
+      const model = models.find(m => m.id === resolvedModelId);
 
       if (!model) {
         const error = await this.errorHandler.createModelError(
-          modelId || app.preferredModel || defaultModel,
+          resolvedModelId,
           'unknown',
           language
         );


### PR DESCRIPTION
## Summary
- default to configured default model when preferred model is missing
- ensure saved settings fall back to a valid model
- mention the fallback behaviour in documentation

## Testing
- `npm run lint:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6878f0664a648322bc95a82f1a7f6b9a