### PR TITLE
Add admin page management

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -23,6 +23,8 @@ import AdminModelEditPage from './features/admin/pages/AdminModelEditPage';
 import AdminModelsPage from './features/admin/pages/AdminModelsPage';
 import AdminPromptsPage from './features/admin/pages/AdminPromptsPage';
 import AdminPromptEditPage from './features/admin/pages/AdminPromptEditPage';
+import AdminPagesPage from './features/admin/pages/AdminPagesPage';
+import AdminPageEditPage from './features/admin/pages/AdminPageEditPage';
 import AppProviders from './features/apps/components/AppProviders';
 import { withSafeRoute } from './shared/components/SafeRoute';
 import useSessionManagement from './shared/hooks/useSessionManagement';
@@ -49,6 +51,8 @@ const SafeAdminModels = withSafeRoute(AdminModelsPage);
 const SafeAdminModelEdit = withSafeRoute(AdminModelEditPage);
 const SafeAdminPrompts = withSafeRoute(AdminPromptsPage);
 const SafeAdminPromptEdit = withSafeRoute(AdminPromptEditPage);
+const SafeAdminPages = withSafeRoute(AdminPagesPage);
+const SafeAdminPageEdit = withSafeRoute(AdminPageEditPage);
 const SafePromptsList = withSafeRoute(PromptsList);
 
 function App() {
@@ -103,6 +107,10 @@ function App() {
               )}
               {showAdminPage('models') && (
                 <Route path="admin/models/:modelId" element={<SafeAdminModelEdit />} />
+              )}
+              {showAdminPage('pages') && <Route path="admin/pages" element={<SafeAdminPages />} />}
+              {showAdminPage('pages') && (
+                <Route path="admin/pages/:pageId" element={<SafeAdminPageEdit />} />
               )}
               {showAdminPage('prompts') && (
                 <Route path="admin/prompts" element={<SafeAdminPrompts />} />

--- a/client/src/api/adminApi.js
+++ b/client/src/api/adminApi.js
@@ -111,3 +111,36 @@ export const updatePrompt = async (promptId, promptData) => {
   });
   return response.json();
 };
+
+export const fetchAdminPages = async () => {
+  const response = await makeAdminApiCall('/api/admin/pages');
+  return response.json();
+};
+
+export const fetchAdminPage = async pageId => {
+  const response = await makeAdminApiCall(`/api/admin/pages/${pageId}`);
+  return response.json();
+};
+
+export const createPage = async pageData => {
+  const response = await makeAdminApiCall('/api/admin/pages', {
+    method: 'POST',
+    body: JSON.stringify(pageData)
+  });
+  return response.json();
+};
+
+export const updatePage = async (pageId, pageData) => {
+  const response = await makeAdminApiCall(`/api/admin/pages/${pageId}`, {
+    method: 'PUT',
+    body: JSON.stringify(pageData)
+  });
+  return response.json();
+};
+
+export const deletePage = async pageId => {
+  const response = await makeAdminApiCall(`/api/admin/pages/${pageId}`, {
+    method: 'DELETE'
+  });
+  return response.json();
+};

--- a/client/src/features/admin/components/AdminNavigation.jsx
+++ b/client/src/features/admin/components/AdminNavigation.jsx
@@ -41,6 +41,13 @@ const AdminNavigation = () => {
       current: location.pathname.startsWith('/admin/prompts')
     },
     {
+      key: 'pages',
+      name: t('admin.nav.pages', 'Pages'),
+      href: '/admin/pages',
+      icon: 'document',
+      current: location.pathname.startsWith('/admin/pages')
+    },
+    {
       key: 'shortlinks',
       name: t('admin.nav.shortlinks', 'Short Links'),
       href: '/admin/shortlinks',

--- a/client/src/features/admin/pages/AdminPageEditPage.jsx
+++ b/client/src/features/admin/pages/AdminPageEditPage.jsx
@@ -1,0 +1,127 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import AdminAuth from '../components/AdminAuth';
+import AdminNavigation from '../components/AdminNavigation';
+import DynamicLanguageEditor from '../../../shared/components/DynamicLanguageEditor';
+import { fetchAdminPage, createPage, updatePage } from '../../../api/adminApi';
+
+const AdminPageEditPage = () => {
+  const { t } = useTranslation();
+  const { pageId } = useParams();
+  const navigate = useNavigate();
+  const isNew = pageId === 'new';
+
+  const [page, setPage] = useState({ id: '', title: { en: '' }, content: { en: '' } });
+  const [loading, setLoading] = useState(!isNew);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (isNew) {
+      setLoading(false);
+    } else {
+      loadPage();
+    }
+  }, [pageId]);
+
+  const loadPage = async () => {
+    try {
+      setLoading(true);
+      const data = await fetchAdminPage(pageId);
+      setPage({
+        id: data.id,
+        title: data.title || { en: '' },
+        content: data.content || { en: '' }
+      });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!page.id) {
+      alert(t('admin.pages.fields.idRequired', 'ID is required'));
+      return;
+    }
+    try {
+      setSaving(true);
+      if (isNew) {
+        await createPage(page);
+      } else {
+        await updatePage(pageId, page);
+      }
+      navigate('/admin/pages');
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-8">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+      </div>
+    );
+  }
+
+  return (
+    <AdminAuth>
+      <AdminNavigation />
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-700">
+              {t('admin.pages.fields.id', 'Page ID')}
+            </label>
+            <input
+              type="text"
+              value={page.id}
+              onChange={e => setPage(prev => ({ ...prev, id: e.target.value }))}
+              disabled={!isNew}
+              required
+              className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+            />
+          </div>
+          <DynamicLanguageEditor
+            label={t('admin.pages.fields.title', 'Title')}
+            value={page.title}
+            onChange={val => setPage(prev => ({ ...prev, title: val }))}
+            required
+          />
+          <DynamicLanguageEditor
+            label={t('admin.pages.fields.content', 'Content')}
+            value={page.content}
+            onChange={val => setPage(prev => ({ ...prev, content: val }))}
+            type="textarea"
+            required
+          />
+          {error && <div className="text-red-600 text-sm">{error}</div>}
+          <div className="flex justify-end space-x-2">
+            <button
+              type="button"
+              onClick={() => navigate('/admin/pages')}
+              className="px-4 py-2 rounded-md bg-gray-200"
+            >
+              {t('common.cancel', 'Cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-4 py-2 rounded-md bg-indigo-600 text-white"
+            >
+              {saving ? t('common.saving', 'Saving...') : t('common.save', 'Save')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </AdminAuth>
+  );
+};
+
+export default AdminPageEditPage;

--- a/client/src/features/admin/pages/AdminPagesPage.jsx
+++ b/client/src/features/admin/pages/AdminPagesPage.jsx
@@ -1,0 +1,139 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import AdminAuth from '../components/AdminAuth';
+import AdminNavigation from '../components/AdminNavigation';
+import Icon from '../../../shared/components/Icon';
+import { fetchAdminPages, deletePage } from '../../../api/adminApi';
+import { getLocalizedContent } from '../../../utils/localizeContent';
+
+const AdminPagesPage = () => {
+  const { t, i18n } = useTranslation();
+  const currentLanguage = i18n.language;
+  const navigate = useNavigate();
+  const [pages, setPages] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    loadPages();
+  }, []);
+
+  const loadPages = async () => {
+    try {
+      setLoading(true);
+      const data = await fetchAdminPages();
+      setPages(data);
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDelete = async id => {
+    if (!window.confirm(t('admin.pages.confirmDelete', 'Delete this page?'))) {
+      return;
+    }
+    try {
+      await deletePage(id);
+      setPages(prev => prev.filter(p => p.id !== id));
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  const getTitle = page => getLocalizedContent(page.title, currentLanguage);
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-8">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="text-center text-red-600 py-8">{error}</div>;
+  }
+
+  return (
+    <AdminAuth>
+      <AdminNavigation />
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="sm:flex sm:items-center">
+          <div className="sm:flex-auto">
+            <h1 className="text-2xl font-semibold text-gray-900">
+              {t('admin.pages.title', 'Pages Administration')}
+            </h1>
+            <p className="mt-2 text-sm text-gray-700">
+              {t('admin.pages.subtitle', 'Manage static pages displayed in the application')}
+            </p>
+          </div>
+          <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+            <button
+              type="button"
+              className="inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto"
+              onClick={() => navigate('/admin/pages/new')}
+            >
+              <Icon name="plus" className="h-4 w-4 mr-2" />
+              {t('admin.pages.create', 'Create Page')}
+            </button>
+          </div>
+        </div>
+
+        <div className="mt-8 flex flex-col">
+          <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
+            <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
+              <div className="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
+                <table className="min-w-full divide-y divide-gray-300">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        ID
+                      </th>
+                      <th className="px-3 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        {t('admin.pages.fields.title', 'Title')}
+                      </th>
+                      <th className="px-3 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        {t('admin.pages.actions', 'Actions')}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {pages.map(page => (
+                      <tr key={page.id}>
+                        <td className="px-3 py-2 whitespace-nowrap text-sm text-gray-900">
+                          {page.id}
+                        </td>
+                        <td className="px-3 py-2 whitespace-nowrap text-sm text-gray-900">
+                          {getTitle(page)}
+                        </td>
+                        <td className="px-3 py-2 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                          <button
+                            onClick={() => navigate(`/admin/pages/${page.id}`)}
+                            className="text-indigo-600 hover:text-indigo-900"
+                          >
+                            {t('common.edit', 'Edit')}
+                          </button>
+                          <button
+                            onClick={() => handleDelete(page.id)}
+                            className="text-red-600 hover:text-red-900"
+                          >
+                            {t('common.delete', 'Delete')}
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </AdminAuth>
+  );
+};
+
+export default AdminPagesPage;

--- a/contents/config/platform.json
+++ b/contents/config/platform.json
@@ -26,7 +26,8 @@
       "apps": true,
       "models": true,
       "prompts": true,
-      "shortlinks": true
+      "shortlinks": true,
+      "pages": true
     }
   }
 }

--- a/server/routes/admin/pages.js
+++ b/server/routes/admin/pages.js
@@ -1,0 +1,135 @@
+import { readFileSync, existsSync } from 'fs';
+import { promises as fs } from 'fs';
+import { join, dirname } from 'path';
+import { getRootDir } from '../../pathUtils.js';
+import { atomicWriteFile, atomicWriteJSON } from '../../utils/atomicWrite.js';
+import configCache from '../../configCache.js';
+import { adminAuth } from '../../middleware/adminAuth.js';
+
+export default function registerAdminPagesRoutes(app) {
+  app.get('/api/admin/pages', adminAuth, async (req, res) => {
+    try {
+      const { data: uiConfig } = configCache.getUI();
+      const pages = Object.entries(uiConfig.pages || {}).map(([id, page]) => ({
+        id,
+        title: page.title
+      }));
+      res.json(pages);
+    } catch (error) {
+      console.error('Error fetching pages:', error);
+      res.status(500).json({ error: 'Failed to fetch pages' });
+    }
+  });
+
+  app.get('/api/admin/pages/:pageId', adminAuth, async (req, res) => {
+    const { pageId } = req.params;
+    try {
+      const { data: uiConfig } = configCache.getUI();
+      const page = uiConfig.pages?.[pageId];
+      if (!page) {
+        return res.status(404).json({ error: 'Page not found' });
+      }
+      const content = {};
+      const rootDir = getRootDir();
+      for (const [lang, relPath] of Object.entries(page.filePath || {})) {
+        try {
+          const abs = join(rootDir, 'contents', relPath);
+          content[lang] = await fs.readFile(abs, 'utf8');
+        } catch {
+          content[lang] = '';
+        }
+      }
+      res.json({ id: pageId, title: page.title, content });
+    } catch (error) {
+      console.error('Error fetching page:', error);
+      res.status(500).json({ error: 'Failed to fetch page' });
+    }
+  });
+
+  app.post('/api/admin/pages', adminAuth, async (req, res) => {
+    try {
+      const { id, title = {}, content = {} } = req.body;
+      if (!id) {
+        return res.status(400).json({ error: 'Missing page ID' });
+      }
+      const rootDir = getRootDir();
+      const uiPath = join(rootDir, 'contents', 'config', 'ui.json');
+      const uiConfig = JSON.parse(readFileSync(uiPath, 'utf8'));
+      uiConfig.pages = uiConfig.pages || {};
+      if (uiConfig.pages[id]) {
+        return res.status(400).json({ error: 'Page with this ID already exists' });
+      }
+      uiConfig.pages[id] = { title, filePath: {} };
+      for (const [lang, md] of Object.entries(content)) {
+        const dir = join(rootDir, 'contents', 'pages', lang);
+        await fs.mkdir(dir, { recursive: true });
+        const rel = `pages/${lang}/${id}.md`;
+        await atomicWriteFile(join(rootDir, 'contents', rel), md);
+        uiConfig.pages[id].filePath[lang] = rel;
+      }
+      await atomicWriteJSON(uiPath, uiConfig);
+      await configCache.refreshCacheEntry('config/ui.json');
+      res.json({ message: 'Page created successfully', page: { id, title } });
+    } catch (error) {
+      console.error('Error creating page:', error);
+      res.status(500).json({ error: 'Failed to create page' });
+    }
+  });
+
+  app.put('/api/admin/pages/:pageId', adminAuth, async (req, res) => {
+    try {
+      const { pageId } = req.params;
+      const { id, title = {}, content = {} } = req.body;
+      if (!id || id !== pageId) {
+        return res.status(400).json({ error: 'Invalid page ID' });
+      }
+      const rootDir = getRootDir();
+      const uiPath = join(rootDir, 'contents', 'config', 'ui.json');
+      const uiConfig = JSON.parse(readFileSync(uiPath, 'utf8'));
+      const pageEntry = uiConfig.pages?.[pageId];
+      if (!pageEntry) {
+        return res.status(404).json({ error: 'Page not found' });
+      }
+      pageEntry.title = title;
+      pageEntry.filePath = pageEntry.filePath || {};
+      for (const [lang, md] of Object.entries(content)) {
+        const dir = join(rootDir, 'contents', 'pages', lang);
+        await fs.mkdir(dir, { recursive: true });
+        const rel = pageEntry.filePath[lang] || `pages/${lang}/${pageId}.md`;
+        await atomicWriteFile(join(rootDir, 'contents', rel), md);
+        pageEntry.filePath[lang] = rel;
+      }
+      await atomicWriteJSON(uiPath, uiConfig);
+      await configCache.refreshCacheEntry('config/ui.json');
+      res.json({ message: 'Page updated successfully', page: { id, title } });
+    } catch (error) {
+      console.error('Error updating page:', error);
+      res.status(500).json({ error: 'Failed to update page' });
+    }
+  });
+
+  app.delete('/api/admin/pages/:pageId', adminAuth, async (req, res) => {
+    try {
+      const { pageId } = req.params;
+      const rootDir = getRootDir();
+      const uiPath = join(rootDir, 'contents', 'config', 'ui.json');
+      const uiConfig = JSON.parse(readFileSync(uiPath, 'utf8'));
+      const pageEntry = uiConfig.pages?.[pageId];
+      if (!pageEntry) {
+        return res.status(404).json({ error: 'Page not found' });
+      }
+      for (const rel of Object.values(pageEntry.filePath || {})) {
+        try {
+          await fs.unlink(join(rootDir, 'contents', rel));
+        } catch {}
+      }
+      delete uiConfig.pages[pageId];
+      await atomicWriteJSON(uiPath, uiConfig);
+      await configCache.refreshCacheEntry('config/ui.json');
+      res.json({ message: 'Page deleted successfully' });
+    } catch (error) {
+      console.error('Error deleting page:', error);
+      res.status(500).json({ error: 'Failed to delete page' });
+    }
+  });
+}

--- a/server/routes/adminRoutes.js
+++ b/server/routes/adminRoutes.js
@@ -3,6 +3,7 @@ import registerAdminCacheRoutes from './admin/cache.js';
 import registerAdminAppsRoutes from './admin/apps.js';
 import registerAdminModelsRoutes from './admin/models.js';
 import registerAdminPromptsRoutes from './admin/prompts.js';
+import registerAdminPagesRoutes from './admin/pages.js';
 
 export default function registerAdminRoutes(app) {
   registerAdminAuthRoutes(app);
@@ -10,4 +11,5 @@ export default function registerAdminRoutes(app) {
   registerAdminAppsRoutes(app);
   registerAdminModelsRoutes(app);
   registerAdminPromptsRoutes(app);
+  registerAdminPagesRoutes(app);
 }

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -370,6 +370,19 @@
         "tokens": "Token",
         "editModel": "Modelldetails bearbeiten"
       }
+    },
+    "pages": {
+      "title": "Seitenverwaltung",
+      "subtitle": "Statische Seiten der Anwendung verwalten",
+      "create": "Seite erstellen",
+      "actions": "Aktionen",
+      "fields": {
+        "id": "Seiten-ID",
+        "title": "Titel",
+        "content": "Inhalt",
+        "idRequired": "ID ist erforderlich"
+      },
+      "confirmDelete": "Möchten Sie diese Seite wirklich löschen?"
     }
   }
 }

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -487,6 +487,19 @@
         "tokens": "Tokens",
         "editModel": "Edit Model Details"
       }
+    },
+    "pages": {
+      "title": "Pages Administration",
+      "subtitle": "Manage static pages displayed in the application",
+      "create": "Create Page",
+      "actions": "Actions",
+      "fields": {
+        "id": "Page ID",
+        "title": "Title",
+        "content": "Content",
+        "idRequired": "ID is required"
+      },
+      "confirmDelete": "Are you sure you want to delete this page?"
     }
   }
 }


### PR DESCRIPTION
## Summary
- allow editing pages with new admin endpoints
- add page management UI with list and editor
- enable pages section in platform config
- wire new admin routes and navigation
- update i18n for pages

## Testing
- `npm run lint:fix`
- `npm run format:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687966663ca88322a07b47b83bf43fb5