### PR TITLE
Implement file-based feedback storage

### DIFF
--- a/server/feedbackStorage.js
+++ b/server/feedbackStorage.js
@@ -1,0 +1,78 @@
+import fs from 'fs/promises';
+import path from 'path';
+import { getRootDir } from './pathUtils.js';
+import config from './config.js';
+import { loadJson } from './configLoader.js';
+
+const contentsDir = config.CONTENTS_DIR;
+const dataFile = path.join(getRootDir(), contentsDir, 'data', 'feedback.jsonl');
+const SAVE_INTERVAL_MS = 10000;
+
+let trackingEnabled = true;
+const pending = new Map();
+let queue = [];
+let saveTimer = null;
+
+async function loadConfig() {
+  try {
+    const cfg = await loadJson('config/platform.json');
+    trackingEnabled = cfg?.features?.feedbackTracking !== false;
+  } catch {
+    trackingEnabled = true;
+  }
+}
+
+async function flushQueue() {
+  if (queue.length === 0) return;
+  await fs.mkdir(path.dirname(dataFile), { recursive: true });
+  const lines = queue.map(entry => JSON.stringify(entry)).join('\n') + '\n';
+  queue = [];
+  await fs.appendFile(dataFile, lines, 'utf8');
+}
+
+function scheduleFlush() {
+  if (saveTimer) return;
+  saveTimer = setTimeout(async () => {
+    saveTimer = null;
+    try {
+      await flushQueue();
+    } catch (e) {
+      console.error('Failed to save feedback data', e);
+    }
+  }, SAVE_INTERVAL_MS);
+}
+
+export function recordResponseMeta({ messageId, appId, modelId, settings, prompt, answer }) {
+  if (!trackingEnabled || !messageId) return;
+  pending.set(messageId, {
+    timestamp: new Date().toISOString(),
+    messageId,
+    appId,
+    modelId,
+    settings,
+    prompt,
+    answer
+  });
+}
+
+export function storeFeedback({ messageId, rating, comment = '' }) {
+  if (!trackingEnabled || !messageId) return;
+  const meta = pending.get(messageId);
+  const entry = meta
+    ? { ...meta, rating, comment }
+    : { timestamp: new Date().toISOString(), messageId, rating, comment };
+  queue.push(entry);
+  pending.delete(messageId);
+  scheduleFlush();
+}
+
+loadConfig();
+setInterval(() => {
+  if (queue.length > 0) {
+    flushQueue().catch(e => console.error('Feedback save error:', e));
+  }
+}, SAVE_INTERVAL_MS);
+
+export async function reloadConfig() {
+  await loadConfig();
+}

--- a/server/routes/chat/feedbackRoutes.js
+++ b/server/routes/chat/feedbackRoutes.js
@@ -1,6 +1,7 @@
 import configCache from '../../configCache.js';
 import { logInteraction } from '../../utils.js';
 import { recordFeedback } from '../../usageTracker.js';
+import { storeFeedback } from '../../feedbackStorage.js';
 import validate from '../../validators/validate.js';
 import { feedbackSchema } from '../../validators/index.js';
 
@@ -29,6 +30,7 @@ export default function registerFeedbackRoutes(app, { getLocalizedError }) {
           contentSnippet: messageContent ? messageContent.substring(0, 300) : ''
         }
       });
+      storeFeedback({ messageId, rating, comment: feedback || '' });
       await recordFeedback({
         userId: userSessionId,
         appId,

--- a/server/services/chat/NonStreamingHandler.js
+++ b/server/services/chat/NonStreamingHandler.js
@@ -1,5 +1,6 @@
 import { getErrorDetails, logInteraction } from '../../utils.js';
 import { recordChatRequest, recordChatResponse } from '../../usageTracker.js';
+import { recordResponseMeta } from '../../feedbackStorage.js';
 import { throttledFetch } from '../../requestThrottler.js';
 import ErrorHandler from '../../utils/ErrorHandler.js';
 
@@ -70,6 +71,17 @@ class NonStreamingHandler {
       if (responseData.choices && responseData.choices.length > 0) {
         aiResponse = responseData.choices[0].message?.content || '';
       }
+
+      const userPrompt = [...llmMessages].reverse().find(m => m.role === 'user')?.content || '';
+
+      recordResponseMeta({
+        messageId,
+        appId: baseLog.appId,
+        modelId: model.id,
+        settings: baseLog.options,
+        prompt: userPrompt,
+        answer: aiResponse
+      });
 
       const responseLog = buildLogData(false, {
         responseType: 'success',


### PR DESCRIPTION
## Summary
- add a new `feedbackStorage` adapter to keep detailed feedback records
- capture prompt, answer and settings when generating responses
- persist user ratings via the feedback route

## Testing
- `npm run lint:fix`
- `npm run format:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_687967d1bcf083229e946edc24c4cf7c