### PR TITLE
Avoid spammy refresh logs

### DIFF
--- a/server/appsLoader.js
+++ b/server/appsLoader.js
@@ -35,12 +35,14 @@ function validateAppConfig(app, source) {
  * Load apps from individual files in contents/apps/
  * @returns {Array} Array of app objects
  */
-export async function loadAppsFromFiles() {
+export async function loadAppsFromFiles(verbose = true) {
   const rootDir = getRootDir();
   const appsDir = join(rootDir, 'contents', 'apps');
 
   if (!existsSync(appsDir)) {
-    console.log('📁 Apps directory not found, skipping individual app files');
+    if (verbose) {
+      console.log('📁 Apps directory not found, skipping individual app files');
+    }
     return [];
   }
 
@@ -48,7 +50,9 @@ export async function loadAppsFromFiles() {
   const dirContents = await fs.readdir(appsDir);
   const files = dirContents.filter(file => file.endsWith('.json'));
 
-  console.log(`📱 Loading ${files.length} individual app files...`);
+  if (verbose) {
+    console.log(`📱 Loading ${files.length} individual app files...`);
+  }
 
   for (const file of files) {
     try {
@@ -63,7 +67,9 @@ export async function loadAppsFromFiles() {
 
       validateAppConfig(app, filePath);
       apps.push(app);
-      console.log(`✅ Loaded ${app.id} (${app.enabled ? 'enabled' : 'disabled'})`);
+      if (verbose) {
+        console.log(`✅ Loaded ${app.id} (${app.enabled ? 'enabled' : 'disabled'})`);
+      }
     } catch (error) {
       console.error(`❌ Error loading app from ${file}:`, error.message);
     }
@@ -76,12 +82,14 @@ export async function loadAppsFromFiles() {
  * Load apps from legacy apps.json file
  * @returns {Array} Array of app objects
  */
-export async function loadAppsFromLegacyFile() {
+export async function loadAppsFromLegacyFile(verbose = true) {
   const rootDir = getRootDir();
   const legacyAppsPath = join(rootDir, 'contents', 'config', 'apps.json');
 
   if (!existsSync(legacyAppsPath)) {
-    console.log('📄 Legacy apps.json not found, skipping');
+    if (verbose) {
+      console.log('📄 Legacy apps.json not found, skipping');
+    }
     return [];
   }
 
@@ -89,7 +97,9 @@ export async function loadAppsFromLegacyFile() {
     const fileContent = await fs.readFile(legacyAppsPath, 'utf8');
     const apps = JSON.parse(fileContent);
 
-    console.log(`📄 Loading ${apps.length} apps from legacy apps.json...`);
+    if (verbose) {
+      console.log(`📄 Loading ${apps.length} apps from legacy apps.json...`);
+    }
 
     // Add enabled field if it doesn't exist (defaults to true)
     apps.forEach((app, idx) => {
@@ -111,9 +121,9 @@ export async function loadAppsFromLegacyFile() {
  * Individual files take precedence over legacy apps.json
  * @returns {Array} Array of enabled app objects, sorted by order
  */
-export async function loadAllApps(includeDisabled = false) {
-  const individualApps = await loadAppsFromFiles();
-  const legacyApps = await loadAppsFromLegacyFile();
+export async function loadAllApps(includeDisabled = false, verbose = true) {
+  const individualApps = await loadAppsFromFiles(verbose);
+  const legacyApps = await loadAppsFromLegacyFile(verbose);
 
   // Create a map to track apps by ID
   const appsMap = new Map();
@@ -139,9 +149,11 @@ export async function loadAllApps(includeDisabled = false) {
     return orderA - orderB;
   });
 
-  console.log(
-    `🎯 Total apps loaded: ${allApps.length}, Enabled: ${enabledApps.length}, Disabled: ${allApps.length - enabledApps.length}, Include Disabled: ${includeDisabled}`
-  );
+  if (verbose) {
+    console.log(
+      `🎯 Total apps loaded: ${allApps.length}, Enabled: ${enabledApps.length}, Disabled: ${allApps.length - enabledApps.length}, Include Disabled: ${includeDisabled}`
+    );
+  }
 
   return enabledApps;
 }

--- a/server/configCache.js
+++ b/server/configCache.js
@@ -179,28 +179,37 @@ class ConfigCache {
     try {
       // Special handling for apps.json - load from both sources
       if (key === 'config/apps.json') {
-        // Refresh enabled apps cache
-        const apps = await loadAllApps(true);
-        this.setCacheEntry(key, apps);
-
+        const apps = await loadAllApps(true, false);
+        const newEtag = this.generateETag(apps);
+        const existing = this.cache.get(key);
+        if (!existing || existing.etag !== newEtag) {
+          this.setCacheEntry(key, apps);
+          console.log(`✓ Cached: config/apps.json (${apps.length} total apps)`);
+        }
         return;
       }
 
       // Special handling for models.json - load from both sources
       if (key === 'config/models.json') {
-        // Refresh enabled models cache
-        const models = await loadAllModels(true);
-        this.setCacheEntry(key, models);
-
+        const models = await loadAllModels(true, false);
+        const newEtag = this.generateETag(models);
+        const existing = this.cache.get(key);
+        if (!existing || existing.etag !== newEtag) {
+          this.setCacheEntry(key, models);
+          console.log(`✓ Cached: config/models.json (${models.length} total models)`);
+        }
         return;
       }
 
       // Special handling for prompts.json - load from both sources
       if (key === 'config/prompts.json') {
-        // Refresh enabled prompts cache
-        const prompts = await loadAllPrompts(true);
-        this.setCacheEntry(key, prompts);
-
+        const prompts = await loadAllPrompts(true, false);
+        const newEtag = this.generateETag(prompts);
+        const existing = this.cache.get(key);
+        if (!existing || existing.etag !== newEtag) {
+          this.setCacheEntry(key, prompts);
+          console.log(`✓ Cached: config/prompts.json (${prompts.length} total prompts)`);
+        }
         return;
       }
 

--- a/server/modelsLoader.js
+++ b/server/modelsLoader.js
@@ -35,12 +35,14 @@ function validateModelConfig(model, source) {
  * Load models from individual files in contents/models/
  * @returns {Array} Array of model objects
  */
-export async function loadModelsFromFiles() {
+export async function loadModelsFromFiles(verbose = true) {
   const rootDir = getRootDir();
   const modelsDir = join(rootDir, 'contents', 'models');
 
   if (!existsSync(modelsDir)) {
-    console.log('📁 Models directory not found, skipping individual model files');
+    if (verbose) {
+      console.log('📁 Models directory not found, skipping individual model files');
+    }
     return [];
   }
 
@@ -48,7 +50,9 @@ export async function loadModelsFromFiles() {
   const dirContents = await fs.readdir(modelsDir);
   const files = dirContents.filter(file => file.endsWith('.json'));
 
-  console.log(`🤖 Loading ${files.length} individual model files...`);
+  if (verbose) {
+    console.log(`🤖 Loading ${files.length} individual model files...`);
+  }
 
   for (const file of files) {
     try {
@@ -63,7 +67,9 @@ export async function loadModelsFromFiles() {
 
       validateModelConfig(model, filePath);
       models.push(model);
-      console.log(`✅ Loaded ${model.id} (${model.enabled ? 'enabled' : 'disabled'})`);
+      if (verbose) {
+        console.log(`✅ Loaded ${model.id} (${model.enabled ? 'enabled' : 'disabled'})`);
+      }
     } catch (error) {
       console.error(`❌ Error loading model from ${file}:`, error.message);
     }
@@ -76,12 +82,14 @@ export async function loadModelsFromFiles() {
  * Load models from legacy models.json file
  * @returns {Array} Array of model objects
  */
-export async function loadModelsFromLegacyFile() {
+export async function loadModelsFromLegacyFile(verbose = true) {
   const rootDir = getRootDir();
   const legacyModelsPath = join(rootDir, 'contents', 'config', 'models.json');
 
   if (!existsSync(legacyModelsPath)) {
-    console.log('📄 Legacy models.json not found, skipping');
+    if (verbose) {
+      console.log('📄 Legacy models.json not found, skipping');
+    }
     return [];
   }
 
@@ -89,7 +97,9 @@ export async function loadModelsFromLegacyFile() {
     const fileContent = await fs.readFile(legacyModelsPath, 'utf8');
     const models = JSON.parse(fileContent);
 
-    console.log(`📄 Loading ${models.length} models from legacy models.json...`);
+    if (verbose) {
+      console.log(`📄 Loading ${models.length} models from legacy models.json...`);
+    }
 
     // Add enabled field if it doesn't exist (defaults to true)
     models.forEach((model, idx) => {
@@ -138,9 +148,9 @@ function ensureOneDefaultModel(models) {
  * @param {boolean} includeDisabled - Whether to include disabled models
  * @returns {Array} Array of model objects
  */
-export async function loadAllModels(includeDisabled = false) {
-  const individualModels = await loadModelsFromFiles();
-  const legacyModels = await loadModelsFromLegacyFile();
+export async function loadAllModels(includeDisabled = false, verbose = true) {
+  const individualModels = await loadModelsFromFiles(verbose);
+  const legacyModels = await loadModelsFromLegacyFile(verbose);
 
   // Create a map to track models by ID
   const modelsMap = new Map();
@@ -162,9 +172,11 @@ export async function loadAllModels(includeDisabled = false) {
   // Ensure exactly one default model
   const processedModels = ensureOneDefaultModel(filteredModels);
 
-  console.log(
-    `🤖 Total models loaded: ${allModels.length}, Enabled: ${processedModels.filter(m => m.enabled).length}, Disabled: ${allModels.length - processedModels.filter(m => m.enabled).length}, Include Disabled: ${includeDisabled}`
-  );
+  if (verbose) {
+    console.log(
+      `🤖 Total models loaded: ${allModels.length}, Enabled: ${processedModels.filter(m => m.enabled).length}, Disabled: ${allModels.length - processedModels.filter(m => m.enabled).length}, Include Disabled: ${includeDisabled}`
+    );
+  }
 
   return processedModels;
 }

--- a/server/promptsLoader.js
+++ b/server/promptsLoader.js
@@ -21,12 +21,14 @@ import { getRootDir } from './pathUtils.js';
  * Load prompts from individual files in contents/prompts/
  * @returns {Array} Array of prompt objects
  */
-export async function loadPromptsFromFiles() {
+export async function loadPromptsFromFiles(verbose = true) {
   const rootDir = getRootDir();
   const promptsDir = join(rootDir, 'contents', 'prompts');
 
   if (!existsSync(promptsDir)) {
-    console.log('📁 Prompts directory not found, skipping individual prompt files');
+    if (verbose) {
+      console.log('📁 Prompts directory not found, skipping individual prompt files');
+    }
     return [];
   }
 
@@ -34,7 +36,9 @@ export async function loadPromptsFromFiles() {
   const dirContents = await fs.readdir(promptsDir);
   const files = dirContents.filter(file => file.endsWith('.json'));
 
-  console.log(`💬 Loading ${files.length} individual prompt files...`);
+  if (verbose) {
+    console.log(`💬 Loading ${files.length} individual prompt files...`);
+  }
 
   for (const file of files) {
     try {
@@ -61,17 +65,21 @@ export async function loadPromptsFromFiles() {
  * Load prompts from legacy prompts.json file
  * @returns {Array} Array of prompt objects
  */
-export async function loadPromptsFromLegacyFile() {
+export async function loadPromptsFromLegacyFile(verbose = true) {
   const rootDir = getRootDir();
   const promptsFile = join(rootDir, 'contents', 'config', 'prompts.json');
 
   if (!existsSync(promptsFile)) {
-    console.log('📄 Legacy prompts.json not found');
+    if (verbose) {
+      console.log('📄 Legacy prompts.json not found');
+    }
     return [];
   }
 
   try {
-    console.log('📄 Loading legacy prompts.json...');
+    if (verbose) {
+      console.log('📄 Loading legacy prompts.json...');
+    }
     const content = await fs.readFile(promptsFile, 'utf8');
     const prompts = JSON.parse(content);
 
@@ -92,9 +100,9 @@ export async function loadPromptsFromLegacyFile() {
  * @param {boolean} includeDisabled Include disabled prompts
  * @returns {Array} Array of prompt objects
  */
-export async function loadAllPrompts(includeDisabled = false) {
-  const individualPrompts = await loadPromptsFromFiles();
-  const legacyPrompts = await loadPromptsFromLegacyFile();
+export async function loadAllPrompts(includeDisabled = false, verbose = true) {
+  const individualPrompts = await loadPromptsFromFiles(verbose);
+  const legacyPrompts = await loadPromptsFromLegacyFile(verbose);
 
   // Combine prompts, giving priority to individual files
   const allPrompts = [...individualPrompts];
@@ -128,8 +136,10 @@ export async function loadAllPrompts(includeDisabled = false) {
     return aName.localeCompare(bName);
   });
 
-  console.log(
-    `💬 Loaded ${filteredPrompts.length} prompts (${includeDisabled ? 'including' : 'excluding'} disabled)`
-  );
+  if (verbose) {
+    console.log(
+      `💬 Loaded ${filteredPrompts.length} prompts (${includeDisabled ? 'including' : 'excluding'} disabled)`
+    );
+  }
   return filteredPrompts;
 }


### PR DESCRIPTION
## Summary
- add `verbose` option to apps, models and prompts loaders
- refresh cache entries only log when config changes

## Testing
- `npm run lint:fix`
- `npm run format:fix`
- `timeout 10s node server/server.js`

------
https://chatgpt.com/codex/tasks/task_e_687a486484f8832292e1c18bd82369cd