### PR TITLE
Add ESC and X close controls for settings

### DIFF
--- a/client/src/features/apps/components/SharedAppHeader.jsx
+++ b/client/src/features/apps/components/SharedAppHeader.jsx
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import ChatHeader from '../../chat/components/ChatHeader';
 import AppConfigForm from './AppConfigForm';
 import Icon from '../../../shared/components/Icon';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Shared app header component for both chat and canvas modes
@@ -43,6 +44,7 @@ const SharedAppHeader = ({
   showShareButton = false
 }) => {
   const navigate = useNavigate();
+  const { t } = useTranslation();
 
   const handleToggleCanvas = () => {
     if (mode === 'chat') {
@@ -59,6 +61,18 @@ const SharedAppHeader = ({
       onClearChat?.();
     }
   };
+
+  // Close settings panel with ESC when open
+  useEffect(() => {
+    if (!showConfig) return;
+    const handleKeyDown = e => {
+      if (e.key === 'Escape') {
+        onToggleConfig();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [showConfig, onToggleConfig]);
 
   // Determine if we should show the clear button
   const showClearButton =
@@ -102,6 +116,15 @@ const SharedAppHeader = ({
             mode === 'canvas' ? 'canvas-config-panel' : 'bg-gray-100'
           }`}
         >
+          <div className="flex justify-end">
+            <button
+              onClick={onToggleConfig}
+              className="text-gray-500 hover:text-gray-700 p-1 mb-2"
+              aria-label={t('common.close', 'Close')}
+            >
+              <Icon name="close" size="lg" className="text-current" />
+            </button>
+          </div>
           <AppConfigForm
             app={app}
             models={models}

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -14,6 +14,7 @@
   "common": {
     "send": "Senden",
     "cancel": "Abbrechen",
+    "close": "Schließen",
     "save": "Speichern",
     "delete": "Löschen",
     "edit": "Bearbeiten",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -14,6 +14,7 @@
   "common": {
     "send": "Send",
     "cancel": "Cancel",
+    "close": "Close",
     "save": "Save",
     "delete": "Delete",
     "edit": "Edit",


### PR DESCRIPTION
## Summary
- add `common.close` translation key for i18n
- allow closing app settings panel with `Escape`
- show an X button to close settings

## Testing
- `npm run lint:fix`
- `npm run format:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687a51ed98108322b9ea98b48487a3b5