### PR TITLE
Update proxy auth concept with login flow

### DIFF
--- a/concepts/2025-07-18 External Authentication Integration.md
+++ b/concepts/2025-07-18 External Authentication Integration.md
@@ -1,6 +1,6 @@
 # External Authentication Integration
 
-This concept outlines how AI Hub Apps can rely on a reverse proxy or external service for user authentication. Instead of handling the login flow ourselves, the server will trust user information provided by upstream components such as nginx, Apache, OAuth proxies, or Microsoft Teams.
+This concept outlines how AI Hub Apps can rely on a reverse proxy or external service for user authentication. Instead of handling the login flow ourselves, the server will trust user information provided by upstream components such as nginx, Apache, OAuth proxies, or Microsoft Teams. The long term goal is to support both this "proxy" mode and a full OpenID Connect (OIDC) flow managed by the server itself.
 
 ## Goals
 
@@ -16,13 +16,16 @@ This concept outlines how AI Hub Apps can rely on a reverse proxy or external se
      - `enabled`: activate or deactivate the feature.
      - `userHeader`: header name containing the user identifier (e.g. `X-Forwarded-User`).
      - `groupsHeader`: optional header with comma‑separated group names.
-     - `jwt` options when tokens are forwarded (issuer, audience, JWK URL).
-   - Document the environment variables that can override these settings.
+     - `jwtProviders`: array of JWT provider configs. Each entry specifies:
+       - `header`: name of the header containing the token (default `Authorization`).
+       - `issuer`/`audience` values expected in the token claims.
+       - `jwkUrl`: location of the JSON Web Key Set for verifying the signature.
+   - Environment variables (e.g. `PROXY_AUTH_ENABLED`, `PROXY_AUTH_USER_HEADER`) can override the values in `platform.json` so deployments may adjust settings without editing the file.
 
 2. **Middleware**
    - Create `server/middleware/proxyAuth.js`.
    - Read the configured headers from each request.
-   - If a JWT is present, verify it using `jsonwebtoken` and the provided JWKs.
+   - If a JWT is present, determine the matching provider from `jwtProviders` and verify the token using `jsonwebtoken` and the provider's JWKs.
    - Populate `req.user` with `{ id, name, email, groups }` so downstream routes can perform authorization.
    - If `proxyAuth.enabled` is false or headers are missing, treat the user as anonymous.
 
@@ -43,3 +46,32 @@ This concept outlines how AI Hub Apps can rely on a reverse proxy or external se
 - Allows immediate integration with corporate SSO solutions without implementing our own login.
 - Keeps the server stateless and scalable.
 - Prepares the codebase for a future full authentication layer by normalizing user data early.
+
+## Next Step: Built-in OIDC Support
+
+After the proxy mode is stable we will integrate full OIDC login in the server. This keeps the platform flexible for customers that cannot provide authenticated headers.
+
+1. **Provider Configuration**
+   - Introduce an `authProviders` array in `platform.json` with one entry per OIDC provider.
+   - Each provider defines `issuer`, `clientId`, `clientSecret`, `scopes`, and `jwkUrl` for token validation.
+   - Multiple providers can coexist so different customers may use their own identity systems.
+
+2. **Passport.js Integration**
+   - Use Passport.js strategies for each configured provider to handle the login redirect and callback.
+   - Upon successful authentication normalize the user profile and groups the same way as the proxy mode.
+   - Issue a short lived token signed by the server so subsequent requests remain stateless.
+
+3. **Compatibility with Proxy Mode**
+   - Both proxy authentication and server managed OIDC can be enabled. If a valid JWT from a proxy is present it is used; otherwise the user may go through the OIDC login flow.
+
+This two phase approach ensures the server can integrate with existing SSO setups immediately while paving the way for a self contained authentication option.
+
+## Client Login Flow Configuration
+
+The frontend loads `/api/configs/platform` during startup. This response will contain an `auth` section describing how users are expected to authenticate. The UI then chooses the appropriate flow:
+
+- `mode: "proxy"` – The client starts an external login (e.g., Microsoft Teams or a corporate SSO page) and receives a JWT. This token is forwarded to the server using the header defined in `proxyAuth.jwtProviders[*].header`.
+- `mode: "local"` – The user enters a username and password directly in the UI. The credentials are sent to `/api/login`, the server verifies them, and replies with its own JWT.
+- `mode: "oidc"` – The UI redirects the browser to a server endpoint which starts an OIDC flow via Passport.js. After the provider calls back, the server issues a JWT for subsequent requests.
+
+The chosen mode can be overridden with an `AUTH_MODE` environment variable so deployments can switch authentication strategies without rebuilding the client.

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -6,27 +6,33 @@ This section covers environment variables and options for running the AI Hub App
 
 The server reads settings from the environment or a `.env` file such as `config.env`.
 
-| Variable                | Description                                                       | Default                                          |
-| ----------------------- | ----------------------------------------------------------------- | ------------------------------------------------ |
-| `PORT`                  | Port the HTTP server listens on                                   | `3000`                                           |
-| `HOST`                  | Host interface to bind to                                         | `0.0.0.0`                                        |
-| `REQUEST_TIMEOUT`       | LLM request timeout in milliseconds                               | `60000`                                          |
-| `WORKERS`               | Number of Node.js cluster workers                                 | CPU count                                        |
-| `OPENAI_API_KEY`        | API key for OpenAI models                                         | –                                                |
-| `ANTHROPIC_API_KEY`     | API key for Anthropic models                                      | –                                                |
-| `MISTRAL_API_KEY`       | API key for Mistral models                                        | –                                                |
-| `GOOGLE_API_KEY`        | API key for Google models                                         | –                                                |
-| `DEFAULT_API_KEY`       | Fallback API key used when a model specific key is missing        | –                                                |
-| `LOCAL_API_KEY`         | Generic API key for local models                                  | –                                                |
-| `CONTENTS_DIR`          | Directory containing the `contents` folder                        | `contents`                                       |
-| `APP_ROOT_DIR`          | Override the application root path when running packaged binaries | –                                                |
-| `MCP_SERVER_URL`        | URL of a Model Context Protocol server for tool discovery         | –                                                |
-| `BRAVE_SEARCH_API_KEY`  | API key for the Brave Search tool                                 | –                                                |
-| `BRAVE_SEARCH_ENDPOINT` | Custom Brave Search API endpoint                                  | `https://api.search.brave.com/res/v1/web/search` |
-| `TAVILY_SEARCH_API_KEY` | API key for the Tavily Search tool                                | –                                                |
-| `TAVILY_ENDPOINT`       | Custom Tavily API endpoint                                        | `https://api.tavily.com/search`                  |
-| `MAGIC_PROMPT_MODEL`    | Default model for the magic prompt feature                        | `gpt-3.5-turbo`                                  |
-| `MAGIC_PROMPT_PROMPT`   | Default prompt used to refine user input                          | `Improve the following prompt.`                  |
+| Variable                   | Description                                                       | Default                                          |
+| -------------------------- | ----------------------------------------------------------------- | ------------------------------------------------ |
+| `PORT`                     | Port the HTTP server listens on                                   | `3000`                                           |
+| `HOST`                     | Host interface to bind to                                         | `0.0.0.0`                                        |
+| `REQUEST_TIMEOUT`          | LLM request timeout in milliseconds                               | `60000`                                          |
+| `WORKERS`                  | Number of Node.js cluster workers                                 | CPU count                                        |
+| `OPENAI_API_KEY`           | API key for OpenAI models                                         | –                                                |
+| `ANTHROPIC_API_KEY`        | API key for Anthropic models                                      | –                                                |
+| `MISTRAL_API_KEY`          | API key for Mistral models                                        | –                                                |
+| `GOOGLE_API_KEY`           | API key for Google models                                         | –                                                |
+| `DEFAULT_API_KEY`          | Fallback API key used when a model specific key is missing        | –                                                |
+| `LOCAL_API_KEY`            | Generic API key for local models                                  | –                                                |
+| `CONTENTS_DIR`             | Directory containing the `contents` folder                        | `contents`                                       |
+| `APP_ROOT_DIR`             | Override the application root path when running packaged binaries | –                                                |
+| `MCP_SERVER_URL`           | URL of a Model Context Protocol server for tool discovery         | –                                                |
+| `BRAVE_SEARCH_API_KEY`     | API key for the Brave Search tool                                 | –                                                |
+| `BRAVE_SEARCH_ENDPOINT`    | Custom Brave Search API endpoint                                  | `https://api.search.brave.com/res/v1/web/search` |
+| `TAVILY_SEARCH_API_KEY`    | API key for the Tavily Search tool                                | –                                                |
+| `TAVILY_ENDPOINT`          | Custom Tavily API endpoint                                        | `https://api.tavily.com/search`                  |
+| `MAGIC_PROMPT_MODEL`       | Default model for the magic prompt feature                        | `gpt-3.5-turbo`                                  |
+| `MAGIC_PROMPT_PROMPT`      | Default prompt used to refine user input                          | `Improve the following prompt.`                  |
+| `AUTH_MODE`                | Login flow (`proxy`, `local`, `oidc`)                             | `proxy`                                          |
+| `PROXY_AUTH_ENABLED`       | Enable proxy authentication mode                                  | `false`                                          |
+| `PROXY_AUTH_USER_HEADER`   | Header containing the authenticated user ID                       | `X-Forwarded-User`                               |
+| `PROXY_AUTH_GROUPS_HEADER` | Optional header with comma separated group names                  | –                                                |
+| `PROXY_AUTH_JWKS`          | JSON Web Key Set URL for verifying forwarded JWTs                 | –                                                |
+| `PROXY_AUTH_JWT_HEADER`    | Header containing the JWT if not using `Authorization`            | `Authorization`                                  |
 
 The concurrency of outbound requests is configured via `requestConcurrency` in `contents/config/platform.json` and can be overridden per model or tool. If this value is omitted or below `1`, requests are not throttled.
 The delay between requests can be adjusted with `requestDelayMs` in the same configuration files. A value of `0` disables the delay.

--- a/server/config.js
+++ b/server/config.js
@@ -30,7 +30,13 @@ const env = cleanEnv(
     MISTRAL_API_KEY: str({ optional: true }),
     GOOGLE_API_KEY: str({ optional: true }),
     LOCAL_API_KEY: str({ optional: true }),
-    DEFAULT_API_KEY: str({ optional: true })
+    DEFAULT_API_KEY: str({ optional: true }),
+    AUTH_MODE: str({ default: 'proxy', optional: true }),
+    PROXY_AUTH_ENABLED: str({ optional: true }),
+    PROXY_AUTH_USER_HEADER: str({ optional: true }),
+    PROXY_AUTH_GROUPS_HEADER: str({ optional: true }),
+    PROXY_AUTH_JWKS: str({ optional: true }),
+    PROXY_AUTH_JWT_HEADER: str({ optional: true })
   },
   {
     reporter: () => {}, // Disable envalid's default reporter that shows missing variables
@@ -60,7 +66,13 @@ const config = Object.freeze({
   MISTRAL_API_KEY: env.MISTRAL_API_KEY,
   GOOGLE_API_KEY: env.GOOGLE_API_KEY,
   LOCAL_API_KEY: env.LOCAL_API_KEY,
-  DEFAULT_API_KEY: env.DEFAULT_API_KEY
+  DEFAULT_API_KEY: env.DEFAULT_API_KEY,
+  AUTH_MODE: env.AUTH_MODE,
+  PROXY_AUTH_ENABLED: env.PROXY_AUTH_ENABLED,
+  PROXY_AUTH_USER_HEADER: env.PROXY_AUTH_USER_HEADER,
+  PROXY_AUTH_GROUPS_HEADER: env.PROXY_AUTH_GROUPS_HEADER,
+  PROXY_AUTH_JWKS: env.PROXY_AUTH_JWKS,
+  PROXY_AUTH_JWT_HEADER: env.PROXY_AUTH_JWT_HEADER
 });
 
 export default config;


### PR DESCRIPTION
## Summary
- extend external authentication concept with client login flow options
- document `AUTH_MODE` environment variable
- add env var definitions to server config

## Testing
- `npm run lint:fix`
- `npm run format:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_687a7773a77c8322918f0bc538044798