### PR TITLE
Adjust settings panel layout

### DIFF
--- a/client/src/features/apps/components/SharedAppHeader.jsx
+++ b/client/src/features/apps/components/SharedAppHeader.jsx
@@ -112,19 +112,17 @@ const SharedAppHeader = ({
       {/* Configuration Panel */}
       {showConfig && (
         <div
-          className={`flex-shrink-0 bg-white p-4 rounded-lg mb-4 shadow-sm border border-gray-200 ${
+          className={`relative flex-shrink-0 bg-white p-4 rounded-lg mb-4 shadow-sm border border-gray-200 ${
             mode === 'canvas' ? 'canvas-config-panel' : 'bg-gray-100'
           }`}
         >
-          <div className="flex justify-end">
-            <button
-              onClick={onToggleConfig}
-              className="text-gray-500 hover:text-gray-700 p-1 mb-2"
-              aria-label={t('common.close', 'Close')}
-            >
-              <Icon name="close" size="lg" className="text-current" />
-            </button>
-          </div>
+          <button
+            onClick={onToggleConfig}
+            className="absolute top-2 right-2 text-gray-500 hover:text-gray-700 p-1"
+            aria-label={t('common.close', 'Close')}
+          >
+            <Icon name="close" size="lg" className="text-current" />
+          </button>
           <AppConfigForm
             app={app}
             models={models}


### PR DESCRIPTION
## Summary
- align the settings panel close button with the grid by placing it at the top-right of the panel

## Testing
- `npm run lint:fix`
- `npm run format:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687a83ace7a88322a6ee31969b44b1ea