### PR TITLE
Add icons to export and action menus

### DIFF
--- a/client/src/features/canvas/components/QuillToolbar.jsx
+++ b/client/src/features/canvas/components/QuillToolbar.jsx
@@ -350,7 +350,7 @@ const QuillToolbar = ({
                 title={t('canvas.export.title', 'Export Document')}
                 type="button"
               >
-                <span>⬇</span>
+                <Icon name="download" size="sm" />
                 <span>{t('canvas.export.export', 'Export')}</span>
               </button>
               {showExportMenu && (

--- a/client/src/features/chat/components/ChatActionsMenu.jsx
+++ b/client/src/features/chat/components/ChatActionsMenu.jsx
@@ -41,7 +41,7 @@ const ChatActionsMenu = ({
         className="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded flex items-center"
         title={t('common.menu', 'Menu')}
       >
-        <Icon name="dots-vertical" size="sm" />
+        <Icon name="menu" size="sm" />
       </button>
       {open && (
         <div className="absolute right-0 mt-2 bg-white border border-gray-200 rounded shadow-lg z-20 min-w-40">


### PR DESCRIPTION
## Summary
- swap arrow for `download` icon on export button in canvas
- use burger `menu` icon for chat actions menu

## Testing
- `npm run lint:fix`
- `npm run format:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687a94c436f48322aaef0584630d2d03