### PR TITLE
Fix burger menu size in app view

### DIFF
--- a/client/src/features/chat/components/ChatActionsMenu.jsx
+++ b/client/src/features/chat/components/ChatActionsMenu.jsx
@@ -38,8 +38,9 @@ const ChatActionsMenu = ({
     <div className="relative" ref={menuRef}>
       <button
         onClick={() => setOpen(o => !o)}
-        className="bg-gray-200 hover:bg-gray-300 text-gray-800 px-3 py-1 rounded flex items-center"
+        className="bg-gray-200 hover:bg-gray-300 text-gray-800 p-2 rounded-full flex items-center justify-center h-10 w-10"
         title={t('common.menu', 'Menu')}
+        aria-label={t('common.menu', 'Menu')}
       >
         <Icon name="menu" size="sm" />
       </button>


### PR DESCRIPTION
## Summary
- match ChatActionsMenu burger button size with "Back to apps" button

## Testing
- `npm run lint:fix`
- `npm run format:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_687a9ca4526c832290858ef22c0fd75e