### PR TITLE
Fix overflow in prompt details popup

### DIFF
--- a/client/src/features/prompts/components/PromptDetailsPopup.jsx
+++ b/client/src/features/prompts/components/PromptDetailsPopup.jsx
@@ -28,7 +28,7 @@ const PromptDetailsPopup = ({ prompt, isOpen, onClose }) => {
 
   return (
     <div className="fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50 flex items-center justify-center p-4">
-      <div className="relative bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+      <div className="relative bg-white rounded-lg shadow-xl max-w-2xl w-full max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
         <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between rounded-t-lg">
           <div className="flex items-center space-x-3">
@@ -51,7 +51,7 @@ const PromptDetailsPopup = ({ prompt, isOpen, onClose }) => {
         </div>
 
         {/* Content */}
-        <div className="p-6 space-y-6">
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
           {/* Status */}
           <div className="flex items-center justify-between">
             <span className="text-sm font-medium text-gray-700">


### PR DESCRIPTION
## Summary
- limit `PromptDetailsPopup` height and make the content scrollable

## Testing
- `npm run lint:fix`
- `npm run format:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_687ab3c430908322b0b90e936536d0c6