### PR TITLE
Add remote server mode for Electron

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,30 @@ Pre-built binaries for all platforms are available on the [GitHub Releases](http
 
 For most users, downloading the complete package is recommended as it includes all necessary configuration files and assets.
 
+## Electron Desktop Application
+
+You can also run AI Hub Apps as a desktop application using Electron. During development run:
+
+```bash
+npm run electron:dev
+```
+
+For a packaged version build the production files and create installers with:
+
+```bash
+npm run electron:build
+```
+
+This creates platform-specific artifacts for macOS, Linux and Windows using `electron-builder`.
+
+To connect the desktop app to an existing backend instead of starting the
+server locally, set the `REMOTE_SERVER_URL` environment variable before
+launching Electron:
+
+```bash
+REMOTE_SERVER_URL=https://your-host.example.com npm run electron:dev
+```
+
 ## Configuration
 
 ### Server Configuration

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -22,3 +22,4 @@
     - [Image Upload Feature](image-upload-feature.md)
     - [Image Generation](image-generation-feature.md)
     - [Server Configuration](server-config.md)
+    - [Electron Desktop Application](electron-app.md)

--- a/docs/electron-app.md
+++ b/docs/electron-app.md
@@ -1,0 +1,56 @@
+# Electron Desktop Application
+
+The Electron wrapper allows AI Hub Apps to run as a standalone desktop
+application that bundles the server and client. It can be packaged for
+macOS, Linux and Windows using `electron-builder`.
+
+## Development
+
+Start the Electron app together with the development servers:
+
+```bash
+npm run electron:dev
+```
+
+This launches the Node.js backend and the Vite dev server, then opens
+the Electron window pointing to `http://localhost:3000`.
+
+## Building Packages
+
+Create optimized production files and package them with Electron:
+
+```bash
+npm run electron:build
+```
+
+The command runs `npm run prod:build` and then uses `electron-builder`
+to create platform specific installers (`dmg`, `AppImage`, `nsis`).
+
+### Code Signing
+
+On macOS and Windows you should sign the binaries before distributing
+them. Provide the signing certificate details to `electron-builder`
+through environment variables or in `package.json`.
+
+## Customization and Updates
+
+Because the server runs locally in the Electron app, you can update the
+`contents` folder or add new integrations without rebuilding the
+frontend. Distribute updated packages to roll out new versions or use
+`autoUpdater` from Electron for in-app updates.
+
+Local deployment can also expose the apps through MCP on `localhost`
+which allows other tools (e.g. Claude.ai) to communicate with your
+server directly.
+
+Authentication behaves the same as in the normal server setup. You can
+still use OIDC or local accounts. The desktop app does not make
+authentication harder but allows storing credentials securely on the
+client.
+
+## Remote Server Mode
+
+Set the `REMOTE_SERVER_URL` environment variable to skip starting the
+embedded Node.js backend and point the Electron window at your existing
+server instance. This mode is useful if you only want to ship the
+frontend while keeping the backend running on a remote host.

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,58 @@
+import { app, BrowserWindow } from 'electron';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { spawn } from 'child_process';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+let serverProcess;
+const remoteUrl = process.env.REMOTE_SERVER_URL;
+
+function getServerEntry() {
+  if (app.isPackaged) {
+    return path.join(process.resourcesPath, 'dist', 'server', 'server.js');
+  }
+  return path.join(__dirname, '../server/server.js');
+}
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 1280,
+    height: 800,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+  if (remoteUrl) {
+    win.loadURL(remoteUrl);
+  } else if (!app.isPackaged) {
+    win.loadURL('http://localhost:3000');
+  } else {
+    win.loadFile(path.join(process.resourcesPath, 'dist', 'public', 'index.html'));
+  }
+}
+
+app.whenReady().then(() => {
+  if (!remoteUrl) {
+    serverProcess = spawn('node', [getServerEntry()], {
+      env: process.env,
+      stdio: 'inherit'
+    });
+  }
+
+  createWindow();
+
+  app.on('activate', () => {
+    if (BrowserWindow.getAllWindows().length === 0) {
+      createWindow();
+    }
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (serverProcess) {
+    serverProcess.kill();
+  }
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,0 +1,3 @@
+import { contextBridge } from 'electron';
+
+contextBridge.exposeInMainWorld('electronAPI', {});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "build:binary:linux": "npm run prod:build && ./build-sea.sh",
     "build:binary:windows": "npm run prod:build && ./build-sea.sh",
     "docker:test:linux": "docker run --rm -it -p 3000:3000 -v \"$(pwd)/dist-bin:/app\" -w /app -e OPENAI_API_KEY=your_openai_api_key -e ANTHROPIC_API_KEY=your_anthropic_api_key -e GOOGLE_API_KEY=your_google_api_key --platform linux/amd64 node:20-slim /bin/bash -c \"chmod +x /app/ai-hub-apps-v1.0.5-linux && /app/ai-hub-apps-v1.0.5-linux\"",
+    "electron:dev": "concurrently \"npm run dev\" \"electron electron/main.js\"",
+    "electron:build": "npm run prod:build && electron-builder",
     "test:openai": "node server/tests/openaiAdapter.test.js",
     "test:mistral": "node server/tests/mistralAdapter.test.js",
     "test:anthropic": "node server/tests/anthropicAdapter.test.js",
@@ -70,7 +72,9 @@
     "nodemon": "^3.1.10",
     "postject": "^1.0.0-alpha.6",
     "prettier": "^3.4.2",
-    "rimraf": "^6.0.1"
+    "rimraf": "^6.0.1",
+    "electron": "^29.2.0",
+    "electron-builder": "^24.6.0"
   },
   "engines": {
     "node": ">=20.0.0"
@@ -80,5 +84,21 @@
       "eslint --fix",
       "prettier --write"
     ]
+  },
+  "build": {
+    "asar": true,
+    "files": [
+      "dist/**/*",
+      "electron/**/*"
+    ],
+    "mac": {
+      "target": "dmg"
+    },
+    "linux": {
+      "target": "AppImage"
+    },
+    "win": {
+      "target": "nsis"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow Electron app to connect to remote backend
- document remote server mode

## Testing
- `npm run lint:fix`
- `npm run format:fix`
- `timeout 10s node server/server.js`
- `timeout 15s npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_687d07bf31588322b3b092e4c909bc51