### PR TITLE
fix: move parameters button to burger menu for all devices

### DIFF
--- a/client/src/features/chat/components/ChatHeader.jsx
+++ b/client/src/features/chat/components/ChatHeader.jsx
@@ -130,21 +130,6 @@ const ChatHeader = ({
               <span className="hidden sm:inline">{t('pages.appChat.canvas', 'Canvas')}</span>
             </button>
           )}
-          {showParametersButton && !isMobile && (
-            <button
-              onClick={onToggleParameters}
-              className={`text-gray-800 px-3 py-1 rounded flex items-center ${
-                parametersVisible ? 'bg-gray-300' : 'bg-gray-200 hover:bg-gray-300'
-              }`}
-              aria-pressed={parametersVisible}
-              title={t('pages.appChat.parameters')}
-            >
-              <Icon name="sliders" size="sm" className="sm:mr-1" />
-              <span className="hidden sm:inline">
-                {t('pages.appChat.parameters', 'Parameters')}
-              </span>
-            </button>
-          )}
           <ChatActionsMenu
             onClearChat={onClearChat}
             onToggleConfig={onToggleConfig}
@@ -157,7 +142,7 @@ const ChatHeader = ({
             onToggleCanvas={onToggleCanvas}
             showCanvasButton={showCanvasButton}
             onToggleParameters={onToggleParameters}
-            showParametersButton={showParametersButton && isMobile}
+            showParametersButton={showParametersButton}
             parametersVisible={parametersVisible}
           />
         </div>


### PR DESCRIPTION
Fixes #245

## Summary
- Remove standalone parameters button that was only shown on desktop
- Show parameters button in burger menu for both mobile and desktop
- Fixes issue where parameters button behavior was broken after refactoring
- Parameters button now properly toggles variables panel on all screen sizes

Generated with [Claude Code](https://claude.ai/code)