### PR TITLE
Fix logout redirect issue - always redirect to apps home after logout

### DIFF
--- a/client/src/shared/contexts/AuthContext.jsx
+++ b/client/src/shared/contexts/AuthContext.jsx
@@ -345,6 +345,10 @@ export function AuthProvider({ children }) {
       // Comprehensive cleanup
       performLogoutCleanup();
       dispatch({ type: AUTH_ACTIONS.LOGOUT });
+      
+      // Redirect to apps home page for security
+      // This ensures users don't remain on admin or other protected pages after logout
+      window.location.href = '/';
     }
   };
 


### PR DESCRIPTION
Fixes logout functionality so users are redirected to apps home instead of staying on admin pages after logout.

After logout, users now get redirected to the apps home page (/) instead of remaining on the current page. This improves security by ensuring users don't accidentally see admin content after logout.

Fixes #296

Generated with [Claude Code](https://claude.ai/code)