### PR TITLE
Clean up lint warnings - remove unused variables

### DIFF
--- a/client/src/features/admin/components/AdminAuth.jsx
+++ b/client/src/features/admin/components/AdminAuth.jsx
@@ -6,7 +6,7 @@ import Icon from '../../../shared/components/Icon';
 
 const AdminAuth = ({ children }) => {
   const { isAuthenticated, authRequired, isLoading, login, logout } = useAdminAuth();
-  const { user, isAuthenticated: userIsAuthenticated } = useAuth();
+  const { isAuthenticated: userIsAuthenticated } = useAuth();
   const { platformConfig } = usePlatformConfig();
   const [adminSecret, setAdminSecret] = useState('');
   const [error, setError] = useState('');

--- a/client/src/features/admin/hooks/useAdminAuth.jsx
+++ b/client/src/features/admin/hooks/useAdminAuth.jsx
@@ -105,7 +105,7 @@ export function AdminAuthProvider({ children }) {
         const data = await response.json();
         return { success: false, error: data.message || 'Authentication failed' };
       }
-    } catch (error) {
+    } catch {
       return { success: false, error: 'Network error during authentication' };
     }
   };

--- a/client/src/features/admin/pages/AdminAppEditPage.jsx
+++ b/client/src/features/admin/pages/AdminAppEditPage.jsx
@@ -234,7 +234,7 @@ const AdminAppEditPage = () => {
       const method = appId === 'new' ? 'POST' : 'PUT';
       const url = appId === 'new' ? '/api/admin/apps' : `/api/admin/apps/${appId}`;
 
-      const response = await makeAdminApiCall(url, {
+      await makeAdminApiCall(url, {
         method,
         body: JSON.stringify(app)
       });

--- a/client/src/features/admin/pages/AdminAuthPage.jsx
+++ b/client/src/features/admin/pages/AdminAuthPage.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
 import AdminAuth from '../components/AdminAuth';
 import AdminNavigation from '../components/AdminNavigation';
@@ -8,7 +7,6 @@ import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import { usePlatformConfig } from '../../../shared/contexts/PlatformConfigContext';
 
 const AdminAuthPage = () => {
-  const { t } = useTranslation();
   const { refreshConfig } = usePlatformConfig();
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);

--- a/client/src/features/admin/pages/AdminGroupEditPage.jsx
+++ b/client/src/features/admin/pages/AdminGroupEditPage.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
-import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
 import AdminAuth from '../components/AdminAuth';
 import AdminNavigation from '../components/AdminNavigation';
@@ -9,7 +8,6 @@ import { makeAdminApiCall } from '../../../api/adminApi';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 
 const AdminGroupEditPage = () => {
-  const { t } = useTranslation();
   const { groupId } = useParams();
   const navigate = useNavigate();
   const [group, setGroup] = useState(null);

--- a/client/src/features/admin/pages/AdminGroupsPage.jsx
+++ b/client/src/features/admin/pages/AdminGroupsPage.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react';
-import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import Icon from '../../../shared/components/Icon';
 import AdminAuth from '../components/AdminAuth';
@@ -8,7 +7,6 @@ import { makeAdminApiCall } from '../../../api/adminApi';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 
 const AdminGroupsPage = () => {
-  const { t } = useTranslation();
   const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [groups, setGroups] = useState({});

--- a/client/src/features/admin/pages/AdminPromptsPage.jsx
+++ b/client/src/features/admin/pages/AdminPromptsPage.jsx
@@ -66,7 +66,7 @@ const AdminPromptsPage = () => {
 
   const handleTogglePrompt = async promptId => {
     try {
-      const response = await makeAdminApiCall(`/api/admin/prompts/${promptId}/toggle`, {
+      await makeAdminApiCall(`/api/admin/prompts/${promptId}/toggle`, {
         method: 'POST'
       });
 

--- a/client/src/features/apps/components/AppConfigForm.jsx
+++ b/client/src/features/apps/components/AppConfigForm.jsx
@@ -89,7 +89,7 @@ const AppConfigForm = ({
             onChange={e => onStyleChange(e.target.value)}
             className="w-full p-2 border rounded focus:ring-indigo-500 focus:border-indigo-500"
           >
-            {Object.entries(styles).map(([id, description]) => (
+            {Object.entries(styles).map(([id]) => (
               <option key={id} value={id}>
                 {t(`responseStyles.${id}`, id.charAt(0).toUpperCase() + id.slice(1))}
               </option>


### PR DESCRIPTION
Fixes #288

Cleans up lint warnings by removing clearly unused variables and imports:

- Remove unused 'user' variable from AdminAuth.jsx destructuring
- Remove unused 'error' parameter from catch blocks
- Remove unused 'description' parameter from map functions
- Remove unused translation imports from admin pages
- Remove unused 'response' variables from API calls

These changes fix genuine no-unused-vars warnings without affecting functionality. Remaining warnings are mostly false positives where ESLint doesn't detect JSX usage.

🤖 Generated with [Claude Code](https://claude.ai/code)