### PR TITLE
fix: return 401 for expired JWT tokens instead of continuing as anonymous

### DIFF
--- a/server/middleware/jwtAuth.js
+++ b/server/middleware/jwtAuth.js
@@ -40,7 +40,11 @@ export default function jwtAuthMiddleware(req, res, next) {
     // Check token expiration
     const now = Math.floor(Date.now() / 1000);
     if (decoded.exp && decoded.exp < now) {
-      return next(); // Expired token, continue as anonymous
+      return res.status(401).json({
+        error: 'Token expired',
+        code: 'TOKEN_EXPIRED',
+        message: 'Your session has expired. Please log in again.'
+      });
     }
 
     // Reconstruct user object from token based on auth mode

--- a/server/tests/authentication-security.test.js
+++ b/server/tests/authentication-security.test.js
@@ -6,7 +6,7 @@
 
 import request from 'supertest';
 import express from 'express';
-import { setupMiddleware } from '../serverHelpers.js';
+import { setupMiddleware } from '../middleware/setup.js';
 import registerChatRoutes from '../routes/chat/index.js';
 import registerGeneralRoutes from '../routes/generalRoutes.js';
 import registerModelRoutes from '../routes/modelRoutes.js';


### PR DESCRIPTION
Fixes #344

This PR resolves the issue where expired JWT tokens were being treated as anonymous requests instead of returning proper 401 responses.

## Changes

- Modified `server/middleware/jwtAuth.js` to return 401 response for expired tokens
- Added `TOKEN_EXPIRED` error code with user-friendly message
- Fixed test import path in `authentication-security.test.js`

## Testing

- ESLint validation passed with no errors
- Implementation follows recommended solution pattern from previous analysis

## Expected Behavior

After this fix:
- Users with expired tokens receive 401 responses
- Frontend automatically logs out users on token expiration
- No more inconsistent state where user name shows but requests fail
- Page refresh no longer needed to detect expiration

Generated with [Claude Code](https://claude.ai/code)