### PR TITLE
Clean up old tool calling code and migrate to generic system

### DIFF
--- a/server/adapters/anthropic.js
+++ b/server/adapters/anthropic.js
@@ -1,7 +1,7 @@
 /**
  * Anthropic API adapter
  */
-import { formatToolsForAnthropic } from './toolFormatter.js';
+import { convertToolsFromGeneric } from './toolCalling/index.js';
 import { BaseAdapter } from './BaseAdapter.js';
 
 class AnthropicAdapterClass extends BaseAdapter {
@@ -121,7 +121,7 @@ class AnthropicAdapterClass extends BaseAdapter {
     }
 
     if (finalTools.length > 0) {
-      requestBody.tools = formatToolsForAnthropic(finalTools);
+      requestBody.tools = convertToolsFromGeneric(finalTools, 'anthropic');
       // // Anthropic-specific instruction to encourage tool use, especially in multi-turn scenarios.
       // const toolInstruction =
       //   "If you need to use a tool to answer, please do so. After using the tools, provide a final answer to the user's question.";

--- a/server/adapters/google.js
+++ b/server/adapters/google.js
@@ -1,7 +1,7 @@
 /**
  * Google Gemini API adapter
  */
-import { formatToolsForGoogle, normalizeName } from './toolFormatter.js';
+import { convertToolsFromGeneric, normalizeToolName } from './toolCalling/index.js';
 import { BaseAdapter } from './BaseAdapter.js';
 
 class GoogleAdapterClass extends BaseAdapter {
@@ -31,7 +31,7 @@ class GoogleAdapterClass extends BaseAdapter {
         responseObj = this.safeJsonParse(message.content, message.content);
         currentToolResponses.push({
           functionResponse: {
-            name: normalizeName(message.name || message.tool_call_id || 'tool'),
+            name: normalizeToolName(message.name || message.tool_call_id || 'tool'),
             response: { result: responseObj }
           }
         });
@@ -57,7 +57,7 @@ class GoogleAdapterClass extends BaseAdapter {
               argsObj = this.safeJsonParse(call.function.arguments, {});
               parts.push({
                 functionCall: {
-                  name: normalizeName(call.function.name),
+                  name: normalizeToolName(call.function.name),
                   args: argsObj
                 }
               });
@@ -149,7 +149,7 @@ class GoogleAdapterClass extends BaseAdapter {
     };
 
     if (tools && tools.length > 0) {
-      requestBody.tools = formatToolsForGoogle(tools);
+      requestBody.tools = convertToolsFromGeneric(tools, 'google');
     }
     if ((responseFormat && responseFormat === 'json') || responseSchema) {
       requestBody.generationConfig.responseMimeType = 'application/json';

--- a/server/adapters/mistral.js
+++ b/server/adapters/mistral.js
@@ -3,7 +3,7 @@
 /**
  * Mistral "La Plateforme" API adapter
  */
-import { formatToolsForOpenAI } from './toolFormatter.js';
+import { convertToolsFromGeneric } from './toolCalling/index.js';
 import { BaseAdapter } from './BaseAdapter.js';
 
 class MistralAdapterClass extends BaseAdapter {
@@ -61,7 +61,7 @@ class MistralAdapterClass extends BaseAdapter {
       max_tokens: maxTokens
     };
 
-    if (tools && tools.length > 0) body.tools = formatToolsForOpenAI(tools);
+    if (tools && tools.length > 0) body.tools = convertToolsFromGeneric(tools, 'mistral');
     if (toolChoice) body.tool_choice = toolChoice;
     if (responseSchema) {
       body.response_format = {

--- a/server/adapters/openai.js
+++ b/server/adapters/openai.js
@@ -1,7 +1,7 @@
 /**
  * OpenAI API adapter
  */
-import { formatToolsForOpenAI } from './toolFormatter.js';
+import { convertToolsFromGeneric } from './toolCalling/index.js';
 import { BaseAdapter } from './BaseAdapter.js';
 
 class OpenAIAdapterClass extends BaseAdapter {
@@ -64,7 +64,7 @@ class OpenAIAdapterClass extends BaseAdapter {
       max_tokens: maxTokens
     };
 
-    if (tools && tools.length > 0) body.tools = formatToolsForOpenAI(tools);
+    if (tools && tools.length > 0) body.tools = convertToolsFromGeneric(tools, 'openai');
     if (toolChoice) body.tool_choice = toolChoice;
     if (responseSchema) {
       // Deep clone incoming schema and enforce additionalProperties:false on all objects

--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -2,7 +2,7 @@ import { createCompletionRequest } from '../../adapters/index.js';
 import { convertResponseToGeneric } from '../../adapters/toolCalling/index.js';
 import { logInteraction, getErrorDetails } from '../../utils.js';
 import { runTool } from '../../toolLoader.js';
-import { normalizeName } from '../../adapters/toolFormatter.js';
+import { normalizeToolName } from '../../adapters/toolCalling/index.js';
 import { activeRequests } from '../../sse.js';
 import { actionTracker } from '../../actionTracker.js';
 import { createParser } from 'eventsource-parser';
@@ -18,7 +18,7 @@ class ToolExecutor {
 
   async executeToolCall(toolCall, tools, chatId, buildLogData, user) {
     const toolId =
-      tools.find(t => normalizeName(t.id) === toolCall.function.name)?.id || toolCall.function.name;
+      tools.find(t => normalizeToolName(t.id) === toolCall.function.name)?.id || toolCall.function.name;
     let args = {};
 
     try {


### PR DESCRIPTION
- Replace old toolFormatter imports with generic tool calling system
- Update all adapters (OpenAI, Anthropic, Google, Mistral) to use convertToolsFromGeneric
- Update ToolExecutor to use normalizeToolName from generic system
- Remove dependencies on legacy formatToolsFor* functions
- Maintain backward compatibility while using new unified interface