### PR TITLE
fix: App Creation Wizard broken - React useEffect import issue

### DIFF
--- a/client/src/features/apps/components/AppCreationWizard.jsx
+++ b/client/src/features/apps/components/AppCreationWizard.jsx
@@ -517,7 +517,7 @@ const CreationMethodStep = ({
   const [fieldErrors, setFieldErrors] = useState({});
 
   // Check for validation errors
-  React.useEffect(() => {
+  useEffect(() => {
     if (error && error.includes('required fields')) {
       const missingFields = validateCurrentStep();
       const newFieldErrors = {};
@@ -944,7 +944,7 @@ const BasicInfoStep = ({
   };
 
   // Check for validation errors and highlight fields
-  React.useEffect(() => {
+  useEffect(() => {
     if (error && error.includes('required fields')) {
       const missingFields = validateCurrentStep();
       const newFieldErrors = {};
@@ -1165,7 +1165,7 @@ const SystemPromptStep = ({
   };
 
   // Check for validation errors and highlight fields
-  React.useEffect(() => {
+  useEffect(() => {
     if (error && error.includes('required fields')) {
       const missingFields = validateCurrentStep();
       const newFieldErrors = {};


### PR DESCRIPTION
Fixes #361

## Summary
Fixed the App Creation Wizard by replacing `React.useEffect` with `useEffect` in AppCreationWizard.jsx.

## Changes
- Fixed 3 instances of `React.useEffect` to use the imported `useEffect` hook
- React was not imported as default export, causing runtime errors
- App creation wizard should now work properly

## Testing
- ✅ Linting passed successfully
- ✅ Client build completed without errors
- ✅ All React.useEffect references removed

Generated with [Claude Code](https://claude.ai/code)