### PR TITLE
fix: FAQ bot source loading issue - correct filesystem base path

### DIFF
--- a/server/services/PromptService.js
+++ b/server/services/PromptService.js
@@ -191,7 +191,7 @@ class PromptService {
       try {
         const sourceManager = createSourceManager({
           filesystem: {
-            basePath: `../${config.CONTENTS_DIR}`
+            basePath: config.CONTENTS_DIR
           }
         });
         let sourceContent = '';

--- a/server/sources/FileSystemHandler.js
+++ b/server/sources/FileSystemHandler.js
@@ -29,13 +29,6 @@ class FileSystemHandler extends SourceHandler {
     // Resolve path relative to base path
     const fullPath = path.resolve(this.basePath, filePath.replace(/^\/+/, ''));
 
-    // Debug logging
-    console.log(`FileSystemHandler Debug:
-      - basePath: ${this.basePath}
-      - requestedPath: ${filePath}
-      - resolvedFullPath: ${fullPath}
-      - basePathResolved: ${path.resolve(this.basePath)}`);
-
     // Security check - ensure path is within base directory
     if (!fullPath.startsWith(path.resolve(this.basePath))) {
       throw new Error(`Access denied: path ${filePath} is outside allowed directory`);


### PR DESCRIPTION
Fixes the FAQ bot and other apps with sources failing to load source files due to incorrect base path configuration.

Changes:
- Fixed base path from '../${config.CONTENTS_DIR}' to 'config.CONTENTS_DIR'
- Removed debug logging from FileSystemHandler.js
- Sources now correctly resolve to the contents directory

Fixes #369

Generated with [Claude Code](https://claude.ai/code)