### PR TITLE
fix: resolve Docker build issues for GitHub Actions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -72,7 +72,8 @@ ENV NODE_ENV=production
 RUN apk add --update --no-cache \
     dumb-init \
     curl \
-    tini
+    tini \
+    netcat-openbsd
 
 # Create non-root user for security
 RUN addgroup -S aihub && \

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -92,7 +92,7 @@ init_directories() {
     # Set proper permissions for writable directories
     if [ "$(id -u)" = "0" ]; then
         # Running as root, set ownership to aihub user
-        chown -R aihub:nodejs \
+        chown -R aihub:aihub \
             /app/contents/data \
             /app/contents/uploads \
             /app/contents/pages \


### PR DESCRIPTION
Fixes #371

This PR resolves the critical Docker build issues identified in issue #371:

### Changes
- **Add netcat-openbsd package**: Required for health checks in docker-entrypoint.sh
- **Fix group reference**: Correct aihub:aihub instead of aihub:nodejs

### Impact
These fixes address the core Docker build failures preventing successful GitHub Actions builds. The container will now start properly with correct health checks and permissions.

### Additional Notes
The GitHub Actions workflow still needs manual fixes for SHA tag references, but those require workflow permissions to modify.

Generated with [Claude Code](https://claude.ai/code)