### PR TITLE
feat: add thinking mode configuration for AI models

### DIFF
--- a/server/actionTracker.js
+++ b/server/actionTracker.js
@@ -61,6 +61,10 @@ export class ActionTracker extends EventEmitter {
   trackSafetyWarning(chatId, data = {}) {
     this.emit('fire-sse', { event: UnifiedEvents.SAFETY_WARNING, chatId, ...data });
   }
+
+  trackThinking(chatId, data = {}) {
+    this.emit('fire-sse', { event: UnifiedEvents.THINKING, chatId, ...data });
+  }
 }
 
 export const actionTracker = new ActionTracker();

--- a/server/services/chat/StreamingHandler.js
+++ b/server/services/chat/StreamingHandler.js
@@ -142,6 +142,12 @@ class StreamingHandler {
             }
           }
 
+          if (result && result.thinking && result.thinking.length > 0) {
+            for (const thinkingContent of result.thinking) {
+              actionTracker.trackThinking(chatId, { content: thinkingContent });
+            }
+          }
+
           if (result && result.error) {
             await logInteraction(
               'chat_error',

--- a/server/validators/modelConfigSchema.js
+++ b/server/validators/modelConfigSchema.js
@@ -13,7 +13,10 @@ export const modelConfigSchema = z
     supportsTools: z.boolean().optional(),
     concurrency: z.number().optional(),
     requestDelayMs: z.number().optional(),
-    enabled: z.boolean().optional()
+    enabled: z.boolean().optional(),
+    supportsThinking: z.boolean().optional(),
+    thinkingBudget: z.number().optional(),
+    includeThoughts: z.boolean().optional()
   })
   .passthrough();
 

--- a/shared/unifiedEventSchema.js
+++ b/shared/unifiedEventSchema.js
@@ -10,5 +10,6 @@ export const UnifiedEvents = {
   TOOL_CALL_PROGRESS: 'tool.call.progress',
   TOOL_CALL_END: 'tool.call.end',
   CITATION: 'citation',
-  SAFETY_WARNING: 'safety.warning'
+  SAFETY_WARNING: 'safety.warning',
+  THINKING: 'thinking'
 };


### PR DESCRIPTION
- Add thinking support fields to model schema (supportsThinking, thinkingBudget, includeThoughts)
- Update Google Gemini adapter to send thinking configuration in requests
- Add thinking content extraction from response parts using thought boolean property
- Add THINKING event type to unified event schema
- Add trackThinking method to action tracker for SSE communication
- Update streaming handler to emit thinking events when received

Enables models like Gemini to configure thinking budget (0=disabled, -1=dynamic) and expose thinking data via action tracker as requested in issue #352.