### PR TITLE
Potential fix for code scanning alert no. 217: Missing rate limiting

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -17,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
+- Focusing on what is best not just for us as individuals, but for the
   overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
+- The use of sexualized language or imagery, and sexual attention or
   advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email
   address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities
@@ -106,7 +106,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within

--- a/server/package.json
+++ b/server/package.json
@@ -49,7 +49,8 @@
     "swagger-ui-express": "^5.0.1",
     "yauzl": "^3.1.3",
     "zod": "^3.25.74",
-    "zod-to-json-schema": "^3.24.6"
+    "zod-to-json-schema": "^3.24.6",
+    "express-rate-limit": "^8.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",

--- a/server/routes/toolRoutes.js
+++ b/server/routes/toolRoutes.js
@@ -13,7 +13,7 @@ export default function registerToolRoutes(app, basePath = '') {
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 100, // limit each IP to 100 requests per windowMs
     standardHeaders: true, // Return rate limit info in the RateLimit-* headers
-    legacyHeaders: false, // Disable the X-RateLimit-* headers
+    legacyHeaders: false // Disable the X-RateLimit-* headers
   });
 
   app.get(buildServerPath('/api/tools', basePath), authRequired, async (req, res) => {


### PR DESCRIPTION
Potential fix for [https://github.com/intrafind/ihub-apps/security/code-scanning/217](https://github.com/intrafind/ihub-apps/security/code-scanning/217)

To fix the missing rate limiting, we should add a rate-limiting middleware to the `/api/tools/:toolId` route. The best way is to use the well-known `express-rate-limit` package, which is designed for this purpose. We should import `express-rate-limit`, configure a reasonable rate limit (e.g., 100 requests per 15 minutes per IP), and apply it specifically to the affected route. This can be done by creating a limiter instance and adding it to the middleware chain for the route at lines 45-71. The import for `express-rate-limit` should be added at the top of the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
