### PR TITLE
Encrypt platform config secrets at rest

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -182,6 +182,7 @@ npm run test:coverage
 - **API key placeholders** - Use `YOUR_API_KEY_HERE` in examples and documentation
 - **Input validation** - Validate all user input on both client and server
 - **Authentication** - Use `authRequired` middleware on protected routes
+- **Secret encryption at rest** - Integration secrets in `platform.json` are encrypted using `TokenStorageService` (AES-256-GCM, format: `ENC[AES256_GCM,data:...,iv:...,tag:...,type:str]`). When encrypting, skip empty values, env var placeholders (`${VAR}`), and already-encrypted values. Key files: `server/services/TokenStorageService.js`, `server/routes/admin/configs.js`, `server/configCache.js`
 
 ## Repository Structure Deep Dive
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,22 @@ Follow the instructions in [LLM_GUIDELINES.md](LLM_GUIDELINES.md):
 
 Always consult the documentation in `docs/` for additional details about configuration files and features.
 
+### Secret Encryption at Rest
+
+Platform config secrets are encrypted on disk in `platform.json` using `TokenStorageService` (AES-256-GCM). The encryption key is at `contents/.encryption-key`.
+
+**Encrypted format:** `ENC[AES256_GCM,data:...,iv:...,tag:...,type:str]`
+
+**Encrypted fields:** `jira.clientSecret`, `cloudStorage.providers[].clientSecret`, `cloudStorage.providers[].tenantId` (office365), `oidcAuth.providers[].clientSecret`, `ldapAuth.providers[].adminPassword`, `ntlmAuth.domainControllerPassword`
+
+**Guard pattern:** When encrypting, always skip empty values, env var placeholders (`${VAR}`), and already-encrypted values (`ENC[...]`).
+
+**Key files:**
+
+- `server/services/TokenStorageService.js` — `encryptString()`, `decryptString()`, `isEncrypted()`
+- `server/routes/admin/configs.js` — encrypt on save, decrypt on read
+- `server/configCache.js` — decrypt at runtime for all consumers
+
 ## Internationalization (i18n)
 
 - Every user-facing string or configuration key must be internationalized.


### PR DESCRIPTION
## Summary
- Encrypts integration secrets in `platform.json` at rest using the existing `TokenStorageService` (AES-256-GCM with per-platform key at `contents/.encryption-key`)
- Fixes missing NTLM `domainControllerPassword` sanitization in admin GET and restore in admin POST
- Sanitizes the POST response so the admin UI never sees raw or encrypted secrets

## Encrypted fields
| Config Path | Field |
|---|---|
| `jira` | `clientSecret` |
| `cloudStorage.providers[]` | `clientSecret`, `tenantId` (office365) |
| `oidcAuth.providers[]` | `clientSecret` |
| `ldapAuth.providers[]` | `adminPassword` |
| `ntlmAuth` | `domainControllerPassword` |

## How it works
- **On admin save**: secrets encrypted before writing to `platform.json`
- **On admin read**: secrets decrypted then sanitized to `***REDACTED***`
- **At runtime**: `configCache.js` decrypts secrets so all consumers (OIDC, LDAP, Jira, etc.) receive plaintext — no code changes needed downstream
- **Backward compatible**: plaintext secrets pass through on read and get encrypted on next admin save (lazy migration)
- **Env vars safe**: `${JWT_SECRET}` style placeholders are never encrypted

## Files changed
- `server/routes/admin/configs.js` — encrypt/decrypt helpers, NTLM gap fix, response sanitization
- `server/configCache.js` — runtime decryption during platform config loading
- `CLAUDE.md`, `AGENTS.md`, `.github/copilot-instructions.md` — documentation

## Test plan
- [ ] Save Jira config via admin UI → verify `platform.json` shows `ENC[AES256_GCM,...]` for `clientSecret`
- [ ] Save OIDC/LDAP/Cloud Storage providers → verify secrets encrypted on disk
- [ ] NTLM `domainControllerPassword` — admin GET returns `***REDACTED***`, save preserves value
- [ ] Restart server → all integrations still work (configCache decrypts)
- [ ] Admin GET → all secrets show `***REDACTED***` (not `ENC[...]`)
- [ ] Existing plaintext secrets work and get encrypted on next admin save
- [ ] Env var placeholders (`${JWT_SECRET}`) are NOT encrypted

🤖 Generated with [Claude Code](https://claude.com/claude-code)