### PR TITLE
feat: add 'View Skill' button in marketplace and sync skill deletion to installations

### DIFF
--- a/client/src/features/admin/components/marketplace/MarketplaceItemDetail.jsx
+++ b/client/src/features/admin/components/marketplace/MarketplaceItemDetail.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import StreamingMarkdown from '../../../chat/components/StreamingMarkdown';
 import {
@@ -62,6 +63,7 @@ const TYPE_COLORS = {
  */
 const MarketplaceItemDetail = ({ item: initialItem, onClose, onAction }) => {
   const { t, i18n } = useTranslation();
+  const navigate = useNavigate();
   const [item, setItem] = useState(initialItem);
   const [loading, setLoading] = useState(false);
   const [actionLoading, setActionLoading] = useState(null);
@@ -179,6 +181,17 @@ const MarketplaceItemDetail = ({ item: initialItem, onClose, onAction }) => {
           )}
           {isInstalled && (
             <>
+              {item?.type === 'skill' && (
+                <button
+                  onClick={() => {
+                    onClose();
+                    navigate(`/admin/skills/${item.name}`);
+                  }}
+                  className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 text-sm font-medium"
+                >
+                  {t('admin.marketplace.viewSkill', 'View Skill')}
+                </button>
+              )}
               <button
                 onClick={() => setConfirmAction('uninstall')}
                 disabled={!!actionLoading}


### PR DESCRIPTION
## Summary

- **MarketplaceItemDetail**: add "View Skill" button for installed skills that closes the panel and navigates to `/admin/skills/:name`
- **Skills DELETE handler**: remove `skill:<name>` from `installations.json` when deleting a skill, so marketplace no longer shows stale "installed" status

## Test plan

- [ ] Install a skill from the marketplace — verify "View Skill" button appears in the detail panel
- [ ] Click "View Skill" — verify panel closes and navigates to `/admin/skills/<name>`
- [ ] Delete an installed skill from the Skills admin page
- [ ] Re-open the marketplace — verify the skill no longer shows as "installed"

🤖 Generated with [Claude Code](https://claude.com/claude-code)