### PR TITLE
fix: replace default MemoryStore with memorystore to prevent session …

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -33,6 +33,7 @@
         "jsonwebtoken": "^9.0.2",
         "jwks-rsa": "^3.0.1",
         "ldap-authentication": "^3.3.4",
+        "memorystore": "^1.6.7",
         "multer": "^2.0.2",
         "node-fetch": "^3.3.0",
         "passport": "^0.7.0",
@@ -9157,6 +9158,35 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/memorystore": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/memorystore/-/memorystore-1.6.7.tgz",
+      "integrity": "sha512-OZnmNY/NDrKohPQ+hxp0muBcBKrzKNtHr55DbqSx9hLsYVNnomSAMRAtI7R64t3gf3ID7tHQA7mG4oL3Hu9hdw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.0",
+        "lru-cache": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/memorystore/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "license": "ISC",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/memorystore/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "license": "ISC"
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -10091,6 +10121,12 @@
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "license": "ISC"
     },
     "node_modules/psl": {
       "version": "1.15.0",

--- a/server/package.json
+++ b/server/package.json
@@ -39,6 +39,7 @@
     "jsonwebtoken": "^9.0.2",
     "jwks-rsa": "^3.0.1",
     "ldap-authentication": "^3.3.4",
+    "memorystore": "^1.6.7",
     "multer": "^2.0.2",
     "node-fetch": "^3.3.0",
     "passport": "^0.7.0",


### PR DESCRIPTION
…memory leak

The default express-session MemoryStore never prunes expired entries, causing unbounded memory growth in production. Replace it with the memorystore package which periodically removes stale sessions based on each store's configured maxAge.

https://claude.ai/code/session_01JBB8h4kSZiTyeikAagPBLN