### PR TITLE
Fix concurrent token expiration handling and auth status checks

### DIFF
--- a/client/src/api/client.js
+++ b/client/src/api/client.js
@@ -86,8 +86,11 @@ const addResponseInterceptor = client => {
           localStorage.removeItem('authToken');
         }
 
-        // Dispatch custom event for auth context to handle (will handle cookie clearing via logout API)
-        window.dispatchEvent(new CustomEvent('authTokenExpired'));
+        // Don't trigger token-expired handling for /auth/status — it's called by
+        // the handler itself, so re-dispatching would cause an infinite loop
+        if (!originalRequest.url?.includes('/auth/status')) {
+          window.dispatchEvent(new CustomEvent('authTokenExpired'));
+        }
 
         // Don't retry auth requests to avoid infinite loops
         return Promise.reject(error);

--- a/client/src/shared/contexts/AuthContext.jsx
+++ b/client/src/shared/contexts/AuthContext.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useReducer, useEffect, useCallback } from 'react';
+import { createContext, useContext, useReducer, useEffect, useCallback, useRef } from 'react';
 import { apiClient } from '../../api/client.js';
 import { buildPath, buildApiUrl } from '../../utils/runtimeBasePath';
 
@@ -285,6 +285,9 @@ export function AuthProvider({ children }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Guard to prevent concurrent/recursive execution of the token-expired handler
+  const isHandlingTokenExpired = useRef(false);
+
   // Load authentication status on mount and handle OIDC callback
   useEffect(() => {
     // Check if this is an OIDC callback
@@ -297,77 +300,84 @@ export function AuthProvider({ children }) {
 
     // Listen for token expiration events from API client
     const handleTokenExpired = async () => {
-      console.log('🔐 Session expired - handling automatic relogin');
+      if (isHandlingTokenExpired.current) return;
+      isHandlingTokenExpired.current = true;
 
-      // Clear the expired token
-      const currentToken = localStorage.getItem('authToken');
-      if (currentToken) {
-        localStorage.removeItem('authToken');
-      }
-
-      // Store the current URL for return after re-authentication
-      const currentUrl = window.location.href;
-      const urlParams = new URLSearchParams(window.location.search);
-      const isLogoutPage = urlParams.get('logout') === 'true';
-
-      // Only store return URL if not on logout page
-      if (!isLogoutPage) {
-        sessionStorage.setItem('authReturnUrl', currentUrl);
-        console.log('📍 Stored return URL for post-authentication redirect:', currentUrl);
-      }
-
-      // Try to get fresh auth config to check for auto-redirect
       try {
-        const response = await apiClient.get('/auth/status');
-        const data = response.data;
+        console.log('🔐 Session expired - handling automatic relogin');
 
-        // If auto-redirect is configured, redirect to the auth provider
-        if (data.autoRedirect && !isLogoutPage) {
-          const redirectAttemptKey = `autoRedirect_${data.autoRedirect.provider}`;
-          const lastRedirectAttempt = sessionStorage.getItem(redirectAttemptKey);
-          const now = Date.now();
-
-          // Only redirect if we haven't attempted recently (prevent loops)
-          if (!lastRedirectAttempt || now - parseInt(lastRedirectAttempt) > 5 * 60 * 1000) {
-            console.log(
-              `🔀 Session expired - auto-redirecting to ${data.autoRedirect.provider} provider`
-            );
-            sessionStorage.setItem(redirectAttemptKey, now.toString());
-
-            // Dispatch event for components to show reconnecting UI
-            window.dispatchEvent(
-              new CustomEvent('sessionExpiredReconnecting', {
-                detail: { provider: data.autoRedirect.provider }
-              })
-            );
-
-            // Redirect to auth provider with return URL
-            const returnUrl = sessionStorage.getItem('authReturnUrl') || currentUrl;
-            const authUrl = data.autoRedirect.url;
-            const separator = authUrl.includes('?') ? '&' : '?';
-            const redirectUrl = `${authUrl}${separator}returnUrl=${encodeURIComponent(returnUrl)}`;
-
-            window.location.href = redirectUrl;
-            return; // Don't logout, we're redirecting for re-auth
-          }
+        // Clear the expired token
+        const currentToken = localStorage.getItem('authToken');
+        if (currentToken) {
+          localStorage.removeItem('authToken');
         }
-      } catch (error) {
-        console.error('Failed to check auto-redirect on session expiry:', error);
+
+        // Store the current URL for return after re-authentication
+        const currentUrl = window.location.href;
+        const urlParams = new URLSearchParams(window.location.search);
+        const isLogoutPage = urlParams.get('logout') === 'true';
+
+        // Only store return URL if not on logout page
+        if (!isLogoutPage) {
+          sessionStorage.setItem('authReturnUrl', currentUrl);
+          console.log('📍 Stored return URL for post-authentication redirect:', currentUrl);
+        }
+
+        // Try to get fresh auth config to check for auto-redirect
+        try {
+          const response = await apiClient.get('/auth/status');
+          const data = response.data;
+
+          // If auto-redirect is configured, redirect to the auth provider
+          if (data.autoRedirect && !isLogoutPage) {
+            const redirectAttemptKey = `autoRedirect_${data.autoRedirect.provider}`;
+            const lastRedirectAttempt = sessionStorage.getItem(redirectAttemptKey);
+            const now = Date.now();
+
+            // Only redirect if we haven't attempted recently (prevent loops)
+            if (!lastRedirectAttempt || now - parseInt(lastRedirectAttempt) > 5 * 60 * 1000) {
+              console.log(
+                `🔀 Session expired - auto-redirecting to ${data.autoRedirect.provider} provider`
+              );
+              sessionStorage.setItem(redirectAttemptKey, now.toString());
+
+              // Dispatch event for components to show reconnecting UI
+              window.dispatchEvent(
+                new CustomEvent('sessionExpiredReconnecting', {
+                  detail: { provider: data.autoRedirect.provider }
+                })
+              );
+
+              // Redirect to auth provider with return URL
+              const returnUrl = sessionStorage.getItem('authReturnUrl') || currentUrl;
+              const authUrl = data.autoRedirect.url;
+              const separator = authUrl.includes('?') ? '&' : '?';
+              const redirectUrl = `${authUrl}${separator}returnUrl=${encodeURIComponent(returnUrl)}`;
+
+              window.location.href = redirectUrl;
+              return; // Don't logout, we're redirecting for re-auth
+            }
+          }
+        } catch (error) {
+          console.error('Failed to check auto-redirect on session expiry:', error);
+        }
+
+        // If we reach here, no auto-redirect is configured or it was attempted recently
+        // Signal the auth gate to show its overlay for re-authentication
+        window.dispatchEvent(
+          new CustomEvent('showAuthGate', {
+            detail: { reason: 'tokenExpired' }
+          })
+        );
+
+        // Also dispatch sessionExpired for any other UI components listening
+        window.dispatchEvent(new CustomEvent('sessionExpired'));
+
+        // Logout the user
+        dispatch({ type: AUTH_ACTIONS.LOGOUT });
+      } finally {
+        isHandlingTokenExpired.current = false;
       }
-
-      // If we reach here, no auto-redirect is configured or it was attempted recently
-      // Signal the auth gate to show its overlay for re-authentication
-      window.dispatchEvent(
-        new CustomEvent('showAuthGate', {
-          detail: { reason: 'tokenExpired' }
-        })
-      );
-
-      // Also dispatch sessionExpired for any other UI components listening
-      window.dispatchEvent(new CustomEvent('sessionExpired'));
-
-      // Logout the user
-      dispatch({ type: AUTH_ACTIONS.LOGOUT });
     };
 
     window.addEventListener('authTokenExpired', handleTokenExpired);

--- a/server/middleware/jwtAuth.js
+++ b/server/middleware/jwtAuth.js
@@ -158,6 +158,14 @@ export default function jwtAuthMiddleware(req, res, next) {
       } else {
         // OAuth not enabled, but token is OAuth type - reject
         logger.warn('[OAuth] Token rejected: OAuth not enabled');
+        res.clearCookie('authToken', {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'lax'
+        });
+        if (req.path === '/api/auth/status') {
+          return next(); // Continue as anonymous — let status endpoint return available auth methods
+        }
         return res.status(401).json({
           error: 'invalid_token',
           error_description: 'OAuth authentication is not enabled'
@@ -203,6 +211,14 @@ export default function jwtAuthMiddleware(req, res, next) {
         }
       } else {
         logger.warn('[OAuth] Auth code token rejected: OAuth not enabled');
+        res.clearCookie('authToken', {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'lax'
+        });
+        if (req.path === '/api/auth/status') {
+          return next();
+        }
         return res.status(401).json({
           error: 'invalid_token',
           error_description: 'OAuth authentication is not enabled'
@@ -258,6 +274,14 @@ export default function jwtAuthMiddleware(req, res, next) {
       } else {
         // Local auth not enabled, but token is local type - reject
         logger.warn('[JWT Auth] Token rejected: Local authentication is not enabled');
+        res.clearCookie('authToken', {
+          httpOnly: true,
+          secure: process.env.NODE_ENV === 'production',
+          sameSite: 'lax'
+        });
+        if (req.path === '/api/auth/status') {
+          return next(); // Continue as anonymous — let status endpoint return available auth methods
+        }
         return res.status(401).json({
           error: 'invalid_token',
           error_description: 'Local authentication is not enabled'


### PR DESCRIPTION
## Summary
This PR fixes issues with concurrent/recursive execution of token expiration handlers and prevents infinite loops when checking authentication status after session expiry.

## Key Changes

- **AuthContext.jsx**: Added a `useRef` guard (`isHandlingTokenExpired`) to prevent concurrent or recursive execution of the token-expired handler. The entire handler logic is now wrapped in a try-finally block to ensure the guard is always reset.

- **client.js**: Modified the response interceptor to skip dispatching the `authTokenExpired` event when the request is to `/auth/status`. This prevents infinite loops since the token expiration handler itself calls `/auth/status` to check for auto-redirect configuration.

- **jwtAuth.js**: Enhanced three token rejection scenarios (OAuth token when OAuth disabled, auth code token when OAuth disabled, and local auth token when local auth disabled) to:
  - Clear the invalid `authToken` cookie
  - Allow requests to `/auth/status` to proceed as anonymous users, enabling the endpoint to return available authentication methods even with an invalid token

## Implementation Details

The changes work together to create a robust token expiration flow:
1. When a token expires, the handler is protected from concurrent execution
2. The handler can safely call `/auth/status` without triggering another expiration event
3. Invalid tokens are properly cleared from cookies
4. The `/auth/status` endpoint can still provide configuration info to unauthenticated requests, allowing the client to determine the appropriate re-authentication flow

https://claude.ai/code/session_01DAYKFnHmRmiSqxVcmPfY4p