### PR TITLE
feat(i18n): add thinking phase and citation translation keys

### DIFF
--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -4,7 +4,8 @@
     "filesCount": "{{count}} Datei(en) angehängt",
     "remove": "Datei entfernen",
     "sourceLocal": "Lokale Datei",
-    "sourceCloud": "Cloud-Datei"
+    "sourceCloud": "Cloud-Datei",
+    "loading": "Dokument wird geladen..."
   },
   "app": {
     "title": "iHub Apps",
@@ -339,6 +340,29 @@
     "qualityLow": "Niedrig (1K)",
     "qualityMedium": "Mittel (2K)",
     "qualityHigh": "Hoch (4K)"
+  },
+  "citations": {
+    "documents": "Dokumente",
+    "passages": "{{count}} Passage",
+    "passages_plural": "{{count}} Passagen",
+    "referenced": "Referenziert",
+    "mentioned": "Erwähnt",
+    "openExternal": "Im Browser öffnen",
+    "preview": "Vorschau (PDF)",
+    "download": "Herunterladen",
+    "openInApp": "In App öffnen",
+    "untitledDocument": "Dokument",
+    "details": "Details",
+    "documentDetails": "Dokumentdetails",
+    "author": "Autor",
+    "fileSize": "Dateigröße",
+    "modified": "Geändert",
+    "indexed": "Indexiert",
+    "source": "Quelle",
+    "fileType": "Dateityp",
+    "language": "Sprache",
+    "breadcrumbs": "Pfad",
+    "loading": "Laden..."
   },
   "chatMessage": {
     "user": "Du",
@@ -1414,5 +1438,58 @@
     "preview": "Vorschau",
     "resetToDefaults": "Auf Standardwerte zurücksetzen",
     "colorInvalid": "Bitte geben Sie eine gültige Hex-Farbe ein (z.B. #4f46e5)"
+  },
+  "thoughts": {
+    "phase": {
+      "assess": "Bewertung",
+      "assess_input": "Eingabeanalyse",
+      "decide": "Entscheidung",
+      "plan": "Plan",
+      "answer": "Antwort",
+      "search": "Suche",
+      "doc_lookup": "Dokumentensuche",
+      "context": "Kontext"
+    },
+    "assess": {
+      "started": "Analyse des aktuellen Wissens",
+      "initializing": "Erstelle erste Wissensbewertung",
+      "revising": "Aktualisiere Wissensbewertung mit neuen Informationen",
+      "complete": "Bewertung abgeschlossen",
+      "compressing": "Komprimiere aktuelles Wissen"
+    },
+    "assess_input": {
+      "started": "Analyse der Benutzereingabe",
+      "complete": "Eingabeanalyse abgeschlossen"
+    },
+    "decide": {
+      "started": "Entscheide nächste Aktion",
+      "analyzing": "Analysiere Optionen und treffe Entscheidung",
+      "complete": "Entscheidung getroffen",
+      "compressing": "Komprimiere aktuelles Wissen"
+    },
+    "plan": {
+      "started": "Erstelle Rechercheplan",
+      "creating": "Entwickle strategischen Rechercheansatz",
+      "revising": "Aktualisiere Rechercheplan mit neuen Informationen",
+      "complete": "Rechercheplan abgeschlossen",
+      "compressing": "Komprimiere Rechercheplan"
+    },
+    "answer": {
+      "started": "Generiere Antwort",
+      "complete": "Antwortgenerierung abgeschlossen"
+    },
+    "search": {
+      "started": "Starte Suche",
+      "generating_queries": "Generiere Suchanfragen",
+      "complete": "Suche abgeschlossen"
+    },
+    "doc_lookup": {
+      "started": "Starte Dokumentensuche",
+      "retrieving": "Rufe Dokumente ab",
+      "complete": "Dokumente abgerufen"
+    },
+    "context": {
+      "compression": "Komprimiere aktuelles Wissen"
+    }
   }
 }

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -4,7 +4,8 @@
     "filesCount": "{{count}} file(s) attached",
     "remove": "Remove file",
     "sourceLocal": "Local file",
-    "sourceCloud": "Cloud file"
+    "sourceCloud": "Cloud file",
+    "loading": "Loading document..."
   },
   "app": {
     "title": "iHub Apps",
@@ -1184,6 +1185,29 @@
     "qualityMedium": "Medium (2K)",
     "qualityHigh": "High (4K)"
   },
+  "citations": {
+    "documents": "Documents",
+    "passages": "{{count}} passage",
+    "passages_plural": "{{count}} passages",
+    "referenced": "Referenced",
+    "mentioned": "Mentioned",
+    "openExternal": "Open in browser",
+    "preview": "Preview (PDF)",
+    "download": "Download",
+    "openInApp": "Open in App",
+    "untitledDocument": "Document",
+    "details": "Details",
+    "documentDetails": "Document Details",
+    "author": "Author",
+    "fileSize": "File Size",
+    "modified": "Modified",
+    "indexed": "Indexed",
+    "source": "Source",
+    "fileType": "File Type",
+    "language": "Language",
+    "breadcrumbs": "Path",
+    "loading": "Loading..."
+  },
   "chatMessage": {
     "user": "You",
     "assistant": "Assistant",
@@ -1451,5 +1475,58 @@
     "preview": "Preview",
     "resetToDefaults": "Reset to Defaults",
     "colorInvalid": "Please enter a valid hex color (e.g., #4f46e5)"
+  },
+  "thoughts": {
+    "phase": {
+      "assess": "Assess",
+      "assess_input": "Analyze Input",
+      "decide": "Decide",
+      "plan": "Plan",
+      "answer": "Answer",
+      "search": "Search",
+      "doc_lookup": "Document Lookup",
+      "context": "Context"
+    },
+    "assess": {
+      "started": "Analyzing current knowledge",
+      "initializing": "Creating initial knowledge assessment",
+      "revising": "Updating knowledge assessment with new information",
+      "complete": "Assessment complete",
+      "compressing": "Compressing current knowledge"
+    },
+    "assess_input": {
+      "started": "Analyzing user input",
+      "complete": "Input analysis complete"
+    },
+    "decide": {
+      "started": "Deciding next action",
+      "analyzing": "Analyzing options and making decision",
+      "complete": "Decision made",
+      "compressing": "Compressing current knowledge"
+    },
+    "plan": {
+      "started": "Creating research plan",
+      "creating": "Developing strategic research approach",
+      "revising": "Updating research plan with new information",
+      "complete": "Research plan completed",
+      "compressing": "Compressing research plan"
+    },
+    "answer": {
+      "started": "Generating answer",
+      "complete": "Answer generation complete"
+    },
+    "search": {
+      "started": "Starting search",
+      "generating_queries": "Generating search queries",
+      "complete": "Search complete"
+    },
+    "doc_lookup": {
+      "started": "Starting document lookup",
+      "retrieving": "Retrieving documents",
+      "complete": "Documents retrieved"
+    },
+    "context": {
+      "compression": "Compressing current knowledge"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add `thoughts.*` i18n keys (34 keys) for the thinking/reasoning UI phases in both `en.json` and `de.json`
- Add `citations.*` i18n keys (22 keys) for the citation panel in both languages
- Add `attachments.loading` key in both languages

### Thinking keys structure
| Section | Keys |
|---------|------|
| `thoughts.phase.*` | 8 phase labels |
| `thoughts.assess.*` | 5 steps |
| `thoughts.assess_input.*` | 2 steps |
| `thoughts.decide.*` | 4 steps |
| `thoughts.plan.*` | 5 steps |
| `thoughts.answer.*` | 2 steps |
| `thoughts.search.*` | 3 steps |
| `thoughts.doc_lookup.*` | 3 steps |
| `thoughts.context.*` | 1 step |

## Test plan
- [ ] Verify thinking phase labels render correctly in English
- [ ] Verify thinking phase labels render correctly in German
- [ ] Verify citation panel labels render in both languages
- [ ] Confirm no missing key warnings in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)