### PR TITLE
Fix Office365 admin consent issues by enforcing minimal permissions

### DIFF
--- a/docs/office365-admin-consent-removal.md
+++ b/docs/office365-admin-consent-removal.md
@@ -107,20 +107,28 @@ OAuth tokens are bound to the specific permission set granted during authorizati
 
 ## Azure AD App Configuration
 
-No changes needed to existing Azure AD app registrations. The app registration should have these permissions configured:
+**Important:** Your Azure AD app registration must **only** have the permissions listed below. Any extra permissions that require admin consent (e.g., `Group.Read.All`, `ChannelSettings.Read.All`) will cause Microsoft to show an "Administrator approval required" screen to regular users, even if admin consent was granted globally.
 
-1. Go to **Azure Portal** → **App registrations**
-2. Select your app
-3. Go to **API permissions**
-4. Ensure these Microsoft Graph delegated permissions are present:
-   - User.Read
-   - Files.Read.All
-   - Sites.Read.All
-   - Team.ReadBasic.All
-   - Channel.ReadBasic.All
-   - offline_access
+### Required Steps
 
-**Note:** You can optionally remove `Group.Read.All` from the app registration if it's no longer needed for other purposes.
+1. Go to **Azure Portal** → **App registrations** → Select your app → **API permissions**
+2. **Remove** any permissions **not** in the list below, especially:
+   - `Group.Read.All` (admin consent required — no longer needed)
+   - `ChannelSettings.Read.All` (admin consent required — never needed)
+3. Ensure **only** these Microsoft Graph delegated permissions remain:
+   - `User.Read`
+   - `Files.Read.All`
+   - `Sites.Read.All`
+   - `Team.ReadBasic.All`
+   - `Channel.ReadBasic.All`
+   - `offline_access`
+4. Click **"Grant admin consent for [your organization]"** to apply the updated permission set
+5. Go to **Enterprise applications** → Select your app → **Properties**
+6. Ensure **"User assignment required?"** is set to **No**
+
+### Why Extra Permissions Cause Problems
+
+Even if the iHub Apps code only requests the 6 scopes above, Azure AD evaluates **all permissions registered on the app**. If any registered permission requires admin consent, Microsoft may block the entire OAuth flow for regular users with an "Administrator approval required" error — regardless of whether admin consent was previously granted.
 
 ## Testing
 

--- a/server/services/integrations/Office365Service.js
+++ b/server/services/integrations/Office365Service.js
@@ -322,11 +322,15 @@ class Office365Service {
       // First, get the tokens to check their scope
       let tokens = await tokenStorage.getUserTokens(userId, this.serviceName);
 
-      // Check if tokens have old scope (Group.Read.All) from before admin rights removal
+      // Check if tokens have old scopes that require admin consent (Group.Read.All, ChannelSettings.Read.All)
       // These tokens need to be invalidated so user can re-authenticate with new scopes
-      if (tokens.scope && tokens.scope.includes('Group.Read.All')) {
+      if (
+        tokens.scope &&
+        (tokens.scope.includes('Group.Read.All') ||
+          tokens.scope.includes('ChannelSettings.Read.All'))
+      ) {
         logger.warn(
-          `⚠️ Detected old Office 365 token with Group.Read.All scope for user ${userId}. Invalidating tokens to force re-authentication with new scopes.`,
+          `⚠️ Detected old Office 365 token with admin-consent scope for user ${userId}. Invalidating tokens to force re-authentication with new scopes.`,
           {
             component: 'Office 365',
             oldScope: tokens.scope


### PR DESCRIPTION
## Summary
Updated Office365 authentication to prevent "Administrator approval required" errors by enforcing a minimal set of permissions on the Azure AD app registration. Extra permissions requiring admin consent were causing OAuth flow failures for regular users even after global admin consent was granted.

## Key Changes

- **Documentation Updates** (`docs/office365-admin-consent-removal.md`):
  - Clarified that Azure AD app registration must have **only** the required permissions listed
  - Added explicit instructions to remove problematic permissions (`Group.Read.All`, `ChannelSettings.Read.All`)
  - Explained why extra admin-consent permissions cause OAuth failures for regular users
  - Added step to verify "User assignment required?" is set to "No"
  - Added step to grant admin consent after updating permissions

- **Token Validation Logic** (`server/services/integrations/Office365Service.js`):
  - Extended token scope validation to detect both `Group.Read.All` and `ChannelSettings.Read.All` scopes
  - Updated token invalidation logic to force re-authentication when old admin-consent scopes are detected
  - Improved warning message to reflect detection of any admin-consent scope, not just `Group.Read.All`

## Implementation Details

The fix addresses a critical Azure AD behavior: even if the application code only requests specific scopes, Azure AD evaluates **all permissions registered on the app**. If any registered permission requires admin consent, Microsoft may block the OAuth flow for regular users with an "Administrator approval required" error, regardless of prior admin consent grants.

The token validation now catches both legacy (`Group.Read.All`) and potentially problematic (`ChannelSettings.Read.All`) scopes to ensure users re-authenticate with the correct minimal permission set.

https://claude.ai/code/session_01Upf8CieETRpdbkBDEkEbtT