### PR TITLE
rewrite .env.example to clarify it is optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,34 +1,35 @@
-# OpenAI API Key
-GPT_3_5_TURBO_API_KEY=sk-...
-GPT_4_API_KEY=sk-...
+# ============================================================
+# iHub Apps — Environment Variables (OPTIONAL)
+# ============================================================
+# You do NOT need this file to get started!
+#
+# Just run: npm run dev
+# Then open http://localhost:3000 and configure API keys
+# through the admin UI at /admin/providers.
+#
+# This file is only needed for:
+#   - CI/CD pipelines or Docker deployments where you want
+#     to inject keys via environment variables
+#   - Overriding settings that aren't in the admin UI
+# ============================================================
 
-# Anthropic API Key
-CLAUDE_3_OPUS_API_KEY=sk-ant-...
-CLAUDE_3_SONNET_API_KEY=sk-ant-...
+# --- API Keys (alternative to admin UI) ---
+#OPENAI_API_KEY=
+#ANTHROPIC_API_KEY=
+#GOOGLE_API_KEY=
+#MISTRAL_API_KEY=
 
-# Google API Key - use unified key for both models
-GEMINI_API_KEY=AIza...
-# (No need for separate keys for different Gemini models)
-OPENAI_API_KEY=sk-...
+# --- Server (rarely needed) ---
+#PORT=3000
+#WORKERS=1
 
-# Microsoft speech Recognition Service
-AZURE_SUBSCRIPTION_ID=...
-
-# Server configuration
-PORT=3000
-
-# Proxy Configuration (optional)
-# Configure HTTP/HTTPS proxy for external service calls
-# These can also be configured in the platform.json file under the "proxy" section
+# --- Proxy (if behind corporate proxy) ---
 #HTTP_PROXY=http://proxy.example.com:8080
 #HTTPS_PROXY=http://proxy.example.com:8080
 #NO_PROXY=localhost,127.0.0.1,.local
 
-# Authentication Configuration
-# JWT Secret for token signing (OPTIONAL - auto-generated and persisted if not set)
-# The application automatically generates and persists a JWT secret on first startup.
-# Only set this explicitly for:
-#   - Multi-node deployments (all nodes must share the same secret)
-#   - When you need to specify a custom secret
-# Generate a secure random value with: node -e "console.log(require('crypto').randomBytes(64).toString('base64'))"
+# --- Authentication ---
+# JWT Secret (OPTIONAL - auto-generated and persisted if not set)
+# Only needed for multi-node deployments where all nodes must share the same secret.
+# Generate with: node -e "console.log(require('crypto').randomBytes(64).toString('base64'))"
 #JWT_SECRET=your-secure-random-value


### PR DESCRIPTION
Rewrites `.env.example` to make it clear the file is optional and not required to get started.

Removes legacy per-model API key entries that caused confusion for new users. All entries are now commented out by default.

Closes #1076

Generated with [Claude Code](https://claude.ai/code)