### PR TITLE
refactor: remove .env copy from setup:dev onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,34 +349,23 @@ npm run install:all && npm run electron:dev
 
    ```bash
    npm run setup:dev
-   # This will copy .env.example to .env and install all dependencies
+   # Installs all dependencies and prepares default configuration
    ```
 
-3. **Configure API keys:**
-
-   Edit the `.env` file with your API keys:
-
-   ```bash
-   # Required API keys
-   OPENAI_API_KEY=sk-...
-   CLAUDE_3_SONNET_API_KEY=sk-ant-...
-   GEMINI_API_KEY=AIza...
-   ```
-
-4. **Optional tools setup:**
+3. **Optional tools setup:**
 
    ```bash
    npx playwright install (optional)
    # Selenium tools require Chrome or Chromium in your PATH
    ```
 
-5. **Start the application** (automatically sets up default configuration):
+4. **Start the application:**
 
    ```bash
    npm run dev
    ```
 
-   🎉 **That's it!** The server will automatically create default configuration files on first startup, so you can start using iHub Apps immediately.
+   🎉 **That's it!** Open http://localhost:3000 — you can configure your AI providers (API keys, models) directly in the Admin UI. No `.env` file required.
 
 ### Method 2: Docker Installation (Recommended for Production)
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "// === DEVELOPMENT ===": "",
-    "setup:dev": "cp .env.example .env && npm run install:all && echo '\\n✅ Setup complete! Edit .env with your API keys, then run: npm run dev'",
+    "setup:dev": "npm run install:all && echo '\\n✅ Dependencies installed\\n✅ Default configuration ready\\n\\nRun: npm run dev\\nThen open http://localhost:3000 to configure your AI providers.'",
     "dev": "cross-env NODE_ENV=development concurrently --kill-others-on-fail \"npm run server\" \"sleep 2 && npm run client\"",
     "server": "cd server && node -r dotenv/config server.js dotenv_config_path=../.env",
     "client": "cd client && npm run dev",


### PR DESCRIPTION
The admin UI already handles API key management, so copying .env.example is unnecessary and confusing for new users. This PR removes the .env copy step from setup:dev and updates the README to point users to the browser-based admin UI for configuration.

Closes #1078

Generated with [Claude Code](https://claude.ai/code)