### PR TITLE
feat: add provider health dashboard to admin providers page

### DIFF
--- a/client/src/features/admin/pages/AdminProvidersPage.jsx
+++ b/client/src/features/admin/pages/AdminProvidersPage.jsx
@@ -467,7 +467,17 @@ const AdminProvidersPage = () => {
                                               toggleExpanded(provider.id);
                                             }}
                                             className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200"
-                                            title={isExpanded ? t('admin.providers.health.hideResults', 'Hide results') : t('admin.providers.health.showResults', 'Show results')}
+                                            title={
+                                              isExpanded
+                                                ? t(
+                                                    'admin.providers.health.hideResults',
+                                                    'Hide results'
+                                                  )
+                                                : t(
+                                                    'admin.providers.health.showResults',
+                                                    'Show results'
+                                                  )
+                                            }
                                           >
                                             <Icon
                                               name={


### PR DESCRIPTION
Enhances the admin providers page with connectivity health status for LLM providers.

**Changes:**
- Loads models alongside providers and groups them by provider
- Adds "Models" column showing enabled model count per LLM provider
- Adds "Connectivity" column with color-coded health badges
- Adds per-provider "Test" button using existing model test endpoint
- Adds "Test All" button to test all LLM providers sequentially
- Expandable per-model results rows with success/error details

Closes #1080

Generated with [Claude Code](https://claude.ai/code)