### PR TITLE
fix: avoid ReactComponentRenderer recompilation on prop updates

### DIFF
--- a/client/src/shared/components/ReactComponentRenderer.jsx
+++ b/client/src/shared/components/ReactComponentRenderer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 // Error fallback component
@@ -52,18 +52,16 @@ function ReactComponentRenderer({ jsxCode, componentProps = {}, className = '' }
   const [CompiledComponent, setCompiledComponent] = useState(null);
   const [compileError, setCompileError] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+  const [compileVersion, setCompileVersion] = useState(0);
 
   // Extract t function for internal components
   const { t } = componentProps;
-
-  // Memoize the JSX code to prevent unnecessary recompilation
-  const memoizedJsxCode = useMemo(() => jsxCode, [jsxCode]);
 
   useEffect(() => {
     let isMounted = true;
 
     const compileJSX = async () => {
-      if (!memoizedJsxCode?.trim()) {
+      if (!jsxCode?.trim()) {
         setCompiledComponent(null);
         setCompileError(null);
         setIsLoading(false);
@@ -138,7 +136,7 @@ function ReactComponentRenderer({ jsxCode, componentProps = {}, className = '' }
         }
 
         // Prepare the JSX code with imports and proper component structure
-        let fullCode = memoizedJsxCode.trim();
+        let fullCode = jsxCode.trim();
 
         // Check if code already starts with import or const/function declarations
         const hasImports = /^(import\s|const\s|function\s|class\s|export\s)/m.test(fullCode);
@@ -226,6 +224,16 @@ UserComponent;
         );
 
         // Execute the compiled code
+        const compileTimeProps = {
+          React,
+          useState: React.useState,
+          useEffect: React.useEffect,
+          useMemo: React.useMemo,
+          useCallback: React.useCallback,
+          useRef: React.useRef,
+          useId: React.useId
+        };
+
         const ComponentFunction = executeInContext(
           React,
           React.useState,
@@ -234,17 +242,17 @@ UserComponent;
           React.useCallback,
           React.useRef,
           React.useId,
-          componentProps
+          compileTimeProps
         );
 
         if (!ComponentFunction) {
           throw new Error('No component was exported from the provided code');
         }
 
-        // Create a wrapper component that provides the React hooks as props
+        // Keep the wrapper stable and inject caller props only at render time
+        // so prop identity changes do not retrigger Babel compilation.
         const WrappedComponent = props => {
-          const combinedProps = {
-            ...componentProps,
+          const runtimeProps = {
             ...props,
             React,
             useState: React.useState,
@@ -255,7 +263,7 @@ UserComponent;
             useId: React.useId
           };
 
-          return React.createElement(ComponentFunction, combinedProps);
+          return React.createElement(ComponentFunction, runtimeProps);
         };
 
         if (isMounted) {
@@ -280,7 +288,7 @@ UserComponent;
     return () => {
       isMounted = false;
     };
-  }, [memoizedJsxCode, componentProps]);
+  }, [jsxCode, compileVersion]);
 
   if (isLoading) {
     return <LoadingComponent t={t} />;
@@ -329,10 +337,12 @@ UserComponent;
         onReset={() => {
           // Force recompilation on reset
           setCompiledComponent(null);
+          setCompileError(null);
           setIsLoading(true);
+          setCompileVersion(version => version + 1);
         }}
       >
-        <CompiledComponent />
+        <CompiledComponent {...componentProps} />
       </ErrorBoundary>
     </div>
   );

--- a/concepts/2026-03-25 ReactComponentRenderer Recompilation Fix.md
+++ b/concepts/2026-03-25 ReactComponentRenderer Recompilation Fix.md
@@ -1,0 +1,40 @@
+# ReactComponentRenderer Recompilation Fix
+
+## Problem
+
+`ReactComponentRenderer` recompiled JSX whenever `componentProps` changed identity, even if
+`jsxCode` stayed the same. In practice, parents often pass `componentProps` as inline object
+literals, so ordinary parent re-renders triggered a full Babel transform, wrapper recreation,
+and visible loading flicker.
+
+## Decision
+
+Keep JSX compilation tied only to `jsxCode` changes and explicit recompilation resets.
+Inject `componentProps` into the compiled wrapper at render time instead of closing over them
+during compilation.
+
+## Implementation
+
+- `client/src/shared/components/ReactComponentRenderer.jsx`
+  - Remove `componentProps` from the compilation effect dependencies
+  - Keep a stable compiled wrapper component in state
+  - Pass the latest `componentProps` into that wrapper during render
+  - Add an explicit `compileVersion` reset path so the error boundary can force recompilation
+
+## Verification
+
+- Reproduced locally before the fix with a direct jsdom-based harness:
+  - initial Babel transforms: `1`
+  - after parent re-render with unchanged `jsxCode`: `2`
+- Verified locally after the fix with the same harness:
+  - initial Babel transforms: `1`
+  - after parent re-render with unchanged `jsxCode`: `1`
+- A Jest regression test was attempted but not kept in the patch because the current repo test
+  environment mixes React versions between the root toolchain and the client package, which makes
+  this component path unreliable under Jest.
+
+## Expected Outcome
+
+- Parent re-renders no longer cause redundant JSX recompilation
+- `componentProps` updates still flow into the rendered component
+- Error boundary resets continue to trigger a fresh compilation when requested


### PR DESCRIPTION
  ## Summary

  Fixes redundant JSX recompilation in `ReactComponentRenderer` when only `componentProps` changes identity.

  Closes #1175.

  ## Root Cause

  `ReactComponentRenderer` was recompiling whenever `componentProps` changed, and the compiled wrapper closed over those props. In places like `UnifiedPage`, `componentProps` is passed as an inline object, so normal parent re-renders triggered a fresh Babel transform even when `jsxCode` was unchanged.

  ## Changes

  - make JSX compilation depend on `jsxCode` only
  - inject the latest `componentProps` at render time instead of during compilation
  - keep explicit recompilation support for error-boundary resets via a version bump
  - add a concept note documenting the fix