### PR TITLE
fix: add appId to handleEvent useCallback dependency array

### DIFF
--- a/client/src/features/chat/hooks/useAppChat.js
+++ b/client/src/features/chat/hooks/useAppChat.js
@@ -325,7 +325,8 @@ function useAppChat({ appId, chatId: initialChatId, onMessageComplete }) {
       mergeCitations,
       onMessageComplete,
       t,
-      messagesRef
+      messagesRef,
+      appId
     ]
   );
 


### PR DESCRIPTION
## Summary                                                                                                                                                                 
  - Fixes stale closure bug where `appId` was missing from the `handleEvent` `useCallback` dependency array in `useAppChat.js`
  - When navigating between app chats without a full page reload, the old `appId` was captured in the closure, causing `setConversationId` to persist the conversation ID    
  under the wrong app's localStorage key                                                                                                                                     
                                                                                                                                                                             
## Changes                                                                                                                                                                 
  - Added `appId` to the `handleEvent` dependency array (`client/src/features/chat/hooks/useAppChat.js:329`)

Closes #1174