### PR TITLE
Potential fix for code scanning alert no. 315: Type confusion through parameter tampering

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -332,7 +332,22 @@ export default function registerAuthRoutes(app) {
       });
 
       // Validate and sanitize return URL to prevent open redirect attacks
-      let returnUrl = req.query.returnUrl || '/';
+      const rawReturnUrl = req.query.returnUrl;
+      let returnUrl;
+
+      if (rawReturnUrl == null) {
+        // No return URL provided, use default
+        returnUrl = '/';
+      } else if (typeof rawReturnUrl === 'string') {
+        returnUrl = rawReturnUrl;
+      } else {
+        // Reject array or non-string values to prevent type confusion attacks
+        logger.warn('[Security] Invalid return URL type', {
+          component: 'Auth',
+          type: typeof rawReturnUrl
+        });
+        return sendBadRequest(res, 'Invalid return URL');
+      }
 
       // Only allow relative URLs (starting with /) and same-origin URLs
       try {


### PR DESCRIPTION
Potential fix for [https://github.com/intrafind/ihub-apps/security/code-scanning/315](https://github.com/intrafind/ihub-apps/security/code-scanning/315)

In general, to fix this kind of problem you must ensure that any value taken from HTTP parameters (query, body, params) is validated for type before using string methods or concatenation, or you must coerce it safely to a string in a controlled way. If the value can be an array, you should either reject it or normalize it (e.g., take the first element) according to your application’s intended behavior.

For this specific code in `server/routes/auth.js`, the best minimal fix is:

- Normalize `req.query.returnUrl` to a single string in a controlled way and reject invalid types.
- Do this immediately after retrieving it, before calling `.startsWith`, `.includes`, or concatenating.
- If the query parameter is:
  - `undefined`/`null`: default to `'/'` (as now).
  - A string: use as-is.
  - An array: either reject the request as bad, or select the first element and validate it. To stay conservative and secure, rejecting non-string values (arrays, objects) as bad input is preferable.
- Ensure that all later operations on `returnUrl` are then safe because it is guaranteed to be a string.

Concretely, around line 335 where `returnUrl` is defined and then used, we will:

1. Replace the current assignment `let returnUrl = req.query.returnUrl || '/';` with a short block that:
   - Reads the raw value.
   - If it’s `undefined` or `null`, sets `returnUrl = '/'`.
   - If it’s a string, keeps it.
   - If it’s an array (or any non-string), logs and returns a 400 error using `sendBadRequest`, avoiding further processing with an ambiguous value.
2. Keep the rest of the URL validation logic unchanged; it will then operate on a guaranteed string.

No new helper functions or external libraries are required; we only add a small in-place type check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
