### PR TITLE
fix: resolve OIDC TypeError for subpath callback URL

### DIFF
--- a/server/middleware/oidcAuth.js
+++ b/server/middleware/oidcAuth.js
@@ -60,15 +60,7 @@ export function configureOidcProviders() {
           tokenURL: provider.tokenURL,
           clientID: provider.clientId,
           clientSecret: provider.clientSecret,
-          // Use function for callbackURL to support subpath deployments
-          // The function receives the request object, allowing us to detect the base path
-          // from X-Forwarded-Prefix header for reverse proxy scenarios
-          callbackURL:
-            provider.callbackURL ||
-            function (req) {
-              // Use buildServerPath to include base path from X-Forwarded-Prefix header
-              return buildServerPath(`/api/auth/oidc/${provider.name}/callback`);
-            },
+          callbackURL: provider.callbackURL || `/api/auth/oidc/${provider.name}/callback`,
           scope: provider.scope || ['openid', 'profile', 'email'],
           state: true,
           pkce: provider.pkce ?? true,
@@ -452,8 +444,13 @@ export function createOidcAuthHandler(providerName) {
       }
     }
 
+    // Pass callbackURL at request time so buildServerPath() can detect the base path
+    // from X-Forwarded-Prefix header for subpath deployments
+    const callbackURL =
+      provider.callbackURL || buildServerPath(`/api/auth/oidc/${providerName}/callback`);
     passport.authenticate(provider.strategyName, {
-      scope: provider.scope || ['openid', 'profile', 'email']
+      scope: provider.scope || ['openid', 'profile', 'email'],
+      callbackURL
     })(req, res, next);
   };
 }
@@ -497,7 +494,10 @@ export function createOidcCallbackHandler(providerName) {
       return res.redirect(`${buildServerPath('/')}?auth=error&message=${errorMessage}`);
     }
 
-    passport.authenticate(provider.strategyName, (err, user, info) => {
+    // Pass callbackURL at request time for subpath deployment support
+    const callbackURL =
+      provider.callbackURL || buildServerPath(`/api/auth/oidc/${providerName}/callback`);
+    passport.authenticate(provider.strategyName, { callbackURL }, (err, user, info) => {
       if (err) {
         authDebugService.log(
           'oidc',


### PR DESCRIPTION
## Summary
- **Root cause**: Commit 0018f637 (#1259) changed the `callbackURL` in the OAuth2Strategy constructor from a string to a function to support subpath deployments. However, `passport-oauth2` expects a string and calls `url.parse()` on it, causing `TypeError: The "url" argument must be of type string. Received function`.
- **Fix**: Revert the constructor's `callbackURL` to a plain string and instead pass the dynamic base-path-aware `callbackURL` via `passport.authenticate()` options, which are evaluated at request time when `X-Forwarded-Prefix` is available.
- Subpath deployment support (`/ihub/`, etc.) is preserved — `buildServerPath()` resolves correctly at request time.

## Test plan
- [x] Deployed hotfix to k3s cluster and verified OIDC login works
- [ ] Verify subpath deployment scenario with `X-Forwarded-Prefix` header
- [ ] Verify root deployment (no prefix) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)