### PR TITLE
fix: convert glob patterns to regex in migration listFiles

### DIFF
--- a/server/migrations/runner.js
+++ b/server/migrations/runner.js
@@ -185,7 +185,9 @@ function createMigrationContext(contentsDir, defaultsDir, migration) {
         throw error;
       }
       if (pattern) {
-        const regex = new RegExp(pattern);
+        // Convert glob pattern to regex (e.g., *.json → ^.*\.json$)
+        const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+        const regex = new RegExp(`^${escaped}$`);
         return entries.filter(e => regex.test(e));
       }
       return entries;


### PR DESCRIPTION
## Summary
- `ctx.listFiles(dir, pattern)` in the migration runner passed the `pattern` directly to `new RegExp()`, but all migrations use glob patterns like `*.json`
- `*` is invalid at the start of a regex ("Nothing to repeat"), causing **V023 to fail on every startup** and blocking V024-V026 from ever running
- This meant the **websearch tool migration (V025)** never executed, leaving deprecated tool IDs (`googleSearch`, `enhancedWebSearch`, `webContentExtractor`) in app configs
- Fix: escape regex metacharacters and convert glob `*` to `.*` before constructing the RegExp

## Impact
Any fresh deployment of v5.2.10 will have V023-V026 blocked. After this fix, all four migrations run successfully on next startup.

## Test plan
- [x] Manually ran migrations on k3s cluster after hotfixing runner.js — all 4 pending migrations applied successfully
- [x] V025 correctly removed websearch tools from `sanctions-checker.json` and `social-media.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)