### PR TITLE
fix: allow SSL-whitelisted domains to bypass SSRF check

### DIFF
--- a/server/tools/webContentExtractor.js
+++ b/server/tools/webContentExtractor.js
@@ -5,7 +5,7 @@ import { throttledFetch } from '../requestThrottler.js';
 import { actionTracker } from '../actionTracker.js';
 import configCache from '../configCache.js';
 import logger from '../utils/logger.js';
-import { enhanceFetchOptions } from '../utils/httpConfig.js';
+import { enhanceFetchOptions, getSSLConfig, isDomainWhitelisted } from '../utils/httpConfig.js';
 
 const dnsLookupAsync = dns.promises.lookup;
 
@@ -94,7 +94,11 @@ export default async function webContentExtractor({
   }
 
   // Block SSRF: prevent LLM tool from accessing internal/cloud metadata services
-  await assertNotPrivateIp(validUrl.hostname);
+  // Skip check for domains explicitly whitelisted by admin in SSL configuration
+  const sslConfig = getSSLConfig();
+  if (!isDomainWhitelisted(validUrl.hostname, sslConfig.domainWhitelist)) {
+    await assertNotPrivateIp(validUrl.hostname);
+  }
 
   // Determine SSL ignore setting: explicit parameter > global config > default false
   const platformConfig = configCache.getPlatform() || {};


### PR DESCRIPTION
## Summary

- Internal services (e.g., `if-wiki`) resolve to private IPs and get blocked by the SSRF protection in `webContentExtractor`
- Reuses the existing admin-configured SSL domain whitelist (`ssl.domainWhitelist` in platform.json) to skip the private IP check for trusted internal hosts
- No new config, UI, or schema changes — just wires up the existing allowlist

## Test plan

- [ ] Add internal hostname (e.g., `if-wiki`) to SSL domain whitelist via Admin → SSL Configuration
- [ ] Use an app with the web content extractor tool to fetch an internal URL — should succeed
- [ ] Confirm non-whitelisted internal hostnames are still blocked
- [ ] Confirm cloud metadata IPs (`169.254.x.x`) remain blocked unless explicitly whitelisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)