### PR TITLE
fix: resolve admin platform config 500 and silent error logging

### DIFF
--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -61,7 +61,12 @@ function restoreSecretIfRedacted(newValue, existingValue) {
 function decryptIfNeeded(value) {
   if (!value || typeof value !== 'string') return value;
   if (tokenStorageService.isEncrypted(value)) {
-    return tokenStorageService.decryptString(value);
+    try {
+      return tokenStorageService.decryptString(value);
+    } catch (error) {
+      logger.error('Failed to decrypt config secret', { component: 'AdminConfigs', error });
+      return value; // Return encrypted value as-is; sanitizeSecret() will redact it downstream
+    }
   }
   return value;
 }

--- a/server/tests/logger-error-serialization.test.js
+++ b/server/tests/logger-error-serialization.test.js
@@ -1,0 +1,101 @@
+/**
+ * Test that the logger correctly serializes Error objects passed as metadata.
+ * Error properties (message, stack, name) are non-enumerable and invisible to
+ * Object.keys(), so without special handling they serialize as empty {}.
+ */
+import logger from '../utils/logger.js';
+
+const originalWrite = process.stdout.write;
+const outputs = [];
+
+process.stdout.write = function (chunk) {
+  outputs.push(chunk.toString());
+  return true;
+};
+
+// Test 1: Basic Error object is serialized with message and name
+logger.error('Something failed', {
+  component: 'Test',
+  error: new Error('test error message')
+});
+
+// Test 2: Error with custom enumerable properties (e.g., code, statusCode)
+const customError = new Error('custom error');
+customError.code = 'ENOENT';
+customError.statusCode = 503;
+logger.error('Custom error occurred', {
+  component: 'Test',
+  error: customError
+});
+
+// Test 3: Non-Error nested objects are unaffected
+logger.error('Plain object error', {
+  component: 'Test',
+  error: { reason: 'something went wrong', code: 42 }
+});
+
+// Test 4: Error at top-level context (as first argument)
+logger.error(new Error('top level error'));
+
+process.stdout.write = originalWrite;
+
+let allPassed = true;
+
+// Check Test 1: error.message and error.name must appear in output
+const test1Output = outputs.find(o => o.includes('Something failed'));
+if (!test1Output) {
+  console.error('❌ FAILED Test 1: log entry not found');
+  allPassed = false;
+} else if (!test1Output.includes('test error message')) {
+  console.error('❌ FAILED Test 1: error.message was not serialized (got empty error object)');
+  console.error('Output:', test1Output);
+  allPassed = false;
+} else if (!test1Output.includes('"name"')) {
+  console.error('❌ FAILED Test 1: error.name was not serialized');
+  console.error('Output:', test1Output);
+  allPassed = false;
+} else {
+  console.log('✓ Test 1 passed: Error message and name serialized correctly');
+}
+
+// Check Test 2: custom enumerable properties preserved
+const test2Output = outputs.find(o => o.includes('Custom error occurred'));
+if (!test2Output) {
+  console.error('❌ FAILED Test 2: log entry not found');
+  allPassed = false;
+} else if (!test2Output.includes('custom error')) {
+  console.error('❌ FAILED Test 2: error.message was not serialized');
+  console.error('Output:', test2Output);
+  allPassed = false;
+} else if (!test2Output.includes('ENOENT')) {
+  console.error('❌ FAILED Test 2: custom error.code not preserved');
+  console.error('Output:', test2Output);
+  allPassed = false;
+} else if (!test2Output.includes('503')) {
+  console.error('❌ FAILED Test 2: custom error.statusCode not preserved');
+  console.error('Output:', test2Output);
+  allPassed = false;
+} else {
+  console.log('✓ Test 2 passed: Custom error properties preserved');
+}
+
+// Check Test 3: plain objects still work normally
+const test3Output = outputs.find(o => o.includes('Plain object error'));
+if (!test3Output) {
+  console.error('❌ FAILED Test 3: log entry not found');
+  allPassed = false;
+} else if (!test3Output.includes('something went wrong')) {
+  console.error('❌ FAILED Test 3: plain object error reason not preserved');
+  console.error('Output:', test3Output);
+  allPassed = false;
+} else {
+  console.log('✓ Test 3 passed: Plain object error fields preserved');
+}
+
+if (allPassed) {
+  console.log('\n✅ All logger error serialization tests passed!');
+  process.exit(0);
+} else {
+  console.error('\n❌ Some tests failed!');
+  process.exit(1);
+}

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -318,6 +318,18 @@ function redactUrlParams(url) {
 function redactSensitiveData(data) {
   if (!data || typeof data !== 'object') return data;
 
+  // Serialize Error objects to plain objects — Error properties (message, stack, name)
+  // are non-enumerable and invisible to Object.keys(), which would produce empty {}
+  if (data instanceof Error) {
+    const serialized = { message: data.message, name: data.name, stack: data.stack };
+    for (const key of Object.keys(data)) {
+      if (!(key in serialized)) {
+        serialized[key] = data[key];
+      }
+    }
+    return redactSensitiveData(serialized);
+  }
+
   // List of sensitive field names (exact match or starts with pattern)
   // Only redact these if they contain string values, not objects
   const exactSensitiveFields = [


### PR DESCRIPTION
## Summary

- **Admin config 500**: `decryptIfNeeded()` in `server/routes/admin/configs.js` lacked try/catch, so any decryption failure (key mismatch, missing/rotated key, corrupted `ENC[...]` value) propagated and crashed `GET /api/admin/configs/platform` with a 500. Now matches the safe pattern already used in `configCache.js` — failures are logged and the field is returned as `***REDACTED***`.
- **Silent error logging**: `redactSensitiveData()` in `server/utils/logger.js` used `Object.keys()` on Error objects, which returns `[]` because `message`/`stack`/`name` are non-enumerable. Every `logger.error('...', { error })` call across the codebase (~30+ sites) was logging the error as empty `{}`. Now detects `Error` instances and serializes them to a plain object before processing.
- **Test**: Added `server/tests/logger-error-serialization.test.js` to verify Error serialization.

## Test plan

- [ ] `GET /api/admin/configs/platform` with a valid setup returns 200
- [ ] With a corrupted `ENC[...]` value or rotated encryption key in `platform.json`, endpoint returns 200 with affected field showing `***REDACTED***` and logs show the actual error message
- [ ] `node server/tests/logger-error-serialization.test.js` passes
- [ ] `node server/tests/logger-redaction.test.js` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)