### PR TITLE
Add LDAP group lookup support for NTLM authentication

### DIFF
--- a/client/src/features/admin/components/PlatformFormEditor.jsx
+++ b/client/src/features/admin/components/PlatformFormEditor.jsx
@@ -1036,8 +1036,8 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
         </div>
       )}
 
-      {/* LDAP Configuration */}
-      {config.ldapAuth?.enabled && (
+      {/* LDAP Configuration - shown when LDAP or NTLM is enabled (NTLM can use LDAP for group lookup) */}
+      {(config.ldapAuth?.enabled || config.ntlmAuth?.enabled) && (
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
           <div className="flex justify-between items-center mb-4">
             <div>
@@ -1490,6 +1490,36 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
                 Generate JWT tokens for API access after NTLM authentication
               </p>
             </div>
+          </div>
+
+          {/* LDAP Group Lookup Provider */}
+          <div className="mt-4">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              LDAP Group Lookup Provider
+            </label>
+            <select
+              value={config.ntlmAuth?.ldapGroupLookupProvider || ''}
+              onChange={e =>
+                updateNestedConfig(
+                  'ntlmAuth',
+                  'ldapGroupLookupProvider',
+                  e.target.value || undefined
+                )
+              }
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm dark:bg-gray-700 dark:text-gray-200"
+            >
+              <option value="">None (use NTLM built-in groups)</option>
+              {(config.ldapAuth?.providers || []).map(p => (
+                <option key={p.name} value={p.name}>
+                  {p.displayName || p.name}
+                </option>
+              ))}
+            </select>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+              Use an LDAP provider to look up user groups during login instead of relying on the
+              domain controller. The LDAP provider must have admin credentials and group search
+              configured.
+            </p>
           </div>
         </div>
       )}

--- a/client/src/features/admin/pages/AdminAuthPage.jsx
+++ b/client/src/features/admin/pages/AdminAuthPage.jsx
@@ -53,6 +53,7 @@ function AdminAuthPage() {
       debug: false,
       getUserInfo: true,
       getGroups: true,
+      ldapGroupLookupProvider: '',
       defaultGroups: [],
       sessionTimeoutMinutes: 480,
       generateJwtToken: true

--- a/docs/ldap-ntlm-authentication.md
+++ b/docs/ldap-ntlm-authentication.md
@@ -167,6 +167,66 @@ Add NTLM configuration to your `contents/config/platform.json`:
 | `defaultGroups`         | Default groups for authenticated users                         | No       | `[]`    |
 | `sessionTimeoutMinutes` | JWT token timeout                                              | No       | `480`   |
 | `generateJwtToken`      | Generate JWT for API access                                    | No       | `true`  |
+| `ldapGroupLookupProvider` | Name of an LDAP provider to use for group lookup (see below) | No       | -       |
+
+### LDAP Group Lookup for NTLM Users
+
+NTLM authentication may not always return group memberships from the domain controller. As an alternative, you can configure NTLM to use an LDAP provider for group lookup. This allows NTLM to handle identity verification while LDAP provides group memberships.
+
+#### How It Works
+
+1. User authenticates via NTLM (identity verification)
+2. During login, the system queries the configured LDAP provider for the user's group memberships using admin bind credentials (no user password needed)
+3. LDAP groups are merged with any groups from NTLM and mapped to internal groups via `groups.json`
+
+The LDAP group lookup only happens during login (session start), not on every request.
+
+#### Configuration
+
+1. Configure an LDAP provider in `ldapAuth.providers` with admin credentials and group search settings. Note: `ldapAuth.enabled` does not need to be `true` — the providers are accessible for group lookup regardless.
+
+2. Set `ldapGroupLookupProvider` in your `ntlmAuth` config to the LDAP provider's `name`:
+
+```json
+{
+  "ldapAuth": {
+    "enabled": false,
+    "providers": [
+      {
+        "name": "corporate-ad",
+        "displayName": "Corporate Active Directory",
+        "url": "ldap://ad.example.com:389",
+        "adminDn": "${AD_BIND_USER}@example.com",
+        "adminPassword": "${AD_BIND_PASSWORD}",
+        "userSearchBase": "dc=example,dc=com",
+        "usernameAttribute": "sAMAccountName",
+        "groupSearchBase": "dc=example,dc=com",
+        "groupClass": "group",
+        "groupMemberAttribute": "member",
+        "groupMemberUserAttribute": "dn"
+      }
+    ]
+  },
+  "ntlmAuth": {
+    "enabled": true,
+    "domain": "EXAMPLE",
+    "domainController": "ldap://dc.example.com:389",
+    "ldapGroupLookupProvider": "corporate-ad",
+    "defaultGroups": ["ntlm-users"],
+    "generateJwtToken": true
+  }
+}
+```
+
+#### Requirements
+
+- The LDAP provider **must** have `adminDn` and `adminPassword` configured (admin bind is used since the user's password is not available during NTLM auth)
+- The LDAP provider **should** have `groupSearchBase` configured for group membership queries
+- The `usernameAttribute` on the LDAP provider should match the NTLM username format (e.g., `sAMAccountName` for Active Directory)
+
+#### Graceful Fallback
+
+If the LDAP group lookup fails for any reason (connection error, user not found, misconfiguration), NTLM authentication still succeeds. The user will be assigned groups from NTLM (if any) plus the configured `defaultGroups`.
 
 ### Platform Requirements
 
@@ -456,6 +516,7 @@ async function makeAuthenticatedRequest(url) {
    - Enable `getGroups` option
    - Check domain permissions
    - Review user account settings
+   - Consider using `ldapGroupLookupProvider` to retrieve groups from an LDAP provider instead of the domain controller
 
 ### Common Issues
 

--- a/server/middleware/ldapAuth.js
+++ b/server/middleware/ldapAuth.js
@@ -10,6 +10,57 @@ import logger from '../utils/logger.js';
  */
 
 /**
+ * Extract a group name from an LDAP group entry.
+ * Handles string values, objects with cn/name/displayName, and DN parsing.
+ * @param {string|Object} group - LDAP group entry
+ * @returns {string|null} Group name or null if not extractable
+ */
+function extractGroupName(group) {
+  if (typeof group === 'string') {
+    return group;
+  }
+
+  if (typeof group === 'object' && group !== null) {
+    if (group.cn) {
+      return Array.isArray(group.cn) ? group.cn[0] : group.cn;
+    }
+    if (group.name) {
+      return Array.isArray(group.name) ? group.name[0] : group.name;
+    }
+    if (group.displayName) {
+      return Array.isArray(group.displayName) ? group.displayName[0] : group.displayName;
+    }
+    if (group.dn) {
+      const dnString = Array.isArray(group.dn) ? group.dn[0] : group.dn;
+      const cnMatch = dnString.match(/^CN=([^,]+)/i);
+      if (cnMatch) {
+        return cnMatch[1];
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Extract group names from an LDAP groups response.
+ * Handles both array and object formats.
+ * @param {Array|Object} groups - Raw groups from LDAP response
+ * @returns {string[]} Array of group name strings
+ */
+function extractGroupNames(groups) {
+  if (!groups) {
+    return [];
+  }
+
+  const groupsArray = Array.isArray(groups)
+    ? groups
+    : Object.values(groups).filter(g => g && typeof g === 'object');
+
+  return groupsArray.map(extractGroupName).filter(g => g !== null);
+}
+
+/**
  * Authenticate user against LDAP server
  * @param {string} username - Username
  * @param {string} password - Password
@@ -90,52 +141,7 @@ async function authenticateLdapUser(username, password, ldapConfig) {
     });
 
     // Extract groups from LDAP response
-    let groups = [];
-    if (user.groups) {
-      // Handle both array and object formats
-      const groupsArray = Array.isArray(user.groups)
-        ? user.groups
-        : Object.values(user.groups).filter(g => g && typeof g === 'object');
-
-      groups = groupsArray
-        .map(group => {
-          // Handle string groups directly
-          if (typeof group === 'string') {
-            return group;
-          }
-
-          // Handle object groups - extract group name
-          if (typeof group === 'object' && group !== null) {
-            // Try different common LDAP group name attributes
-            if (group.cn) {
-              return Array.isArray(group.cn) ? group.cn[0] : group.cn;
-            }
-            if (group.name) {
-              return Array.isArray(group.name) ? group.name[0] : group.name;
-            }
-            if (group.displayName) {
-              return Array.isArray(group.displayName) ? group.displayName[0] : group.displayName;
-            }
-            // Try to extract from DN (e.g., "CN=Developers,OU=..." -> "Developers")
-            if (group.dn) {
-              const dnString = Array.isArray(group.dn) ? group.dn[0] : group.dn;
-              const cnMatch = dnString.match(/^CN=([^,]+)/i);
-              if (cnMatch) {
-                return cnMatch[1];
-              }
-            }
-          }
-
-          // If we can't extract a meaningful name, skip this entry
-          logger.warn('LDAP Auth: could not extract group name from group object', {
-            component: 'LdapAuth',
-            username,
-            group
-          });
-          return null;
-        })
-        .filter(g => g !== null); // Remove null entries
-    }
+    const groups = extractGroupNames(user.groups);
 
     // Log extracted LDAP groups for troubleshooting
     if (groups.length > 0) {
@@ -323,4 +329,92 @@ export function getConfiguredLdapProviders() {
     displayName: provider.displayName || provider.name,
     url: provider.url
   }));
+}
+
+/**
+ * Get LDAP provider by name regardless of whether ldapAuth is enabled.
+ * Used for NTLM LDAP group lookup where LDAP auth itself may be disabled
+ * but providers are configured for group queries.
+ * @param {string} providerName - LDAP provider name
+ * @returns {Object|null} LDAP provider configuration
+ */
+export function getLdapProviderByName(providerName) {
+  const platform = configCache.getPlatform() || {};
+  const ldapAuth = platform.ldapAuth || {};
+
+  if (!ldapAuth.providers || !Array.isArray(ldapAuth.providers)) {
+    return null;
+  }
+
+  return ldapAuth.providers.find(provider => provider.name === providerName) || null;
+}
+
+/**
+ * Look up a user's LDAP group memberships without authenticating them.
+ * Uses admin bind credentials and verifyUserExists mode to search for the user
+ * and retrieve their group memberships. Designed for use with NTLM auth where
+ * the user's password is not available.
+ * @param {string} username - Username to look up
+ * @param {Object} ldapProviderConfig - LDAP provider configuration with admin credentials
+ * @returns {Promise<string[]>} Array of LDAP group name strings
+ */
+export async function lookupLdapGroupsForUser(username, ldapProviderConfig) {
+  if (!ldapProviderConfig.adminDn || !ldapProviderConfig.adminPassword) {
+    throw new Error(
+      'LDAP provider must have adminDn and adminPassword configured for group lookup'
+    );
+  }
+
+  if (!ldapProviderConfig.url || !ldapProviderConfig.userSearchBase) {
+    throw new Error('LDAP provider must have url and userSearchBase configured');
+  }
+
+  const options = {
+    ldapOpts: {
+      url: ldapProviderConfig.url,
+      ...(ldapProviderConfig.tlsOptions && { tlsOptions: ldapProviderConfig.tlsOptions }),
+      ...(ldapProviderConfig.timeout && { timeout: ldapProviderConfig.timeout }),
+      ...(ldapProviderConfig.reconnect && { reconnect: ldapProviderConfig.reconnect })
+    },
+    adminDn: ldapProviderConfig.adminDn,
+    adminPassword: ldapProviderConfig.adminPassword,
+    userSearchBase: ldapProviderConfig.userSearchBase,
+    usernameAttribute: ldapProviderConfig.usernameAttribute || 'uid',
+    username: username,
+    verifyUserExists: true,
+    ...(ldapProviderConfig.groupSearchBase && {
+      groupsSearchBase: ldapProviderConfig.groupSearchBase,
+      groupClass: ldapProviderConfig.groupClass || 'groupOfNames',
+      groupMemberAttribute: ldapProviderConfig.groupMemberAttribute || 'member',
+      groupMemberUserAttribute: ldapProviderConfig.groupMemberUserAttribute || 'dn'
+    })
+  };
+
+  logger.info('LDAP Group Lookup: searching groups for user', {
+    component: 'LdapGroupLookup',
+    username,
+    url: ldapProviderConfig.url,
+    groupSearchBase: ldapProviderConfig.groupSearchBase || 'NOT CONFIGURED'
+  });
+
+  const user = await authenticate(options);
+
+  if (!user) {
+    logger.warn('LDAP Group Lookup: user not found in LDAP', {
+      component: 'LdapGroupLookup',
+      username
+    });
+    return [];
+  }
+
+  const groups = extractGroupNames(user.groups);
+
+  logger.info('LDAP Group Lookup: found groups for user', {
+    component: 'LdapGroupLookup',
+    username,
+    groupCount: groups.length,
+    groups: groups.join(', ')
+  });
+
+  return groups;
 }

--- a/server/middleware/ldapAuth.js
+++ b/server/middleware/ldapAuth.js
@@ -10,6 +10,17 @@ import logger from '../utils/logger.js';
  */
 
 /**
+ * Escape special characters in a string for use in LDAP search filters (RFC 4515).
+ * Prevents LDAP filter injection when user-supplied values are used in queries.
+ * @param {string} str - Raw string to escape
+ * @returns {string} Escaped string safe for LDAP filter use
+ */
+function escapeLdapFilterValue(str) {
+  if (typeof str !== 'string') return str;
+  return str.replace(/[\\*()\x00]/g, c => '\\' + c.charCodeAt(0).toString(16).padStart(2, '0'));
+}
+
+/**
  * Extract a group name from an LDAP group entry.
  * Handles string values, objects with cn/name/displayName, and DN parsing.
  * @param {string|Object} group - LDAP group entry
@@ -57,7 +68,18 @@ function extractGroupNames(groups) {
     ? groups
     : Object.values(groups).filter(g => g && typeof g === 'object');
 
-  return groupsArray.map(extractGroupName).filter(g => g !== null);
+  return groupsArray
+    .map(group => {
+      const name = extractGroupName(group);
+      if (name === null && group != null) {
+        logger.warn('LDAP: could not extract group name from group object', {
+          component: 'LdapAuth',
+          group
+        });
+      }
+      return name;
+    })
+    .filter(g => g !== null);
 }
 
 /**
@@ -359,6 +381,10 @@ export function getLdapProviderByName(providerName) {
  * @returns {Promise<string[]>} Array of LDAP group name strings
  */
 export async function lookupLdapGroupsForUser(username, ldapProviderConfig) {
+  if (!username || typeof username !== 'string') {
+    throw new Error('Username is required for LDAP group lookup');
+  }
+
   if (!ldapProviderConfig.adminDn || !ldapProviderConfig.adminPassword) {
     throw new Error(
       'LDAP provider must have adminDn and adminPassword configured for group lookup'
@@ -368,6 +394,9 @@ export async function lookupLdapGroupsForUser(username, ldapProviderConfig) {
   if (!ldapProviderConfig.url || !ldapProviderConfig.userSearchBase) {
     throw new Error('LDAP provider must have url and userSearchBase configured');
   }
+
+  // Escape username for safe use in LDAP search filters (RFC 4515)
+  const safeUsername = escapeLdapFilterValue(username);
 
   const options = {
     ldapOpts: {
@@ -380,7 +409,7 @@ export async function lookupLdapGroupsForUser(username, ldapProviderConfig) {
     adminPassword: ldapProviderConfig.adminPassword,
     userSearchBase: ldapProviderConfig.userSearchBase,
     usernameAttribute: ldapProviderConfig.usernameAttribute || 'uid',
-    username: username,
+    username: safeUsername,
     verifyUserExists: true,
     ...(ldapProviderConfig.groupSearchBase && {
       groupsSearchBase: ldapProviderConfig.groupSearchBase,

--- a/server/middleware/ntlmAuth.js
+++ b/server/middleware/ntlmAuth.js
@@ -495,9 +495,13 @@ export function ntlmAuthMiddleware(req, res, next) {
         const authConfig = platform.auth || {};
         user = enhanceUserGroups(user, authConfig, ntlmAuth);
 
-        // LDAP group lookup - only when generating JWT (session start)
+        // LDAP group lookup - only when generating JWT (session start).
+        // When generateJwtToken is false, NTLM re-authenticates every request
+        // and LDAP lookup would be too expensive.
         if (ntlmAuth.ldapGroupLookupProvider && ntlmAuth.generateJwtToken) {
           user = await enhanceUserWithLdapGroups(user, ntlmAuth);
+          // Re-apply: enhanceUserWithLdapGroups replaces user.groups with freshly
+          // mapped groups, so we need to re-add authenticated/provider default groups.
           user = enhanceUserGroups(user, authConfig, ntlmAuth);
         }
 
@@ -609,6 +613,8 @@ export async function processNtlmLogin(req, ntlmConfig) {
   // LDAP group lookup (only during login/session start)
   if (ntlmConfig.ldapGroupLookupProvider) {
     user = await enhanceUserWithLdapGroups(user, ntlmConfig);
+    // Re-apply: enhanceUserWithLdapGroups replaces user.groups with freshly
+    // mapped groups, so we need to re-add authenticated/provider default groups.
     user = enhanceUserGroups(user, authConfig, ntlmConfig);
   }
 

--- a/server/middleware/ntlmAuth.js
+++ b/server/middleware/ntlmAuth.js
@@ -3,6 +3,7 @@ import configCache from '../configCache.js';
 import { enhanceUserGroups, mapExternalGroups } from '../utils/authorization.js';
 import { generateJwt } from '../utils/tokenService.js';
 import { validateAndPersistExternalUser } from '../utils/userManager.js';
+import { getLdapProviderByName, lookupLdapGroupsForUser } from './ldapAuth.js';
 import logger from '../utils/logger.js';
 
 /**
@@ -195,6 +196,92 @@ function processNtlmUser(req, ntlmConfig) {
     groups: user.groups,
     externalGroups: user.externalGroups
   });
+
+  return user;
+}
+
+/**
+ * Perform LDAP group lookup for an NTLM-authenticated user and merge groups.
+ * Only called during login/session start, not on every request.
+ * @param {Object} user - Processed NTLM user object
+ * @param {Object} ntlmConfig - NTLM configuration
+ * @returns {Promise<Object>} User with merged LDAP groups
+ */
+async function enhanceUserWithLdapGroups(user, ntlmConfig) {
+  if (!ntlmConfig.ldapGroupLookupProvider) {
+    return user;
+  }
+
+  try {
+    const ldapProvider = getLdapProviderByName(ntlmConfig.ldapGroupLookupProvider);
+
+    if (!ldapProvider) {
+      logger.error('NTLM Auth: ldapGroupLookupProvider references non-existent LDAP provider', {
+        component: 'NtlmAuth',
+        ldapGroupLookupProvider: ntlmConfig.ldapGroupLookupProvider
+      });
+      return user;
+    }
+
+    if (!ldapProvider.adminDn || !ldapProvider.adminPassword) {
+      logger.error(
+        'NTLM Auth: LDAP provider for group lookup is missing adminDn or adminPassword',
+        {
+          component: 'NtlmAuth',
+          ldapProvider: ntlmConfig.ldapGroupLookupProvider
+        }
+      );
+      return user;
+    }
+
+    logger.info('NTLM Auth: performing LDAP group lookup for user', {
+      component: 'NtlmAuth',
+      username: user.username,
+      ldapProvider: ntlmConfig.ldapGroupLookupProvider
+    });
+
+    const ldapGroups = await lookupLdapGroupsForUser(user.username, ldapProvider);
+
+    if (ldapGroups.length > 0) {
+      // Merge LDAP groups with any existing external groups (deduplicate)
+      const mergedExternalGroups = [...new Set([...user.externalGroups, ...ldapGroups])];
+      user.externalGroups = mergedExternalGroups;
+
+      // Re-map all external groups to internal groups
+      const mappedGroups = mapExternalGroups(mergedExternalGroups);
+
+      // Re-add default groups
+      if (ntlmConfig.defaultGroups && Array.isArray(ntlmConfig.defaultGroups)) {
+        ntlmConfig.defaultGroups.forEach(g => {
+          if (!mappedGroups.includes(g)) {
+            mappedGroups.push(g);
+          }
+        });
+      }
+
+      user.groups = mappedGroups;
+
+      logger.info('NTLM Auth: merged LDAP groups into user', {
+        component: 'NtlmAuth',
+        username: user.username,
+        ldapGroupCount: ldapGroups.length,
+        totalExternalGroups: mergedExternalGroups.length,
+        mappedGroups: mappedGroups.join(', ')
+      });
+    } else {
+      logger.info('NTLM Auth: LDAP group lookup returned no groups', {
+        component: 'NtlmAuth',
+        username: user.username
+      });
+    }
+  } catch (error) {
+    logger.error('NTLM Auth: LDAP group lookup failed, continuing with NTLM groups only', {
+      component: 'NtlmAuth',
+      username: user.username,
+      ldapGroupLookupProvider: ntlmConfig.ldapGroupLookupProvider,
+      error: error.message
+    });
+  }
 
   return user;
 }
@@ -408,6 +495,12 @@ export function ntlmAuthMiddleware(req, res, next) {
         const authConfig = platform.auth || {};
         user = enhanceUserGroups(user, authConfig, ntlmAuth);
 
+        // LDAP group lookup - only when generating JWT (session start)
+        if (ntlmAuth.ldapGroupLookupProvider && ntlmAuth.generateJwtToken) {
+          user = await enhanceUserWithLdapGroups(user, ntlmAuth);
+          user = enhanceUserGroups(user, authConfig, ntlmAuth);
+        }
+
         // Validate and persist NTLM user (similar to OIDC/Proxy)
         // User must be persisted - if this fails, authentication fails
         user = await validateAndPersistExternalUser(user, platform);
@@ -512,6 +605,12 @@ export async function processNtlmLogin(req, ntlmConfig) {
   const authConfig = platform.auth || {};
 
   user = enhanceUserGroups(user, authConfig, ntlmConfig);
+
+  // LDAP group lookup (only during login/session start)
+  if (ntlmConfig.ldapGroupLookupProvider) {
+    user = await enhanceUserWithLdapGroups(user, ntlmConfig);
+    user = enhanceUserGroups(user, authConfig, ntlmConfig);
+  }
 
   // Validate and persist NTLM user (similar to OIDC/Proxy)
   try {

--- a/server/middleware/ntlmAuth.js
+++ b/server/middleware/ntlmAuth.js
@@ -500,11 +500,7 @@ export function ntlmAuthMiddleware(req, res, next) {
         // and LDAP lookup would be too expensive.
         // Skip for login endpoints — processNtlmLogin() handles LDAP lookup
         // separately to avoid duplicate LDAP queries on the same request.
-        if (
-          ntlmAuth.ldapGroupLookupProvider &&
-          ntlmAuth.generateJwtToken &&
-          !isNtlmLoginEndpoint
-        ) {
+        if (ntlmAuth.ldapGroupLookupProvider && ntlmAuth.generateJwtToken && !isNtlmLoginEndpoint) {
           user = await enhanceUserWithLdapGroups(user, ntlmAuth);
           // Re-apply: enhanceUserWithLdapGroups replaces user.groups with freshly
           // mapped groups, so we need to re-add authenticated/provider default groups.

--- a/server/middleware/ntlmAuth.js
+++ b/server/middleware/ntlmAuth.js
@@ -279,7 +279,7 @@ async function enhanceUserWithLdapGroups(user, ntlmConfig) {
       component: 'NtlmAuth',
       username: user.username,
       ldapGroupLookupProvider: ntlmConfig.ldapGroupLookupProvider,
-      error: error.message
+      error
     });
   }
 
@@ -498,7 +498,13 @@ export function ntlmAuthMiddleware(req, res, next) {
         // LDAP group lookup - only when generating JWT (session start).
         // When generateJwtToken is false, NTLM re-authenticates every request
         // and LDAP lookup would be too expensive.
-        if (ntlmAuth.ldapGroupLookupProvider && ntlmAuth.generateJwtToken) {
+        // Skip for login endpoints — processNtlmLogin() handles LDAP lookup
+        // separately to avoid duplicate LDAP queries on the same request.
+        if (
+          ntlmAuth.ldapGroupLookupProvider &&
+          ntlmAuth.generateJwtToken &&
+          !isNtlmLoginEndpoint
+        ) {
           user = await enhanceUserWithLdapGroups(user, ntlmAuth);
           // Re-apply: enhanceUserWithLdapGroups replaces user.groups with freshly
           // mapped groups, so we need to re-add authenticated/provider default groups.

--- a/server/validators/platformConfigSchema.js
+++ b/server/validators/platformConfigSchema.js
@@ -150,6 +150,7 @@ export const platformConfigSchema = z
         debug: z.boolean().default(false),
         getUserInfo: z.boolean().default(true),
         getGroups: z.boolean().default(true),
+        ldapGroupLookupProvider: z.string().optional(),
         defaultGroups: z.array(z.string()).default([]),
         sessionTimeoutMinutes: z.number().min(1).default(480),
         generateJwtToken: z.boolean().default(true),


### PR DESCRIPTION
## Summary

This PR adds the ability for NTLM-authenticated users to retrieve their group memberships from an LDAP provider during login. This allows NTLM to handle identity verification while delegating group lookup to LDAP, which is useful when the domain controller doesn't reliably return group information via NTLM.

## Key Changes

- **LDAP group extraction utilities**: Added `extractGroupName()` and `extractGroupNames()` helper functions to handle various LDAP group response formats (strings, objects with cn/name/displayName, DN parsing)

- **LDAP group lookup function**: Implemented `lookupLdapGroupsForUser()` that performs admin-bind LDAP queries to retrieve a user's group memberships without requiring the user's password

- **LDAP provider lookup**: Added `getLdapProviderByName()` to retrieve LDAP provider configurations regardless of whether LDAP authentication is enabled (allows LDAP providers to be used for group lookup only)

- **NTLM group enhancement**: Implemented `enhanceUserWithLdapGroups()` to perform LDAP group lookup during NTLM login and merge results with existing groups

- **Integration points**: Updated NTLM middleware and `processNtlmLogin()` to call LDAP group lookup during session start (not on every request)

- **Configuration**: Added `ldapGroupLookupProvider` field to NTLM config to specify which LDAP provider to use for group lookup

- **UI support**: Updated platform form editor to show LDAP configuration when either LDAP or NTLM is enabled, and added dropdown to select LDAP group lookup provider

- **Documentation**: Added comprehensive guide explaining LDAP group lookup for NTLM, including configuration examples, requirements, and graceful fallback behavior

- **Validation**: Updated platform config schema to include the new `ldapGroupLookupProvider` field

## Implementation Details

- Group lookup only occurs during login/session start, not on every request, to minimize LDAP queries
- LDAP group lookup failures are handled gracefully—authentication succeeds but user gets NTLM groups + default groups
- LDAP groups are merged with NTLM groups and deduplicated before being mapped to internal groups
- The LDAP provider used for group lookup doesn't require LDAP authentication to be enabled globally
- Admin bind credentials are required on the LDAP provider for group lookup functionality

https://claude.ai/code/session_017vDUHbsoqY2ouLVDCESJ3h