### PR TITLE
fix: graceful handling of VPN/network loss for internal deployments

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, Suspense } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
 import './App.css';
 import { initializeBasePath, getBasePath } from './utils/runtimeBasePath';

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,18 +2,19 @@ import React, { useEffect, useState, Suspense } from 'react';
 import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
 import './App.css';
 import { initializeBasePath, getBasePath } from './utils/runtimeBasePath';
+import lazyWithRetry from './utils/lazyWithRetry';
 import Layout from './shared/components/Layout';
 import AppsList from './features/apps/pages/AppsList';
 import PromptsList from './features/prompts/pages/PromptsList';
 import AppRouterWrapper from './features/apps/components/AppRouterWrapper';
 // Lazy load workflow components
-const WorkflowsPage = React.lazy(() => import('./features/workflows/pages/WorkflowsPage'));
-const SetupWizard = React.lazy(() => import('./features/setup/SetupWizard'));
-const WorkflowExecutionPage = React.lazy(
+const WorkflowsPage = lazyWithRetry(() => import('./features/workflows/pages/WorkflowsPage'));
+const SetupWizard = lazyWithRetry(() => import('./features/setup/SetupWizard'));
+const WorkflowExecutionPage = lazyWithRetry(
   () => import('./features/workflows/pages/WorkflowExecutionPage')
 );
 // Lazy load canvas (pulls in react-quill/ajv — vendor-forms chunk, ~370KB)
-const AppCanvas = React.lazy(() => import('./features/canvas/pages/AppCanvas'));
+const AppCanvas = lazyWithRetry(() => import('./features/canvas/pages/AppCanvas'));
 import NotFound from './pages/error/NotFound';
 import Unauthorized from './pages/error/Unauthorized';
 import Forbidden from './pages/error/Forbidden';
@@ -21,71 +22,75 @@ import ServerError from './pages/error/ServerError';
 import UnifiedPage from './pages/UnifiedPage';
 import LoginPage from './pages/LoginPage';
 // Lazy load admin components
-const AdminHome = React.lazy(() => import('./features/admin/pages/AdminHome'));
-const AdminUsageReports = React.lazy(() => import('./features/admin/pages/AdminUsageReports'));
-const AdminSystemPage = React.lazy(() => import('./features/admin/pages/AdminSystemPage'));
-const AdminAppsPage = React.lazy(() => import('./features/admin/pages/AdminAppsPage'));
-const AdminAppEditPage = React.lazy(() => import('./features/admin/pages/AdminAppEditPage'));
-const AdminShortLinks = React.lazy(() => import('./features/admin/pages/AdminShortLinks'));
-const AdminShortLinkEditPage = React.lazy(
+const AdminHome = lazyWithRetry(() => import('./features/admin/pages/AdminHome'));
+const AdminUsageReports = lazyWithRetry(() => import('./features/admin/pages/AdminUsageReports'));
+const AdminSystemPage = lazyWithRetry(() => import('./features/admin/pages/AdminSystemPage'));
+const AdminAppsPage = lazyWithRetry(() => import('./features/admin/pages/AdminAppsPage'));
+const AdminAppEditPage = lazyWithRetry(() => import('./features/admin/pages/AdminAppEditPage'));
+const AdminShortLinks = lazyWithRetry(() => import('./features/admin/pages/AdminShortLinks'));
+const AdminShortLinkEditPage = lazyWithRetry(
   () => import('./features/admin/pages/AdminShortLinkEditPage')
 );
-const AdminModelEditPage = React.lazy(() => import('./features/admin/pages/AdminModelEditPage'));
-const AdminModelsPage = React.lazy(() => import('./features/admin/pages/AdminModelsPage'));
-const AdminProvidersPage = React.lazy(() => import('./features/admin/pages/AdminProvidersPage'));
-const AdminProviderEditPage = React.lazy(
+const AdminModelEditPage = lazyWithRetry(() => import('./features/admin/pages/AdminModelEditPage'));
+const AdminModelsPage = lazyWithRetry(() => import('./features/admin/pages/AdminModelsPage'));
+const AdminProvidersPage = lazyWithRetry(() => import('./features/admin/pages/AdminProvidersPage'));
+const AdminProviderEditPage = lazyWithRetry(
   () => import('./features/admin/pages/AdminProviderEditPage')
 );
-const AdminProviderCreatePage = React.lazy(
+const AdminProviderCreatePage = lazyWithRetry(
   () => import('./features/admin/pages/AdminProviderCreatePage')
 );
-const AdminPromptsPage = React.lazy(() => import('./features/admin/pages/AdminPromptsPage'));
-const AdminPromptEditPage = React.lazy(() => import('./features/admin/pages/AdminPromptEditPage'));
-const AdminToolsPage = React.lazy(() => import('./features/admin/pages/AdminToolsPage'));
-const AdminToolEditPage = React.lazy(() => import('./features/admin/pages/AdminToolEditPage'));
-const AdminSkillsPage = React.lazy(() => import('./features/admin/pages/AdminSkillsPage'));
-const AdminSkillEditPage = React.lazy(() => import('./features/admin/pages/AdminSkillEditPage'));
-const AdminWorkflowsPage = React.lazy(() => import('./features/admin/pages/AdminWorkflowsPage'));
-const AdminWorkflowEditPage = React.lazy(
+const AdminPromptsPage = lazyWithRetry(() => import('./features/admin/pages/AdminPromptsPage'));
+const AdminPromptEditPage = lazyWithRetry(
+  () => import('./features/admin/pages/AdminPromptEditPage')
+);
+const AdminToolsPage = lazyWithRetry(() => import('./features/admin/pages/AdminToolsPage'));
+const AdminToolEditPage = lazyWithRetry(() => import('./features/admin/pages/AdminToolEditPage'));
+const AdminSkillsPage = lazyWithRetry(() => import('./features/admin/pages/AdminSkillsPage'));
+const AdminSkillEditPage = lazyWithRetry(() => import('./features/admin/pages/AdminSkillEditPage'));
+const AdminWorkflowsPage = lazyWithRetry(() => import('./features/admin/pages/AdminWorkflowsPage'));
+const AdminWorkflowEditPage = lazyWithRetry(
   () => import('./features/admin/pages/AdminWorkflowEditPage')
 );
-const AdminWorkflowExecutionsPage = React.lazy(
+const AdminWorkflowExecutionsPage = lazyWithRetry(
   () => import('./features/admin/pages/AdminWorkflowExecutionsPage')
 );
-const AdminSourcesPage = React.lazy(() => import('./features/admin/pages/AdminSourcesPage'));
-const AdminSourceEditPage = React.lazy(() => import('./features/admin/pages/AdminSourceEditPage'));
-const AdminPagesPage = React.lazy(() => import('./features/admin/pages/AdminPagesPage'));
-const AdminPageEditPage = React.lazy(() => import('./features/admin/pages/AdminPageEditPage'));
-const AdminAuthPage = React.lazy(() => import('./features/admin/pages/AdminAuthPage'));
-const AdminOAuthPage = React.lazy(() => import('./features/admin/pages/AdminOAuthPage'));
-const AdminOAuthClientsPage = React.lazy(
+const AdminSourcesPage = lazyWithRetry(() => import('./features/admin/pages/AdminSourcesPage'));
+const AdminSourceEditPage = lazyWithRetry(
+  () => import('./features/admin/pages/AdminSourceEditPage')
+);
+const AdminPagesPage = lazyWithRetry(() => import('./features/admin/pages/AdminPagesPage'));
+const AdminPageEditPage = lazyWithRetry(() => import('./features/admin/pages/AdminPageEditPage'));
+const AdminAuthPage = lazyWithRetry(() => import('./features/admin/pages/AdminAuthPage'));
+const AdminOAuthPage = lazyWithRetry(() => import('./features/admin/pages/AdminOAuthPage'));
+const AdminOAuthClientsPage = lazyWithRetry(
   () => import('./features/admin/pages/AdminOAuthClientsPage')
 );
-const AdminOAuthClientEditPage = React.lazy(
+const AdminOAuthClientEditPage = lazyWithRetry(
   () => import('./features/admin/pages/AdminOAuthClientEditPage')
 );
-const AdminOAuthServerPage = React.lazy(
+const AdminOAuthServerPage = lazyWithRetry(
   () => import('./features/admin/pages/AdminOAuthServerPage')
 );
-const AdminUsersPage = React.lazy(() => import('./features/admin/pages/AdminUsersPage'));
-const AdminUserEditPage = React.lazy(() => import('./features/admin/pages/AdminUserEditPage'));
-const AdminUserViewPage = React.lazy(() => import('./features/admin/pages/AdminUserViewPage'));
-const AdminGroupsPage = React.lazy(() => import('./features/admin/pages/AdminGroupsPage'));
-const AdminGroupEditPage = React.lazy(() => import('./features/admin/pages/AdminGroupEditPage'));
-const AdminUICustomization = React.lazy(
+const AdminUsersPage = lazyWithRetry(() => import('./features/admin/pages/AdminUsersPage'));
+const AdminUserEditPage = lazyWithRetry(() => import('./features/admin/pages/AdminUserEditPage'));
+const AdminUserViewPage = lazyWithRetry(() => import('./features/admin/pages/AdminUserViewPage'));
+const AdminGroupsPage = lazyWithRetry(() => import('./features/admin/pages/AdminGroupsPage'));
+const AdminGroupEditPage = lazyWithRetry(() => import('./features/admin/pages/AdminGroupEditPage'));
+const AdminUICustomization = lazyWithRetry(
   () => import('./features/admin/pages/AdminUICustomization')
 );
-const AdminLoggingPage = React.lazy(() => import('./features/admin/pages/AdminLoggingPage'));
-const AdminFeaturesPage = React.lazy(() => import('./features/admin/pages/AdminFeaturesPage'));
-const AdminMarketplacePage = React.lazy(
+const AdminLoggingPage = lazyWithRetry(() => import('./features/admin/pages/AdminLoggingPage'));
+const AdminFeaturesPage = lazyWithRetry(() => import('./features/admin/pages/AdminFeaturesPage'));
+const AdminMarketplacePage = lazyWithRetry(
   () => import('./features/admin/pages/AdminMarketplacePage')
 );
-const AdminMarketplaceRegistriesPage = React.lazy(
+const AdminMarketplaceRegistriesPage = lazyWithRetry(
   () => import('./features/admin/pages/AdminMarketplaceRegistriesPage')
 );
-const IntegrationsPage = React.lazy(() => import('./features/settings/pages/IntegrationsPage'));
-const OcrPage = React.lazy(() => import('./features/tools/pages/OcrPage'));
-const JobListPage = React.lazy(() => import('./features/tools/pages/JobListPage'));
+const IntegrationsPage = lazyWithRetry(() => import('./features/settings/pages/IntegrationsPage'));
+const OcrPage = lazyWithRetry(() => import('./features/tools/pages/OcrPage'));
+const JobListPage = lazyWithRetry(() => import('./features/tools/pages/JobListPage'));
 import AppProviders from './features/apps/components/AppProviders';
 import { withSafeRoute } from './shared/components/SafeRoute';
 import useSessionManagement from './shared/hooks/useSessionManagement';
@@ -97,9 +102,9 @@ import { AuthProvider } from './shared/contexts/AuthContext';
 import MarkdownRenderer from './shared/components/MarkdownRenderer';
 import useFeatureFlags from './shared/hooks/useFeatureFlags';
 // Lazy load Teams features (only needed in Microsoft Teams environment)
-const TeamsWrapper = React.lazy(() => import('./features/teams/TeamsWrapper'));
-const TeamsAuthStart = React.lazy(() => import('./features/teams/TeamsAuthStart'));
-const TeamsAuthEnd = React.lazy(() => import('./features/teams/TeamsAuthEnd'));
+const TeamsWrapper = lazyWithRetry(() => import('./features/teams/TeamsWrapper'));
+const TeamsAuthStart = lazyWithRetry(() => import('./features/teams/TeamsAuthStart'));
+const TeamsAuthEnd = lazyWithRetry(() => import('./features/teams/TeamsAuthEnd'));
 
 // Create safe versions of components that need error boundaries
 const SafeAppsList = withSafeRoute(AppsList);

--- a/client/src/features/apps/components/AppProviders.jsx
+++ b/client/src/features/apps/components/AppProviders.jsx
@@ -3,6 +3,8 @@ import { UIConfigProvider } from '../../../shared/contexts/UIConfigContext';
 import { PlatformConfigProvider } from '../../../shared/contexts/PlatformConfigContext';
 import ErrorBoundaryFallback from '../../../shared/components/ErrorBoundary';
 import { initializeForceRefresh } from '../../../utils/forceRefresh';
+import { NetworkStatusProvider } from '../../../shared/hooks/useNetworkStatus';
+import OfflineOverlay from '../../../shared/components/OfflineOverlay';
 
 /**
  * Consolidates all application-level providers in a single component
@@ -28,9 +30,12 @@ function AppProviders({ children }) {
 
   return (
     <ErrorBoundaryFallback>
-      <PlatformConfigProvider>
-        <UIConfigProvider>{children}</UIConfigProvider>
-      </PlatformConfigProvider>
+      <NetworkStatusProvider>
+        <OfflineOverlay />
+        <PlatformConfigProvider>
+          <UIConfigProvider>{children}</UIConfigProvider>
+        </PlatformConfigProvider>
+      </NetworkStatusProvider>
     </ErrorBoundaryFallback>
   );
 }

--- a/client/src/shared/components/ErrorBoundary.jsx
+++ b/client/src/shared/components/ErrorBoundary.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Navigate } from 'react-router-dom';
 import Icon from './Icon';
 import { buildPath } from '../../utils/runtimeBasePath';
+import { isChunkLoadError } from '../../utils/lazyWithRetry';
 
 // Error boundary wrapper component
 class ErrorBoundaryComponent extends Component {
@@ -52,6 +53,7 @@ class ErrorBoundaryComponent extends Component {
 // Error fallback display component with reset capability and translation
 function ErrorFallback({ error, resetErrorBoundary }) {
   const { t } = useTranslation();
+  const chunkError = isChunkLoadError(error);
 
   if (error?.status === 401) {
     return <Navigate to="/unauthorized" replace />;
@@ -63,35 +65,57 @@ function ErrorFallback({ error, resetErrorBoundary }) {
     return <Navigate to="/server-error" replace />;
   }
 
+  const title = chunkError
+    ? t('error.chunkLoadTitle', 'Page failed to load')
+    : t('error.title', 'Something went wrong');
+
+  const description = chunkError
+    ? t(
+        'error.chunkLoadDescription',
+        'A required resource could not be loaded. This may be due to a network issue or an application update.'
+      )
+    : t(
+        'error.description',
+        'An unexpected error occurred in the application. The development team has been notified.'
+      );
+
   return (
     <div role="alert" className="p-4 m-4 bg-red-50 border border-red-200 rounded-md">
       <div className="flex items-center mb-4">
         <Icon name="exclamation-triangle" size="lg" className="text-red-500 mr-2" />
-        <h2 className="text-xl font-bold text-red-700">
-          {t('error.title', 'Something went wrong')}
-        </h2>
+        <h2 className="text-xl font-bold text-red-700">{title}</h2>
       </div>
 
       <div className="mb-4">
-        <p className="text-gray-700 mb-2">
-          {t(
-            'error.description',
-            'An unexpected error occurred in the application. The development team has been notified.'
-          )}
-        </p>
-        <p className="text-gray-500 text-sm mb-1">{t('error.errorMessage', 'Error details:')}</p>
-        <div className="bg-gray-100 p-2 rounded overflow-auto max-h-32 text-xs font-mono text-gray-800">
-          {error && error.toString()}
-        </div>
+        <p className="text-gray-700 mb-2">{description}</p>
+        {!chunkError && (
+          <>
+            <p className="text-gray-500 text-sm mb-1">
+              {t('error.errorMessage', 'Error details:')}
+            </p>
+            <div className="bg-gray-100 p-2 rounded overflow-auto max-h-32 text-xs font-mono text-gray-800">
+              {error && error.toString()}
+            </div>
+          </>
+        )}
       </div>
 
       <div className="flex flex-col space-y-2">
-        <button
-          onClick={resetErrorBoundary}
-          className="bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-4 rounded transition-colors"
-        >
-          {t('error.tryAgain', 'Try Again')}
-        </button>
+        {chunkError ? (
+          <button
+            onClick={() => window.location.reload()}
+            className="bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-4 rounded transition-colors"
+          >
+            {t('error.reloadPage', 'Reload Page')}
+          </button>
+        ) : (
+          <button
+            onClick={resetErrorBoundary}
+            className="bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-4 rounded transition-colors"
+          >
+            {t('error.tryAgain', 'Try Again')}
+          </button>
+        )}
 
         <button
           onClick={() => (window.location.href = buildPath('/'))}

--- a/client/src/shared/components/OfflineOverlay.jsx
+++ b/client/src/shared/components/OfflineOverlay.jsx
@@ -1,0 +1,98 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useNetworkStatus } from '../hooks/useNetworkStatus';
+
+function WifiOffIcon({ className }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={1.5}
+    >
+      {/* Wifi arcs */}
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M8.288 15.038a5.25 5.25 0 017.424 0M5.106 11.856c3.807-3.808 9.98-3.808 13.788 0M1.924 8.674c5.565-5.565 14.587-5.565 20.152 0"
+      />
+      {/* Center dot */}
+      <circle cx="12" cy="18" r="1.5" fill="currentColor" stroke="none" />
+      {/* Slash line */}
+      <path strokeLinecap="round" strokeLinejoin="round" d="M3 3l18 18" strokeWidth={2} />
+    </svg>
+  );
+}
+
+export default function OfflineOverlay() {
+  const { t } = useTranslation();
+  const { isOnline, retryCount } = useNetworkStatus();
+  const [showReconnected, setShowReconnected] = useState(false);
+  const [wasOffline, setWasOffline] = useState(false);
+
+  useEffect(() => {
+    if (!isOnline) {
+      setWasOffline(true);
+    } else if (wasOffline) {
+      // Just reconnected — show brief toast then reload to get fresh assets
+      setShowReconnected(true);
+      const timer = setTimeout(() => {
+        setShowReconnected(false);
+        setWasOffline(false);
+        window.location.reload();
+      }, 1500);
+      return () => clearTimeout(timer);
+    }
+  }, [isOnline, wasOffline]);
+
+  // Reconnected toast
+  if (showReconnected) {
+    return (
+      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 dark:bg-black/50">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow-xl p-6 text-center">
+          <div className="text-green-500 text-4xl mb-2">&#10003;</div>
+          <p className="text-gray-800 dark:text-gray-200 font-medium">
+            {t('network.reconnected', 'Connection restored')}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (isOnline) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 dark:bg-black/60 backdrop-blur-sm">
+      <div className="bg-white dark:bg-gray-800 rounded-xl shadow-2xl p-8 max-w-md mx-4 text-center">
+        <WifiOffIcon className="w-16 h-16 mx-auto text-red-500 mb-4" />
+
+        <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100 mb-2">
+          {t('network.offline.title', 'Server Unreachable')}
+        </h2>
+
+        <p className="text-gray-600 dark:text-gray-400 mb-6">
+          {t(
+            'network.offline.description',
+            'The connection to the server was lost. This usually happens when the VPN disconnects. Trying to reconnect...'
+          )}
+        </p>
+
+        <div className="flex items-center justify-center mb-6 text-sm text-gray-500 dark:text-gray-400">
+          <div className="animate-spin rounded-full h-4 w-4 border-2 border-indigo-600 border-t-transparent mr-2" />
+          {t('network.offline.reconnecting', 'Reconnecting... (attempt {{count}})', {
+            count: retryCount
+          })}
+        </div>
+
+        <button
+          onClick={() => window.location.reload()}
+          className="w-full bg-indigo-600 hover:bg-indigo-700 text-white py-2 px-4 rounded transition-colors"
+        >
+          {t('network.offline.reloadPage', 'Reload Page')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/shared/hooks/useNetworkStatus.jsx
+++ b/client/src/shared/hooks/useNetworkStatus.jsx
@@ -11,7 +11,6 @@ import { buildApiUrl } from '../../utils/runtimeBasePath';
 
 const NetworkStatusContext = createContext({ isOnline: true, isChecking: false, retryCount: 0 });
 
-const HEALTH_URL = buildApiUrl('/health');
 const HEALTH_TIMEOUT_MS = 5000;
 const INITIAL_POLL_INTERVAL = 5000;
 const MAX_POLL_INTERVAL = 30000;
@@ -20,7 +19,7 @@ async function checkHealth() {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
   try {
-    const res = await fetch(HEALTH_URL, {
+    const res = await fetch(buildApiUrl('/health'), {
       method: 'GET',
       cache: 'no-store',
       signal: controller.signal

--- a/client/src/shared/hooks/useNetworkStatus.jsx
+++ b/client/src/shared/hooks/useNetworkStatus.jsx
@@ -1,4 +1,12 @@
-import { createContext, useContext, useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  useRef,
+  useCallback,
+  useMemo
+} from 'react';
 import { buildApiUrl } from '../../utils/runtimeBasePath';
 
 const NetworkStatusContext = createContext({ isOnline: true, isChecking: false, retryCount: 0 });
@@ -122,9 +130,7 @@ export function NetworkStatusProvider({ children }) {
   );
 
   return (
-    <NetworkStatusContext.Provider value={contextValue}>
-      {children}
-    </NetworkStatusContext.Provider>
+    <NetworkStatusContext.Provider value={contextValue}>{children}</NetworkStatusContext.Provider>
   );
 }
 

--- a/client/src/shared/hooks/useNetworkStatus.jsx
+++ b/client/src/shared/hooks/useNetworkStatus.jsx
@@ -1,0 +1,125 @@
+import { createContext, useContext, useState, useEffect, useRef, useCallback } from 'react';
+import { buildApiUrl } from '../../utils/runtimeBasePath';
+
+const NetworkStatusContext = createContext({ isOnline: true, isChecking: false, retryCount: 0 });
+
+const HEALTH_URL = buildApiUrl('/health');
+const HEALTH_TIMEOUT_MS = 5000;
+const INITIAL_POLL_INTERVAL = 5000;
+const MAX_POLL_INTERVAL = 30000;
+
+async function checkHealth() {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
+  try {
+    const res = await fetch(HEALTH_URL, {
+      method: 'GET',
+      cache: 'no-store',
+      signal: controller.signal
+    });
+    return res.ok;
+  } catch {
+    return false;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function NetworkStatusProvider({ children }) {
+  const [isOnline, setIsOnline] = useState(true);
+  const [isChecking, setIsChecking] = useState(false);
+  const [retryCount, setRetryCount] = useState(0);
+  const pollRef = useRef(null);
+  const pollIntervalRef = useRef(INITIAL_POLL_INTERVAL);
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current) {
+      clearTimeout(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const markOnline = useCallback(() => {
+    stopPolling();
+    setIsOnline(true);
+    setRetryCount(0);
+    pollIntervalRef.current = INITIAL_POLL_INTERVAL;
+  }, [stopPolling]);
+
+  const startPolling = useCallback(() => {
+    stopPolling();
+    const poll = async () => {
+      setIsChecking(true);
+      const healthy = await checkHealth();
+      setIsChecking(false);
+      if (healthy) {
+        markOnline();
+      } else {
+        setRetryCount(prev => prev + 1);
+        // Exponential backoff capped at MAX_POLL_INTERVAL
+        pollIntervalRef.current = Math.min(pollIntervalRef.current * 1.5, MAX_POLL_INTERVAL);
+        pollRef.current = setTimeout(poll, pollIntervalRef.current);
+      }
+    };
+    poll();
+  }, [stopPolling, markOnline]);
+
+  const markOffline = useCallback(() => {
+    setIsOnline(prev => {
+      if (prev) {
+        // Transition from online → offline: start recovery polling
+        startPolling();
+      }
+      return false;
+    });
+  }, [startPolling]);
+
+  // Verify connectivity on mount and after visibility change (laptop wake)
+  const verifyConnectivity = useCallback(async () => {
+    const healthy = await checkHealth();
+    if (healthy) {
+      markOnline();
+    } else {
+      markOffline();
+    }
+  }, [markOnline, markOffline]);
+
+  useEffect(() => {
+    // Browser online/offline events
+    const handleOnline = () => verifyConnectivity();
+    const handleOffline = () => markOffline();
+
+    // Visibility change — user reopened laptop, VPN may be gone or back
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        verifyConnectivity();
+      }
+    };
+
+    // Custom event dispatched by lazyWithRetry when chunk loads fail
+    const handleServerUnreachable = () => markOffline();
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('serverUnreachable', handleServerUnreachable);
+
+    return () => {
+      stopPolling();
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('serverUnreachable', handleServerUnreachable);
+    };
+  }, [verifyConnectivity, markOffline, stopPolling]);
+
+  return (
+    <NetworkStatusContext.Provider value={{ isOnline, isChecking, retryCount }}>
+      {children}
+    </NetworkStatusContext.Provider>
+  );
+}
+
+export function useNetworkStatus() {
+  return useContext(NetworkStatusContext);
+}

--- a/client/src/shared/hooks/useNetworkStatus.jsx
+++ b/client/src/shared/hooks/useNetworkStatus.jsx
@@ -1,4 +1,4 @@
-import { createContext, useContext, useState, useEffect, useRef, useCallback } from 'react';
+import { createContext, useContext, useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { buildApiUrl } from '../../utils/runtimeBasePath';
 
 const NetworkStatusContext = createContext({ isOnline: true, isChecking: false, retryCount: 0 });
@@ -31,6 +31,7 @@ export function NetworkStatusProvider({ children }) {
   const [retryCount, setRetryCount] = useState(0);
   const pollRef = useRef(null);
   const pollIntervalRef = useRef(INITIAL_POLL_INTERVAL);
+  const isOnlineRef = useRef(true);
 
   const stopPolling = useCallback(() => {
     if (pollRef.current) {
@@ -41,6 +42,7 @@ export function NetworkStatusProvider({ children }) {
 
   const markOnline = useCallback(() => {
     stopPolling();
+    isOnlineRef.current = true;
     setIsOnline(true);
     setRetryCount(0);
     pollIntervalRef.current = INITIAL_POLL_INTERVAL;
@@ -65,13 +67,11 @@ export function NetworkStatusProvider({ children }) {
   }, [stopPolling, markOnline]);
 
   const markOffline = useCallback(() => {
-    setIsOnline(prev => {
-      if (prev) {
-        // Transition from online → offline: start recovery polling
-        startPolling();
-      }
-      return false;
-    });
+    if (isOnlineRef.current) {
+      isOnlineRef.current = false;
+      setIsOnline(false);
+      startPolling();
+    }
   }, [startPolling]);
 
   // Verify connectivity on mount and after visibility change (laptop wake)
@@ -104,6 +104,9 @@ export function NetworkStatusProvider({ children }) {
     document.addEventListener('visibilitychange', handleVisibilityChange);
     window.addEventListener('serverUnreachable', handleServerUnreachable);
 
+    // Verify on mount — if app starts while server/VPN is already unreachable
+    verifyConnectivity();
+
     return () => {
       stopPolling();
       window.removeEventListener('online', handleOnline);
@@ -113,8 +116,13 @@ export function NetworkStatusProvider({ children }) {
     };
   }, [verifyConnectivity, markOffline, stopPolling]);
 
+  const contextValue = useMemo(
+    () => ({ isOnline, isChecking, retryCount }),
+    [isOnline, isChecking, retryCount]
+  );
+
   return (
-    <NetworkStatusContext.Provider value={{ isOnline, isChecking, retryCount }}>
+    <NetworkStatusContext.Provider value={contextValue}>
       {children}
     </NetworkStatusContext.Provider>
   );

--- a/client/src/utils/lazyWithRetry.js
+++ b/client/src/utils/lazyWithRetry.js
@@ -1,0 +1,54 @@
+import { lazy } from 'react';
+
+/**
+ * Checks whether an error is a chunk/module load failure
+ * (network down, deployment changed hashes, etc.)
+ */
+export function isChunkLoadError(error) {
+  if (!error) return false;
+  const msg = error.message || '';
+  return (
+    msg.includes('Failed to fetch dynamically imported module') ||
+    msg.includes('Loading chunk') ||
+    msg.includes('Loading CSS chunk') ||
+    error.name === 'ChunkLoadError'
+  );
+}
+
+const RELOAD_GUARD_KEY = 'chunk-reload-attempted';
+
+/**
+ * Drop-in replacement for React.lazy that retries failed dynamic imports
+ * with exponential backoff before giving up.
+ *
+ * On final failure it attempts a single page reload (to pick up new asset
+ * hashes after a deployment). A sessionStorage guard prevents infinite loops.
+ */
+export default function lazyWithRetry(importFn, retries = 3, baseDelay = 1000) {
+  return lazy(() => retryImport(importFn, retries, baseDelay));
+}
+
+async function retryImport(importFn, retries, baseDelay) {
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      return await importFn();
+    } catch (error) {
+      if (!isChunkLoadError(error) || attempt === retries) {
+        // Not a chunk error, or we exhausted retries — try a one-time reload
+        if (isChunkLoadError(error) && !sessionStorage.getItem(RELOAD_GUARD_KEY)) {
+          sessionStorage.setItem(RELOAD_GUARD_KEY, '1');
+          window.dispatchEvent(new CustomEvent('serverUnreachable'));
+          window.location.reload();
+          // Return a never-resolving promise so React doesn't render stale state
+          return new Promise(() => {});
+        }
+        // Clear the guard so future navigations can try again
+        sessionStorage.removeItem(RELOAD_GUARD_KEY);
+        throw error;
+      }
+
+      const delay = baseDelay * Math.pow(2, attempt);
+      await new Promise(resolve => setTimeout(resolve, delay));
+    }
+  }
+}

--- a/client/src/utils/lazyWithRetry.js
+++ b/client/src/utils/lazyWithRetry.js
@@ -31,7 +31,9 @@ export default function lazyWithRetry(importFn, retries = 3, baseDelay = 1000) {
 async function retryImport(importFn, retries, baseDelay) {
   for (let attempt = 0; attempt <= retries; attempt++) {
     try {
-      return await importFn();
+      const module = await importFn();
+      sessionStorage.removeItem(RELOAD_GUARD_KEY);
+      return module;
     } catch (error) {
       if (!isChunkLoadError(error) || attempt === retries) {
         // Not a chunk error, or we exhausted retries — try a one-time reload

--- a/server/routes/generalRoutes.js
+++ b/server/routes/generalRoutes.js
@@ -1,7 +1,7 @@
 import configCache from '../configCache.js';
 import { enhanceUserWithPermissions, isAnonymousAccessAllowed } from '../utils/authorization.js';
 import { authRequired, appAccessRequired } from '../middleware/authRequired.js';
-import { buildServerPath } from '../utils/basePath.js';
+import { buildServerPath, getRelativeRequestPath } from '../utils/basePath.js';
 import {
   sendInternalError,
   sendFailedOperationError,
@@ -318,7 +318,7 @@ export default function registerGeneralRoutes(app, { getLocalizedError }) {
         basePathConfig: basePathInfo,
         requestPath: req.path,
         requestUrl: req.url,
-        relativePath: req.path.replace(basePath, '') || '/',
+        relativePath: getRelativeRequestPath(req.path),
         environment: process.env.NODE_ENV || 'development'
       });
     } catch (error) {

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -325,7 +325,21 @@
     "streamingError": "Ein Fehler ist beim Streaming aufgetreten",
     "failedToGenerateResponse": "Fehler beim Generieren der Antwort. Bitte versuchen Sie es erneut oder wählen Sie ein anderes Modell.",
     "sessionExpired": "Ihre Sitzung ist abgelaufen. Bitte melden Sie sich erneut an, um fortzufahren.",
-    "sessionExpiredReconnecting": "Sitzung abgelaufen. Verbindung zum Authentifizierungsanbieter wird wiederhergestellt..."
+    "sessionExpiredReconnecting": "Sitzung abgelaufen. Verbindung zum Authentifizierungsanbieter wird wiederhergestellt...",
+    "chunkLoadTitle": "Seite konnte nicht geladen werden",
+    "chunkLoadDescription": "Eine benötigte Ressource konnte nicht geladen werden. Dies kann an einem Netzwerkproblem oder einem Anwendungsupdate liegen.",
+    "reloadPage": "Seite neu laden",
+    "tryAgain": "Erneut versuchen",
+    "backToHome": "Zurück zur Startseite"
+  },
+  "network": {
+    "offline": {
+      "title": "Server nicht erreichbar",
+      "description": "Die Verbindung zum Server wurde unterbrochen. Dies passiert normalerweise, wenn die VPN-Verbindung getrennt wird. Verbindung wird wiederhergestellt...",
+      "reconnecting": "Verbindung wird wiederhergestellt... (Versuch {{count}})",
+      "reloadPage": "Seite neu laden"
+    },
+    "reconnected": "Verbindung wiederhergestellt"
   },
   "message": {
     "generationCancelled": " [Generierung abgebrochen]"

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1259,7 +1259,21 @@
     "streamingError": "An error occurred during streaming",
     "failedToGenerateResponse": "Failed to generate response. Please try again or select a different model.",
     "sessionExpired": "Your session has expired. Please log in again to continue.",
-    "sessionExpiredReconnecting": "Session expired. Reconnecting to authentication provider..."
+    "sessionExpiredReconnecting": "Session expired. Reconnecting to authentication provider...",
+    "chunkLoadTitle": "Page failed to load",
+    "chunkLoadDescription": "A required resource could not be loaded. This may be due to a network issue or an application update.",
+    "reloadPage": "Reload Page",
+    "tryAgain": "Try Again",
+    "backToHome": "Back to Home"
+  },
+  "network": {
+    "offline": {
+      "title": "Server Unreachable",
+      "description": "The connection to the server was lost. This usually happens when the VPN disconnects. Trying to reconnect...",
+      "reconnecting": "Reconnecting... (attempt {{count}})",
+      "reloadPage": "Reload Page"
+    },
+    "reconnected": "Connection restored"
   },
   "message": {
     "generationCancelled": " [Generation cancelled]"


### PR DESCRIPTION
## Summary

- **`lazyWithRetry`**: Replaces all `React.lazy()` calls with a retry wrapper that retries failed dynamic imports 3 times with exponential backoff (1s, 2s, 4s), then attempts a single page reload as a last resort (with sessionStorage guard to prevent infinite loops)
- **Network status detection**: New `useNetworkStatus` hook monitors browser online/offline events, `visibilitychange` (laptop wake from sleep), and polls `/api/health` to detect when the server becomes unreachable — with exponential backoff polling for reconnection
- **Offline overlay**: Shows a clear "Server Unreachable" overlay explaining VPN likely disconnected, with animated reconnection counter and manual "Reload Page" button — auto-recovers when connection is restored
- **Enhanced error boundary**: Detects chunk load errors specifically and shows "Page failed to load" with a "Reload Page" button instead of the broken "Try Again" that just re-triggers the same failed import

## Test plan

- [ ] Open app normally — verify lazy routes (admin pages, workflows, canvas) still load correctly
- [ ] Open DevTools > Network > set Offline mode → navigate to a lazy-loaded route → verify the offline overlay appears instead of the cryptic error
- [ ] Re-enable network → overlay should auto-dismiss and page should reload
- [ ] Throttle network to "Slow 3G" → navigate to a lazy route → verify retries appear in console, then page loads
- [ ] Verify German translations show correctly when browser language is set to German
- [ ] Production build succeeds (`npm run prod:build`)

https://claude.ai/code/session_01D3RT5bACCJRLQ1mmB8vxQZ