### PR TITLE
feat: iFinder/iAssistant JWT signing via iHub OIDC keypair

### DIFF
--- a/client/src/features/admin/components/IFinderConfig.jsx
+++ b/client/src/features/admin/components/IFinderConfig.jsx
@@ -17,6 +17,7 @@ function IFinderConfig() {
   const [iFinderConfig, setIFinderConfig] = useState({
     enabled: false,
     baseUrl: '',
+    useOidcKeyPair: false,
     privateKey: '',
     algorithm: 'RS256',
     issuer: 'ihub-apps',
@@ -26,10 +27,10 @@ function IFinderConfig() {
     jwtSubjectField: 'email'
   });
   const [iAssistantConfig, setIAssistantConfig] = useState({
-    baseUrl: '',
     defaultProfileId: '',
     timeout: 60000
   });
+  const [oauthIssuer, setOauthIssuer] = useState('');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [testing, setTesting] = useState({ iFinder: false, iAssistant: false });
@@ -45,6 +46,7 @@ function IFinderConfig() {
         const iFinder = response.data.iFinder || {
           enabled: false,
           baseUrl: '',
+          useOidcKeyPair: false,
           privateKey: '',
           algorithm: 'RS256',
           issuer: 'ihub-apps',
@@ -54,12 +56,12 @@ function IFinderConfig() {
           jwtSubjectField: 'email'
         };
         const iAssistant = response.data.iAssistant || {
-          baseUrl: '',
           defaultProfileId: '',
           timeout: 60000
         };
         setIFinderConfig(iFinder);
         setIAssistantConfig(iAssistant);
+        setOauthIssuer(response.data.oauth?.issuer || '');
         setMessage('');
       } catch (error) {
         setMessage({
@@ -82,6 +84,13 @@ function IFinderConfig() {
     }));
   };
 
+  const handleToggleOidcKeyPair = e => {
+    setIFinderConfig(prev => ({
+      ...prev,
+      useOidcKeyPair: e.target.checked
+    }));
+  };
+
   const handleIFinderChange = (field, value) => {
     setIFinderConfig(prev => ({
       ...prev,
@@ -97,6 +106,17 @@ function IFinderConfig() {
   };
 
   const handleSave = async () => {
+    if (iFinderConfig.useOidcKeyPair && (!oauthIssuer || !oauthIssuer.startsWith('http'))) {
+      setMessage({
+        type: 'error',
+        text: t(
+          'admin.iFinder.oidcKeyPairNeedsIssuer',
+          'OIDC Keypair mode requires an OAuth Issuer URL. Configure it in Admin > Authentication > OAuth Server.'
+        )
+      });
+      return;
+    }
+
     setSaving(true);
     setMessage('');
 
@@ -290,94 +310,213 @@ function IFinderConfig() {
                     placeholder="https://dama.dev.intrafind.io"
                   />
                   <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    {t('admin.iFinder.baseUrlHelp', 'Your iFinder instance URL')}
+                    {t('admin.iFinder.baseUrlHelp', 'Your iFinder / iAssistant instance URL')}
                   </p>
                 </div>
 
+                {/* JWT Signing Mode */}
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    {t('admin.iFinder.privateKey', 'Private Key (PEM)')} *
-                  </label>
-                  <textarea
-                    value={iFinderConfig.privateKey}
-                    onChange={e => handleIFinderChange('privateKey', e.target.value)}
-                    rows={4}
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-mono text-sm"
-                    placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;...&#10;-----END RSA PRIVATE KEY-----"
-                  />
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                  <div className="flex items-start">
+                    <input
+                      type="checkbox"
+                      id="iFinderUseOidcKeyPair"
+                      checked={iFinderConfig.useOidcKeyPair}
+                      onChange={handleToggleOidcKeyPair}
+                      className="h-4 w-4 mt-0.5 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+                    />
+                    <label
+                      htmlFor="iFinderUseOidcKeyPair"
+                      className="ml-2 block text-sm text-gray-900 dark:text-gray-100"
+                    >
+                      {t('admin.iFinder.useOidcKeyPair', 'Use iHub OIDC Keypair for JWT signing')}
+                    </label>
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400 ml-6">
                     {t(
-                      'admin.iFinder.privateKeyHelp',
-                      'RSA/EC private key in PEM format for signing JWT tokens'
+                      'admin.iFinder.useOidcKeyPairHelp',
+                      'When enabled, tokens are signed with the same RSA key as the iHub OIDC server. iFinder can then validate tokens via JWKS Discovery (/.well-known/jwks.json) — no manual key distribution needed.'
                     )}
                   </p>
                 </div>
 
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      {t('admin.iFinder.algorithm', 'JWT Algorithm')}
-                    </label>
-                    <select
-                      value={iFinderConfig.algorithm}
-                      onChange={e => handleIFinderChange('algorithm', e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
-                    >
-                      {ALGORITHM_OPTIONS.map(alg => (
-                        <option key={alg} value={alg}>
-                          {alg}
-                        </option>
-                      ))}
-                    </select>
+                {/* OIDC Keypair info box */}
+                {iFinderConfig.useOidcKeyPair && (
+                  <div
+                    className={`border rounded-md p-4 ${
+                      oauthIssuer && oauthIssuer.startsWith('http')
+                        ? 'bg-green-50 dark:bg-green-900/20 border-green-200 dark:border-green-800'
+                        : 'bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800'
+                    }`}
+                  >
+                    <div className="flex">
+                      <Icon
+                        name={oauthIssuer && oauthIssuer.startsWith('http') ? 'check' : 'warning'}
+                        size="md"
+                        className={`mt-0.5 mr-3 flex-shrink-0 ${
+                          oauthIssuer && oauthIssuer.startsWith('http')
+                            ? 'text-green-500'
+                            : 'text-amber-500'
+                        }`}
+                      />
+                      <div className="text-sm">
+                        {oauthIssuer && oauthIssuer.startsWith('http') ? (
+                          <>
+                            <p className="font-medium text-green-800 dark:text-green-200">
+                              {t('admin.iFinder.oidcKeyPairReady', 'OIDC Keypair ready')}
+                            </p>
+                            <p className="mt-1 text-green-700 dark:text-green-300">
+                              {t('admin.iFinder.oidcKeyPairReadyHelp', 'Configure iFinder with:')}
+                            </p>
+                            <pre className="mt-2 text-xs bg-green-100 dark:bg-green-900/40 rounded p-2 font-mono text-green-800 dark:text-green-200 whitespace-pre-wrap">
+                              {`spring.security.oauth2.resourceserver.jwt.issuer-uri: ${oauthIssuer}\nintrafind.security.auth.enable-oauth2-resource-server: true`}
+                            </pre>
+                          </>
+                        ) : (
+                          <>
+                            <p className="font-medium text-amber-800 dark:text-amber-200">
+                              {t(
+                                'admin.iFinder.oidcKeyPairMissingIssuer',
+                                'OAuth Issuer URL required'
+                              )}
+                            </p>
+                            <p className="mt-1 text-amber-700 dark:text-amber-300">
+                              {t(
+                                'admin.iFinder.oidcKeyPairMissingIssuerHelp',
+                                'Set the OAuth Issuer URL in Admin > Authentication > OAuth Server before saving.'
+                              )}
+                            </p>
+                          </>
+                        )}
+                      </div>
+                    </div>
                   </div>
+                )}
 
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      {t('admin.iFinder.tokenExpiration', 'Token Expiration (seconds)')}
-                    </label>
-                    <input
-                      type="number"
-                      value={iFinderConfig.tokenExpirationSeconds}
-                      onChange={e =>
-                        handleIFinderChange(
-                          'tokenExpirationSeconds',
-                          parseInt(e.target.value, 10) || 3600
-                        )
-                      }
-                      min={60}
-                      max={86400}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
-                    />
-                  </div>
-                </div>
+                {/* Private key and algorithm: only shown when NOT using OIDC keypair */}
+                {!iFinderConfig.useOidcKeyPair && (
+                  <>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                        {t('admin.iFinder.privateKey', 'Private Key (PEM)')} *
+                      </label>
+                      <textarea
+                        value={iFinderConfig.privateKey}
+                        onChange={e => handleIFinderChange('privateKey', e.target.value)}
+                        rows={4}
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-mono text-sm"
+                        placeholder="-----BEGIN RSA PRIVATE KEY-----&#10;...&#10;-----END RSA PRIVATE KEY-----"
+                      />
+                      <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                        {t(
+                          'admin.iFinder.privateKeyHelp',
+                          'RSA/EC private key in PEM format for signing JWT tokens'
+                        )}
+                      </p>
+                    </div>
 
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      {t('admin.iFinder.issuer', 'JWT Issuer')}
-                    </label>
-                    <input
-                      type="text"
-                      value={iFinderConfig.issuer}
-                      onChange={e => handleIFinderChange('issuer', e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
-                      placeholder="ihub-apps"
-                    />
-                  </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          {t('admin.iFinder.algorithm', 'JWT Algorithm')}
+                        </label>
+                        <select
+                          value={iFinderConfig.algorithm}
+                          onChange={e => handleIFinderChange('algorithm', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                        >
+                          {ALGORITHM_OPTIONS.map(alg => (
+                            <option key={alg} value={alg}>
+                              {alg}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
 
-                  <div>
-                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      {t('admin.iFinder.audience', 'JWT Audience')}
-                    </label>
-                    <input
-                      type="text"
-                      value={iFinderConfig.audience}
-                      onChange={e => handleIFinderChange('audience', e.target.value)}
-                      className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
-                      placeholder="ifinder-api"
-                    />
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          {t('admin.iFinder.tokenExpiration', 'Token Expiration (seconds)')}
+                        </label>
+                        <input
+                          type="number"
+                          value={iFinderConfig.tokenExpirationSeconds}
+                          onChange={e =>
+                            handleIFinderChange(
+                              'tokenExpirationSeconds',
+                              parseInt(e.target.value, 10) || 3600
+                            )
+                          }
+                          min={60}
+                          max={86400}
+                          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                        />
+                      </div>
+                    </div>
+
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          {t('admin.iFinder.issuer', 'JWT Issuer')}
+                        </label>
+                        <input
+                          type="text"
+                          value={iFinderConfig.issuer}
+                          onChange={e => handleIFinderChange('issuer', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                          placeholder="ihub-apps"
+                        />
+                      </div>
+
+                      <div>
+                        <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                          {t('admin.iFinder.audience', 'JWT Audience')}
+                        </label>
+                        <input
+                          type="text"
+                          value={iFinderConfig.audience}
+                          onChange={e => handleIFinderChange('audience', e.target.value)}
+                          className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                          placeholder="ifinder-api"
+                        />
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                {/* Token expiration also shown when using OIDC keypair */}
+                {iFinderConfig.useOidcKeyPair && (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                        {t('admin.iFinder.audience', 'JWT Audience')}
+                      </label>
+                      <input
+                        type="text"
+                        value={iFinderConfig.audience}
+                        onChange={e => handleIFinderChange('audience', e.target.value)}
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                        placeholder="ifinder-api"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                        {t('admin.iFinder.tokenExpiration', 'Token Expiration (seconds)')}
+                      </label>
+                      <input
+                        type="number"
+                        value={iFinderConfig.tokenExpirationSeconds}
+                        onChange={e =>
+                          handleIFinderChange(
+                            'tokenExpirationSeconds',
+                            parseInt(e.target.value, 10) || 3600
+                          )
+                        }
+                        min={60}
+                        max={86400}
+                        className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                      />
+                    </div>
                   </div>
-                </div>
+                )}
 
                 <div>
                   <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
@@ -453,25 +592,6 @@ function IFinderConfig() {
                 {t('admin.iFinder.iAssistantSection', 'iAssistant Settings')}
               </h4>
               <div className="space-y-4 mb-6">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    {t('admin.iFinder.iAssistantBaseUrl', 'iAssistant Base URL')}
-                  </label>
-                  <input
-                    type="url"
-                    value={iAssistantConfig.baseUrl}
-                    onChange={e => handleIAssistantChange('baseUrl', e.target.value)}
-                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
-                    placeholder="https://dama.dev.intrafind.io"
-                  />
-                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                    {t(
-                      'admin.iFinder.iAssistantBaseUrlHelp',
-                      'Override if iAssistant runs on a different URL than iFinder'
-                    )}
-                  </p>
-                </div>
-
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   <div>
                     <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">

--- a/server/defaults/config/platform.json
+++ b/server/defaults/config/platform.json
@@ -131,6 +131,7 @@
   "iFinder": {
     "enabled": false,
     "baseUrl": "",
+    "useOidcKeyPair": false,
     "privateKey": "",
     "algorithm": "RS256",
     "issuer": "ihub-apps",
@@ -140,7 +141,6 @@
     "jwtSubjectField": "email"
   },
   "iAssistant": {
-    "baseUrl": "",
     "defaultProfileId": "",
     "timeout": 60000
   }

--- a/server/migrations/V027__add_ifinder_oidc_keypair.js
+++ b/server/migrations/V027__add_ifinder_oidc_keypair.js
@@ -1,0 +1,22 @@
+export const version = '027';
+export const description = 'add_ifinder_oidc_keypair';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  // Add useOidcKeyPair flag (default false - backward compatible)
+  ctx.setDefault(platform, 'iFinder.useOidcKeyPair', false);
+
+  // Remove iAssistant.baseUrl - iAssistant always runs on the same host as iFinder
+  if (platform.iAssistant && 'baseUrl' in platform.iAssistant) {
+    ctx.removeKey(platform, 'iAssistant.baseUrl');
+    ctx.log('Removed iAssistant.baseUrl (iAssistant always uses iFinder.baseUrl)');
+  }
+
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Added iFinder.useOidcKeyPair default (false)');
+}

--- a/server/services/integrations/iAssistantService.js
+++ b/server/services/integrations/iAssistantService.js
@@ -30,11 +30,7 @@ class IAssistantService {
       const iAssistantConfig = this.platform.iAssistant || {};
 
       this.config = {
-        baseUrl:
-          config.IASSISTANT_API_URL ||
-          process.env.IASSISTANT_API_URL ||
-          iAssistantConfig.baseUrl ||
-          this.platform.iFinder?.baseUrl,
+        baseUrl: this.platform.iFinder?.baseUrl,
         defaultProfileId:
           iAssistantConfig.defaultProfileId || process.env.IASSISTANT_PROFILE_ID || '',
         defaultFilter: iAssistantConfig.defaultFilter || [],

--- a/server/utils/iFinderJwt.js
+++ b/server/utils/iFinderJwt.js
@@ -151,8 +151,10 @@ export function generateIFinderJWT(user, options = {}) {
   const iFinderConfig = getIFinderConfig();
   const privateKey = getIFinderPrivateKey(iFinderConfig);
 
-  const { scope = iFinderConfig.defaultScope, expiresIn = iFinderConfig.tokenExpirationSeconds || 3600 } =
-    options;
+  const {
+    scope = iFinderConfig.defaultScope,
+    expiresIn = iFinderConfig.tokenExpirationSeconds || 3600
+  } = options;
 
   // Create JWT payload matching iFinder expected format
   const payload = {
@@ -162,7 +164,7 @@ export function generateIFinderJWT(user, options = {}) {
     scope: scope
   };
 
-  const algorithm = iFinderConfig.useOidcKeyPair ? 'RS256' : (iFinderConfig.algorithm || 'RS256');
+  const algorithm = iFinderConfig.useOidcKeyPair ? 'RS256' : iFinderConfig.algorithm || 'RS256';
   const issuer = getEffectiveIssuer(iFinderConfig);
 
   logger.info(
@@ -206,7 +208,7 @@ export function validateIFinderJWT(token) {
 
   try {
     const decoded = jwt.verify(token, verificationKey, {
-      algorithms: [iFinderConfig.useOidcKeyPair ? 'RS256' : (iFinderConfig.algorithm || 'RS256')],
+      algorithms: [iFinderConfig.useOidcKeyPair ? 'RS256' : iFinderConfig.algorithm || 'RS256'],
       issuer: getEffectiveIssuer(iFinderConfig),
       audience: iFinderConfig.audience || 'ifinder-api'
     });

--- a/server/utils/iFinderJwt.js
+++ b/server/utils/iFinderJwt.js
@@ -1,6 +1,8 @@
 import jwt from 'jsonwebtoken';
+import crypto from 'crypto';
 import config from '../config.js';
 import configCache from '../configCache.js';
+import tokenStorageService from '../services/TokenStorageService.js';
 import logger from './logger.js';
 
 /**
@@ -17,10 +19,66 @@ import logger from './logger.js';
  */
 
 /**
- * Get iFinder private key from configuration or environment
+ * Get iFinder configuration from platform config
+ * @returns {Object} iFinder configuration
+ */
+function getIFinderConfig() {
+  const platform = configCache.getPlatform() || {};
+  return platform.iFinder || {};
+}
+
+/**
+ * Compute the kid (Key ID) matching /.well-known/jwks.json
+ * @returns {string|undefined} Key ID or undefined if OIDC key pair not available
+ */
+function computeOidcKid() {
+  const publicKey = tokenStorageService.getRSAPublicKey();
+  if (!publicKey) return undefined;
+  return crypto.createHash('sha256').update(publicKey).digest('hex').substring(0, 16);
+}
+
+/**
+ * Get the effective issuer for iFinder JWTs.
+ * When useOidcKeyPair is true, uses the OIDC server issuer (platform.oauth.issuer)
+ * so that iFinder can validate via JWKS Discovery.
+ * @param {Object} iFinderConfig - iFinder configuration
+ * @returns {string} Issuer string
+ */
+function getEffectiveIssuer(iFinderConfig) {
+  if (iFinderConfig.useOidcKeyPair) {
+    const platform = configCache.getPlatform() || {};
+    const oauthIssuer = platform.oauth?.issuer;
+    if (oauthIssuer && oauthIssuer.startsWith('http')) {
+      return oauthIssuer;
+    }
+    logger.warn(
+      'iFinder useOidcKeyPair is enabled but platform.oauth.issuer is not a URL. ' +
+        'iFinder JWT issuer will not match OIDC Discovery. ' +
+        'Configure the OAuth Issuer URL in Admin > Authentication > OAuth Server.',
+      { component: 'iFinderJwt' }
+    );
+    return iFinderConfig.issuer || 'ihub-apps';
+  }
+  return iFinderConfig.issuer || 'ihub-apps';
+}
+
+/**
+ * Get iFinder private key from configuration or environment.
+ * When useOidcKeyPair is true, uses the iHub OIDC RSA key pair directly.
+ * @param {Object} iFinderConfig - iFinder configuration
  * @returns {string} Private key for JWT signing
  */
-function getIFinderPrivateKey() {
+function getIFinderPrivateKey(iFinderConfig) {
+  if (iFinderConfig.useOidcKeyPair) {
+    const keyPair = tokenStorageService.getRSAKeyPair();
+    if (!keyPair?.privateKey) {
+      throw new Error(
+        'iHub OIDC RSA key pair not initialized. Cannot sign iFinder JWT with OIDC key pair.'
+      );
+    }
+    return keyPair.privateKey;
+  }
+
   let privateKey;
 
   // Try environment variable first
@@ -53,15 +111,6 @@ function getIFinderPrivateKey() {
   }
 
   return privateKey;
-}
-
-/**
- * Get iFinder configuration from platform config
- * @returns {Object} iFinder configuration
- */
-function getIFinderConfig() {
-  const platform = configCache.getPlatform() || {};
-  return platform.iFinder || {};
 }
 
 /**
@@ -99,33 +148,42 @@ export function generateIFinderJWT(user, options = {}) {
     throw new Error('iFinder JWT requires authenticated user');
   }
 
-  const privateKey = getIFinderPrivateKey();
-  const config = getIFinderConfig();
+  const iFinderConfig = getIFinderConfig();
+  const privateKey = getIFinderPrivateKey(iFinderConfig);
 
-  const { scope = config.defaultScope, expiresIn = config.tokenExpirationSeconds || 3600 } =
+  const { scope = iFinderConfig.defaultScope, expiresIn = iFinderConfig.tokenExpirationSeconds || 3600 } =
     options;
 
   // Create JWT payload matching iFinder expected format
   const payload = {
-    sub: resolveJwtSubject(user, config),
+    sub: resolveJwtSubject(user, iFinderConfig),
     name: user.name || user.displayName || user.username || user.id,
     iat: Math.floor(Date.now() / 1000),
     scope: scope
   };
 
+  const algorithm = iFinderConfig.useOidcKeyPair ? 'RS256' : (iFinderConfig.algorithm || 'RS256');
+  const issuer = getEffectiveIssuer(iFinderConfig);
+
   logger.info(
-    `Generating iFinder JWT for user ${payload.sub} with scope '${scope}' and expiresIn ${expiresIn} seconds`
+    `Generating iFinder JWT for user ${payload.sub} with scope '${scope}', issuer '${issuer}', expiresIn ${expiresIn}s`,
+    { component: 'iFinderJwt', useOidcKeyPair: iFinderConfig.useOidcKeyPair }
   );
 
-  // Sign the JWT token with the private key
-  const token = jwt.sign(payload, privateKey, {
-    algorithm: config.algorithm || 'RS256', // Default to RS256 for private key signing
+  const signOptions = {
+    algorithm,
     expiresIn: expiresIn,
-    issuer: config.issuer || 'ihub-apps',
-    audience: config.audience || 'ifinder-api'
-  });
+    issuer,
+    audience: iFinderConfig.audience || 'ifinder-api'
+  };
 
-  return token;
+  // When using the OIDC key pair, include the kid so iFinder can match against JWKS
+  if (iFinderConfig.useOidcKeyPair) {
+    const kid = computeOidcKid();
+    if (kid) signOptions.keyid = kid;
+  }
+
+  return jwt.sign(payload, privateKey, signOptions);
 }
 
 /**
@@ -134,14 +192,23 @@ export function generateIFinderJWT(user, options = {}) {
  * @returns {Object} Decoded token payload
  */
 export function validateIFinderJWT(token) {
-  const privateKey = getIFinderPrivateKey();
-  const config = getIFinderConfig();
+  const iFinderConfig = getIFinderConfig();
+
+  let verificationKey;
+  if (iFinderConfig.useOidcKeyPair) {
+    verificationKey = tokenStorageService.getRSAPublicKey();
+    if (!verificationKey) {
+      throw new Error('iHub OIDC RSA public key not available for iFinder JWT validation');
+    }
+  } else {
+    verificationKey = getIFinderPrivateKey(iFinderConfig);
+  }
 
   try {
-    const decoded = jwt.verify(token, privateKey, {
-      algorithms: [config.algorithm || 'RS256'],
-      issuer: config.issuer || 'ihub-apps',
-      audience: config.audience || 'ifinder-api'
+    const decoded = jwt.verify(token, verificationKey, {
+      algorithms: [iFinderConfig.useOidcKeyPair ? 'RS256' : (iFinderConfig.algorithm || 'RS256')],
+      issuer: getEffectiveIssuer(iFinderConfig),
+      audience: iFinderConfig.audience || 'ifinder-api'
     });
 
     return decoded;


### PR DESCRIPTION
## Summary

- Adds `useOidcKeyPair` flag to `platform.iFinder` config — when enabled, iFinder/iAssistant JWTs are signed with the same RSA keypair as the iHub OIDC authorization server
- iFinder can then validate tokens via standard JWKS Discovery (`/.well-known/jwks.json`) — no more manual key distribution
- Removes separate `iAssistant.baseUrl` config; iAssistant always uses the same host as iFinder

## How it works

**iHub side (this PR):**
- `iFinderJwt.js` uses `TokenStorageService.getRSAKeyPair()` when `useOidcKeyPair: true`
- JWT `kid` header is set to match the JWKS key ID
- JWT `iss` claim is automatically taken from `platform.oauth.issuer` for OIDC Discovery compatibility
- Admin UI shows a toggle with validation (requires `oauth.issuer` to be a URL) and a ready-to-use iFinder config snippet

**iFinder side (config only, no code change):**
```yaml
intrafind:
  security:
    auth:
      enable-oauth2-resource-server: true
spring:
  security:
    oauth2:
      resourceserver:
        jwt:
          issuer-uri: https://<ihub-host>
```

## Test plan

- [ ] Enable `useOidcKeyPair` in Admin UI — verify warning if `oauth.issuer` is not set
- [ ] Set `oauth.issuer` to a URL — verify green info box with correct YAML snippet appears
- [ ] Decode a generated iFinder JWT with jwt.io — confirm `kid` matches `/.well-known/jwks.json`, `iss` matches `oauth.issuer`, `aud` = `ifinder-api`
- [ ] Verify backward compat: `useOidcKeyPair: false` — existing private key signing unchanged
- [ ] Verify migration V027 runs cleanly on existing install (adds `useOidcKeyPair: false`, removes `iAssistant.baseUrl`)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)