### PR TITLE
fix(office): eliminate spurious JWT audience warning for Outlook add-in tokens

### DIFF
--- a/server/middleware/jwtAuth.js
+++ b/server/middleware/jwtAuth.js
@@ -34,32 +34,37 @@ export default function jwtAuthMiddleware(req, res, next) {
   const platform = configCache.getPlatform() || {};
 
   try {
-    let decoded = verifyJwt(token);
+    // Peek at the token first to determine the correct audience for verification.
+    // OAuth authorization_code tokens use the client ID as audience instead of 'ihub-apps'.
+    // Checking this upfront avoids a spurious verification failure (and log warning)
+    // for every Outlook add-in request.
+    let decoded = null;
+    const peeked = decodeJwt(token);
 
-    // If standard verification failed, check if it's an OAuth authorization code token
-    // with a client-specific audience (aud: clientId instead of 'ihub-apps')
-    if (!decoded) {
-      const peeked = decodeJwt(token);
-      if (
-        peeked?.payload?.authMode === 'oauth_authorization_code' &&
-        peeked?.payload?.aud &&
-        peeked.payload.aud !== 'ihub-apps'
-      ) {
-        // Verify the audience against registered OAuth clients before using it
-        // This prevents an attacker from using an arbitrary audience claim to influence verification
-        const oauthConfig = platform.oauth || {};
-        if (oauthConfig.enabled?.clients) {
-          try {
-            const clientsFilePath = oauthConfig.clientsFile || 'contents/config/oauth-clients.json';
-            const clientsConfig = loadOAuthClients(clientsFilePath);
-            if (clientsConfig.clients[peeked.payload.aud]) {
-              decoded = verifyJwt(token, { audience: peeked.payload.aud });
-            }
-          } catch {
-            // If we can't load clients, don't allow the alternative audience
+    if (
+      peeked?.payload?.authMode === 'oauth_authorization_code' &&
+      peeked?.payload?.aud &&
+      peeked.payload.aud !== 'ihub-apps'
+    ) {
+      // Verify the audience against registered OAuth clients before trusting it.
+      // This prevents an attacker from using an arbitrary audience claim to influence verification.
+      const oauthConfig = platform.oauth || {};
+      if (oauthConfig.enabled?.clients) {
+        try {
+          const clientsFilePath = oauthConfig.clientsFile || 'contents/config/oauth-clients.json';
+          const clientsConfig = loadOAuthClients(clientsFilePath);
+          if (clientsConfig.clients[peeked.payload.aud]) {
+            decoded = verifyJwt(token, { audience: peeked.payload.aud });
           }
+        } catch {
+          // If we can't load clients, fall through to standard verification
         }
       }
+    }
+
+    // Standard verification for all other tokens (or if client-audience path didn't match)
+    if (!decoded) {
+      decoded = verifyJwt(token);
     }
 
     if (!decoded) {


### PR DESCRIPTION
## Summary

- OAuth authorization_code tokens (used by the Outlook add-in) carry `aud: <clientId>` instead of `aud: 'ihub-apps'` by design
- `jwtAuth` middleware previously tried standard audience verification first, which always failed for Outlook tokens, logging a spurious `JWT verification failed` warning on every request
- Authentication still succeeded (second-pass re-verification with the correct audience worked), but the warning polluted logs

## Changes

Reorder verification in `server/middleware/jwtAuth.js`: peek at the token **before** verifying. If `authMode === 'oauth_authorization_code'` with a non-standard audience, validate the audience against registered OAuth clients and verify with the correct audience directly — eliminating the unnecessary first-pass failure and its log warning.

Security invariant preserved: the unverified `aud` claim is only accepted after confirming it matches a registered client ID in the OAuth clients config.

## Test Plan

- [ ] Authenticate via the Outlook add-in and confirm no `JWT verification failed` warnings appear in logs for valid tokens
- [ ] Confirm standard auth flows (local, OIDC, cookie-based sessions) still authenticate correctly
- [ ] Confirm that an invalid or tampered token still produces the warning (security baseline intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)