### PR TITLE
fix(office): handle token expiration with silent refresh in Outlook add-in

### DIFF
--- a/client/office/taskpane-entry.jsx
+++ b/client/office/taskpane-entry.jsx
@@ -39,8 +39,10 @@ Office.onReady(async () => {
     return;
   }
 
-  // Install Office Bearer token interceptor so apiClient works in the taskpane
-  installOfficeAuthInterceptor();
+  // Install Office Bearer token interceptor so apiClient works in the taskpane.
+  // Passing config stores it in officeAuth so the SSE hook and Axios interceptor
+  // can call refreshTokenOrExpireSession() without threading config everywhere.
+  installOfficeAuthInterceptor(config);
 
   // Register the ItemChanged event to reset chat when user switches emails
   if (Office.context?.mailbox?.addHandlerAsync) {

--- a/client/src/api/client.js
+++ b/client/src/api/client.js
@@ -79,6 +79,14 @@ const addResponseInterceptor = client => {
 
       // Handle authentication errors
       if (error.response?.status === 401) {
+        // Office add-in requests are tagged with _isOfficeRequest and handled
+        // by the Office interceptor in officeAuthBridge.js (which does a silent
+        // token refresh + retry). Skip all main-app 401 logic for them to avoid
+        // clearing the wrong localStorage key and dispatching stale events.
+        if (originalRequest?._isOfficeRequest) {
+          return Promise.reject(error);
+        }
+
         // Token expired or invalid - clear localStorage token for backward compatibility
         const currentToken = localStorage.getItem('authToken');
         if (currentToken) {

--- a/client/src/features/office/api/officeAuth.js
+++ b/client/src/features/office/api/officeAuth.js
@@ -199,17 +199,41 @@ export const refreshAccessToken = async config => {
 let onSessionExpiredCallback = null;
 let refreshPromise = null;
 
+// Stored at startup via setOfficeConfig — allows modules (Axios interceptor,
+// SSE hook) to call refreshTokenOrExpireSession() without threading config through.
+let officeConfig = null;
+
 export function setOnSessionExpired(callback) {
   onSessionExpiredCallback = callback;
 }
 
+export function setOfficeConfig(config) {
+  officeConfig = config;
+}
+
 function ensureTokenRefreshed(config) {
+  const cfg = config ?? officeConfig;
+  if (!cfg) throw new Error('Office config not initialized');
   if (!refreshPromise) {
-    refreshPromise = refreshAccessToken(config).finally(() => {
+    refreshPromise = refreshAccessToken(cfg).finally(() => {
       refreshPromise = null;
     });
   }
   return refreshPromise;
+}
+
+/**
+ * Attempt a silent token refresh using the stored Office config.
+ * On failure, invokes the session-expired callback and re-throws so callers
+ * can propagate the error appropriately.
+ */
+export async function refreshTokenOrExpireSession() {
+  try {
+    await ensureTokenRefreshed();
+  } catch (err) {
+    onSessionExpiredCallback?.();
+    throw err;
+  }
 }
 
 export async function authenticatedFetch(config, url, options = {}) {
@@ -223,9 +247,8 @@ export async function authenticatedFetch(config, url, options = {}) {
 
   if (response.status === 401) {
     try {
-      await ensureTokenRefreshed(config);
+      await refreshTokenOrExpireSession();
     } catch {
-      onSessionExpiredCallback?.();
       throw new Error('Session expired');
     }
 

--- a/client/src/features/office/api/officeAuth.js
+++ b/client/src/features/office/api/officeAuth.js
@@ -200,7 +200,8 @@ let onSessionExpiredCallback = null;
 let refreshPromise = null;
 
 // Stored at startup via setOfficeConfig — allows modules (Axios interceptor,
-// SSE hook) to call refreshTokenOrExpireSession() without threading config through.
+// SSE hook) to call refreshTokenOrExpireSession() without threading config
+// through every call site.
 let officeConfig = null;
 
 export function setOnSessionExpired(callback) {
@@ -223,13 +224,15 @@ function ensureTokenRefreshed(config) {
 }
 
 /**
- * Attempt a silent token refresh using the stored Office config.
- * On failure, invokes the session-expired callback and re-throws so callers
- * can propagate the error appropriately.
+ * Attempt a silent token refresh, invoking the session-expired callback and
+ * re-throwing if the refresh fails.
+ *
+ * @param {object} [config] - Office config ({ baseUrl, clientId }). Falls back
+ *   to the config stored via setOfficeConfig() when omitted.
  */
-export async function refreshTokenOrExpireSession() {
+export async function refreshTokenOrExpireSession(config) {
   try {
-    await ensureTokenRefreshed();
+    await ensureTokenRefreshed(config);
   } catch (err) {
     onSessionExpiredCallback?.();
     throw err;
@@ -247,7 +250,9 @@ export async function authenticatedFetch(config, url, options = {}) {
 
   if (response.status === 401) {
     try {
-      await refreshTokenOrExpireSession();
+      // Pass config explicitly so the caller's config is honoured even if
+      // setOfficeConfig() was not called (e.g. in isolated unit tests).
+      await refreshTokenOrExpireSession(config);
     } catch {
       throw new Error('Session expired');
     }

--- a/client/src/features/office/api/officeAuthBridge.js
+++ b/client/src/features/office/api/officeAuthBridge.js
@@ -33,7 +33,7 @@ import {
  *
  * Response interceptor:
  *   - Catches 401 errors for Office requests.
- *   - Attempts a silent token refresh via refreshTokenOrExpireSession().
+ *   - Attempts a silent token refresh via refreshTokenOrExpireSession(config).
  *   - Retries the original request once with the new token (_officeRetry flag
  *     prevents infinite loops).
  *   - If the refresh fails, the session-expired callback fires (navigates to
@@ -78,7 +78,7 @@ export function installOfficeAuthInterceptor(config) {
           originalRequest._officeRetry = true;
 
           try {
-            await refreshTokenOrExpireSession();
+            await refreshTokenOrExpireSession(config);
           } catch {
             // Refresh failed — session-expired callback already invoked.
             return Promise.reject(error);

--- a/client/src/features/office/api/officeAuthBridge.js
+++ b/client/src/features/office/api/officeAuthBridge.js
@@ -1,34 +1,59 @@
 /**
  * Auth bridge for the Office add-in.
  *
- * Installs an Axios interceptor on apiClient and streamingApiClient that injects
- * the Office Bearer token into all requests. This allows the main app's API layer
- * (sendAppChatMessage, checkAppChatStatus, stopAppChatStream, fetchApps, etc.) to
- * work seamlessly within the Office taskpane without any changes to those functions.
+ * Installs request and response interceptors on apiClient and streamingApiClient so that:
+ * - Every outgoing request carries the Office Bearer token (Authorization header).
+ * - 401 responses automatically attempt a silent token refresh and retry once.
+ * - If the refresh fails, the session-expired callback is invoked (navigates to login).
  *
- * Call installOfficeAuthInterceptor() once from taskpane-entry.jsx after Office.onReady.
+ * Call installOfficeAuthInterceptor(config) once from taskpane-entry.jsx after Office.onReady.
+ * The config object ({ baseUrl, clientId, redirectUri }) is stored in officeAuth so that
+ * the SSE hook and other modules can also call refreshTokenOrExpireSession() without
+ * needing to thread the config through their call stacks.
  */
 import { apiClient, streamingApiClient } from '../../../api/client';
-import { OFFICE_TOKEN_KEY } from './officeAuth';
+import {
+  OFFICE_TOKEN_KEY,
+  getAccessToken,
+  setOfficeConfig,
+  refreshTokenOrExpireSession
+} from './officeAuth';
 
 /**
- * Installs a request interceptor on both apiClient and streamingApiClient that
- * reads the Office access token and sets the Authorization header.
+ * Installs auth interceptors on both Axios clients.
  *
- * Axios request interceptors execute in LIFO order, so an interceptor registered
- * last runs first — meaning the pre-existing auth interceptor would overwrite ours.
- * To guarantee the Office token takes precedence, we move our handler to index 0
- * of the internal handlers array so it is unshifted first into the dispatch chain
- * and therefore executes last (after the existing interceptor).
+ * Request interceptor:
+ *   - Injects the Office access token as Authorization: Bearer <token>.
+ *   - Tags each request with _isOfficeRequest = true so the main app's 401
+ *     handler (which clears the wrong localStorage key and dispatches
+ *     authTokenExpired) skips processing for Office requests.
+ *   - Moved to index 0 of the internal handlers array so it executes last
+ *     (Axios request interceptors run LIFO), overriding the main app's
+ *     interceptor that would otherwise set the wrong token.
+ *
+ * Response interceptor:
+ *   - Catches 401 errors for Office requests.
+ *   - Attempts a silent token refresh via refreshTokenOrExpireSession().
+ *   - Retries the original request once with the new token (_officeRetry flag
+ *     prevents infinite loops).
+ *   - If the refresh fails, the session-expired callback fires (navigates to
+ *     login) and the error propagates.
  */
-export function installOfficeAuthInterceptor() {
+export function installOfficeAuthInterceptor(config) {
+  // Store config so refreshTokenOrExpireSession() and the SSE hook can use it
+  // without needing the config threaded through every call site.
+  setOfficeConfig(config);
+
   const addInterceptor = client => {
-    client.interceptors.request.use(config => {
+    // --- Request interceptor ---
+    client.interceptors.request.use(reqConfig => {
       const token = localStorage.getItem(OFFICE_TOKEN_KEY);
       if (token) {
-        config.headers['Authorization'] = `Bearer ${token}`;
+        reqConfig.headers['Authorization'] = `Bearer ${token}`;
       }
-      return config;
+      // Tag so the main app's response interceptor skips 401 handling for us.
+      reqConfig._isOfficeRequest = true;
+      return reqConfig;
     });
 
     // Move the just-added handler to index 0 so it executes last (Axios LIFO).
@@ -37,6 +62,39 @@ export function installOfficeAuthInterceptor() {
       const officeHandler = handlers.pop();
       handlers.unshift(officeHandler);
     }
+
+    // --- Response interceptor ---
+    client.interceptors.response.use(
+      response => response,
+      async error => {
+        const originalRequest = error.config;
+
+        // Only handle 401s for Office requests, and only attempt one refresh.
+        if (
+          error.response?.status === 401 &&
+          originalRequest?._isOfficeRequest &&
+          !originalRequest._officeRetry
+        ) {
+          originalRequest._officeRetry = true;
+
+          try {
+            await refreshTokenOrExpireSession();
+          } catch {
+            // Refresh failed — session-expired callback already invoked.
+            return Promise.reject(error);
+          }
+
+          // Refresh succeeded — retry with the new token.
+          const newToken = getAccessToken();
+          if (newToken) {
+            originalRequest.headers['Authorization'] = `Bearer ${newToken}`;
+          }
+          return client(originalRequest);
+        }
+
+        return Promise.reject(error);
+      }
+    );
   };
 
   addInterceptor(apiClient);

--- a/client/src/shared/hooks/useEventSource.js
+++ b/client/src/shared/hooks/useEventSource.js
@@ -1,7 +1,7 @@
 import { useRef, useCallback, useEffect } from 'react';
 import { checkAppChatStatus, stopAppChatStream } from '../../api/api';
 import { parseSseStream } from '../utils/parseSseStream';
-import { refreshTokenOrExpireSession } from '../../features/office/api/officeAuth';
+import { getRefreshToken, refreshTokenOrExpireSession } from '../../features/office/api/officeAuth';
 
 /**
  * Hook for handling Server Sent Events via fetch + ReadableStream.
@@ -148,9 +148,11 @@ function useEventSource({ appId, chatId, timeoutDuration = 30000, onEvent, onPro
         });
 
         // For the Office add-in: attempt a silent token refresh on 401 and retry once.
-        // refreshTokenOrExpireSession() uses the config stored at startup and invokes
-        // the session-expired callback (navigates to login) if the refresh fails.
-        if (res.status === 401 && localStorage.getItem('office_ihubtoken')) {
+        // Keyed off getRefreshToken() so the refresh is attempted even when the
+        // access token is already gone (expired and removed) but a refresh token exists.
+        // refreshTokenOrExpireSession() invokes the session-expired callback and throws
+        // if the refresh itself fails, letting the outer catch report the error.
+        if (res.status === 401 && getRefreshToken()) {
           await refreshTokenOrExpireSession();
           res = await fetch(url, {
             method: 'GET',

--- a/client/src/shared/hooks/useEventSource.js
+++ b/client/src/shared/hooks/useEventSource.js
@@ -1,6 +1,7 @@
 import { useRef, useCallback, useEffect } from 'react';
 import { checkAppChatStatus, stopAppChatStream } from '../../api/api';
 import { parseSseStream } from '../utils/parseSseStream';
+import { refreshTokenOrExpireSession } from '../../features/office/api/officeAuth';
 
 /**
  * Hook for handling Server Sent Events via fetch + ReadableStream.
@@ -136,7 +137,7 @@ function useEventSource({ appId, chatId, timeoutDuration = 30000, onEvent, onPro
       }, timeoutDuration);
 
       try {
-        const res = await fetch(url, {
+        let res = await fetch(url, {
           method: 'GET',
           headers: {
             Accept: 'text/event-stream',
@@ -145,6 +146,22 @@ function useEventSource({ appId, chatId, timeoutDuration = 30000, onEvent, onPro
           credentials: 'include',
           signal: ac.signal
         });
+
+        // For the Office add-in: attempt a silent token refresh on 401 and retry once.
+        // refreshTokenOrExpireSession() uses the config stored at startup and invokes
+        // the session-expired callback (navigates to login) if the refresh fails.
+        if (res.status === 401 && localStorage.getItem('office_ihubtoken')) {
+          await refreshTokenOrExpireSession();
+          res = await fetch(url, {
+            method: 'GET',
+            headers: {
+              Accept: 'text/event-stream',
+              ...getAuthHeaders()
+            },
+            credentials: 'include',
+            signal: ac.signal
+          });
+        }
 
         if (!res.ok) {
           let body = null;


### PR DESCRIPTION
## Summary

- **Root cause:** `officeAuthBridge.js` only had a request interceptor (token injection) but no response interceptor, so 401s after token expiry were handled by the main app's interceptor — which cleared the wrong localStorage key (`authToken` vs `office_ihubtoken`) and dispatched `authTokenExpired` which nothing in the Office context listened for. The app silently degraded to anonymous access while still showing the Logout button.
- **Fix:** Wire the existing refresh token infrastructure (`refreshAccessToken`, `ensureTokenRefreshed` in `officeAuth.js`) into all three auth paths: Axios requests, SSE chat streams, and the existing `authenticatedFetch` wrapper.
- **Anonymous never allowed:** by properly handling 401s, the Office integration now either silently refreshes (transparent to the user) or shows the login screen — it no longer falls through to anonymous access.

## Changes

| File | What changed |
|------|------|
| `officeAuth.js` | Add `setOfficeConfig()` to store config at startup; export `refreshTokenOrExpireSession()` shared helper; simplify `authenticatedFetch` to reuse it |
| `officeAuthBridge.js` | Accept `config` param → calls `setOfficeConfig`; tag every request with `_isOfficeRequest`; add response interceptor: refresh on 401 + retry once (`_officeRetry` prevents loops) |
| `client.js` | Skip main-app 401 handling (wrong key clear + `authTokenExpired` dispatch) for `_isOfficeRequest` tagged requests |
| `taskpane-entry.jsx` | Pass `config` to `installOfficeAuthInterceptor(config)` |
| `useEventSource.js` | Refresh + retry SSE stream fetch on 401 when in Office context (direct `fetch()` bypasses Axios interceptors) |

## Test plan

- [ ] Log in to the Office add-in; manually delete `office_ihubtoken` from localStorage (keep `office_ihub_refresh_token`); trigger an API call or send a chat message — should transparently refresh and succeed without any login prompt
- [ ] Delete both `office_ihubtoken` and `office_ihub_refresh_token`; trigger an API call — should navigate to login screen with "Your session has expired. Please log in again."
- [ ] Verify the app list shows only authenticated apps after silent refresh (not a limited anonymous list)
- [ ] Verify the main web app's session expiry still works correctly (no regression from the `_isOfficeRequest` guard)
- [ ] Run `npm run lint:fix && npm run format:fix` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)