### PR TITLE
feat(server): sticky-session cluster, default 4 workers

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -72,6 +72,7 @@
     - [Proxy Testing Guide](proxy-testing-guide.md)
     - [Production Reverse Proxy Guide](production-reverse-proxy-guide.md)
     - [Rate Limiting](rate-limiting.md)
+    - [Scaling with Multiple Workers](scaling.md)
   - [Development & Deployment]()
     - [Developer Onboarding](developer-onboarding.md)
     - [Docker Quick Reference](DOCKER-QUICK-REFERENCE.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -233,21 +233,32 @@ server/
 
 ### Clustering and Process Management
 
-The server supports horizontal scaling through Node.js clustering:
+The server scales across CPU cores with a sticky-session Node.js cluster
+(default: 4 workers; dev scripts pin `WORKERS=1`). The primary process owns
+the public TCP socket, hashes each connection's source address to a worker,
+and forwards the paused handle over IPC. This keeps every chat session
+pinned to a single worker so the per-process SSE state in
+`server/sse.js` and `server/actionTracker.js` stays consistent without any
+cross-worker coordination.
 
 ```javascript
-const workerCount = config.WORKERS; // Configurable worker count
+const workerCount = config.WORKERS; // default 4; set WORKERS=1 to disable
 
 if (cluster.isPrimary && workerCount > 1) {
-  // Primary process manages workers
-  for (let i = 0; i < workerCount; i++) {
-    cluster.fork();
-  }
+  const workers = [];
+  for (let i = 0; i < workerCount; i++) workers.push(cluster.fork());
+
+  // Sticky router: sha256(remoteAddress) % workerCount
+  startStickyPrimary({ getWorkers: () => workers, port, host });
+} else if (cluster.isWorker) {
+  attachStickyWorker(httpServer); // receives connections via IPC, no listen()
 } else {
-  // Worker processes handle requests
-  startServer();
+  httpServer.listen(port, host); // single-process mode
 }
 ```
+
+See [Scaling with Multiple Workers](scaling.md) for tuning guidance and the
+limitations (NAT-pinning, session failover).
 
 ### Request Processing Pipeline
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -1,0 +1,188 @@
+# Scaling with Multiple Workers
+
+iHub Apps ships with a sticky-session Node.js cluster so a single host can use
+multiple CPU cores without breaking the streaming chat experience. The default
+is **4 workers**; this page explains how it works, how to tune it, and what
+the trade-offs are.
+
+## TL;DR
+
+- **Default:** `WORKERS=4` in production.
+- **Dev scripts (`npm run dev`, `npm run server`):** pinned to `WORKERS=1` for
+  fast reloads and straightforward debugging.
+- **Override:** set the `WORKERS` (or `NUM_WORKERS`) environment variable
+  before starting the server.
+- **Do not** put the worker count behind a reverse proxy load balancer without
+  stickiness — see the [Limitations](#limitations) section.
+
+```bash
+# Start with 8 workers on port 8080
+PORT=8080 WORKERS=8 npm run start:prod
+
+# Disable clustering entirely
+WORKERS=1 npm run start:prod
+```
+
+## Why clustering
+
+Node.js runs a single JavaScript thread per process. A chat request that ties
+up the event loop (large tool-call fan-out, JSON parsing of a big response,
+CPU-heavy middleware) blocks every concurrent request handled by that
+process. On a multi-core host this leaves CPUs idle while latency climbs.
+Cluster mode runs `N` worker processes behind one listening socket, so each
+core can make progress independently.
+
+## Why sticky sessions
+
+The standard `node:cluster` scheduler distributes connections round-robin.
+That breaks iHub's chat flow because streaming state is in-memory per worker:
+
+- `server/sse.js` holds two `Map`s (`clients`, `activeRequests`) keyed by
+  `chatId`.
+- `server/actionTracker.js` is a `Node.js EventEmitter` whose events only
+  reach listeners in the same process.
+
+A browser opens an SSE stream on `GET /api/apps/:appId/chat/:chatId` and then
+POSTs prompts to the same URL. If the GET lands on worker A but the POST
+lands on worker B, worker B has no `clients` entry for that chat, so tokens
+never reach the browser and cancellations silently drop.
+
+To keep chats consistent, every connection from a given client must route to
+the same worker. iHub does this by running a small sticky router in the
+primary process:
+
+1. The primary owns the real TCP listening socket (`net.createServer` with
+   `pauseOnConnect: true`).
+2. On each incoming connection it hashes the client's remote address
+   (`sha256(remoteAddress) % workerCount`) to pick a worker.
+3. The paused socket handle is forwarded to the chosen worker via IPC.
+4. The worker re-emits the connection on its HTTP server and resumes it.
+
+All in-memory per-chat state therefore stays in one process, without any
+cross-worker coordination or external broker.
+
+Relevant code: [`server/clusterSticky.js`](../server/clusterSticky.js) and
+the primary/worker branches in [`server/server.js`](../server/server.js).
+
+## Configuration
+
+| Variable      | Default | Description                                           |
+| ------------- | ------- | ----------------------------------------------------- |
+| `WORKERS`     | `4`     | Number of worker processes. `1` = no cluster.         |
+| `NUM_WORKERS` | `4`     | Alias of `WORKERS` (accepted for backwards-compat).   |
+
+`WORKERS` is read **once at process start** by `server/config.js`. Changing
+it at runtime has no effect — see [Why it is not in the Admin UI](#why-it-is-not-in-the-admin-ui).
+
+### Picking a value
+
+- **Small dev box / single-user:** `1`.
+- **Production host:** start with `min(cpuCores, 4)`. Profile and go higher
+  only if CPU utilisation on all workers is sustained above ~70%.
+- **Docker / Kubernetes:** match `WORKERS` to the CPU limit assigned to the
+  container, not to the host's physical cores. A 2-core container running
+  `WORKERS=8` will thrash the scheduler.
+- **Memory budget:** each worker holds its own copy of the config cache,
+  loaded adapters, and in-flight state. Budget roughly 200–400 MB per worker.
+
+## Startup behaviour
+
+With `WORKERS > 1` the primary logs:
+
+```
+Primary process 1234 starting 4 workers
+Sticky cluster primary listening { host: '0.0.0.0', port: 3000, workerCount: 4 }
+```
+
+Each worker logs exactly once when it is ready to receive forwarded
+connections:
+
+```
+Worker ready for sticky connections { pid: 1245, workerIndex: '0' }
+Worker ready for sticky connections { pid: 1246, workerIndex: '1' }
+...
+```
+
+With `WORKERS=1` the server runs as a plain single process; it binds the port
+itself and you see the usual `Server is listening on all interfaces` log.
+
+### Crash recovery
+
+If a worker exits (crash, OOM, signal), the primary logs a warning with the
+exit code, forks a replacement into the same slot, and resumes routing to it.
+Clients whose chat was pinned to the dead worker lose their SSE connection
+and need to reconnect — the browser's reconnect logic handles this, but any
+mid-stream tokens are dropped.
+
+### Shutdown
+
+`SIGTERM` / `SIGINT` on the primary forwards the signal to all workers and
+then exits after a 5-second grace period. Use a process supervisor
+(systemd, Docker, PM2, Kubernetes) to orchestrate rolling restarts.
+
+## Limitations
+
+### Uneven load behind NAT / proxies
+
+Routing is hashed on source IP. If many users share one source IP (corporate
+NAT, shared VPN egress, a fronting reverse proxy that does not preserve
+client IPs), they all pile onto the same worker.
+
+**Mitigations:**
+
+- Put a stickiness-aware reverse proxy (nginx `hash $cookie_chatid consistent;`,
+  HAProxy `balance uri` / cookie-based stickiness) in front of **multiple
+  separate iHub instances**, each with its own port — then iHub's own
+  cluster scales per-instance.
+- Ensure upstream proxies forward `X-Forwarded-For` and that iHub sees the
+  real client address. (Current build routes on `connection.remoteAddress`
+  only, not on the `X-Forwarded-For` header — that would require parsing the
+  HTTP request in the primary, which is a larger change.)
+
+### Worker-local state
+
+Any new feature that needs cross-worker visibility (shared rate-limit
+counters, in-memory caches that must be coherent, cross-session pub/sub)
+will not work out of the box. Options:
+
+- Persist to disk or a database that every worker already reads.
+- Introduce Redis pub/sub and have every worker subscribe.
+- Keep the feature strictly per-chat (preferred — most existing code does
+  this already).
+
+### Session failover
+
+A chat is pinned to a single worker for its lifetime. If that worker
+crashes, the stream drops and the browser must reconnect (and the assistant
+response in progress is lost). For strict failover you would need to
+externalise the SSE fan-out to Redis; the trade-off is latency + operational
+complexity, and it is not planned.
+
+## Why it is not in the Admin UI
+
+Worker count is an infrastructure setting, not a runtime setting, for two
+reasons:
+
+1. **No hot-apply path.** `cluster.fork()` happens once at startup. To change
+   the count live you either (a) require a process restart — in which case an
+   env var is simpler and more transparent, or (b) fork/kill workers on the
+   fly, which drops every SSE stream and in-flight tool call on the affected
+   worker mid-response. That is a poor experience.
+2. **Scope mismatch.** Platform-level process concerns belong next to
+   `PORT`, `HOST`, and SSL certificates — the deployment owner's domain. The
+   Admin UI manages *content* (apps, prompts, models, groups), not the
+   process topology.
+
+If you want visibility without the foot-guns, add a read-only display in a
+future "Server info" panel showing `WORKERS` alongside `PORT`, `HOST`, and
+the Node version.
+
+## Alternatives considered
+
+| Option                                        | Status       | Notes                                                                                    |
+| --------------------------------------------- | ------------ | ---------------------------------------------------------------------------------------- |
+| Default round-robin cluster                   | Rejected     | Breaks SSE streaming (per-worker in-memory state).                                       |
+| **Sticky session cluster (this page)**        | **Shipping** | Simple; IP-hashed routing; no new deps; handles the common case.                         |
+| Redis pub/sub fan-out                         | Deferred     | Enables true cross-worker delivery and clean failover. Adds Redis + ~a week of refactor. |
+| PM2 cluster mode                              | Rejected     | PM2's built-in LB is round-robin — same SSE problem.                                     |
+| Multi-instance + nginx cookie stickiness      | Compatible   | Works; recommended when fronting multiple boxes. Orthogonal to this feature.             |

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -55,8 +55,8 @@ The server reads settings from the environment or a `.env` file such as `config.
 | `HOST`                     | Host interface to bind to. Use `0.0.0.0` to listen on all interfaces (recommended), then access via `localhost` or `127.0.0.1` in your browser. **Never access via `http://0.0.0.0:*` as browsers will reject cookies.** | `0.0.0.0`                                        |
 | `NODE_ENV`                 | Runtime environment (`development`, `production`, `test`). Affects cookie security flags, debug logging, and cache TTLs. | – |
 | `REQUEST_TIMEOUT`          | LLM request timeout in milliseconds                               | `300000`                                         |
-| `WORKERS`                  | Number of Node.js cluster workers (alias: `NUM_WORKERS`)          | `1`                                              |
-| `NUM_WORKERS`              | Number of Node.js cluster workers (alias of `WORKERS`)            | `1`                                              |
+| `WORKERS`                  | Number of Node.js cluster workers (alias: `NUM_WORKERS`). Set to `1` to disable clustering. See [Scaling with Multiple Workers](scaling.md). | `4`                                              |
+| `NUM_WORKERS`              | Number of Node.js cluster workers (alias of `WORKERS`)            | `4`                                              |
 | `OPENAI_API_KEY`           | API key for OpenAI models                                         | –                                                |
 | `ANTHROPIC_API_KEY`        | API key for Anthropic models                                      | –                                                |
 | `MISTRAL_API_KEY`          | API key for Mistral models                                        | –                                                |
@@ -248,3 +248,9 @@ Run the production build with four workers on port 8080:
 ```bash
 PORT=8080 HOST=127.0.0.1 WORKERS=4 npm run start:prod
 ```
+
+Four workers is now the default; set `WORKERS=1` to fall back to a single
+process (recommended in development because hot reloaders and breakpoints
+behave badly across forked children). See
+[Scaling with Multiple Workers](scaling.md) for details on the sticky-session
+cluster, tuning guidance, and the limitations to be aware of.

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "scripts": {
     "// === DEVELOPMENT ===": "",
     "setup:dev": "npm run install:all && echo '\\n✅ Dependencies installed\\n✅ Default configuration ready\\n\\nRun: npm run dev\\nThen open http://localhost:3000 to configure your AI providers.'",
-    "dev": "cross-env NODE_ENV=development concurrently --kill-others-on-fail \"npm run server\" \"sleep 2 && npm run client\"",
-    "server": "cd server && node -r dotenv/config server.js dotenv_config_path=../.env",
+    "dev": "cross-env NODE_ENV=development WORKERS=1 concurrently --kill-others-on-fail \"npm run server\" \"sleep 2 && npm run client\"",
+    "server": "cd server && cross-env WORKERS=1 node -r dotenv/config server.js dotenv_config_path=../.env",
     "client": "cd client && npm run dev",
     "start": "cd server && node -r dotenv/config server.js dotenv_config_path=../.env",
     "// === INSTALLATION & CLEANUP ===": "",

--- a/server/clusterSticky.js
+++ b/server/clusterSticky.js
@@ -1,0 +1,124 @@
+/**
+ * Sticky session cluster primary.
+ *
+ * Node.js's built-in cluster scheduler distributes incoming TCP connections
+ * round-robin (or OS-scheduled) across workers. That breaks SSE-based chat
+ * because our streaming state (`clients` and `activeRequests` maps in
+ * `server/sse.js`, and the `actionTracker` EventEmitter) lives in the worker's
+ * process memory. A client that opens an SSE stream on worker A and then POSTs
+ * a prompt that lands on worker B will never receive tokens and cannot cancel.
+ *
+ * This module replaces the default scheduler with a simple sticky router:
+ *   - Primary owns the real listening socket (`net.createServer`).
+ *   - Each incoming connection is hashed by `remoteAddress` to a worker index.
+ *   - The paused socket handle is forwarded to that worker over IPC.
+ *   - Workers re-emit the connection on their HTTP server and resume it.
+ *
+ * The same browser (same source IP) therefore always lands on the same worker
+ * for the lifetime of a chat session, so all per-chat in-memory state remains
+ * consistent without any cross-worker coordination.
+ *
+ * Tradeoff: many users sharing one source IP (NAT, corporate proxy) will pile
+ * on the same worker. For that case, deploy behind a reverse proxy that does
+ * cookie or chatId-aware stickiness, or migrate to a Redis pub/sub fan-out.
+ */
+
+import net from 'node:net';
+import { createHash } from 'node:crypto';
+import logger from './utils/logger.js';
+
+const STICKY_MESSAGE = 'sticky:connection';
+
+function hashToIndex(key, size) {
+  if (size <= 1) return 0;
+  const digest = createHash('sha256').update(String(key)).digest();
+  return digest.readUInt32LE(0) % size;
+}
+
+function pickWorker(workers, key) {
+  if (!workers.length) return null;
+  const idx = hashToIndex(key, workers.length);
+  const candidate = workers[idx];
+  if (candidate && !candidate.isDead?.()) return candidate;
+  for (let offset = 1; offset < workers.length; offset++) {
+    const fallback = workers[(idx + offset) % workers.length];
+    if (fallback && !fallback.isDead?.()) return fallback;
+  }
+  return null;
+}
+
+/**
+ * Start a sticky TCP listener on the primary process.
+ *
+ * @param {object} options
+ * @param {() => Array} options.getWorkers - Returns the current list of live workers.
+ *   Called for every connection so that replaced workers (after a crash
+ *   restart) are picked up without restarting the primary.
+ * @param {number} options.port
+ * @param {string} options.host
+ * @param {(server: net.Server) => void} [options.onListening]
+ */
+export function startStickyPrimary({ getWorkers, port, host, onListening }) {
+  const server = net.createServer({ pauseOnConnect: true }, connection => {
+    const workers = getWorkers();
+    if (!workers.length) {
+      connection.destroy();
+      return;
+    }
+    const routingKey = connection.remoteAddress || String(connection.remotePort || Math.random());
+    const worker = pickWorker(workers, routingKey);
+    if (!worker) {
+      connection.destroy();
+      return;
+    }
+    try {
+      worker.send(STICKY_MESSAGE, connection, err => {
+        if (err) {
+          logger.warn({
+            component: 'StickyCluster',
+            message: 'Failed to hand off connection to worker',
+            workerPid: worker.process?.pid,
+            error: err.message
+          });
+          connection.destroy();
+        }
+      });
+    } catch (err) {
+      logger.error({
+        component: 'StickyCluster',
+        message: 'Error forwarding connection to worker',
+        workerPid: worker.process?.pid,
+        error: err.message
+      });
+      connection.destroy();
+    }
+  });
+
+  server.on('error', err => {
+    logger.error({
+      component: 'StickyCluster',
+      message: 'Sticky primary listener error',
+      error: err.message,
+      code: err.code
+    });
+  });
+
+  server.listen(port, host, () => {
+    if (typeof onListening === 'function') onListening(server);
+  });
+
+  return server;
+}
+
+/**
+ * Wire a worker's HTTP/HTTPS server to receive sticky connections from the
+ * primary. The worker must NOT call `server.listen()` on the public port when
+ * running inside a sticky cluster — connections arrive exclusively via IPC.
+ */
+export function attachStickyWorker(httpServer) {
+  process.on('message', (msg, socket) => {
+    if (msg !== STICKY_MESSAGE || !socket) return;
+    httpServer.emit('connection', socket);
+    socket.resume();
+  });
+}

--- a/server/config.js
+++ b/server/config.js
@@ -57,7 +57,7 @@ const config = Object.freeze({
   PORT: env.PORT,
   HOST: env.HOST,
   REQUEST_TIMEOUT: env.REQUEST_TIMEOUT,
-  WORKERS: env.WORKERS ?? env.NUM_WORKERS ?? 1,
+  WORKERS: env.WORKERS ?? env.NUM_WORKERS ?? 4,
   SSL_KEY: env.SSL_KEY,
   SSL_CERT: env.SSL_CERT,
   SSL_CA: env.SSL_CA,

--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,7 @@ import { loadJson } from './configLoader.js';
 import { getRootDir } from './pathUtils.js';
 import configCache from './configCache.js';
 import logger from './utils/logger.js';
+import { startStickyPrimary, attachStickyWorker } from './clusterSticky.js';
 
 // Import adapters and utilities
 import registerChatRoutes from './routes/chat/index.js';
@@ -75,20 +76,85 @@ if (cluster.isPrimary && workerCount > 1) {
     pid: process.pid,
     workerCount
   });
+
+  // Track live workers so the sticky router can pick a healthy one on each
+  // incoming connection. Dead entries are replaced in the `exit` handler.
+  const workers = [];
   for (let workerIndex = 0; workerIndex < workerCount; workerIndex++) {
-    cluster.fork();
+    workers[workerIndex] = cluster.fork({ WORKER_INDEX: String(workerIndex) });
   }
 
   cluster.on('exit', (worker, code, signal) => {
+    const slot = workers.findIndex(w => w === worker);
     logger.warn({
       component: 'Server',
-      message: `Worker ${worker.process.pid} exited (${code || signal})`,
+      message: `Worker ${worker.process.pid} exited (${code || signal}), respawning`,
       workerPid: worker.process.pid,
       code,
-      signal
+      signal,
+      slot
     });
-    cluster.fork();
+    const replacement = cluster.fork({ WORKER_INDEX: String(slot >= 0 ? slot : workers.length) });
+    if (slot >= 0) {
+      workers[slot] = replacement;
+    } else {
+      workers.push(replacement);
+    }
   });
+
+  // Primary owns the public listening socket and hands each connection to a
+  // worker by hashing the client's remote address. This keeps every chat
+  // session pinned to one worker so in-memory SSE state stays consistent.
+  startStickyPrimary({
+    getWorkers: () => workers,
+    port: config.PORT,
+    host: config.HOST,
+    onListening: () => {
+      logger.info({
+        component: 'Server',
+        message: 'Sticky cluster primary listening',
+        host: config.HOST,
+        port: config.PORT,
+        workerCount
+      });
+      if (config.HOST === '0.0.0.0' || config.HOST === '::') {
+        logger.info({
+          component: 'Server',
+          message: 'Access the application at one of these URLs:',
+          urls: [
+            `http://localhost:${config.PORT}`,
+            `http://127.0.0.1:${config.PORT}`,
+            "(or use your machine's hostname/IP address)"
+          ]
+        });
+      } else {
+        logger.info({
+          component: 'Server',
+          message: 'Access the application at',
+          url: `http://${config.HOST}:${config.PORT}`
+        });
+      }
+    }
+  });
+
+  const handlePrimaryShutdown = signal => {
+    logger.info({
+      component: 'Server',
+      message: `Primary received ${signal}, shutting down workers`,
+      workerCount: workers.length
+    });
+    for (const w of workers) {
+      try {
+        w.kill(signal);
+      } catch {
+        // worker may already be dead
+      }
+    }
+    // Give workers a moment to exit cleanly, then force-exit the primary.
+    setTimeout(() => process.exit(0), 5000).unref();
+  };
+  process.on('SIGTERM', () => handlePrimaryShutdown('SIGTERM'));
+  process.on('SIGINT', () => handlePrimaryShutdown('SIGINT'));
 } else {
   // Determine if we're running from a packaged binary
   // Either via process.pkg (when using pkg directly) or APP_ROOT_DIR env var (our shell script approach)
@@ -408,46 +474,54 @@ if (cluster.isPrimary && workerCount > 1) {
     });
   }
 
-  // Start server
-  server.listen(PORT, HOST, () => {
-    const protocol = server instanceof https.Server ? 'https' : 'http';
-
-    // Log bind address
+  if (cluster.isWorker) {
+    // Inside a sticky cluster the primary owns the public port; this worker
+    // only receives already-accepted connections via IPC.
+    attachStickyWorker(server);
     logger.info({
       component: 'Server',
-      message: 'Server is listening on all interfaces',
-      protocol,
-      bindAddress: HOST,
-      port: PORT
+      message: 'Worker ready for sticky connections',
+      pid: process.pid,
+      workerIndex: process.env.WORKER_INDEX ?? 'unknown'
     });
+  } else {
+    // Single-process mode (WORKERS=1): bind the port directly.
+    server.listen(PORT, HOST, () => {
+      const protocol = server instanceof https.Server ? 'https' : 'http';
 
-    // Provide access URLs based on bind address
-    if (HOST === '0.0.0.0' || HOST === '::') {
-      // Server is bound to all interfaces - provide recommended access URLs
       logger.info({
         component: 'Server',
-        message: 'Access the application at one of these URLs:',
-        urls: [
-          `${protocol}://localhost:${PORT}`,
-          `${protocol}://127.0.0.1:${PORT}`,
-          "(or use your machine's hostname/IP address)"
-        ]
+        message: 'Server is listening on all interfaces',
+        protocol,
+        bindAddress: HOST,
+        port: PORT
       });
-      logger.warn({
-        component: 'Server',
-        message: '⚠️  IMPORTANT: Do not access via http://0.0.0.0:* in your browser',
-        reason: 'Browsers will reject cookies from 0.0.0.0, causing authentication to fail',
-        recommendation: 'Always use localhost, 127.0.0.1, or your actual hostname'
-      });
-    } else {
-      // Server is bound to specific interface
-      logger.info({
-        component: 'Server',
-        message: 'Access the application at',
-        url: `${protocol}://${HOST}:${PORT}`
-      });
-    }
-  });
+
+      if (HOST === '0.0.0.0' || HOST === '::') {
+        logger.info({
+          component: 'Server',
+          message: 'Access the application at one of these URLs:',
+          urls: [
+            `${protocol}://localhost:${PORT}`,
+            `${protocol}://127.0.0.1:${PORT}`,
+            "(or use your machine's hostname/IP address)"
+          ]
+        });
+        logger.warn({
+          component: 'Server',
+          message: '⚠️  IMPORTANT: Do not access via http://0.0.0.0:* in your browser',
+          reason: 'Browsers will reject cookies from 0.0.0.0, causing authentication to fail',
+          recommendation: 'Always use localhost, 127.0.0.1, or your actual hostname'
+        });
+      } else {
+        logger.info({
+          component: 'Server',
+          message: 'Access the application at',
+          url: `${protocol}://${HOST}:${PORT}`
+        });
+      }
+    });
+  }
 
   const handleShutdownSignal = async () => {
     await shutdownTelemetry();


### PR DESCRIPTION
## Summary

iHub was running on a single worker under load. Clustering was already coded but defaulted to 1, and turning it up would have broken SSE chat because the per-chat streaming state in `server/sse.js` (the `clients` and `activeRequests` maps) and `server/actionTracker.js` (an `EventEmitter`) live in each worker's own process memory. With round-robin scheduling, a chat's SSE connection could land on worker A while its POST lands on worker B, and no tokens would reach the browser.

This PR enables multi-CPU scaling on a single host with a sticky-session cluster:

- **`server/clusterSticky.js` (new)** — the primary owns the public TCP socket (`net.createServer({ pauseOnConnect: true })`), hashes each connection's remote address (sha256, mod worker count) to pick a worker, and forwards the paused socket handle over IPC. A dead-worker fallback walks the ring to the next live worker. Workers attach via `attachStickyWorker(httpServer)` and re-emit connections on their HTTP server instead of calling `listen()`.
- **`server/server.js`** — primary branch forks workers, tracks them in a live array (crashed workers are respawned into the same slot), starts the sticky listener, logs the access URLs, and forwards `SIGTERM`/`SIGINT` to all children with a 5s grace period. Worker branch calls `attachStickyWorker`; single-process mode (`WORKERS=1`) still calls `server.listen()` as before.
- **Defaults** — `WORKERS` default is now `4` (was `1`); `npm run dev` and `npm run server` pin `WORKERS=1` so dev reload/debugging stays single-process.
- **Docs** — new `docs/scaling.md` with design rationale, tuning guidance, limitations (NAT-pinning, no session failover), and why worker count is not in the Admin UI; `server-config.md` and `architecture.md` updated; added to `SUMMARY.md`.

## Why not make it configurable in the Admin UI?

Short answer: worker count is infrastructure, not runtime config.
- `cluster.fork()` happens once at startup, so a UI change would either need a restart (at which point an env var is simpler) or live fork/kill, which would drop every SSE stream on the affected worker mid-token.
- It belongs next to `PORT` / `HOST` / SSL, which are also env vars. The Admin UI manages content (apps, prompts, models, groups), not process topology.
- A future read-only display in a "Server info" panel is fine; editable isn't.

## Trade-offs shipped

- Routing is by source IP, so many users behind one NAT/proxy pile on one worker. For that topology, put a stickiness-aware reverse proxy in front of multiple iHub instances.
- A chat is pinned to its worker for life; if that worker crashes, the browser's SSE reconnect handles it but the in-flight response is lost. Full cross-worker failover would require Redis pub/sub — deferred, called out in the alternatives section of `scaling.md`.

## Test plan

- [x] `WORKERS=1 node server/server.js` — server binds port itself, `/api/health` returns 200 (verified in smoke test).
- [x] `WORKERS=3 node server/server.js` — primary + 3 workers start, all "Worker ready for sticky connections" logged, `/api/health` 200 via sticky router (verified; `pstree` shows 3 workers under primary).
- [x] `kill -TERM <primary>` — all workers exit within the 5s grace window, no orphans (verified).
- [ ] Manual browser test: open a chat, confirm streaming and cancellation both work with `WORKERS=4`.
- [ ] Soak test: 4 concurrent chats from distinct IPs, confirm each pins to one worker and load balances across workers.
- [ ] Verify behaviour behind a reverse proxy that forwards the original client IP (or document the need to set `trust proxy` if we later route on `X-Forwarded-For`).

https://claude.ai/code/session_018MZoS1yXX53RAUwb2B2zzn