### PR TITLE
fix(office): skip auth-gate transform for office add-in HTML pages

### DIFF
--- a/client/vite-plugins/vite-plugin-auth-gate.js
+++ b/client/vite-plugins/vite-plugin-auth-gate.js
@@ -31,7 +31,12 @@ export default function authGatePlugin() {
 
     transformIndexHtml: {
       order: 'post',
-      handler(html) {
+      handler(html, ctx) {
+        // Skip office add-in pages — they have their own auth flow (PKCE OAuth)
+        if (ctx.filename && !ctx.filename.endsWith('/index.html')) {
+          return html;
+        }
+
         if (!isBuild && !isDevGateEnabled) {
           return html;
         }


### PR DESCRIPTION
## Summary

- The Outlook add-in taskpane at `/office/taskpane.html` rendered an empty page in production
- Root cause: `vite-plugin-auth-gate.js` strips `<script type="module">` tags from **all** MPA HTML entry points, then tries to inject an auth-gate loader anchored on `<div id="root">` — which doesn't exist in the office pages (they use `<div id="office-root">`)
- Scripts were silently removed with no replacement, so the built HTML had zero JavaScript
- Fix: bail out early in `transformIndexHtml` for any HTML entry that is not `index.html` — the office add-in has its own PKCE OAuth flow and never needed the auth gate

## Test plan

- [ ] Run `cd client && npm run build`
- [ ] Verify `client/dist/office/taskpane.html` contains a `<script type="module" src="../assets/office-taskpane-*.js">` tag
- [ ] Verify `client/dist/office/commands.html` contains its script tag
- [ ] Verify `client/dist/index.html` still contains `auth-gate-data` and `auth-gate-script` (no regression)
- [ ] Deploy to k3s and confirm the Outlook add-in taskpane loads and renders the React app

🤖 Generated with [Claude Code](https://claude.com/claude-code)