### PR TITLE
feat(office): add offline resilience to Outlook add-in

### DIFF
--- a/client/office/taskpane-entry.jsx
+++ b/client/office/taskpane-entry.jsx
@@ -1,4 +1,4 @@
-/* global Office, document */
+/* global Office, document, window */
 import { createRoot } from 'react-dom/client';
 import { MemoryRouter } from 'react-router-dom';
 import './office.css';
@@ -8,6 +8,16 @@ import '../src/i18n/i18n';
 import { OfficeConfigContext } from '../src/features/office/contexts/OfficeConfigContext';
 import OfficeApp from '../src/features/office/components/OfficeApp';
 import { installOfficeAuthInterceptor } from '../src/features/office/api/officeAuthBridge';
+
+// Signal that the JS bundle loaded successfully and cancel the offline fallback timer
+// set in taskpane.html. This runs before Office.onReady() so the timer is cleared
+// as early as possible even if Office.onReady takes a moment.
+window.__appInitialized = true;
+if (window.__offlineTimer) {
+  clearTimeout(window.__offlineTimer);
+}
+
+const CONFIG_STORAGE_KEY = 'office_ihub_config';
 
 /**
  * Derive the base path from the current URL so the config fetch works
@@ -24,19 +34,42 @@ Office.onReady(async () => {
   const basePath = detectBasePath();
 
   let config;
+  let offline = false;
+
   try {
     const res = await fetch(`${basePath}/api/integrations/office-addin/config`);
     if (!res.ok) {
       throw new Error(`Config fetch failed: ${res.status}`);
     }
     config = await res.json();
-  } catch (err) {
-    const rootEl = document.getElementById('office-root');
-    if (rootEl) {
-      rootEl.textContent = `Failed to load add-in configuration. Please contact your administrator. (${err.message})`;
-      rootEl.style.cssText = 'padding:16px;font-family:sans-serif;color:#b91c1c;';
+    // Cache for offline use on next load.
+    try {
+      localStorage.setItem(CONFIG_STORAGE_KEY, JSON.stringify(config));
+    } catch {
+      // localStorage may be unavailable in some managed environments.
     }
-    return;
+  } catch {
+    // Network or server error — try the locally cached config.
+    try {
+      const cached = localStorage.getItem(CONFIG_STORAGE_KEY);
+      if (cached) {
+        config = JSON.parse(cached);
+        // Re-derive baseUrl from the current URL in case the deployment address changed.
+        config.baseUrl = window.location.origin + basePath;
+        offline = true;
+      }
+    } catch {
+      // Parse error or localStorage unavailable.
+    }
+
+    if (!config) {
+      // No cache and no network — show the inline offline fallback.
+      const rootEl = document.getElementById('office-root');
+      const fallback = document.getElementById('office-offline-fallback');
+      if (rootEl) rootEl.style.display = 'none';
+      if (fallback) fallback.style.display = 'flex';
+      return;
+    }
   }
 
   // Install Office Bearer token interceptor so apiClient works in the taskpane.
@@ -59,7 +92,7 @@ Office.onReady(async () => {
     // eslint-disable-next-line @eslint-react/no-context-provider
     <OfficeConfigContext.Provider value={config}>
       <MemoryRouter>
-        <OfficeApp />
+        <OfficeApp offline={offline} />
       </MemoryRouter>
     </OfficeConfigContext.Provider>
   );

--- a/client/office/taskpane.html
+++ b/client/office/taskpane.html
@@ -47,6 +47,128 @@
         document.getElementById('office-root').style.display = 'none';
       }
     </script>
+
+    <!-- Register the Office add-in service worker for offline resilience. -->
+    <script>
+      if ('serviceWorker' in navigator) {
+        try {
+          var _m = location.pathname.match(/^(\/.*?)\/office(?:\/.*)?$/);
+          var _base = _m ? _m[1] : '';
+          navigator.serviceWorker.register(_base + '/office/office-sw.js', {
+            scope: _base + '/office/'
+          });
+        } catch (e) {
+          // SW registration failure is non-fatal — the add-in still works when online.
+        }
+      }
+    </script>
+
+    <!-- Offline fallback: shown if the JS bundle fails to load (e.g. browser cache cleared
+         while server is unreachable). The timer is cancelled by taskpane-entry.jsx. -->
+    <div
+      id="office-offline-fallback"
+      style="
+        display: none;
+        height: 100vh;
+        width: 100%;
+        align-items: center;
+        justify-content: center;
+        background: #f8fafc;
+        padding: 24px;
+        font-family: 'Segoe UI', system-ui, sans-serif;
+      "
+    >
+      <div
+        style="
+          background: #fff;
+          border: 1px solid #e2e8f0;
+          border-radius: 12px;
+          padding: 32px 24px;
+          max-width: 320px;
+          width: 100%;
+          text-align: center;
+        "
+      >
+        <div style="color: #94a3b8; margin-bottom: 16px">
+          <svg
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            style="display: inline-block"
+          >
+            <line x1="1" y1="1" x2="23" y2="23" />
+            <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55" />
+            <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39" />
+            <path d="M10.71 5.05A16 16 0 0 1 22.56 9" />
+            <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88" />
+            <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
+            <line x1="12" y1="20" x2="12.01" y2="20" />
+          </svg>
+        </div>
+        <h2
+          id="offline-heading"
+          style="font-size: 1.05rem; font-weight: 600; color: #1e293b; margin-bottom: 8px"
+        >
+          Server Not Reachable
+        </h2>
+        <p
+          id="offline-body"
+          style="font-size: 0.875rem; color: #64748b; line-height: 1.5; margin-bottom: 24px"
+        >
+          Please check your network connection and try again.
+        </p>
+        <button
+          id="offline-retry-btn"
+          onclick="location.reload()"
+          style="
+            background: #3b82f6;
+            color: #fff;
+            border: none;
+            border-radius: 8px;
+            padding: 10px 24px;
+            font-size: 0.875rem;
+            font-family: inherit;
+            cursor: pointer;
+            width: 100%;
+          "
+        >
+          Retry
+        </button>
+      </div>
+    </div>
+    <script>
+      // Apply German strings if the user's language is German.
+      (function () {
+        var lang = (navigator.language || 'en').split('-')[0].toLowerCase();
+        if (lang === 'de') {
+          var h = document.getElementById('offline-heading');
+          var p = document.getElementById('offline-body');
+          var b = document.getElementById('offline-retry-btn');
+          if (h) h.textContent = 'Server nicht erreichbar';
+          if (p)
+            p.textContent =
+              'Bitte überprüfen Sie Ihre Netzwerkverbindung und versuchen Sie es erneut.';
+          if (b) b.textContent = 'Erneut versuchen';
+        }
+      })();
+
+      // Show the offline fallback if the JS app hasn't initialised within 8 seconds.
+      // taskpane-entry.jsx sets window.__appInitialized = true on load and cancels this timer.
+      window.__offlineTimer = setTimeout(function () {
+        if (!window.__appInitialized) {
+          var root = document.getElementById('office-root');
+          var fallback = document.getElementById('office-offline-fallback');
+          if (root) root.style.display = 'none';
+          if (fallback) fallback.style.display = 'flex';
+        }
+      }, 8000);
+    </script>
+
     <script type="module" src="./taskpane-entry.jsx"></script>
   </body>
 </html>

--- a/client/public/office/office-sw.js
+++ b/client/public/office/office-sw.js
@@ -1,0 +1,158 @@
+/* global self, caches, fetch, Response */
+
+/**
+ * iHub Office Add-in Service Worker
+ *
+ * Provides offline resilience for the Outlook taskpane when the iHub server
+ * is unreachable. Strategy: network-first with cache fallback for /office/* requests.
+ *
+ * Critical: Outlook appends ?_host_Info=... query strings to the taskpane URL.
+ * All cache lookups use { ignoreSearch: true } to match regardless of query params.
+ */
+
+const CACHE_NAME = 'ihub-office-v1';
+
+// Minimal bilingual offline fallback page served when both network and cache are unavailable.
+const OFFLINE_HTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>iHub Apps</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    html, body { height: 100%; }
+    body {
+      font-family: 'Segoe UI', system-ui, sans-serif;
+      background: #f8fafc;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+    }
+    .card {
+      background: #fff;
+      border: 1px solid #e2e8f0;
+      border-radius: 12px;
+      padding: 32px 24px;
+      max-width: 320px;
+      width: 100%;
+      text-align: center;
+    }
+    .icon { color: #94a3b8; margin-bottom: 16px; }
+    h1 { font-size: 1.1rem; font-weight: 600; color: #1e293b; margin-bottom: 8px; }
+    p { font-size: 0.875rem; color: #64748b; line-height: 1.5; margin-bottom: 24px; }
+    button {
+      background: #3b82f6;
+      color: #fff;
+      border: none;
+      border-radius: 8px;
+      padding: 10px 24px;
+      font-size: 0.875rem;
+      font-family: inherit;
+      cursor: pointer;
+      width: 100%;
+    }
+    button:hover { background: #2563eb; }
+    [lang] { display: none; }
+  </style>
+  <script>
+    var lang = (navigator.language || 'en').split('-')[0].toLowerCase();
+    document.addEventListener('DOMContentLoaded', function() {
+      var els = document.querySelectorAll('[lang]');
+      for (var i = 0; i < els.length; i++) {
+        els[i].style.display = els[i].getAttribute('lang') === lang ? '' : 'none';
+      }
+      // Fallback to English if no match found
+      var visible = document.querySelector('[lang]:not([style*="none"])');
+      if (!visible) {
+        var enEls = document.querySelectorAll('[lang="en"]');
+        for (var j = 0; j < enEls.length; j++) enEls[j].style.display = '';
+      }
+    });
+  </script>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">
+      <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+        <line x1="1" y1="1" x2="23" y2="23"/>
+        <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"/>
+        <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"/>
+        <path d="M10.71 5.05A16 16 0 0 1 22.56 9"/>
+        <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"/>
+        <path d="M8.53 16.11a6 6 0 0 1 6.95 0"/>
+        <line x1="12" y1="20" x2="12.01" y2="20"/>
+      </svg>
+    </div>
+    <h1 lang="en">Server Not Reachable</h1>
+    <h1 lang="de">Server nicht erreichbar</h1>
+    <p lang="en">Please check your network connection and try again.</p>
+    <p lang="de">Bitte überprüfen Sie Ihre Netzwerkverbindung und versuchen Sie es erneut.</p>
+    <button lang="en" onclick="location.reload()">Retry</button>
+    <button lang="de" onclick="location.reload()">Erneut versuchen</button>
+  </div>
+</body>
+</html>`;
+
+// Install: skip waiting so the new SW activates immediately.
+self.addEventListener('install', event => {
+  event.waitUntil(self.skipWaiting());
+});
+
+// Activate: claim all clients and prune old ihub-office-v* caches.
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then(keys =>
+        Promise.all(
+          keys
+            .filter(key => key.startsWith('ihub-office-') && key !== CACHE_NAME)
+            .map(key => caches.delete(key))
+        )
+      )
+      .then(() => self.clients.claim())
+  );
+});
+
+// Fetch: network-first with cache fallback for same-origin /office/* GET requests.
+self.addEventListener('fetch', event => {
+  const { request } = event;
+
+  // Only handle GET requests.
+  if (request.method !== 'GET') return;
+
+  // Only handle same-origin requests under /office/.
+  const url = new URL(request.url);
+  if (url.origin !== self.location.origin) return;
+
+  // Normalize the path to strip any subpath prefix, then check for /office/.
+  if (!url.pathname.includes('/office/')) return;
+
+  event.respondWith(
+    fetch(request)
+      .then(response => {
+        // Cache successful HTML/JS/CSS responses.
+        if (response.ok) {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(cache => {
+            // Store keyed by pathname only so ignoreSearch lookups work.
+            cache.put(url.pathname, clone);
+          });
+        }
+        return response;
+      })
+      .catch(() =>
+        // Network failed — try cache, ignoring any query string Outlook may have appended.
+        caches.match(request, { ignoreSearch: true }).then(
+          cached =>
+            cached ||
+            new Response(OFFLINE_HTML, {
+              status: 200,
+              headers: { 'Content-Type': 'text/html; charset=utf-8' }
+            })
+        )
+      )
+  );
+});

--- a/client/src/features/office/components/OfficeApp.jsx
+++ b/client/src/features/office/components/OfficeApp.jsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Routes, Route, Navigate, useNavigate } from 'react-router-dom';
 import OfficeLogin from './OfficeLogin';
 import OfficeChatPanel from './OfficeChatPanel';
+import OfficeOfflineScreen from './OfficeOfflineScreen';
 import ChatHeader from './chat/ChatHeader';
 import SettingsDialog from './settings-dialog';
 import AppListPanel from '../../../shared/components/AppListPanel';
@@ -79,9 +80,10 @@ function SelectPage({ user, onLogout, onSelect }) {
   );
 }
 
-const OfficeApp = () => {
+const OfficeApp = ({ offline = false }) => {
   const config = useOfficeConfig();
   const navigate = useNavigate();
+  const [isOffline, setIsOffline] = React.useState(offline);
   const [authData, setAuthData] = React.useState(getStoredAuth);
   const [selectedApp, setSelectedApp] = React.useState(getStoredSelectedApp);
   const [sessionError, setSessionError] = React.useState(null);
@@ -100,6 +102,28 @@ const OfficeApp = () => {
     setOnSessionExpired(handleSessionExpired);
     return () => setOnSessionExpired(null);
   }, [handleSessionExpired]);
+
+  // Retry handler called by OfficeOfflineScreen when connectivity is restored.
+  const handleRetry = React.useCallback(() => {
+    setIsOffline(false);
+  }, []);
+
+  // Listen for the browser 'offline' event and verify with a real fetch before
+  // switching to offline mode (navigator.onLine can be unreliable in managed environments).
+  React.useEffect(() => {
+    const handleOfflineEvent = async () => {
+      try {
+        const res = await fetch(`${config.baseUrl}/api/integrations/office-addin/config`, {
+          signal: AbortSignal.timeout(3000)
+        });
+        if (!res.ok) setIsOffline(true);
+      } catch {
+        setIsOffline(true);
+      }
+    };
+    window.addEventListener('offline', handleOfflineEvent);
+    return () => window.removeEventListener('offline', handleOfflineEvent);
+  }, [config.baseUrl]);
 
   const handleLoginSuccess = React.useCallback(
     async data => {
@@ -155,6 +179,10 @@ const OfficeApp = () => {
     const id = window.setTimeout(() => setSessionError(null), 5000);
     return () => window.clearTimeout(id);
   }, [sessionError]);
+
+  if (isOffline) {
+    return <OfficeOfflineScreen onRetry={handleRetry} />;
+  }
 
   return (
     <Routes>

--- a/client/src/features/office/components/OfficeOfflineScreen.jsx
+++ b/client/src/features/office/components/OfficeOfflineScreen.jsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { officeLocale } from '../utilities/officeLocale';
+import { useOfficeConfig } from '../contexts/OfficeConfigContext';
+
+// Hardcoded bilingual strings — intentionally NOT using useTranslation() because
+// i18n translations are loaded from the server, which is unreachable in offline mode.
+const STRINGS = {
+  en: {
+    heading: 'Server Not Reachable',
+    body: 'Please check your network connection and try again.',
+    retry: 'Retry',
+    checking: 'Checking connection...'
+  },
+  de: {
+    heading: 'Server nicht erreichbar',
+    body: 'Bitte überprüfen Sie Ihre Netzwerkverbindung und versuchen Sie es erneut.',
+    retry: 'Erneut versuchen',
+    checking: 'Verbindung wird geprüft...'
+  }
+};
+
+const RETRY_INTERVAL_MS = 30_000;
+
+function OfficeOfflineScreen({ onRetry }) {
+  const config = useOfficeConfig();
+  const t = STRINGS[officeLocale] ?? STRINGS.en;
+  const [checking, setChecking] = React.useState(false);
+
+  const checkConnection = React.useCallback(async () => {
+    if (checking) return;
+    setChecking(true);
+    try {
+      const res = await fetch(`${config.baseUrl}/api/integrations/office-addin/config`, {
+        signal: AbortSignal.timeout(5000)
+      });
+      if (res.ok) {
+        onRetry();
+        return;
+      }
+    } catch {
+      // still offline
+    }
+    setChecking(false);
+  }, [checking, config.baseUrl, onRetry]);
+
+  // Auto-retry when the browser reports it came back online.
+  React.useEffect(() => {
+    window.addEventListener('online', checkConnection);
+    return () => window.removeEventListener('online', checkConnection);
+  }, [checkConnection]);
+
+  // Periodic background check every 30 seconds.
+  React.useEffect(() => {
+    const id = window.setInterval(checkConnection, RETRY_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [checkConnection]);
+
+  return (
+    <div className="h-screen w-full flex items-center justify-center bg-slate-50 p-6">
+      <div className="bg-white border border-slate-200 rounded-xl p-8 max-w-xs w-full text-center shadow-sm">
+        {/* Wifi-off icon */}
+        <div className="flex justify-center mb-4 text-slate-300">
+          <svg
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <line x1="1" y1="1" x2="23" y2="23" />
+            <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55" />
+            <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39" />
+            <path d="M10.71 5.05A16 16 0 0 1 22.56 9" />
+            <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88" />
+            <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
+            <line x1="12" y1="20" x2="12.01" y2="20" />
+          </svg>
+        </div>
+
+        <h2 className="text-base font-semibold text-slate-800 mb-2">{t.heading}</h2>
+        <p className="text-sm text-slate-500 leading-relaxed mb-6">{t.body}</p>
+
+        <button
+          onClick={checkConnection}
+          disabled={checking}
+          className="w-full py-2.5 px-4 rounded-lg text-sm font-medium bg-blue-500 hover:bg-blue-600 disabled:bg-slate-300 disabled:cursor-not-allowed text-white transition-colors"
+        >
+          {checking ? t.checking : t.retry}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default OfficeOfflineScreen;

--- a/server/routes/office.js
+++ b/server/routes/office.js
@@ -27,6 +27,16 @@ export default function registerOfficeRoutes(app) {
   // browser can cache icon files even when the integration is toggled.
   app.use(buildServerPath('/office/assets'), express.static(path.join(officePath, 'assets')));
 
+  // Serve the Office add-in service worker without the requireOfficeEnabled guard so
+  // that it can be fetched for unregistration even after the integration is disabled.
+  // Cache-Control: no-cache forces the browser to revalidate on every load so SW updates
+  // are picked up promptly.
+  app.get(buildServerPath('/office/office-sw.js'), (req, res) => {
+    res.set('Content-Type', 'application/javascript');
+    res.set('Cache-Control', 'no-cache');
+    res.sendFile(path.join(officePath, 'office-sw.js'));
+  });
+
   // Guard middleware: return 404 when the integration is not enabled
   function requireOfficeEnabled(req, res, next) {
     const enabled = configCache.getPlatform()?.officeIntegration?.enabled;


### PR DESCRIPTION
## Summary

- Adds a Service Worker (`office-sw.js`) that caches the taskpane HTML shell using a network-first strategy. Uses `ignoreSearch: true` on cache lookups to handle the query strings Outlook appends to the taskpane URL (`?_host_Info=...`).
- Caches the config API response in `localStorage` so the React app can boot from cached data when the server is unreachable.
- New `OfficeOfflineScreen` component shows a "Server Not Reachable" screen with retry button, 30s background polling, and auto-retry on the browser `online` event. Bilingual (en/de), hardcoded strings (not i18next, since translations require the server).
- An 8-second inline HTML fallback in `taskpane.html` covers the edge case where the JS bundle is not in the browser cache either.

## Failure mode coverage

| Scenario | Handled by |
|----------|-----------|
| Server unreachable, JS in browser cache | SW serves HTML + localStorage config → React offline screen |
| Server unreachable, browser cache cleared too | SW serves HTML → 8s timeout → inline offline UI |
| SW cache also cleared | SW embedded fallback HTML |
| First-ever load while unreachable | Unavoidable — no cache exists yet |
| Mid-session connectivity loss | `window offline` event → verify fetch → React offline screen |

## Test plan

- [ ] Load the add-in while connected, verify SW registered in DevTools → Application → Service Workers
- [ ] Disconnect network / disable connection, reload taskpane → offline screen appears with Retry button
- [ ] Click Retry after reconnecting → add-in recovers
- [ ] Clear SW cache + reload while offline → inline HTML fallback shows after 8s
- [ ] Switch browser language to German → verify German strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)