### PR TITLE
Fix magic prompt broken by missing await on async convertResponseToGeneric

### DIFF
--- a/server/utils.js
+++ b/server/utils.js
@@ -562,7 +562,7 @@ export async function simpleCompletion(
   const responseData = await response.json();
 
   // Use the adapter to parse the response
-  const parsed = convertResponseToGeneric(JSON.stringify(responseData), modelConfig.provider);
+  const parsed = await convertResponseToGeneric(JSON.stringify(responseData), modelConfig.provider);
 
   // Return both content and usage data
   return {


### PR DESCRIPTION
## Summary

- `convertResponseToGeneric` was made `async` in #1240 but the call site in `simpleCompletion` (`server/utils.js:565`) was not updated
- Without `await`, `parsed` was a `Promise` object — `parsed.content` was `undefined`, causing `.join()` to throw a `TypeError`
- Adds the missing `await` to resolve the Promise before accessing `.content`

## Test plan

- [ ] Start the dev server
- [ ] Open any app and click the magic prompt (wand) icon
- [ ] Submit a prompt and confirm the refined prompt is returned without errors
- [ ] Confirm no `TypeError: Cannot read properties of undefined (reading 'join')` in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)