### PR TITLE
fix: add missing await on async convertResponseToGeneric and processResponseBuffer

### DIFF
--- a/server/services/chat/StreamingHandler.js
+++ b/server/services/chat/StreamingHandler.js
@@ -474,7 +474,7 @@ class StreamingHandler {
 
         // Process any remaining data in buffer after stream ends
         if (buffer.trim() && !doneEmitted && finishReason !== 'error') {
-          const result = adapter.processResponseBuffer(buffer);
+          const result = await adapter.processResponseBuffer(buffer);
 
           if (result?.usage) {
             accumulatedUsage = mergeUsage(accumulatedUsage, result.usage);


### PR DESCRIPTION
## Summary

- `server/utils.js`: missing `await` on `convertResponseToGeneric()` in `simpleCompletion()` — `parsed` received a Promise instead of the resolved value, causing `parsed.content.join()` to throw a TypeError → **500 on the admin translate endpoint and magic prompt feature**
- `server/services/chat/StreamingHandler.js`: missing `await` on `adapter.processResponseBuffer(buffer)` in the remaining-buffer path after stream end → **silent loss of final chunk content and usage data**

Both functions were made async in #1240 but these two call sites were not updated.

## Test plan

- [ ] Trigger a translation from the admin UI — should return translated text (no 500)
- [ ] Use magic prompt feature — should complete without error
- [ ] Run a streaming chat and verify final chunk content/usage is not lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)