### PR TITLE
fix(outlook): open auth dialog as separate webview, not iframe

### DIFF
--- a/client/src/features/office/utilities/officeAuthDialog.js
+++ b/client/src/features/office/utilities/officeAuthDialog.js
@@ -14,12 +14,20 @@ export const openOfficeAuthDialog = (authorizeUrl, onRedirectUrl, onError) => {
     return;
   }
 
+  // Per Microsoft guidance, the dialog must open in a separate webview (not an
+  // iframe) for sign-in scenarios. With displayInIframe:true, Outlook on the web
+  // renders the dialog as a third-party iframe inside outlook.office.com — that
+  // breaks SameSite=Lax session cookies and modern browser third-party cookie
+  // policies, so the OIDC state cookie set during /api/oauth/authorize is not
+  // returned on the IDP callback and Passport rejects it with
+  // "Failed to verify request state". Desktop Outlook ignores the flag, which is
+  // why the same flow works there.
+  // https://learn.microsoft.com/en-us/office/dev/add-ins/develop/auth-with-office-dialog-api
   Office.context.ui.displayDialogAsync(
     authorizeUrl,
     {
       height: 65,
-      width: 40,
-      displayInIframe: true
+      width: 40
     },
     asyncResult => {
       if (asyncResult.status !== Office.AsyncResultStatus.Succeeded) {


### PR DESCRIPTION
## Summary

Fixes the Outlook add-in sign-in flow on Outlook on the web. Clicking **Authenticate** in the task pane currently dead-ends at `https://<host>/?auth=error&message=Unable%20to%20verify%20authorization%20request%20state.` and the task pane shows "the add-in may not load properly". The same flow works in desktop Outlook clients.

### Root cause

`Office.context.ui.displayDialogAsync` was being called with `displayInIframe: true`. In Outlook on the web that renders the OAuth dialog as a **third-party iframe inside `outlook.office.com`**, not as a real popup. Inside that cross-site iframe:

- The `oidc.session` cookie is configured with `SameSite=Lax` (`server/middleware/setup.js`).
- A `Lax` cookie is **not** sent on cross-site iframe requests.
- Modern browsers (Safari ITP, Firefox ETP, Chrome 3rd-party-cookie phase-out) may also block or partition third-party cookies entirely.

So the OIDC `state` set by Passport during `/api/oauth/authorize` is missing on the IDP callback. Passport rejects it (`server/middleware/oidcAuth.js:609`) and the iframe is redirected to `/?auth=error&message=Unable%20to%20verify%20authorization%20request%20state.`.

Desktop Outlook silently ignores `displayInIframe` and opens an OS popup window — first-party context, cookies work, OAuth completes. That's why this only manifests on Outlook on the web.

### Fix

Drop `displayInIframe: true` so the dialog opens in a separate webview / popup window. This matches Microsoft's official guidance, which explicitly says the option **must not be used for sign-in scenarios**:

> "While it's possible to configure the dialog to open in a floating iframe using `displayInIframe: true`, this option should not be used when the Office dialog API is employed for sign-in purposes."  
> — [Authenticate and authorize with the Office dialog API](https://learn.microsoft.com/en-us/office/dev/add-ins/develop/auth-with-office-dialog-api)

## Out of scope (unrelated symptoms in the same bug report)

- **Missing icons in Outlook on the web** — this customer's iHub is reachable only via VPN (`ihub.local.intrafind.io`). Outlook on the web fetches add-in ribbon icons through a Microsoft-hosted proxy/CDN; their backend can't reach VPN-only hosts. Not fixable in code unless we expose the icons on a publicly reachable URL.
- **`Reading pane state not found. Unable to launch add-in without message context.`** — manifest only declares `MessageReadCommandSurface` / `MessageComposeCommandSurface`. Launching from new Outlook on the web's Apps sidebar without a selected message triggers this error. Workaround: open an email first.

## Test plan

- [ ] Reload the add-in in Outlook on the web (force-refresh the manifest if cached).
- [ ] Open an email so the add-in can launch (resolves the unrelated "Reading pane state" error).
- [ ] Click **Authenticate** — confirm a real popup window opens (not an in-page iframe).
- [ ] Complete the OIDC flow — confirm redirect to `/office/callback.html` and the task pane loads the chat panel.
- [ ] Repeat in desktop Outlook to confirm no regression there.

https://claude.ai/code/session_01VCJ1a8gKyjxuBAyh4HxirZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VCJ1a8gKyjxuBAyh4HxirZ)_