### PR TITLE
feat: add server-configured quick actions to Outlook ribbon

### DIFF
--- a/client/office/taskpane-entry.jsx
+++ b/client/office/taskpane-entry.jsx
@@ -51,6 +51,12 @@ Office.onReady(async () => {
     });
   }
 
+  const params = new URLSearchParams(window.location.search);
+  const qaParam = params.get('qa');
+  const qaIndex = qaParam != null ? Number(qaParam) : -1;
+  const quickAction =
+    qaIndex >= 0 && Number.isInteger(qaIndex) ? (config.quickActions?.[qaIndex] ?? null) : null;
+
   const rootEl = document.getElementById('office-root');
   if (!rootEl) return;
 
@@ -59,7 +65,7 @@ Office.onReady(async () => {
     // eslint-disable-next-line @eslint-react/no-context-provider
     <OfficeConfigContext.Provider value={config}>
       <MemoryRouter>
-        <OfficeApp />
+        <OfficeApp quickAction={quickAction} />
       </MemoryRouter>
     </OfficeConfigContext.Provider>
   );

--- a/client/src/features/admin/pages/AdminOfficeIntegrationPage.jsx
+++ b/client/src/features/admin/pages/AdminOfficeIntegrationPage.jsx
@@ -4,11 +4,13 @@ import { Link } from 'react-router-dom';
 import AdminAuth from '../components/AdminAuth';
 import AdminNavigation from '../components/AdminNavigation';
 import DynamicLanguageEditor from '../../../shared/components/DynamicLanguageEditor';
-import { makeAdminApiCall } from '../../../api/adminApi';
+import { makeAdminApiCall, fetchAdminApps } from '../../../api/adminApi';
 import { buildApiUrl } from '../../../utils/runtimeBasePath';
+import { getLocalizedContent } from '../../../utils/localizeContent';
 
 function AdminOfficeIntegrationPage() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const currentLanguage = i18n.language;
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [toggling, setToggling] = useState(false);
@@ -18,6 +20,8 @@ function AdminOfficeIntegrationPage() {
   const [displayName, setDisplayName] = useState({});
   const [description, setDescription] = useState({});
   const [starterPrompts, setStarterPrompts] = useState([]);
+  const [quickActions, setQuickActions] = useState([]);
+  const [availableApps, setAvailableApps] = useState([]);
 
   // Stable client-side ids are used as React keys while the prompt list is edited.
   // They are stripped before persisting so the server never sees them.
@@ -38,6 +42,16 @@ function AdminOfficeIntegrationPage() {
     return out;
   };
 
+  const sanitizeAndKeyQuickActions = raw => {
+    if (!Array.isArray(raw)) return [];
+    return raw.map(item => ({
+      _id: crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2),
+      appId: typeof item?.appId === 'string' ? item.appId : '',
+      label: sanitizeLocalized(item?.label ?? {}),
+      prompt: sanitizeLocalized(item?.prompt ?? {})
+    }));
+  };
+
   const loadStatus = async () => {
     try {
       setLoading(true);
@@ -55,6 +69,7 @@ function AdminOfficeIntegrationPage() {
             }))
           : []
       );
+      setQuickActions(sanitizeAndKeyQuickActions(data.quickActions));
     } catch (_err) {
       setMessage({
         type: 'error',
@@ -68,6 +83,12 @@ function AdminOfficeIntegrationPage() {
   useEffect(() => {
     loadStatus();
     // eslint-disable-next-line @eslint-react/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    fetchAdminApps()
+      .then(data => setAvailableApps(Array.isArray(data) ? data : []))
+      .catch(err => console.error('Failed to load apps', err));
   }, []);
 
   const handleToggle = async () => {
@@ -122,12 +143,22 @@ function AdminOfficeIntegrationPage() {
         }))
         .filter(p => Object.keys(p.title).length > 0 && Object.keys(p.message).length > 0);
 
+      const cleanedQuickActions = quickActions
+        .filter(qa => qa.appId && Object.values(trimLocalized(qa.label)).some(v => v))
+        .map(({ _id: _ignored, ...qa }) => {
+          const trimmedPrompt = trimLocalized(qa.prompt ?? {});
+          const entry = { appId: qa.appId, label: trimLocalized(qa.label) };
+          if (Object.values(trimmedPrompt).some(v => v)) entry.prompt = trimmedPrompt;
+          return entry;
+        });
+
       await makeAdminApiCall('/admin/office-integration/config', {
         method: 'PUT',
         data: {
           displayName: trimLocalized(displayName),
           description: trimLocalized(description),
-          starterPrompts: cleanedPrompts
+          starterPrompts: cleanedPrompts,
+          quickActions: cleanedQuickActions
         }
       });
       await loadStatus();
@@ -168,6 +199,40 @@ function AdminOfficeIntegrationPage() {
 
   const handleMovePrompt = (index, direction) => {
     setStarterPrompts(prev => {
+      const target = index + direction;
+      if (target < 0 || target >= prev.length) return prev;
+      const next = [...prev];
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  };
+
+  const handleQuickActionChange = (index, field, value) => {
+    setQuickActions(prev => {
+      const next = [...prev];
+      next[index] = { ...next[index], [field]: value };
+      return next;
+    });
+  };
+
+  const handleAddQuickAction = () => {
+    setQuickActions(prev => [
+      ...prev,
+      {
+        _id: crypto.randomUUID ? crypto.randomUUID() : Math.random().toString(36).slice(2),
+        appId: '',
+        label: {},
+        prompt: {}
+      }
+    ]);
+  };
+
+  const handleRemoveQuickAction = index => {
+    setQuickActions(prev => prev.filter((_, i) => i !== index));
+  };
+
+  const handleMoveQuickAction = (index, direction) => {
+    setQuickActions(prev => {
       const target = index + direction;
       if (target < 0 || target >= prev.length) return prev;
       const next = [...prev];
@@ -434,6 +499,138 @@ function AdminOfficeIntegrationPage() {
                             label={t('admin.officeIntegration.promptMessage', 'Message')}
                             value={prompt?.message || {}}
                             onChange={value => handlePromptChange(index, 'message', value)}
+                            type="textarea"
+                          />
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                <div className="mt-6 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={handleSaveConfig}
+                    disabled={saving}
+                    className="rounded-lg bg-indigo-600 text-white px-4 py-2 text-sm font-medium hover:bg-indigo-700 disabled:opacity-60"
+                  >
+                    {saving ? '…' : t('admin.officeIntegration.save', 'Save')}
+                  </button>
+                </div>
+              </div>
+
+              {/* Quick Actions */}
+              <div className="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                      {t('admin.officeIntegration.quickActionsTitle', 'Quick Actions')}
+                    </h2>
+                    <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+                      {t(
+                        'admin.officeIntegration.quickActionsDesc',
+                        'Quick actions appear as a dropdown menu in the Outlook ribbon. Each action opens the add-in with a specific app pre-selected. Changing quick actions requires re-downloading and re-deploying the manifest.'
+                      )}
+                    </p>
+                  </div>
+                  <div className="flex items-center gap-3 shrink-0">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
+                      {quickActions.length} / 10
+                    </span>
+                    <button
+                      type="button"
+                      onClick={handleAddQuickAction}
+                      disabled={quickActions.length >= 10}
+                      className="rounded-lg border border-gray-300 dark:border-gray-600 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-40 disabled:cursor-not-allowed"
+                    >
+                      {t('admin.officeIntegration.addQuickAction', 'Add Quick Action')}
+                    </button>
+                  </div>
+                </div>
+
+                {quickActions.length === 0 ? (
+                  <p className="mt-4 text-sm text-gray-500 dark:text-gray-400 italic">
+                    {t(
+                      'admin.officeIntegration.noQuickActions',
+                      'No quick actions configured. Add one to show actions in the Outlook ribbon.'
+                    )}
+                  </p>
+                ) : (
+                  <div className="mt-4 space-y-4">
+                    {quickActions.map((qa, index) => (
+                      <div
+                        key={qa._id}
+                        className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 bg-gray-50/60 dark:bg-gray-900/40"
+                      >
+                        <div className="flex items-center justify-between mb-3">
+                          <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                            {t('admin.officeIntegration.quickActionIndex', 'Quick Action #{{n}}', {
+                              n: index + 1
+                            })}
+                          </span>
+                          <div className="flex items-center gap-1">
+                            <button
+                              type="button"
+                              onClick={() => handleMoveQuickAction(index, -1)}
+                              disabled={index === 0}
+                              className="rounded px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-40 disabled:hover:bg-transparent"
+                              aria-label={t('admin.officeIntegration.moveUp', 'Move up')}
+                            >
+                              ↑
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleMoveQuickAction(index, 1)}
+                              disabled={index === quickActions.length - 1}
+                              className="rounded px-2 py-1 text-xs text-gray-600 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 disabled:opacity-40 disabled:hover:bg-transparent"
+                              aria-label={t('admin.officeIntegration.moveDown', 'Move down')}
+                            >
+                              ↓
+                            </button>
+                            <button
+                              type="button"
+                              onClick={() => handleRemoveQuickAction(index)}
+                              className="rounded px-2 py-1 text-xs text-red-600 hover:bg-red-50 dark:hover:bg-red-900/30"
+                            >
+                              {t('admin.officeIntegration.remove', 'Remove')}
+                            </button>
+                          </div>
+                        </div>
+                        <div className="space-y-3">
+                          <div>
+                            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                              {t('admin.officeIntegration.quickActionApp', 'App')}
+                            </label>
+                            <select
+                              value={qa.appId}
+                              onChange={e =>
+                                handleQuickActionChange(index, 'appId', e.target.value)
+                              }
+                              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                            >
+                              <option value="">
+                                {t('admin.officeIntegration.selectApp', 'Select app...')}
+                              </option>
+                              {availableApps.map(app => (
+                                <option key={app.id} value={app.id}>
+                                  {getLocalizedContent(app.name, currentLanguage) || app.id}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <DynamicLanguageEditor
+                            label={t('admin.officeIntegration.quickActionLabel', 'Label')}
+                            value={qa?.label || {}}
+                            onChange={value => handleQuickActionChange(index, 'label', value)}
+                            type="text"
+                          />
+                          <DynamicLanguageEditor
+                            label={t(
+                              'admin.officeIntegration.quickActionPrompt',
+                              'Prompt (optional)'
+                            )}
+                            value={qa?.prompt || {}}
+                            onChange={value => handleQuickActionChange(index, 'prompt', value)}
                             type="textarea"
                           />
                         </div>

--- a/client/src/features/office/components/OfficeApp.jsx
+++ b/client/src/features/office/components/OfficeApp.jsx
@@ -6,7 +6,9 @@ import ChatHeader from './chat/ChatHeader';
 import SettingsDialog from './settings-dialog';
 import AppListPanel from '../../../shared/components/AppListPanel';
 import { officeLocale } from '../utilities/officeLocale';
+import { getLocalizedContent } from '../../../utils/localizeContent';
 import { useOfficeConfig } from '../contexts/OfficeConfigContext';
+import { fetchApps } from '../../../api/api';
 import {
   storeTokenResponse,
   clearTokens,
@@ -79,12 +81,17 @@ function SelectPage({ user, onLogout, onSelect }) {
   );
 }
 
-const OfficeApp = () => {
+const OfficeApp = ({ quickAction = null }) => {
   const config = useOfficeConfig();
   const navigate = useNavigate();
   const [authData, setAuthData] = React.useState(getStoredAuth);
   const [selectedApp, setSelectedApp] = React.useState(getStoredSelectedApp);
   const [sessionError, setSessionError] = React.useState(null);
+
+  const pendingQuickActionRef = React.useRef(quickAction);
+  const [pendingPrompt, setPendingPrompt] = React.useState(() =>
+    quickAction ? getLocalizedContent(quickAction.prompt, officeLocale) || null : null
+  );
 
   const handleSessionExpired = React.useCallback(() => {
     clearTokens();
@@ -101,6 +108,26 @@ const OfficeApp = () => {
     return () => setOnSessionExpired(null);
   }, [handleSessionExpired]);
 
+  const applyPendingQuickAction = React.useCallback(async () => {
+    const qa = pendingQuickActionRef.current;
+    if (!qa?.appId) return false;
+    try {
+      const apps = await fetchApps();
+      const app = Array.isArray(apps) ? apps.find(a => a.id === qa.appId) : null;
+      if (app) {
+        setSelectedApp(app);
+        storeSelectedApp(app);
+        pendingQuickActionRef.current = null;
+        navigate('/chat', { replace: true });
+        return true;
+      }
+    } catch {
+      // ignore
+    }
+    pendingQuickActionRef.current = null;
+    return false;
+  }, [navigate]);
+
   const handleLoginSuccess = React.useCallback(
     async data => {
       storeTokenResponse(data);
@@ -115,9 +142,13 @@ const OfficeApp = () => {
 
       setAuthData({ user });
       setSessionError(null);
-      navigate('/select', { replace: true });
+
+      const applied = await applyPendingQuickAction();
+      if (!applied) {
+        navigate('/select', { replace: true });
+      }
     },
-    [config, navigate]
+    [config, navigate, applyPendingQuickAction]
   );
 
   const handleLogout = React.useCallback(() => {
@@ -145,10 +176,14 @@ const OfficeApp = () => {
   }, []);
 
   React.useEffect(() => {
-    if (authData && !selectedApp && window.location.pathname === '/') {
-      navigate('/select', { replace: true });
+    if (!authData) return;
+    if (!selectedApp) {
+      applyPendingQuickAction().then(applied => {
+        if (!applied) navigate('/select', { replace: true });
+      });
     }
-  }, [authData, selectedApp, navigate]);
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+  }, []);
 
   React.useEffect(() => {
     if (!sessionError) return undefined;
@@ -169,6 +204,8 @@ const OfficeApp = () => {
               selectedApp={selectedApp}
               setSelectedApp={handleSetSelectedApp}
               onLogout={handleLogout}
+              initialPrompt={pendingPrompt}
+              onInitialPromptConsumed={() => setPendingPrompt(null)}
             />
           ) : (
             <OfficeLogin onSuccess={handleLoginSuccess} initialError={sessionError} />
@@ -194,6 +231,8 @@ const OfficeApp = () => {
               selectedApp={selectedApp}
               setSelectedApp={handleSetSelectedApp}
               onLogout={handleLogout}
+              initialPrompt={pendingPrompt}
+              onInitialPromptConsumed={() => setPendingPrompt(null)}
             />
           ) : (
             <Navigate to="/" replace />

--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -35,7 +35,14 @@ function buildParamsFromApp(app) {
   return params;
 }
 
-function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
+function OfficeChatPanel({
+  authData,
+  selectedApp,
+  setSelectedApp,
+  onLogout,
+  initialPrompt,
+  onInitialPromptConsumed
+}) {
   const navigate = useNavigate();
   const officeConfig = useOfficeConfig();
 
@@ -46,6 +53,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   // Chat ID: use a stable ref, reset on item change or new chat
   const chatIdRef = useRef(`office-${uuidv4()}`);
   const selectedStarterPromptRef = useRef(null);
+  const initialPromptFiredRef = useRef(false);
 
   const adapter = useOfficeChatAdapter({
     appId: selectedApp?.id,
@@ -147,6 +155,16 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
       fileUploadHandler
     ]
   );
+
+  // Auto-fire the initial prompt from a quick action once on mount
+  useEffect(() => {
+    if (!initialPrompt || initialPromptFiredRef.current || adapter.messages.length > 0) return;
+    initialPromptFiredRef.current = true;
+    submitMessage(initialPrompt);
+    if (onInitialPromptConsumed) onInitialPromptConsumed();
+    // adapter.messages.length intentionally NOT in deps to avoid re-firing
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+  }, [initialPrompt, submitMessage, onInitialPromptConsumed]);
 
   const handleSubmit = useCallback(
     e => {

--- a/server/migrations/V031__add_office_quick_actions.js
+++ b/server/migrations/V031__add_office_quick_actions.js
@@ -1,0 +1,13 @@
+export const version = '031';
+export const description = 'add_office_quick_actions';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+  ctx.setDefault(platform, 'officeIntegration.quickActions', []);
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Added officeIntegration.quickActions default');
+}

--- a/server/routes/admin/officeIntegration.js
+++ b/server/routes/admin/officeIntegration.js
@@ -54,6 +54,7 @@ export default function registerAdminOfficeIntegrationRoutes(app) {
         de: 'KI-gestützter Assistent für Outlook'
       },
       starterPrompts: Array.isArray(officeConfig.starterPrompts) ? officeConfig.starterPrompts : [],
+      quickActions: Array.isArray(officeConfig.quickActions) ? officeConfig.quickActions : [],
       manifestUrl: `${baseUrl}/api/integrations/office-addin/manifest.xml`,
       taskpaneUrl: `${baseUrl}/office/taskpane.html`
     });
@@ -213,7 +214,7 @@ export default function registerAdminOfficeIntegrationRoutes(app) {
    */
   app.put(buildServerPath('/api/admin/office-integration/config'), adminAuth, async (req, res) => {
     try {
-      const { displayName, description, starterPrompts } = req.body;
+      const { displayName, description, starterPrompts, quickActions } = req.body;
       const platform = configCache.getPlatform();
 
       // Accept only `{ [lang: string]: string }` objects. Any non-string locale value
@@ -284,6 +285,53 @@ export default function registerAdminOfficeIntegrationRoutes(app) {
           sanitized.push({ title: titleResult.value, message: messageResult.value });
         }
         allowed.starterPrompts = sanitized;
+      }
+      if (quickActions !== undefined) {
+        if (!Array.isArray(quickActions)) {
+          return sendBadRequest(res, 'quickActions must be an array');
+        }
+        if (quickActions.length > 10) {
+          return sendBadRequest(res, 'quickActions must not contain more than 10 entries');
+        }
+        const apps = configCache.getApps?.() ?? [];
+        const sanitized = [];
+        for (let i = 0; i < quickActions.length; i++) {
+          const entry = quickActions[i];
+          if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+            return sendBadRequest(res, `quickActions[${i}] must be an object`);
+          }
+          if (!entry.appId || typeof entry.appId !== 'string' || entry.appId.trim() === '') {
+            return sendBadRequest(res, `quickActions[${i}].appId must be a non-empty string`);
+          }
+          if (entry.appId.trim().length > 50) {
+            return sendBadRequest(res, `quickActions[${i}].appId must not exceed 50 characters`);
+          }
+          if (!apps.some(a => a.id === entry.appId.trim())) {
+            return sendBadRequest(
+              res,
+              `quickActions[${i}].appId references unknown app "${entry.appId.trim()}"`
+            );
+          }
+          const labelResult = validateLocalizedObject(`quickActions[${i}].label`, entry.label, {
+            maxLength: 250,
+            requireNonEmpty: true
+          });
+          if (labelResult.error) return sendBadRequest(res, labelResult.error);
+          const sanitizedEntry = { appId: entry.appId.trim(), label: labelResult.value };
+          if (entry.prompt !== undefined) {
+            const promptResult = validateLocalizedObject(
+              `quickActions[${i}].prompt`,
+              entry.prompt,
+              { maxLength: 4000, requireNonEmpty: false }
+            );
+            if (promptResult.error) return sendBadRequest(res, promptResult.error);
+            if (Object.keys(promptResult.value).length > 0) {
+              sanitizedEntry.prompt = promptResult.value;
+            }
+          }
+          sanitized.push(sanitizedEntry);
+        }
+        allowed.quickActions = sanitized;
       }
 
       await savePlatformConfig({

--- a/server/routes/integrations/officeAddin.js
+++ b/server/routes/integrations/officeAddin.js
@@ -51,6 +51,22 @@ function sanitizeStarterPrompts(value) {
   return out;
 }
 
+function sanitizeQuickActions(value) {
+  if (!Array.isArray(value)) return [];
+  const out = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    if (!item.appId || typeof item.appId !== 'string' || item.appId.trim() === '') continue;
+    const label = sanitizeLocalizedObject(item.label);
+    if (Object.keys(label).length === 0) continue;
+    const entry = { appId: item.appId.trim(), label };
+    const prompt = sanitizeLocalizedObject(item.prompt);
+    if (Object.keys(prompt).length > 0) entry.prompt = prompt;
+    out.push(entry);
+  }
+  return out;
+}
+
 /**
  * @swagger
  * /api/integrations/office-addin/config:
@@ -79,7 +95,8 @@ router.get('/config', (req, res) => {
     baseUrl,
     clientId: officeConfig.oauthClientId || '',
     redirectUri: `${baseUrl}/office/callback.html`,
-    starterPrompts: sanitizeStarterPrompts(officeConfig.starterPrompts)
+    starterPrompts: sanitizeStarterPrompts(officeConfig.starterPrompts),
+    quickActions: sanitizeQuickActions(officeConfig.quickActions)
   });
 });
 
@@ -122,14 +139,154 @@ router.get('/manifest.xml', (req, res) => {
     displayName
   });
 
-  const manifest = generateManifest({ baseUrl, origin, displayName, description });
+  const quickActions = sanitizeQuickActions(officeConfig.quickActions);
+  const manifest = generateManifest({ baseUrl, origin, displayName, description, quickActions });
 
   res.set('Content-Type', 'application/xml; charset=utf-8');
   res.set('Content-Disposition', 'attachment; filename="manifest.xml"');
   res.send(manifest);
 });
 
-function generateManifest({ baseUrl, origin, displayName, description }) {
+function generateManifest({ baseUrl, origin, displayName, description, quickActions = [] }) {
+  function generateMenuItems(qas, supportsPinning, context) {
+    const items = qas
+      .map(
+        (qa, i) => `\
+                  <Item id="QuickAction_${i}_${context}">
+                    <Label resid="QuickAction_${i}.Label"/>
+                    <Supertip>
+                      <Title resid="QuickAction_${i}.Label"/>
+                      <Description resid="QuickAction_${i}.Label"/>
+                    </Supertip>
+                    <Icon>
+                      <bt:Image size="16" resid="Icon.16x16"/>
+                      <bt:Image size="32" resid="Icon.32x32"/>
+                      <bt:Image size="80" resid="Icon.80x80"/>
+                    </Icon>
+                    <Action xsi:type="ShowTaskpane">
+                      <SourceLocation resid="QuickAction_${i}.Url"/>${supportsPinning ? '\n                      <SupportsPinning>true</SupportsPinning>' : ''}
+                    </Action>
+                  </Item>`
+      )
+      .join('\n');
+    const openItem = `\
+                  <Item id="OpenChat_${context}">
+                    <Label resid="OpenChat.Label"/>
+                    <Supertip>
+                      <Title resid="OpenChat.Label"/>
+                      <Description resid="OpenChat.Label"/>
+                    </Supertip>
+                    <Icon>
+                      <bt:Image size="16" resid="Icon.16x16"/>
+                      <bt:Image size="32" resid="Icon.32x32"/>
+                      <bt:Image size="80" resid="Icon.80x80"/>
+                    </Icon>
+                    <Action xsi:type="ShowTaskpane">
+                      <SourceLocation resid="Taskpane.Url"/>${supportsPinning ? '\n                      <SupportsPinning>true</SupportsPinning>' : ''}
+                    </Action>
+                  </Item>`;
+    return `${items}\n${openItem}`;
+  }
+
+  function generateQuickActionResources(qas) {
+    const urls = qas
+      .map(
+        (_, i) =>
+          `        <bt:Url id="QuickAction_${i}.Url" DefaultValue="${baseUrl}/office/taskpane.html?qa=${i}"/>`
+      )
+      .join('\n');
+    const strings = qas
+      .map(
+        (qa, i) =>
+          `        <bt:String id="QuickAction_${i}.Label" DefaultValue="${escapeXml(qa.label?.en ?? '')}"/>`
+      )
+      .join('\n');
+    return { urls, strings };
+  }
+
+  const hasQuickActions = quickActions.length > 0;
+
+  function renderControl(id, groupSuffix, supportsPinning) {
+    if (!hasQuickActions) {
+      return `\
+                <Control xsi:type="Button" id="${id}">
+                  <Label resid="TaskpaneButton.Label"/>
+                  <Supertip>
+                    <Title resid="TaskpaneButton.Label"/>
+                    <Description resid="TaskpaneButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Icon.16x16"/>
+                    <bt:Image size="32" resid="Icon.32x32"/>
+                    <bt:Image size="80" resid="Icon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="Taskpane.Url"/>${supportsPinning ? '\n                    <SupportsPinning>true</SupportsPinning>' : ''}
+                  </Action>
+                </Control>`;
+    }
+    return `\
+                <Control xsi:type="Menu" id="${id}">
+                  <Label resid="MenuButton.Label"/>
+                  <Supertip>
+                    <Title resid="MenuButton.Label"/>
+                    <Description resid="TaskpaneButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Icon.16x16"/>
+                    <bt:Image size="32" resid="Icon.32x32"/>
+                    <bt:Image size="80" resid="Icon.80x80"/>
+                  </Icon>
+                  <Items>
+${generateMenuItems(quickActions, supportsPinning, groupSuffix)}
+                  </Items>
+                </Control>`;
+  }
+
+  function renderResources(qas) {
+    if (!hasQuickActions) {
+      return `\
+      <bt:Images>
+        <bt:Image id="Icon.16x16" DefaultValue="${baseUrl}/office/assets/icon-16.png"/>
+        <bt:Image id="Icon.32x32" DefaultValue="${baseUrl}/office/assets/icon-32.png"/>
+        <bt:Image id="Icon.80x80" DefaultValue="${baseUrl}/office/assets/icon-80.png"/>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="Commands.Url" DefaultValue="${baseUrl}/office/commands.html"/>
+        <bt:Url id="Taskpane.Url" DefaultValue="${baseUrl}/office/taskpane.html"/>
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="GroupLabel" DefaultValue="${escapeXml(displayName)} Add-in"/>
+        <bt:String id="TaskpaneButton.Label" DefaultValue="Show Task Pane"/>
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="${escapeXml(description)}"/>
+      </bt:LongStrings>`;
+    }
+    const { urls, strings } = generateQuickActionResources(qas);
+    return `\
+      <bt:Images>
+        <bt:Image id="Icon.16x16" DefaultValue="${baseUrl}/office/assets/icon-16.png"/>
+        <bt:Image id="Icon.32x32" DefaultValue="${baseUrl}/office/assets/icon-32.png"/>
+        <bt:Image id="Icon.80x80" DefaultValue="${baseUrl}/office/assets/icon-80.png"/>
+      </bt:Images>
+      <bt:Urls>
+        <bt:Url id="Commands.Url" DefaultValue="${baseUrl}/office/commands.html"/>
+        <bt:Url id="Taskpane.Url" DefaultValue="${baseUrl}/office/taskpane.html"/>
+${urls}
+      </bt:Urls>
+      <bt:ShortStrings>
+        <bt:String id="GroupLabel" DefaultValue="${escapeXml(displayName)} Add-in"/>
+        <bt:String id="TaskpaneButton.Label" DefaultValue="Show Task Pane"/>
+        <bt:String id="MenuButton.Label" DefaultValue="${escapeXml(displayName)}"/>
+        <bt:String id="OpenChat.Label" DefaultValue="Open ${escapeXml(displayName)}"/>
+${strings}
+      </bt:ShortStrings>
+      <bt:LongStrings>
+        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="${escapeXml(description)}"/>
+      </bt:LongStrings>`;
+  }
+
   return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
@@ -188,21 +345,7 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
             <OfficeTab id="TabDefault">
               <Group id="msgReadGroup">
                 <Label resid="GroupLabel"/>
-                <Control xsi:type="Button" id="msgReadOpenPaneButton">
-                  <Label resid="TaskpaneButton.Label"/>
-                  <Supertip>
-                    <Title resid="TaskpaneButton.Label"/>
-                    <Description resid="TaskpaneButton.Tooltip"/>
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="Icon.16x16"/>
-                    <bt:Image size="32" resid="Icon.32x32"/>
-                    <bt:Image size="80" resid="Icon.80x80"/>
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <SourceLocation resid="Taskpane.Url"/>
-                  </Action>
-                </Control>
+${renderControl('msgReadMenuButton', 'msgRead', false)}
               </Group>
             </OfficeTab>
           </ExtensionPoint>
@@ -210,21 +353,7 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
             <OfficeTab id="TabDefault">
               <Group id="msgComposeGroup">
                 <Label resid="GroupLabel"/>
-                <Control xsi:type="Button" id="msgComposeOpenPaneButton">
-                  <Label resid="TaskpaneButton.Label"/>
-                  <Supertip>
-                    <Title resid="TaskpaneButton.Label"/>
-                    <Description resid="TaskpaneButton.Tooltip"/>
-                  </Supertip>
-                  <Icon>
-                    <bt:Image size="16" resid="Icon.16x16"/>
-                    <bt:Image size="32" resid="Icon.32x32"/>
-                    <bt:Image size="80" resid="Icon.80x80"/>
-                  </Icon>
-                  <Action xsi:type="ShowTaskpane">
-                    <SourceLocation resid="Taskpane.Url"/>
-                  </Action>
-                </Control>
+${renderControl('msgComposeMenuButton', 'msgCompose', false)}
               </Group>
             </OfficeTab>
           </ExtensionPoint>
@@ -232,22 +361,7 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
       </Host>
     </Hosts>
     <Resources>
-      <bt:Images>
-        <bt:Image id="Icon.16x16" DefaultValue="${baseUrl}/office/assets/icon-16.png"/>
-        <bt:Image id="Icon.32x32" DefaultValue="${baseUrl}/office/assets/icon-32.png"/>
-        <bt:Image id="Icon.80x80" DefaultValue="${baseUrl}/office/assets/icon-80.png"/>
-      </bt:Images>
-      <bt:Urls>
-        <bt:Url id="Commands.Url" DefaultValue="${baseUrl}/office/commands.html"/>
-        <bt:Url id="Taskpane.Url" DefaultValue="${baseUrl}/office/taskpane.html"/>
-      </bt:Urls>
-      <bt:ShortStrings>
-        <bt:String id="GroupLabel" DefaultValue="${escapeXml(displayName)} Add-in"/>
-        <bt:String id="TaskpaneButton.Label" DefaultValue="Show Task Pane"/>
-      </bt:ShortStrings>
-      <bt:LongStrings>
-        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="${escapeXml(description)}"/>
-      </bt:LongStrings>
+${renderResources(quickActions)}
     </Resources>
     <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides/1.1" xsi:type="VersionOverridesV1_1">
       <Requirements>
@@ -263,22 +377,7 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
               <OfficeTab id="TabDefault">
                 <Group id="msgReadGroupV1_1">
                   <Label resid="GroupLabel"/>
-                  <Control xsi:type="Button" id="msgReadOpenPaneButtonV1_1">
-                    <Label resid="TaskpaneButton.Label"/>
-                    <Supertip>
-                      <Title resid="TaskpaneButton.Label"/>
-                      <Description resid="TaskpaneButton.Tooltip"/>
-                    </Supertip>
-                    <Icon>
-                      <bt:Image size="16" resid="Icon.16x16"/>
-                      <bt:Image size="32" resid="Icon.32x32"/>
-                      <bt:Image size="80" resid="Icon.80x80"/>
-                    </Icon>
-                    <Action xsi:type="ShowTaskpane">
-                      <SourceLocation resid="Taskpane.Url"/>
-                      <SupportsPinning>true</SupportsPinning>
-                    </Action>
-                  </Control>
+${renderControl('msgReadMenuButtonV1_1', 'msgReadV1_1', true)}
                 </Group>
               </OfficeTab>
             </ExtensionPoint>
@@ -286,22 +385,7 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
               <OfficeTab id="TabDefault">
                 <Group id="msgComposeGroupV1_1">
                   <Label resid="GroupLabel"/>
-                  <Control xsi:type="Button" id="msgComposeOpenPaneButtonV1_1">
-                    <Label resid="TaskpaneButton.Label"/>
-                    <Supertip>
-                      <Title resid="TaskpaneButton.Label"/>
-                      <Description resid="TaskpaneButton.Tooltip"/>
-                    </Supertip>
-                    <Icon>
-                      <bt:Image size="16" resid="Icon.16x16"/>
-                      <bt:Image size="32" resid="Icon.32x32"/>
-                      <bt:Image size="80" resid="Icon.80x80"/>
-                    </Icon>
-                    <Action xsi:type="ShowTaskpane">
-                      <SourceLocation resid="Taskpane.Url"/>
-                      <SupportsPinning>true</SupportsPinning>
-                    </Action>
-                  </Control>
+${renderControl('msgComposeMenuButtonV1_1', 'msgComposeV1_1', true)}
                 </Group>
               </OfficeTab>
             </ExtensionPoint>
@@ -309,22 +393,7 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
         </Host>
       </Hosts>
       <Resources>
-        <bt:Images>
-          <bt:Image id="Icon.16x16" DefaultValue="${baseUrl}/office/assets/icon-16.png"/>
-          <bt:Image id="Icon.32x32" DefaultValue="${baseUrl}/office/assets/icon-32.png"/>
-          <bt:Image id="Icon.80x80" DefaultValue="${baseUrl}/office/assets/icon-80.png"/>
-        </bt:Images>
-        <bt:Urls>
-          <bt:Url id="Commands.Url" DefaultValue="${baseUrl}/office/commands.html"/>
-          <bt:Url id="Taskpane.Url" DefaultValue="${baseUrl}/office/taskpane.html"/>
-        </bt:Urls>
-        <bt:ShortStrings>
-          <bt:String id="GroupLabel" DefaultValue="${escapeXml(displayName)} Add-in"/>
-          <bt:String id="TaskpaneButton.Label" DefaultValue="Show Task Pane"/>
-        </bt:ShortStrings>
-        <bt:LongStrings>
-          <bt:String id="TaskpaneButton.Tooltip" DefaultValue="${escapeXml(description)}"/>
-        </bt:LongStrings>
+${renderResources(quickActions)}
       </Resources>
     </VersionOverrides>
   </VersionOverrides>


### PR DESCRIPTION
## Summary

- Replaces the single Outlook ribbon button with a configurable **dropdown menu** where each item is an admin-configured app shortcut with an optional auto-send prompt
- All labels, apps, and prompts are server-configured (no hardcoded strings) — admins manage them via the Office Integration admin page
- When `quickActions` is empty the manifest falls back to the existing single button (fully backward compatible)

## How it works

1. Admin configures quick actions in **Admin → Office Integration → Quick Actions**: select an app, set a localized label, optionally set a localized auto-send prompt
2. Admin re-downloads and re-deploys the manifest (required for ribbon changes)
3. Users see a dropdown in the Outlook ribbon; clicking an item opens the taskpane, auto-selects the configured app, and (if a prompt is set) sends it immediately with the current email as context

## Changes

| Area | File | Change |
|------|------|--------|
| Migration | `server/migrations/V031__add_office_quick_actions.js` | Adds `officeIntegration.quickActions: []` default |
| Config endpoint | `server/routes/integrations/officeAddin.js` | Serves `quickActions`; generates `Menu` vs `Button` control conditionally |
| Admin API | `server/routes/admin/officeIntegration.js` | Validates/saves `quickActions` (max 10, app existence check) |
| Admin UI | `client/src/features/admin/pages/AdminOfficeIntegrationPage.jsx` | Quick Actions editor section |
| Taskpane entry | `client/office/taskpane-entry.jsx` | Parses `?qa=` URL param |
| OfficeApp | `client/src/features/office/components/OfficeApp.jsx` | Auto-selects app and navigates to chat |
| OfficeChatPanel | `client/src/features/office/components/OfficeChatPanel.jsx` | Auto-sends `initialPrompt` on mount |

## Test plan

- [ ] No quick actions configured → manifest has single Button control (existing behaviour unchanged)
- [ ] Quick actions configured → manifest has Menu dropdown with one item per action + "Open {name}" fallback
- [ ] Click action with prompt → correct app selected, prompt auto-sent with email context
- [ ] Click action without prompt → correct app selected, empty chat with starter prompts shown
- [ ] Not logged in → quick action stored, resumes after login
- [ ] Referenced app deleted/no permission → falls back to app selection screen
- [ ] Admin UI: add/remove/reorder quick actions, app selector populates correctly, save persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)