### PR TITLE
feat(auth): include request method and path in JwtAuth log

### DIFF
--- a/server/middleware/jwtAuth.js
+++ b/server/middleware/jwtAuth.js
@@ -78,7 +78,9 @@ export default function jwtAuthMiddleware(req, res, next) {
         component: 'JwtAuth',
         userId: decoded.sub || decoded.username || decoded.id,
         name: decoded.name,
-        authMode: decoded.authMode
+        authMode: decoded.authMode,
+        method: req.method,
+        path: req.path
       });
     }
 


### PR DESCRIPTION
## Summary

Closes #1347.

The `JWT user authenticated` log entry told us *who* authenticated but
not *what* they were trying to do. This adds the HTTP method and request
path to the log fields so the resource being accessed is visible.

### Before
```
{"component":"JwtAuth","level":"info","message":"JWT user authenticated",
 "userId":"user_demo_admin","name":"Demo Administrator","authMode":"local"}
```

### After
```
{"component":"JwtAuth","level":"info","message":"JWT user authenticated",
 "userId":"user_demo_admin","name":"Demo Administrator","authMode":"local",
 "method":"POST","path":"/api/apps/chat"}
```

`req.path` is used (not `req.originalUrl`) so query strings — which can
contain sensitive values like tokens — are kept out of the log.

## Test plan
- [ ] Run server in development (`NODE_ENV=development`) and authenticate via JWT
- [ ] Confirm the `JWT user authenticated` log line includes `method` and `path` fields
- [ ] Confirm no query string content is leaked into the log

https://claude.ai/code/session_015YoEeSajipFNoanzpkvh1U

---
_Generated by [Claude Code](https://claude.ai/code/session_015YoEeSajipFNoanzpkvh1U)_