### PR TITLE
fix(chat): raise SSE connection timeout and heartbeat to 60s

### DIFF
--- a/client/src/shared/hooks/useEventSource.js
+++ b/client/src/shared/hooks/useEventSource.js
@@ -14,11 +14,11 @@ import { getRefreshToken, refreshTokenOrExpireSession } from '../../features/off
  * @param {Object} options
  * @param {string} options.appId - App ID (used for heartbeat + cleanup)
  * @param {string} options.chatId - Chat session ID (used for heartbeat + cleanup)
- * @param {number} [options.timeoutDuration=30000] - Connection timeout in ms
+ * @param {number} [options.timeoutDuration=60000] - Connection timeout in ms
  * @param {Function} options.onEvent - Called for each SSE event: ({ type, data, fullContent })
  * @param {Function} [options.onProcessingChange] - Called with true/false as stream starts/stops
  */
-function useEventSource({ appId, chatId, timeoutDuration = 30000, onEvent, onProcessingChange }) {
+function useEventSource({ appId, chatId, timeoutDuration = 60000, onEvent, onProcessingChange }) {
   // Stores the AbortController for the active fetch stream — non-null == connected
   const abortControllerRef = useRef(null);
   // Exposed as eventSourceRef for backward-compatible isConnected check by callers
@@ -85,7 +85,7 @@ function useEventSource({ appId, chatId, timeoutDuration = 30000, onEvent, onPro
       } catch (err) {
         console.warn('Error checking chat status:', err);
       }
-    }, 30000);
+    }, 60000);
   }, [appId, chatId, cleanupEventSource, onProcessingChange]);
 
   /**


### PR DESCRIPTION
## Summary
- Bumps the SSE connection timeout default in `useEventSource` from 30s to 60s
- Bumps the in-stream heartbeat poll from 30s to 60s

## Motivation
A customer reports recurring "not connected" screens on slower backends (local vLLM with large prompts often takes >30s to start streaming). The server-side `REQUEST_TIMEOUT` is already 5 minutes, so the 30s client-side cap was the bottleneck — the client would abort while the server kept processing.

## Test plan
- [ ] Send a chat request to a slow model and confirm the UI no longer disconnects after 30s
- [ ] Confirm normal-speed chats still work (heartbeat keeps stream alive)
- [ ] Confirm `Stop` button still aborts the stream cleanly

## Notes
This is a default-only change; `timeoutDuration` is still configurable via the hook prop (not currently passed by `useAppChat.js`, so changing the default takes effect everywhere).

https://claude.ai/code/session_018cPMYTC4dS1a3sfimxpacu

---
_Generated by [Claude Code](https://claude.ai/code/session_018cPMYTC4dS1a3sfimxpacu)_