### PR TITLE
fix: support ldaps:// with self-signed/internal CA certificates

### DIFF
--- a/client/src/features/admin/components/PlatformFormEditor.jsx
+++ b/client/src/features/admin/components/PlatformFormEditor.jsx
@@ -1357,7 +1357,8 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
                 placeholder="ldap://dc.example.com:389"
               />
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                LDAP URL of domain controller (e.g., ldap://dc.example.com:389 or ldaps://dc.example.com:636)
+                LDAP URL of domain controller (e.g., ldap://dc.example.com:389 or
+                ldaps://dc.example.com:636)
               </p>
             </div>
             <div>

--- a/client/src/features/admin/components/PlatformFormEditor.jsx
+++ b/client/src/features/admin/components/PlatformFormEditor.jsx
@@ -1290,6 +1290,30 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
                     Groups automatically assigned to LDAP users
                   </p>
                 </div>
+
+                <div className="md:col-span-2">
+                  <label className="flex items-center space-x-3 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={provider.tlsOptions?.rejectUnauthorized === false}
+                      onChange={e =>
+                        updateLdapProvider(
+                          index,
+                          'tlsOptions',
+                          e.target.checked ? { rejectUnauthorized: false } : undefined
+                        )
+                      }
+                      className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                    />
+                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Allow self-signed / internal CA certificates (ldaps://)
+                    </span>
+                  </label>
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-7">
+                    Enable when the LDAP server uses a certificate from a private or internal CA.
+                    Required for most on-premise ldaps:// setups.
+                  </p>
+                </div>
               </div>
             </div>
           ))}
@@ -1333,7 +1357,7 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
                 placeholder="ldap://dc.example.com:389"
               />
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                LDAP URL of domain controller (e.g., ldap://dc.example.com:389)
+                LDAP URL of domain controller (e.g., ldap://dc.example.com:389 or ldaps://dc.example.com:636)
               </p>
             </div>
             <div>
@@ -1488,6 +1512,29 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
               </label>
               <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
                 Generate JWT tokens for API access after NTLM authentication
+              </p>
+            </div>
+            <div className="md:col-span-2">
+              <label className="flex items-center space-x-3 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={config.ntlmAuth?.tlsOptions?.rejectUnauthorized === false}
+                  onChange={e =>
+                    updateNestedConfig(
+                      'ntlmAuth',
+                      'tlsOptions',
+                      e.target.checked ? { rejectUnauthorized: false } : undefined
+                    )
+                  }
+                  className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Allow self-signed / internal CA certificates (ldaps://)
+                </span>
+              </label>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-7">
+                Enable when the domain controller uses a certificate from a private or internal CA.
+                Required for most on-premise ldaps:// setups.
               </p>
             </div>
           </div>

--- a/server/middleware/ntlmAuth.js
+++ b/server/middleware/ntlmAuth.js
@@ -36,6 +36,8 @@ function createNtlmMiddleware(ntlmConfig = {}) {
     // LDAP bind credentials (required for group queries)
     domaincontrolleruser: ldapUser,
     domaincontrollerpassword: ldapPassword,
+    // TLS options for ldaps:// connections with self-signed/internal CA certs
+    ...(ntlmConfig.tlsOptions && { tlsOptions: ntlmConfig.tlsOptions }),
     ...ntlmConfig.options
   };
 

--- a/server/validators/platformConfigSchema.js
+++ b/server/validators/platformConfigSchema.js
@@ -154,6 +154,7 @@ export const platformConfigSchema = z
         defaultGroups: z.array(z.string()).default([]),
         sessionTimeoutMinutes: z.number().min(1).default(480),
         generateJwtToken: z.boolean().default(true),
+        tlsOptions: z.record(z.any()).optional(),
         options: z.record(z.any()).optional()
       })
       .default({}),


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds "Allow self-signed / internal CA certificates (ldaps://)" checkbox to the LDAP provider form in the admin UI — sets `tlsOptions: { rejectUnauthorized: false }` on the provider config
- Adds the same toggle to the NTLM config section (domain controller can also use `ldaps://`)
- Adds `tlsOptions` field to the NTLM schema and forwards it explicitly to `express-ntlm`
- Updates the NTLM domain controller URL hint to mention `ldaps://`

**Root cause:** Node.js rejects `ldaps://` connections whose server certificate is signed by a private/internal CA (`unable to get local issuer certificate`). The LDAP backend already supported `tlsOptions` passthrough to `ldap-authentication` — the only missing piece was a way to set it via the admin UI.

## Test plan

- [ ] Configure an LDAP provider with `ldaps://` URL and check the new checkbox in the admin UI
- [ ] Verify the saved config contains `tlsOptions: { rejectUnauthorized: false }` under the provider
- [ ] Confirm LDAP login succeeds against an ldaps:// server with an internal CA cert
- [ ] Configure NTLM with an `ldaps://` domain controller, enable the checkbox, verify group lookup works
- [ ] Verify that leaving the checkbox unchecked leaves `tlsOptions` undefined (no regression for standard LDAP/plain ldaps with a trusted cert)

https://claude.ai/code/session_01BQMWpKi4nsqLCegwMkkJSy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQMWpKi4nsqLCegwMkkJSy)_