### PR TITLE
fix(auth): preserve LDAP identity and groups in JWT

### DIFF
--- a/server/middleware/jwtAuth.js
+++ b/server/middleware/jwtAuth.js
@@ -479,13 +479,20 @@ export default function jwtAuthMiddleware(req, res, next) {
         const usersFilePath = platform.localAuth?.usersFile || 'contents/config/users.json';
         const usersConfig = loadUsers(usersFilePath);
 
-        const userId = decoded.username;
+        // users.json is keyed by the persisted UUID (decoded.sub). Fall back to
+        // username for legacy tokens minted before sub was the canonical id.
+        const userId = decoded.sub || decoded.username;
         let userRecord = usersConfig.users?.[userId];
 
-        // If not found by username, try to find by email
         if (!userRecord && decoded.email) {
           userRecord = Object.values(usersConfig.users || {}).find(
             u => u.email === decoded.email && u.authMethods?.includes('ldap')
+          );
+        }
+
+        if (!userRecord && decoded.username) {
+          userRecord = Object.values(usersConfig.users || {}).find(
+            u => u.ldapData?.username === decoded.username && u.authMethods?.includes('ldap')
           );
         }
 
@@ -501,8 +508,8 @@ export default function jwtAuthMiddleware(req, res, next) {
         }
 
         user = {
-          id: decoded.username,
-          username: decoded.username,
+          id: decoded.sub || decoded.username,
+          username: decoded.username || decoded.sub,
           name: decoded.name || decoded.displayName || decoded.username,
           email: decoded.email || decoded.mail || '',
           groups: decoded.groups || [],

--- a/server/middleware/ldapAuth.js
+++ b/server/middleware/ldapAuth.js
@@ -258,6 +258,7 @@ export async function loginLdapUser(username, password, ldapConfig) {
   // in authenticateLdapUser(). Passing externalGroups would cause duplicate mapping.
   const externalUser = {
     id: user.id,
+    username: username, // Original LDAP login (sAMAccountName), needed for the JWT username claim
     name: user.name,
     email: user.email,
     authMethod: 'ldap',

--- a/server/utils/userManager.js
+++ b/server/utils/userManager.js
@@ -452,9 +452,14 @@ export async function validateAndPersistExternalUser(externalUser, platformConfi
     await updateUserActivity(persistedUser.id, usersFilePath);
 
     // Merge groups: external groups (from auth provider) + internal groups (from users.json)
-    // Use externalGroups (raw from token) if available, otherwise fall back to processed groups
-    const externalGroupsToMap = externalUser.externalGroups || [];
-    const mappedExternalGroups = mapExternalGroups(externalGroupsToMap);
+    // Only call mapExternalGroups when raw external groups were actually supplied. Some
+    // auth providers (e.g. LDAP) pre-map their groups before reaching this point and
+    // intentionally omit externalGroups; calling mapExternalGroups([]) would otherwise
+    // taint the result with the anonymous fallback.
+    const mappedExternalGroups =
+      Array.isArray(externalUser.externalGroups) && externalUser.externalGroups.length > 0
+        ? mapExternalGroups(externalUser.externalGroups)
+        : [];
 
     // Include automatic internal groups (authenticated, provider defaults) + manual internal groups
     const automaticInternalGroups = externalUser.groups || []; // These include authenticated, provider defaults
@@ -503,9 +508,14 @@ export async function validateAndPersistExternalUser(externalUser, platformConfi
   const persistedUser = await createOrUpdateExternalUser(externalUser, usersFilePath);
 
   // Combine external groups from auth provider with internal groups from users.json
-  // Use externalGroups (raw from token) if available, otherwise fall back to processed groups
-  const externalGroupsToMap = externalUser.externalGroups || [];
-  const mappedExternalGroups = mapExternalGroups(externalGroupsToMap);
+  // Only call mapExternalGroups when raw external groups were actually supplied. Some
+  // auth providers (e.g. LDAP) pre-map their groups before reaching this point and
+  // intentionally omit externalGroups; calling mapExternalGroups([]) would otherwise
+  // taint the result with the anonymous fallback.
+  const mappedExternalGroups =
+    Array.isArray(externalUser.externalGroups) && externalUser.externalGroups.length > 0
+      ? mapExternalGroups(externalUser.externalGroups)
+      : [];
 
   // Include automatic internal groups (authenticated, provider defaults) + manual internal groups
   const automaticInternalGroups = externalUser.groups || []; // These include authenticated, provider defaults


### PR DESCRIPTION
## Summary

Two related defects in the LDAP login path produced sessions that *looked* successful in the logs but left the user in a half-authenticated state:

1. **Spurious `anonymous` group in the JWT.** `validateAndPersistExternalUser` calls `mapExternalGroups(externalUser.externalGroups || [])`. LDAP intentionally omits `externalGroups` (groups are pre-mapped in `authenticateLdapUser`). With an empty array, `mapExternalGroups` falls back to `["anonymous"]`, which is then merged into the user's groups. The resulting JWT carried `["anonymous", "admins", "authenticated"]`. Permissions still resolved correctly via additive merge, but downstream code that special-cases the `anonymous` group could misclassify an authenticated admin.

2. **`username` claim missing from the JWT for LDAP users.** The LDAP `externalUser` had no top-level `username`, so `persistedUser.username` ended up `undefined`. `generateJwt` then wrote `username: undefined` into the token, and `jwtAuth.js` set `req.user.id = decoded.username = undefined` on every subsequent request. `/api/auth/status` returned a user object with `id: undefined`, breaking any feature keyed on user identity (history, favorites, audit logs).

OIDC and NTLM did not exhibit either bug — they pass `externalGroups` and a `username` field, and their `jwtAuth` paths derive `id` from `decoded.sub || decoded.username`. This PR brings the LDAP flow in line with those.

## Changes

- **`server/utils/userManager.js`** (both call sites in `validateAndPersistExternalUser`): only invoke `mapExternalGroups` when `externalUser.externalGroups` is a non-empty array. The `[] → ["anonymous"]` fallback inside `mapExternalGroups` itself is preserved — it's correct for the request-time path in `enhanceUserWithPermissions`. The bug was at the call site.
- **`server/middleware/ldapAuth.js`**: add `username: username` (the original sAMAccountName) to the `externalUser` literal so it spreads into `userWithAdminCheck` and through to the JWT. Mirrors NTLM at `ntlmAuth.js:181`.
- **`server/middleware/jwtAuth.js`** (LDAP path): use `decoded.sub || decoded.username` for both `user.id` and the `users.json` lookup key, matching the OIDC and NTLM paths. Adds an `ldapData.username` fallback for legacy users persisted before this change.

## Backward compatibility

- **JWTs already in browsers** keep working. They have always carried `sub` (`tokenService.js:112` is unchanged); pre-fix tokens lack `username` but the `decoded.sub` fallback covers them.
- **`users.json` schema** is unchanged. No migration needed.
- **OIDC / NTLM / Proxy / Local flows** are untouched. Fix 1 only short-circuits when `externalGroups` is missing, which only LDAP does.

## Test plan

- [x] Lint clean for the three modified files (`npx eslint`).
- [x] Prettier reports all three files unchanged.
- [x] Server boots cleanly (`node server/server.js`).
- [x] Standalone logic smoke test (mocking `mapExternalGroups` and JWT decoding) confirms:
  - LDAP merged groups: `["admins", "authenticated"]` (no `anonymous`).
  - OIDC regression: `["admins", "authenticated"]` still produced from `externalGroups`.
  - `req.user.id` is the persisted UUID (not `undefined`).
  - Legacy tokens without `sub` fall back to `decoded.username`.
- [ ] **Manual E2E (requires LDAP environment):**
  - LDAP login → confirm the second `Mapping external groups [] / No groups mapped, assigning anonymous group` log block is gone.
  - `GET /api/auth/status` returns `user.id` = UUID, `user.username` = LDAP login, `user.groups` without `anonymous`.
  - Decode the `authToken` cookie at jwt.io and confirm payload.
  - Admin route accessible (admins permissions intact).
  - Regression: OIDC login still produces correct mapped groups.

## Out of scope

- The HTTP-only-cookie-only auth design (no `data.token` in the LDAP login response body) is intentional for XSS protection and is **not** changed.
- Pre-existing Jest config bug in `server/jest.config.js` (`preset: '@babel/preset-env'` is invalid; `moduleNameMapping` should be `moduleNameMapper`). The auth-related tests can't run on this branch and on `main` either — leaving for a separate PR.

https://claude.ai/code/session_01MHZn7Ud6rbBFFLkTrKRSiN

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHZn7Ud6rbBFFLkTrKRSiN)_