### PR TITLE
fix(http): forward rejectUnauthorized to destination TLS through proxy

### DIFF
--- a/server/tests/httpConfig.proxy-tls.test.js
+++ b/server/tests/httpConfig.proxy-tls.test.js
@@ -1,0 +1,80 @@
+/**
+ * Regression test for `TlsForwardingHttpsProxyAgent` in server/utils/httpConfig.js.
+ *
+ * The subclass exists to work around a bug in `https-proxy-agent` >=7.0.0 (verified
+ * through 9.0.0) where constructor `rejectUnauthorized` does not reach the destination
+ * TLS handshake — only the proxy connection itself. This test pins the contract that our
+ * subclass injects `rejectUnauthorized` into the `opts` argument of `connect()`, which is
+ * what the parent `connect()` spreads into `tls.connect()` for the destination upgrade.
+ *
+ * Asserting on the `opts` passed to `super.connect()` catches the regression case where
+ * a future upgrade either fixes the upstream bug (making our injection redundant but still
+ * correct) or changes the `connect()` signature in a way that breaks our injection.
+ */
+
+import { describe, expect, jest, test, beforeEach, afterEach } from '@jest/globals';
+import { HttpsProxyAgent } from 'https-proxy-agent';
+import { TlsForwardingHttpsProxyAgent } from '../utils/httpConfig.js';
+
+describe('TlsForwardingHttpsProxyAgent', () => {
+  let connectSpy;
+
+  beforeEach(() => {
+    connectSpy = jest
+      .spyOn(HttpsProxyAgent.prototype, 'connect')
+      .mockImplementation(async () => ({}));
+  });
+
+  afterEach(() => {
+    connectSpy.mockRestore();
+  });
+
+  test('injects rejectUnauthorized: false into destination connect opts', async () => {
+    const agent = new TlsForwardingHttpsProxyAgent('http://proxy.example:8080', {
+      rejectUnauthorized: false
+    });
+    const incomingOpts = { host: 'destination.example', port: 443, secureEndpoint: true };
+
+    await agent.connect({}, incomingOpts);
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+    const forwardedOpts = connectSpy.mock.calls[0][1];
+    expect(forwardedOpts).toMatchObject({
+      host: 'destination.example',
+      port: 443,
+      secureEndpoint: true,
+      rejectUnauthorized: false
+    });
+  });
+
+  test('preserves rejectUnauthorized: true when explicitly provided', async () => {
+    const agent = new TlsForwardingHttpsProxyAgent('http://proxy.example:8080', {
+      rejectUnauthorized: true
+    });
+
+    await agent.connect({}, { host: 'd', port: 443, secureEndpoint: true });
+
+    const forwardedOpts = connectSpy.mock.calls[0][1];
+    expect(forwardedOpts.rejectUnauthorized).toBe(true);
+  });
+
+  test('does not inject rejectUnauthorized when ctor opts omit it', async () => {
+    const agent = new TlsForwardingHttpsProxyAgent('http://proxy.example:8080');
+
+    await agent.connect({}, { host: 'd', port: 443, secureEndpoint: true });
+
+    const forwardedOpts = connectSpy.mock.calls[0][1];
+    expect(Object.prototype.hasOwnProperty.call(forwardedOpts, 'rejectUnauthorized')).toBe(false);
+  });
+
+  test('does not mutate the caller-supplied opts object', async () => {
+    const agent = new TlsForwardingHttpsProxyAgent('http://proxy.example:8080', {
+      rejectUnauthorized: false
+    });
+    const incomingOpts = { host: 'd', port: 443, secureEndpoint: true };
+
+    await agent.connect({}, incomingOpts);
+
+    expect(Object.prototype.hasOwnProperty.call(incomingOpts, 'rejectUnauthorized')).toBe(false);
+  });
+});

--- a/server/utils/httpConfig.js
+++ b/server/utils/httpConfig.js
@@ -12,16 +12,35 @@ import config from '../config.js';
 import logger from './logger.js';
 
 /**
- * HttpsProxyAgent v7+/v9 has a bug where its constructor sets `this.options = { path: undefined }`
- * after `super(opts)`, which prevents constructor options like `rejectUnauthorized` from being
- * merged into the request options used during the TLS upgrade to the destination server.
- * As a result, `rejectUnauthorized: false` only applies to the proxy connection itself, not the
- * destination TLS handshake — so self-signed certificates on the upstream LLM endpoint still fail.
+ * Workaround for `https-proxy-agent` >=7.0.0 (verified through 9.0.0).
  *
- * This subclass re-injects `rejectUnauthorized` into the connect options, which `connect()`
- * spreads into `tls.connect()` for the destination upgrade.
+ * The upstream constructor in `https-proxy-agent/dist/index.js` does:
+ *
+ *   constructor(proxy, opts) {
+ *     super(opts);                        // http.Agent stores opts in this.options
+ *     this.options = { path: undefined }; // overwrites — rejectUnauthorized lost here
+ *     ...
+ *     this.connectOpts = { ALPNProtocols: ['http/1.1'], ...omit(opts,'headers'), host, port };
+ *   }
+ *
+ * `http.Agent.addRequest` merges `{...requestOptions, ...this.options}` before calling
+ * `createSocket`. Because `this.options` was clobbered to `{ path: undefined }`,
+ * `rejectUnauthorized: false` from the constructor never reaches the options that
+ * `agent-base.createSocket` forwards as `connectOpts` to `connect()`. The destination
+ * TLS upgrade (`tls.connect({...omit(opts, 'host','path','port'), socket})`) therefore
+ * runs with Node's default `rejectUnauthorized: true` and rejects self-signed certs.
+ *
+ * `this.connectOpts` does retain `rejectUnauthorized`, but it's used only for the socket to
+ * the proxy itself, which is irrelevant when the proxy is plain HTTP (the common case).
+ *
+ * This subclass re-injects `rejectUnauthorized` into the `opts` argument of `connect()`,
+ * which the parent then spreads into `tls.connect()` for the destination upgrade.
+ *
+ * Remove this subclass once upstream stops clobbering `this.options` in the constructor or
+ * exposes a TLS-options pass-through API. See `node_modules/https-proxy-agent/dist/index.js`
+ * to verify on dependency upgrades.
  */
-class TlsForwardingHttpsProxyAgent extends HttpsProxyAgent {
+export class TlsForwardingHttpsProxyAgent extends HttpsProxyAgent {
   constructor(proxy, opts = {}) {
     super(proxy, opts);
     this._destinationTlsOptions = {};

--- a/server/utils/httpConfig.js
+++ b/server/utils/httpConfig.js
@@ -12,6 +12,30 @@ import config from '../config.js';
 import logger from './logger.js';
 
 /**
+ * HttpsProxyAgent v7+/v9 has a bug where its constructor sets `this.options = { path: undefined }`
+ * after `super(opts)`, which prevents constructor options like `rejectUnauthorized` from being
+ * merged into the request options used during the TLS upgrade to the destination server.
+ * As a result, `rejectUnauthorized: false` only applies to the proxy connection itself, not the
+ * destination TLS handshake — so self-signed certificates on the upstream LLM endpoint still fail.
+ *
+ * This subclass re-injects `rejectUnauthorized` into the connect options, which `connect()`
+ * spreads into `tls.connect()` for the destination upgrade.
+ */
+class TlsForwardingHttpsProxyAgent extends HttpsProxyAgent {
+  constructor(proxy, opts = {}) {
+    super(proxy, opts);
+    this._destinationTlsOptions = {};
+    if (typeof opts.rejectUnauthorized === 'boolean') {
+      this._destinationTlsOptions.rejectUnauthorized = opts.rejectUnauthorized;
+    }
+  }
+
+  async connect(req, opts) {
+    return super.connect(req, { ...opts, ...this._destinationTlsOptions });
+  }
+}
+
+/**
  * Get SSL configuration from platform config
  * @returns {Object} SSL configuration object with ignoreInvalidCertificates and domainWhitelist
  */
@@ -295,11 +319,12 @@ export function createAgent(url = '', forceIgnoreSSL = null) {
     }
 
     try {
-      // For HttpsProxyAgent v7+, rejectUnauthorized is passed as a top-level option
       const agentOptions = shouldIgnoreSSL ? { rejectUnauthorized: false } : {};
 
       if (isHttps) {
-        return new HttpsProxyAgent(proxyUrl, agentOptions);
+        // TlsForwardingHttpsProxyAgent ensures rejectUnauthorized propagates to the
+        // destination TLS handshake, not just the proxy connection.
+        return new TlsForwardingHttpsProxyAgent(proxyUrl, agentOptions);
       } else {
         return new HttpProxyAgent(proxyUrl, agentOptions);
       }


### PR DESCRIPTION
## Summary

LLM calls through an HTTP proxy to an upstream HTTPS endpoint with a self-signed cert were still failing with `SELF_SIGNED_CERT_IN_CHAIN` even when `ssl.ignoreInvalidCertificates` was enabled and the destination was in `domainWhitelist`. The log line `"SSL certificate verification disabled for proxied request"` was printed, but the TLS handshake to the destination still rejected the cert.

## Root cause

`HttpsProxyAgent` v7+/v9 has this in its constructor:

```js
constructor(proxy, opts) {
    super(opts);                            // sets http.Agent's this.options
    this.options = { path: undefined };     // ← clobbers it
    ...
}
```

`http.Agent.addRequest` merges `this.options` into the per-request options, and those request options are what `HttpsProxyAgent.connect()` spreads into `tls.connect()` for the destination TLS upgrade after the proxy `CONNECT`. Because `this.options` is overwritten to `{ path: undefined }`, the `rejectUnauthorized: false` we pass via the constructor never reaches the destination handshake — it only ends up in `connectOpts`, which is used for the proxy connection itself (irrelevant when the proxy is plain HTTP).

## Fix

Subclass `HttpsProxyAgent` so `rejectUnauthorized` is re-injected into the `opts` passed to `connect()`, where it propagates to `tls.connect()` for the destination.

```js
class TlsForwardingHttpsProxyAgent extends HttpsProxyAgent {
  constructor(proxy, opts = {}) {
    super(proxy, opts);
    this._destinationTlsOptions = {};
    if (typeof opts.rejectUnauthorized === 'boolean') {
      this._destinationTlsOptions.rejectUnauthorized = opts.rejectUnauthorized;
    }
  }
  async connect(req, opts) {
    return super.connect(req, { ...opts, ...this._destinationTlsOptions });
  }
}
```

Used in `createAgent()` only on the proxy + HTTPS-destination path. The non-proxy path already worked correctly because `https.Agent` honors `rejectUnauthorized` natively.

## Test plan

- [ ] Reproduce: configure `proxy.https = http://...:8080`, set `ssl.ignoreInvalidCertificates: true`, add the LLM hostname to `domainWhitelist`, point a model at an HTTPS endpoint with a self-signed cert behind the proxy, send a chat request — request now completes instead of failing with `SELF_SIGNED_CERT_IN_CHAIN`.
- [ ] Sanity: with `ignoreInvalidCertificates: false` (or hostname not whitelisted), self-signed cert through the proxy still fails (we are not silently disabling validation everywhere).
- [ ] Direct HTTPS (no proxy) with whitelisted self-signed host still works.
- [ ] HTTP destination through proxy unaffected (still uses `HttpProxyAgent`).

https://claude.ai/code/session_014bjgRUY5HF5PBQd17oTknK

---
_Generated by [Claude Code](https://claude.ai/code/session_014bjgRUY5HF5PBQd17oTknK)_