### PR TITLE
fix(http): log when SSL bypass is silently skipped

### DIFF
--- a/server/utils/httpConfig.js
+++ b/server/utils/httpConfig.js
@@ -145,36 +145,54 @@ export function isDomainWhitelisted(hostname, whitelist) {
 export function shouldIgnoreSSLForURL(url, sslConfig = null) {
   const config = sslConfig || getSSLConfig();
 
+  let hostname = '';
+  try {
+    hostname = new URL(url).hostname;
+  } catch {
+    // hostname stays empty; we still log below so the operator sees why bypass didn't apply
+  }
+
   // If ignoreInvalidCertificates is false, always validate SSL
   if (!config.ignoreInvalidCertificates) {
+    logger.debug('SSL bypass not applied: ignoreInvalidCertificates is false', {
+      component: 'HttpConfig',
+      hostname
+    });
     return false;
   }
 
-  // If whitelist is empty, do NOT ignore SSL (security: require explicit domain whitelisting)
+  // If whitelist is empty, do NOT ignore SSL (security: require explicit domain whitelisting).
+  // Operators upgrading from older versions used to rely on a global bypass when whitelist
+  // was empty — that behavior was removed for security. This warning makes the silent skip visible.
   if (!config.domainWhitelist || config.domainWhitelist.length === 0) {
+    logger.warn(
+      'SSL bypass not applied: ignoreInvalidCertificates is true but ssl.domainWhitelist is empty. Add the LLM hostname to ssl.domainWhitelist in platform.json.',
+      { component: 'HttpConfig', hostname }
+    );
     return false;
   }
 
-  // Extract hostname from URL
-  try {
-    const urlObj = new URL(url);
-    const hostname = urlObj.hostname;
-
-    // Check if hostname is in whitelist
-    const isWhitelisted = isDomainWhitelisted(hostname, config.domainWhitelist);
-
-    if (isWhitelisted) {
-      logger.debug('SSL validation will be ignored for whitelisted domain', {
-        component: 'HttpConfig',
-        hostname
-      });
-    }
-
-    return isWhitelisted;
-  } catch (error) {
-    logger.warn('Error parsing URL for SSL whitelist check', { component: 'HttpConfig', error });
+  if (!hostname) {
+    logger.warn('Error parsing URL for SSL whitelist check', { component: 'HttpConfig', url });
     return false;
   }
+
+  // Check if hostname is in whitelist
+  const isWhitelisted = isDomainWhitelisted(hostname, config.domainWhitelist);
+
+  if (isWhitelisted) {
+    logger.debug('SSL validation will be ignored for whitelisted domain', {
+      component: 'HttpConfig',
+      hostname
+    });
+  } else {
+    logger.warn(
+      'SSL bypass not applied: hostname is not in ssl.domainWhitelist. Self-signed certs will be rejected for this host.',
+      { component: 'HttpConfig', hostname, domainWhitelist: config.domainWhitelist }
+    );
+  }
+
+  return isWhitelisted;
 }
 
 /**
@@ -352,11 +370,24 @@ export function createAgent(url = '', forceIgnoreSSL = null) {
     }
   }
 
-  // Fallback to SSL-only configuration if needed
+  // No proxy path: optionally bypass SSL via plain https.Agent.
   if (isHttps && shouldIgnoreSSL) {
+    logger.info('SSL certificate verification disabled for direct HTTPS request', {
+      component: 'HttpConfig',
+      url
+    });
     return new https.Agent({ rejectUnauthorized: false });
   }
 
+  // No agent applied. If the request later fails with a TLS error, the operator can
+  // look at the preceding shouldIgnoreSSLForURL log to see why bypass was skipped.
+  if (isHttps) {
+    logger.debug('No SSL bypass agent applied for HTTPS request', {
+      component: 'HttpConfig',
+      url,
+      proxyConfigured: Boolean(proxyConfig.https)
+    });
+  }
   return undefined;
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1363. That fix only handled the **proxy + HTTPS** path via `TlsForwardingHttpsProxyAgent`. When no proxy is configured, the request falls through to the direct `https.Agent` fallback in `createAgent()` (server/utils/httpConfig.js:356), which only bypasses SSL when `shouldIgnoreSSLForURL()` returns `true` — i.e. **both** `ssl.ignoreInvalidCertificates: true` AND the hostname is in `ssl.domainWhitelist`.

If either is missing, bypass is skipped silently, no log line prints, `createAgent()` returns `undefined`, node-fetch uses Node's default agent, and we get back:

```
request to https://litellm.info.med.uni-muenchen.de/v1/chat/completions failed,
reason: self-signed certificate in certificate chain
```

…with zero indication of why bypass didn't apply. This is the most common cause of post-#1363 reports of "we still see the cert error":

1. Operator is on a network without an HTTP_PROXY/HTTPS_PROXY (so the proxy fix isn't on the request path)
2. They have `ignoreInvalidCertificates: true` from before the security tightening
3. But `domainWhitelist` is empty (previously meant "bypass for all", now means "bypass for nothing")

## Changes

`server/utils/httpConfig.js`:

- `shouldIgnoreSSLForURL()` now logs at every skip point with the hostname:
  - `debug` when `ignoreInvalidCertificates` is false
  - `warn` when whitelist is empty (most common upgrade footgun) — message points to the exact config key to fix
  - `warn` when hostname doesn't match any whitelist entry (lists the whitelist for comparison)
- `createAgent()` now logs `info` on the direct-HTTPS bypass path (mirrors the existing log on the proxy bypass path) and `debug` when no agent is applied to an HTTPS request, including whether a proxy was configured

No behavior change for successful requests; this is purely diagnostic.

## Test plan

- [ ] With `ignoreInvalidCertificates: true` + empty `domainWhitelist`, send a chat request to a self-signed-cert host: still fails (correct), but server log now contains `SSL bypass not applied: ... ssl.domainWhitelist is empty`.
- [ ] With `ignoreInvalidCertificates: true` + `domainWhitelist: ["other.example.com"]`, request to `litellm.info.med.uni-muenchen.de`: still fails, log shows `hostname is not in ssl.domainWhitelist` with the actual whitelist values.
- [ ] With `ignoreInvalidCertificates: true` + `domainWhitelist: ["litellm.info.med.uni-muenchen.de"]` and no proxy: log shows `SSL certificate verification disabled for direct HTTPS request` and request succeeds.
- [ ] Successful request without bypass (valid cert, no whitelist): no warn logs, `debug` line only.

https://claude.ai/code/session_01RqUseB9fcaz3BhNR2kFbup

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqUseB9fcaz3BhNR2kFbup)_