### PR TITLE
feat(bedrock): AWS Bedrock Converse API adapter (#1373)

### DIFF
--- a/client/src/features/admin/components/ModelFormEditor.jsx
+++ b/client/src/features/admin/components/ModelFormEditor.jsx
@@ -8,6 +8,7 @@ import {
   isFieldRequired
 } from '../../../utils/schemaValidation';
 import Icon from '../../../shared/components/Icon';
+import { makeAdminApiCall } from '../../../api/adminApi';
 
 /**
  * Generate list of environment variable names that can be used for a model's API key
@@ -116,8 +117,47 @@ function ModelFormEditor({
     // eslint-disable-next-line @eslint-react/exhaustive-deps
   }, [data, jsonSchema]);
 
+  // Adapter-declared provider config schema (e.g. AWS Bedrock region).
+  // Drives dynamic field rendering in the Configuration section.
+  const [providerSchema, setProviderSchema] = useState(null);
+  useEffect(() => {
+    let cancelled = false;
+    if (!data?.provider) {
+      setProviderSchema(null);
+      return () => {
+        cancelled = true;
+      };
+    }
+    (async () => {
+      try {
+        const response = await makeAdminApiCall(
+          `/admin/providers/${encodeURIComponent(data.provider)}/schema`
+        );
+        if (cancelled) return;
+        if (response.ok) {
+          const schema = await response.json();
+          setProviderSchema(schema);
+        } else {
+          setProviderSchema(null);
+        }
+      } catch {
+        if (!cancelled) setProviderSchema(null);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [data?.provider]);
+
   const handleChange = (field, value) => {
     onChange({ ...data, [field]: value });
+  };
+
+  const handleConfigChange = (key, value) => {
+    onChange({
+      ...data,
+      config: { ...(data.config || {}), [key]: value }
+    });
   };
 
   const handleInputChange = e => {
@@ -133,7 +173,8 @@ function ModelFormEditor({
     { value: 'mistral', label: 'Mistral' },
     { value: 'local', label: 'Local' },
     { value: 'iassistant', label: 'iAssistant' },
-    { value: 'iassistant-conversation', label: 'iAssistant Conversation' }
+    { value: 'iassistant-conversation', label: 'iAssistant Conversation' },
+    { value: 'bedrock', label: 'AWS Bedrock' }
   ];
 
   // Memoize environment variables tooltip text for API Key field
@@ -685,6 +726,102 @@ function ModelFormEditor({
                           )}
                         </p>
                       </div>
+                    </div>
+                  </fieldset>
+                </div>
+              )}
+
+              {/* Provider-specific configuration (adapter-declared schema). */}
+              {providerSchema?.fields?.length > 0 && (
+                <div className="col-span-6">
+                  <fieldset>
+                    <legend className="text-base font-medium text-gray-900 dark:text-gray-100">
+                      {t('admin.models.sections.providerConfig', 'Provider Settings')}
+                    </legend>
+                    <div className="mt-4 grid grid-cols-6 gap-6">
+                      {providerSchema.fields.map(field => {
+                        const value =
+                          data.config?.[field.key] ??
+                          (field.default !== undefined ? field.default : '');
+                        const label =
+                          (field.label && (field.label[DEFAULT_LANGUAGE] || field.label.en)) ||
+                          field.key;
+                        const description =
+                          field.description &&
+                          (field.description[DEFAULT_LANGUAGE] || field.description.en);
+                        const inputId = `config.${field.key}`;
+                        return (
+                          <div key={field.key} className="col-span-6 sm:col-span-3">
+                            <label
+                              htmlFor={inputId}
+                              className="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                            >
+                              {label}
+                              {field.required && <span className="text-red-500"> *</span>}
+                            </label>
+                            {field.type === 'json' ? (
+                              <textarea
+                                id={inputId}
+                                rows={3}
+                                value={
+                                  value && typeof value === 'object'
+                                    ? JSON.stringify(value, null, 2)
+                                    : value || ''
+                                }
+                                onChange={e => {
+                                  const raw = e.target.value;
+                                  if (!raw.trim()) {
+                                    handleConfigChange(field.key, null);
+                                    return;
+                                  }
+                                  try {
+                                    handleConfigChange(field.key, JSON.parse(raw));
+                                  } catch {
+                                    handleConfigChange(field.key, raw);
+                                  }
+                                }}
+                                className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full font-mono text-xs shadow-sm sm:text-sm border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md"
+                              />
+                            ) : Array.isArray(field.enumHint) && field.enumHint.length > 0 ? (
+                              <input
+                                id={inputId}
+                                list={`${inputId}-options`}
+                                type="text"
+                                value={value}
+                                onChange={e => handleConfigChange(field.key, e.target.value)}
+                                className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md"
+                              />
+                            ) : (
+                              <input
+                                id={inputId}
+                                type={field.type === 'number' ? 'number' : 'text'}
+                                value={value}
+                                onChange={e =>
+                                  handleConfigChange(
+                                    field.key,
+                                    field.type === 'number'
+                                      ? Number(e.target.value)
+                                      : e.target.value
+                                  )
+                                }
+                                className="mt-1 focus:ring-indigo-500 focus:border-indigo-500 block w-full shadow-sm sm:text-sm border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 rounded-md"
+                              />
+                            )}
+                            {Array.isArray(field.enumHint) && field.enumHint.length > 0 && (
+                              <datalist id={`${inputId}-options`}>
+                                {field.enumHint.map(opt => (
+                                  <option key={opt} value={opt} />
+                                ))}
+                              </datalist>
+                            )}
+                            {description && (
+                              <p className="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                                {description}
+                              </p>
+                            )}
+                          </div>
+                        );
+                      })}
                     </div>
                   </fieldset>
                 </div>

--- a/docs/models.md
+++ b/docs/models.md
@@ -105,6 +105,68 @@ The system currently supports the following providers:
    - Requires `iAssistant.baseUrl` configured in `platform.json`
    - Uses the iAssistant profile and search settings defined at the platform or app level
 
+8. **AWS Bedrock** (`provider: "bedrock"`)
+   - Calls the unified [Bedrock Converse / ConverseStream API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference.html)
+   - Authentication uses a long-lived **Bedrock API key** as `Authorization: Bearer …` (no AWS SDK or SigV4 signing required)
+   - Region is configured per-model via `config.region` (default `eu-central-1`); the value `global` selects the cross-region inference profile prefix
+   - Model IDs accept either bare foundation IDs (`anthropic.claude-3-5-sonnet-20241022-v2:0`) or pre-prefixed inference profile IDs (`us.…`, `eu.…`, `apac.…`, `global.…`); the adapter auto-prepends the cluster prefix when the chosen region requires it
+   - Supports text, vision (`png/jpeg/gif/webp`), tool calling, parallel tool use, streaming, and reasoning (extended thinking)
+   - Bedrock service limits enforced client-side: max 5 documents per request and a strict filename character allowlist (alphanumerics, single spaces, `-`, `()`, `[]`)
+   - See [AWS Bedrock](#aws-bedrock) below for full setup instructions
+
+### AWS Bedrock
+
+#### Authentication
+
+The adapter uses Bedrock's long-lived API key feature. Mint a key in the AWS console (Bedrock → API keys → Create API key) and configure it via any of:
+
+- **Per-model:** encrypted `apiKey` field on the model JSON (set via Admin → Models → Edit)
+- **Per-provider:** encrypted `apiKey` field on the `bedrock` provider in `providers.json` (set via Admin → Providers)
+- **Environment:** `BEDROCK_API_KEY=<key>`
+
+Resolution order matches every other provider: model.apiKey → providers.json → env. Keys configured via the admin UI are encrypted at rest using AES-256-GCM.
+
+#### Region configuration
+
+Each model can override the AWS Region via `config.region`. The Admin Model Editor renders a "Region" field with autocomplete suggestions. Supported values:
+
+| Value | Behavior |
+| --- | --- |
+| `eu-central-1`, `eu-west-1`, `eu-west-3` | Frankfurt / Ireland / Paris. Auto-prepends `eu.` for inference-profile-required models. |
+| `us-east-1`, `us-west-2` | Auto-prepends `us.` for inference-profile-required models. |
+| `apac-northeast-1`, `ap-…` | Auto-prepends `apac.`. |
+| `global` | Auto-prepends `global.` and routes to a supported source region. Supported by the Anthropic Claude Sonnet 4 family. |
+
+If you write the modelId with an explicit prefix (e.g., `us.anthropic.claude-sonnet-4-6`) the adapter honors it as-is.
+
+Fallback order: `model.config.region` → `providers.json` `bedrock.config.region` → env `AWS_REGION` / `AWS_DEFAULT_REGION` → default `eu-central-1`.
+
+#### Supported models (Converse-compatible families)
+
+| Model family | Vision | Documents | Tools | Notes |
+| --- | --- | --- | --- | --- |
+| Anthropic Claude 3 / 3.5 / 3.7 / 4.x (Sonnet, Haiku, Opus) | yes | yes | yes | PDF size cap waived on Claude 4+ |
+| Amazon Nova Pro / Lite / Premier | yes | yes | yes | PDF/DOCX size cap waived |
+| Amazon Nova Micro | no | yes | yes | text-only |
+| Meta Llama 3.3 70B Instruct | no | yes | yes | requires inference profile |
+| Meta Llama 4 Scout / Maverick | yes | yes | yes | requires inference profile |
+| Mistral Large / Mistral Large 2 | no | yes | yes | text-only |
+| Mistral Pixtral Large | yes | yes | yes | |
+| Cohere Command R / R+ | no | yes | yes | RAG-optimized |
+| AI21 Jamba 1.5 Mini / Large | no | yes | partial | |
+| DeepSeek R1 / V3.x | no | yes | yes (V3.1+) | |
+
+#### Limits enforced by the adapter
+
+- **Documents per request:** Bedrock caps at 5; the adapter rejects requests with more.
+- **Document filename:** Bedrock requires `^[A-Za-z0-9\-()[\] ]{1,200}$` with no consecutive whitespace. The adapter sanitizes upstream filenames automatically (strips disallowed chars, removes extensions, collapses spaces).
+- **Image format:** restricted to `png`, `jpeg`, `gif`, `webp`. Other formats are dropped with a warning.
+- **Empty content blocks** (`{ text: '' }`) are stripped before sending — Bedrock rejects them.
+
+#### Ready-to-import example models
+
+Example configurations for the most common Bedrock models live in `examples/models/bedrock/` and are exposed through the **iHub Examples** marketplace registry. Open Admin → Marketplace → "iHub Examples" to browse and one-click install. All examples ship `enabled: false` so you can opt-in selectively.
+
 ### Image Generation Defaults
 
 For models with `supportsImageGeneration: true`, the `imageGeneration` object sets the default parameters:

--- a/examples/catalog.json
+++ b/examples/catalog.json
@@ -1,0 +1,188 @@
+{
+  "name": "iHub Examples",
+  "description": "In-repo example apps, models, prompts, and skills shipped with iHub Apps.",
+  "version": "1",
+  "categories": ["models"],
+  "items": [
+    {
+      "type": "model",
+      "name": "bedrock-claude-3-5-sonnet",
+      "displayName": {
+        "en": "Claude 3.5 Sonnet (Bedrock)",
+        "de": "Claude 3.5 Sonnet (Bedrock)"
+      },
+      "description": {
+        "en": "Anthropic Claude 3.5 Sonnet via AWS Bedrock — vision, documents, and tool calling.",
+        "de": "Anthropic Claude 3.5 Sonnet über AWS Bedrock — Vision, Dokumente und Tool-Aufrufe."
+      },
+      "category": "model",
+      "tags": ["bedrock", "anthropic", "claude", "vision", "tools"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-claude-3-5-sonnet.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-claude-3-7-sonnet",
+      "displayName": {
+        "en": "Claude 3.7 Sonnet (Bedrock)",
+        "de": "Claude 3.7 Sonnet (Bedrock)"
+      },
+      "description": {
+        "en": "Anthropic Claude 3.7 Sonnet via AWS Bedrock — extended thinking, vision, documents, tool calling.",
+        "de": "Anthropic Claude 3.7 Sonnet über AWS Bedrock — erweitertes Denken, Vision, Dokumente, Tool-Aufrufe."
+      },
+      "category": "model",
+      "tags": ["bedrock", "anthropic", "claude", "vision", "tools", "thinking"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-claude-3-7-sonnet.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-claude-sonnet-4-6",
+      "displayName": {
+        "en": "Claude Sonnet 4.6 (Bedrock)",
+        "de": "Claude Sonnet 4.6 (Bedrock)"
+      },
+      "description": {
+        "en": "Anthropic Claude Sonnet 4.6 via AWS Bedrock cross-region inference (global).",
+        "de": "Anthropic Claude Sonnet 4.6 über AWS Bedrock mit regionsübergreifender Inferenz (global)."
+      },
+      "category": "model",
+      "tags": ["bedrock", "anthropic", "claude", "vision", "tools", "global"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-claude-sonnet-4-6.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-claude-haiku-3-5",
+      "displayName": {
+        "en": "Claude 3.5 Haiku (Bedrock)",
+        "de": "Claude 3.5 Haiku (Bedrock)"
+      },
+      "description": {
+        "en": "Anthropic Claude 3.5 Haiku via AWS Bedrock — fast, low-cost, with vision and tool calling.",
+        "de": "Anthropic Claude 3.5 Haiku über AWS Bedrock — schnell, kostengünstig, mit Vision und Tool-Aufrufen."
+      },
+      "category": "model",
+      "tags": ["bedrock", "anthropic", "claude", "vision", "tools", "fast"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-claude-haiku-3-5.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-nova-pro",
+      "displayName": {
+        "en": "Amazon Nova Pro (Bedrock)",
+        "de": "Amazon Nova Pro (Bedrock)"
+      },
+      "description": {
+        "en": "Amazon Nova Pro via AWS Bedrock — multimodal with vision, video, documents, and tools.",
+        "de": "Amazon Nova Pro über AWS Bedrock — multimodal mit Vision, Video, Dokumenten und Tools."
+      },
+      "category": "model",
+      "tags": ["bedrock", "amazon", "nova", "vision", "tools", "documents"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-nova-pro.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-nova-lite",
+      "displayName": {
+        "en": "Amazon Nova Lite (Bedrock)",
+        "de": "Amazon Nova Lite (Bedrock)"
+      },
+      "description": {
+        "en": "Amazon Nova Lite via AWS Bedrock — fast multimodal with vision and tool calling.",
+        "de": "Amazon Nova Lite über AWS Bedrock — schnelles multimodales Modell mit Vision und Tool-Aufrufen."
+      },
+      "category": "model",
+      "tags": ["bedrock", "amazon", "nova", "vision", "tools"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-nova-lite.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-nova-micro",
+      "displayName": {
+        "en": "Amazon Nova Micro (Bedrock)",
+        "de": "Amazon Nova Micro (Bedrock)"
+      },
+      "description": {
+        "en": "Amazon Nova Micro via AWS Bedrock — text-only, optimized for low-latency tool calling.",
+        "de": "Amazon Nova Micro über AWS Bedrock — nur Text, optimiert für latenzarme Tool-Aufrufe."
+      },
+      "category": "model",
+      "tags": ["bedrock", "amazon", "nova", "tools", "fast"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-nova-micro.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-llama-3-3-70b",
+      "displayName": {
+        "en": "Llama 3.3 70B Instruct (Bedrock)",
+        "de": "Llama 3.3 70B Instruct (Bedrock)"
+      },
+      "description": {
+        "en": "Meta Llama 3.3 70B via AWS Bedrock cross-region inference. Tool calling, no vision.",
+        "de": "Meta Llama 3.3 70B über AWS Bedrock mit regionsübergreifender Inferenz. Tool-Aufrufe, keine Vision."
+      },
+      "category": "model",
+      "tags": ["bedrock", "meta", "llama", "tools"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-llama-3-3-70b.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-llama-4-scout",
+      "displayName": {
+        "en": "Llama 4 Scout (Bedrock)",
+        "de": "Llama 4 Scout (Bedrock)"
+      },
+      "description": {
+        "en": "Meta Llama 4 Scout via AWS Bedrock — multimodal with vision and tool calling.",
+        "de": "Meta Llama 4 Scout über AWS Bedrock — multimodal mit Vision und Tool-Aufrufen."
+      },
+      "category": "model",
+      "tags": ["bedrock", "meta", "llama", "vision", "tools"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-llama-4-scout.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-mistral-large-2",
+      "displayName": {
+        "en": "Mistral Large 2 (Bedrock)",
+        "de": "Mistral Large 2 (Bedrock)"
+      },
+      "description": {
+        "en": "Mistral Large 2 via AWS Bedrock — strong reasoning and tool calling, text-only.",
+        "de": "Mistral Large 2 über AWS Bedrock — starkes Reasoning und Tool-Aufrufe, nur Text."
+      },
+      "category": "model",
+      "tags": ["bedrock", "mistral", "tools"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-mistral-large-2.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-pixtral-large",
+      "displayName": {
+        "en": "Pixtral Large (Bedrock)",
+        "de": "Pixtral Large (Bedrock)"
+      },
+      "description": {
+        "en": "Mistral Pixtral Large via AWS Bedrock — multimodal with vision and tool calling.",
+        "de": "Mistral Pixtral Large über AWS Bedrock — multimodal mit Vision und Tool-Aufrufen."
+      },
+      "category": "model",
+      "tags": ["bedrock", "mistral", "pixtral", "vision", "tools"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-pixtral-large.json" }
+    },
+    {
+      "type": "model",
+      "name": "bedrock-command-r-plus",
+      "displayName": {
+        "en": "Cohere Command R+ (Bedrock)",
+        "de": "Cohere Command R+ (Bedrock)"
+      },
+      "description": {
+        "en": "Cohere Command R+ via AWS Bedrock — RAG-optimized with strong tool calling.",
+        "de": "Cohere Command R+ über AWS Bedrock — RAG-optimiert mit starken Tool-Aufrufen."
+      },
+      "category": "model",
+      "tags": ["bedrock", "cohere", "command-r", "tools", "rag"],
+      "source": { "type": "relative", "path": "models/bedrock/bedrock-command-r-plus.json" }
+    }
+  ]
+}

--- a/examples/models/bedrock/README.md
+++ b/examples/models/bedrock/README.md
@@ -1,0 +1,39 @@
+# AWS Bedrock Example Models
+
+This folder contains example model configurations for AWS Bedrock's Converse
+API. Every entry ships **disabled** so you can choose which ones to enable.
+
+These models are exposed through the **iHub Examples** marketplace registry
+(`examples/catalog.json`). Open Admin → Marketplace → "iHub Examples" to
+browse and install them with one click.
+
+## Setup
+
+1. Create an AWS Bedrock long-lived API key in the AWS console
+   (Bedrock → API keys → Create API key).
+2. Set `BEDROCK_API_KEY=<your key>` in your environment.
+3. Install one or more example models from the marketplace, or copy a JSON
+   file from this folder into `contents/models/` and set `enabled: true`.
+4. Optionally adjust the `config.region` field on a per-model basis —
+   defaults to `eu-central-1`. Use `global` for cross-region inference
+   profiles (Anthropic Claude Sonnet 4 family only).
+
+## Region behavior
+
+- `eu-*` regions auto-prepend the `eu.` cross-region inference profile prefix
+  for models that require it (Claude 4.x, Llama 4, Llama 3.3).
+- `us-*` regions auto-prepend `us.` under the same conditions.
+- `apac-*` / `ap-*` regions auto-prepend `apac.`.
+- `global` auto-prepends `global.` and routes to a supported source region.
+- An explicit `us.…` / `eu.…` / `apac.…` / `global.…` modelId is always
+  honored as-is.
+
+## Limits enforced client-side
+
+- Max **5 documents** per request (Bedrock service limit).
+- Document filenames are sanitized to Bedrock's character allowlist
+  (alphanumerics, single spaces, `-`, `()`, `[]`).
+- Image formats are restricted to `png`, `jpeg`, `gif`, `webp`.
+- Empty text blocks are stripped before sending.
+
+For full details, see `docs/models.md` (AWS Bedrock section).

--- a/examples/models/bedrock/bedrock-claude-3-5-sonnet.json
+++ b/examples/models/bedrock/bedrock-claude-3-5-sonnet.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-claude-3-5-sonnet",
+  "modelId": "anthropic.claude-3-5-sonnet-20241022-v2:0",
+  "name": {
+    "en": "Claude 3.5 Sonnet (Bedrock)",
+    "de": "Claude 3.5 Sonnet (Bedrock)"
+  },
+  "description": {
+    "en": "Anthropic Claude 3.5 Sonnet via AWS Bedrock — vision, documents, and tool calling.",
+    "de": "Anthropic Claude 3.5 Sonnet über AWS Bedrock — Vision, Dokumente und Tool-Aufrufe."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 200000,
+  "supportsTools": true,
+  "supportsVision": true,
+  "enabled": false,
+  "config": {
+    "region": "eu-central-1"
+  }
+}

--- a/examples/models/bedrock/bedrock-claude-3-7-sonnet.json
+++ b/examples/models/bedrock/bedrock-claude-3-7-sonnet.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-claude-3-7-sonnet",
+  "modelId": "anthropic.claude-3-7-sonnet-20250219-v1:0",
+  "name": {
+    "en": "Claude 3.7 Sonnet (Bedrock)",
+    "de": "Claude 3.7 Sonnet (Bedrock)"
+  },
+  "description": {
+    "en": "Anthropic Claude 3.7 Sonnet via AWS Bedrock — extended thinking, vision, documents, and tool calling.",
+    "de": "Anthropic Claude 3.7 Sonnet über AWS Bedrock — erweitertes Denken, Vision, Dokumente und Tool-Aufrufe."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 200000,
+  "supportsTools": true,
+  "supportsVision": true,
+  "enabled": false,
+  "config": {
+    "region": "eu-central-1"
+  }
+}

--- a/examples/models/bedrock/bedrock-claude-haiku-3-5.json
+++ b/examples/models/bedrock/bedrock-claude-haiku-3-5.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-claude-haiku-3-5",
+  "modelId": "anthropic.claude-3-5-haiku-20241022-v1:0",
+  "name": {
+    "en": "Claude 3.5 Haiku (Bedrock)",
+    "de": "Claude 3.5 Haiku (Bedrock)"
+  },
+  "description": {
+    "en": "Anthropic Claude 3.5 Haiku via AWS Bedrock — fast, low-cost, with vision and tool calling.",
+    "de": "Anthropic Claude 3.5 Haiku über AWS Bedrock — schnell, kostengünstig, mit Vision und Tool-Aufrufen."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 200000,
+  "supportsTools": true,
+  "supportsVision": true,
+  "enabled": false,
+  "config": {
+    "region": "eu-central-1"
+  }
+}

--- a/examples/models/bedrock/bedrock-claude-sonnet-4-6.json
+++ b/examples/models/bedrock/bedrock-claude-sonnet-4-6.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-claude-sonnet-4-6",
+  "modelId": "anthropic.claude-sonnet-4-6",
+  "name": {
+    "en": "Claude Sonnet 4.6 (Bedrock)",
+    "de": "Claude Sonnet 4.6 (Bedrock)"
+  },
+  "description": {
+    "en": "Anthropic Claude Sonnet 4.6 via AWS Bedrock cross-region inference (global). PDF size cap waived.",
+    "de": "Anthropic Claude Sonnet 4.6 über AWS Bedrock mit regionsübergreifender Inferenz (global). PDF-Größenlimit aufgehoben."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 200000,
+  "supportsTools": true,
+  "supportsVision": true,
+  "enabled": false,
+  "config": {
+    "region": "global"
+  }
+}

--- a/examples/models/bedrock/bedrock-command-r-plus.json
+++ b/examples/models/bedrock/bedrock-command-r-plus.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-command-r-plus",
+  "modelId": "cohere.command-r-plus-v1:0",
+  "name": {
+    "en": "Cohere Command R+ (Bedrock)",
+    "de": "Cohere Command R+ (Bedrock)"
+  },
+  "description": {
+    "en": "Cohere Command R+ via AWS Bedrock — RAG-optimized with strong tool calling.",
+    "de": "Cohere Command R+ über AWS Bedrock — RAG-optimiert mit starken Tool-Aufrufen."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 128000,
+  "supportsTools": true,
+  "supportsVision": false,
+  "enabled": false,
+  "config": {
+    "region": "eu-central-1"
+  }
+}

--- a/examples/models/bedrock/bedrock-llama-3-3-70b.json
+++ b/examples/models/bedrock/bedrock-llama-3-3-70b.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-llama-3-3-70b",
+  "modelId": "meta.llama3-3-70b-instruct-v1:0",
+  "name": {
+    "en": "Llama 3.3 70B Instruct (Bedrock)",
+    "de": "Llama 3.3 70B Instruct (Bedrock)"
+  },
+  "description": {
+    "en": "Meta Llama 3.3 70B via AWS Bedrock cross-region inference. Tool calling, no vision.",
+    "de": "Meta Llama 3.3 70B über AWS Bedrock mit regionsübergreifender Inferenz. Tool-Aufrufe, keine Vision."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 128000,
+  "supportsTools": true,
+  "supportsVision": false,
+  "enabled": false,
+  "config": {
+    "region": "us-east-1"
+  }
+}

--- a/examples/models/bedrock/bedrock-llama-4-scout.json
+++ b/examples/models/bedrock/bedrock-llama-4-scout.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-llama-4-scout",
+  "modelId": "meta.llama4-scout-17b-instruct-v1:0",
+  "name": {
+    "en": "Llama 4 Scout (Bedrock)",
+    "de": "Llama 4 Scout (Bedrock)"
+  },
+  "description": {
+    "en": "Meta Llama 4 Scout via AWS Bedrock cross-region inference. Multimodal with vision and tool calling.",
+    "de": "Meta Llama 4 Scout über AWS Bedrock mit regionsübergreifender Inferenz. Multimodal mit Vision und Tool-Aufrufen."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 128000,
+  "supportsTools": true,
+  "supportsVision": true,
+  "enabled": false,
+  "config": {
+    "region": "us-east-1"
+  }
+}

--- a/examples/models/bedrock/bedrock-mistral-large-2.json
+++ b/examples/models/bedrock/bedrock-mistral-large-2.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-mistral-large-2",
+  "modelId": "mistral.mistral-large-2407-v1:0",
+  "name": {
+    "en": "Mistral Large 2 (Bedrock)",
+    "de": "Mistral Large 2 (Bedrock)"
+  },
+  "description": {
+    "en": "Mistral Large 2 via AWS Bedrock — strong reasoning and tool calling, text-only.",
+    "de": "Mistral Large 2 über AWS Bedrock — starkes Reasoning und Tool-Aufrufe, nur Text."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 128000,
+  "supportsTools": true,
+  "supportsVision": false,
+  "enabled": false,
+  "config": {
+    "region": "eu-central-1"
+  }
+}

--- a/examples/models/bedrock/bedrock-nova-lite.json
+++ b/examples/models/bedrock/bedrock-nova-lite.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-nova-lite",
+  "modelId": "amazon.nova-lite-v1:0",
+  "name": {
+    "en": "Amazon Nova Lite (Bedrock)",
+    "de": "Amazon Nova Lite (Bedrock)"
+  },
+  "description": {
+    "en": "Amazon Nova Lite via AWS Bedrock — fast multimodal model with vision, documents, and tool calling.",
+    "de": "Amazon Nova Lite über AWS Bedrock — schnelles multimodales Modell mit Vision, Dokumenten und Tool-Aufrufen."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 300000,
+  "supportsTools": true,
+  "supportsVision": true,
+  "enabled": false,
+  "config": {
+    "region": "eu-central-1"
+  }
+}

--- a/examples/models/bedrock/bedrock-nova-micro.json
+++ b/examples/models/bedrock/bedrock-nova-micro.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-nova-micro",
+  "modelId": "amazon.nova-micro-v1:0",
+  "name": {
+    "en": "Amazon Nova Micro (Bedrock)",
+    "de": "Amazon Nova Micro (Bedrock)"
+  },
+  "description": {
+    "en": "Amazon Nova Micro via AWS Bedrock — text-only, optimized for low-latency tool calling.",
+    "de": "Amazon Nova Micro über AWS Bedrock — nur Text, optimiert für latenzarme Tool-Aufrufe."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 128000,
+  "supportsTools": true,
+  "supportsVision": false,
+  "enabled": false,
+  "config": {
+    "region": "eu-central-1"
+  }
+}

--- a/examples/models/bedrock/bedrock-nova-pro.json
+++ b/examples/models/bedrock/bedrock-nova-pro.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-nova-pro",
+  "modelId": "amazon.nova-pro-v1:0",
+  "name": {
+    "en": "Amazon Nova Pro (Bedrock)",
+    "de": "Amazon Nova Pro (Bedrock)"
+  },
+  "description": {
+    "en": "Amazon Nova Pro via AWS Bedrock — multimodal (text, image, video), documents, and tool calling. PDF/DOCX size cap waived.",
+    "de": "Amazon Nova Pro über AWS Bedrock — multimodal (Text, Bild, Video), Dokumente und Tool-Aufrufe. PDF/DOCX-Größenlimit aufgehoben."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 300000,
+  "supportsTools": true,
+  "supportsVision": true,
+  "enabled": false,
+  "config": {
+    "region": "eu-central-1"
+  }
+}

--- a/examples/models/bedrock/bedrock-pixtral-large.json
+++ b/examples/models/bedrock/bedrock-pixtral-large.json
@@ -1,0 +1,20 @@
+{
+  "id": "bedrock-pixtral-large",
+  "modelId": "mistral.pixtral-large-2502-v1:0",
+  "name": {
+    "en": "Pixtral Large (Bedrock)",
+    "de": "Pixtral Large (Bedrock)"
+  },
+  "description": {
+    "en": "Mistral Pixtral Large via AWS Bedrock — multimodal model with vision and tool calling.",
+    "de": "Mistral Pixtral Large über AWS Bedrock — multimodales Modell mit Vision und Tool-Aufrufen."
+  },
+  "provider": "bedrock",
+  "tokenLimit": 128000,
+  "supportsTools": true,
+  "supportsVision": true,
+  "enabled": false,
+  "config": {
+    "region": "eu-central-1"
+  }
+}

--- a/server/adapters/BaseAdapter.js
+++ b/server/adapters/BaseAdapter.js
@@ -1,4 +1,8 @@
 import logger from '../utils/logger.js';
+import { createParser } from 'eventsource-parser';
+import { getReadableStream } from '../utils/streamUtils.js';
+import { convertResponseToGeneric } from './toolCalling/index.js';
+
 /**
  * Base adapter class for LLM providers to reduce duplication
  */
@@ -125,5 +129,122 @@ export class BaseAdapter {
       name: message.name,
       is_error: message.is_error || false
     };
+  }
+
+  /**
+   * Default streaming-response parser. Subclasses may override to handle
+   * non-SSE wire formats (e.g. AWS Bedrock binary EventStream).
+   *
+   * @param {Response} response
+   * @param {{ model: object, chatId?: string, request?: object }} ctx
+   * @yields {object} Normalized result chunks consumed by StreamingHandler
+   */
+  async *parseResponseStream(response, ctx) {
+    yield* this.parseSseStream(response, ctx.model.provider);
+  }
+
+  /**
+   * Generic SSE parser used by OpenAI-compatible providers. Reads the
+   * response body, feeds chunks through eventsource-parser, and yields the
+   * normalized result of convertResponseToGeneric for each event.
+   *
+   * @param {Response} response
+   * @param {string} provider - Provider name passed to the converter registry
+   * @yields {object} Normalized result chunks
+   */
+  async *parseSseStream(response, provider) {
+    const readable = getReadableStream(response);
+    const reader = readable.getReader();
+    const decoder = new TextDecoder();
+    const queue = [];
+    const parser = createParser({
+      onEvent: event => {
+        if (event.type === 'event' || !event.type) {
+          queue.push(event);
+        }
+      }
+    });
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        parser.feed(decoder.decode(value, { stream: true }));
+        while (queue.length > 0) {
+          const evt = queue.shift();
+          const result = await convertResponseToGeneric(evt.data, provider);
+          if (!result) continue;
+          yield result;
+          if (result.error || result.complete) return;
+        }
+      }
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  /**
+   * Custom SSE parser for providers that emit multi-event blocks separated
+   * by `\n\n` and expect the adapter to interpret entire blocks at once
+   * (currently iAssistant Conversation).
+   *
+   * The adapter must implement `processResponseBuffer(buffer)` which returns
+   * a normalized result object.
+   *
+   * @param {Response} response
+   * @yields {object} Normalized result chunks
+   */
+  async *parseLineDelimitedSseStream(response) {
+    const readable = getReadableStream(response);
+    const reader = readable.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        if (buffer.includes('\n\n')) {
+          const parts = buffer.split('\n\n');
+          const completeEvents = parts.slice(0, -1).join('\n\n');
+          buffer = parts[parts.length - 1];
+          if (!completeEvents) continue;
+
+          let result;
+          try {
+            result = await this.processResponseBuffer(completeEvents + '\n\n');
+          } catch (err) {
+            yield {
+              content: [],
+              complete: false,
+              finishReason: 'error',
+              error: true,
+              errorMessage: `Processing error: ${err.message}`
+            };
+            return;
+          }
+          if (!result) continue;
+          yield result;
+          if (result.error || result.complete) return;
+        }
+      }
+
+      if (buffer.trim()) {
+        const result = await this.processResponseBuffer(buffer);
+        if (result) yield result;
+      }
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        /* ignore */
+      }
+    }
   }
 }

--- a/server/adapters/bedrock.js
+++ b/server/adapters/bedrock.js
@@ -1,0 +1,537 @@
+/**
+ * AWS Bedrock Converse API adapter
+ *
+ * Authenticates with a Bedrock long-lived API key over `Authorization: Bearer …`.
+ * No AWS SDK dependency: requests are sent with `fetch`, and the binary
+ * `application/vnd.amazon.eventstream` response is parsed by
+ * BedrockEventStreamDecoder.
+ *
+ * Provider name: "bedrock"
+ */
+
+import { BaseAdapter } from './BaseAdapter.js';
+import { convertToolsFromGeneric } from './toolCalling/index.js';
+import { convertBedrockToolChoice } from './toolCalling/BedrockConverter.js';
+import { BedrockEventStreamDecoder } from './bedrockEventStream.js';
+import { getReadableStream } from '../utils/streamUtils.js';
+import configCache from '../configCache.js';
+import logger from '../utils/logger.js';
+
+/**
+ * Provider-specific configuration schema. Consumed by the admin Model Form
+ * Editor via `GET /api/admin/providers/bedrock/schema` to render dynamic
+ * configuration fields. Values are written to `model.config[key]`.
+ */
+export const providerConfigSchema = {
+  fields: [
+    {
+      key: 'region',
+      label: { en: 'AWS Region', de: 'AWS-Region' },
+      type: 'string',
+      default: 'eu-central-1',
+      enumHint: [
+        'eu-central-1',
+        'eu-west-1',
+        'eu-west-3',
+        'us-east-1',
+        'us-west-2',
+        'apac-northeast-1',
+        'global'
+      ],
+      description: {
+        en: 'AWS region for the Bedrock Runtime endpoint, or "global" for cross-region inference profiles (Claude Sonnet 4 family only).',
+        de: 'AWS-Region für den Bedrock-Runtime-Endpunkt oder "global" für regionsübergreifende Inferenzprofile (nur Claude Sonnet 4).'
+      },
+      required: false
+    },
+    {
+      key: 'additionalModelRequestFields',
+      label: { en: 'Additional Model Request Fields', de: 'Zusätzliche Modell-Felder' },
+      type: 'json',
+      default: null,
+      description: {
+        en: 'Optional provider-specific fields passed in `additionalModelRequestFields` (e.g. `{ "top_k": 200 }` for Anthropic).',
+        de: 'Optionale providerspezifische Felder im `additionalModelRequestFields`-Objekt.'
+      },
+      required: false
+    }
+  ]
+};
+
+const IMAGE_FORMAT_BY_MIME = {
+  'image/jpeg': 'jpeg',
+  'image/jpg': 'jpeg',
+  'image/png': 'png',
+  'image/gif': 'gif',
+  'image/webp': 'webp'
+};
+
+const VALID_IMAGE_FORMATS = new Set(['jpeg', 'png', 'gif', 'webp']);
+
+const DOCUMENT_NAME_RE = /^[A-Za-z0-9\-()[\] ]{1,200}$/;
+
+/**
+ * Models that Bedrock requires to be invoked through a cross-region
+ * inference profile (rather than a bare foundation-model ID). When the
+ * configured region implies a profile cluster (us-/eu-/apac-) and the
+ * model ID is bare, the adapter prepends the matching prefix.
+ */
+const REQUIRES_INFERENCE_PROFILE = [
+  'anthropic.claude-3-5-sonnet-',
+  'anthropic.claude-3-7-sonnet-',
+  'anthropic.claude-sonnet-4',
+  'anthropic.claude-opus-4',
+  'anthropic.claude-haiku-4',
+  'meta.llama4-',
+  'meta.llama3-3-'
+];
+
+function regionToProfilePrefix(region) {
+  if (!region) return null;
+  if (region === 'global') return 'global.';
+  if (region.startsWith('us-')) return 'us.';
+  if (region.startsWith('eu-')) return 'eu.';
+  if (region.startsWith('apac-') || region.startsWith('ap-')) return 'apac.';
+  return null;
+}
+
+function modelIdHasProfilePrefix(modelId) {
+  return /^(us|eu|apac|global)\./.test(modelId);
+}
+
+function modelRequiresInferenceProfile(modelId) {
+  return REQUIRES_INFERENCE_PROFILE.some(prefix => modelId.startsWith(prefix));
+}
+
+function resolveEndpointRegion(region) {
+  // The `global` cross-region profile is invoked through a supported source
+  // region. Default to eu-central-1 to match the iHub default region.
+  if (!region || region === 'global') return 'eu-central-1';
+  return region;
+}
+
+function sanitizeDocumentName(name) {
+  if (!name || typeof name !== 'string') return 'document';
+  let sanitized = name
+    .replace(/\.[A-Za-z0-9]+$/, '')
+    .replace(/[^A-Za-z0-9\-()[\] ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200);
+  if (!sanitized) sanitized = 'document';
+  if (!DOCUMENT_NAME_RE.test(sanitized)) sanitized = 'document';
+  return sanitized;
+}
+
+class BedrockAdapterClass extends BaseAdapter {
+  /**
+   * Resolve the effective region from model → provider → env → default.
+   */
+  resolveRegion(model) {
+    if (model?.config?.region) return model.config.region;
+    try {
+      const { data: providers = [] } = configCache.getProviders(true) || {};
+      const providerConfig = providers.find(p => p.id === 'bedrock');
+      if (providerConfig?.config?.region) return providerConfig.config.region;
+    } catch {
+      /* configCache may be unavailable in tests */
+    }
+    return process.env.AWS_REGION || process.env.AWS_DEFAULT_REGION || 'eu-central-1';
+  }
+
+  /**
+   * Resolve the effective Bedrock model ID, automatically prepending the
+   * cross-region inference-profile prefix where required.
+   */
+  resolveBedrockModelId(model, region) {
+    const raw = model.modelId || model.id;
+    if (modelIdHasProfilePrefix(raw)) return raw;
+    const prefix = regionToProfilePrefix(region);
+    if (!prefix) return raw;
+    if (region === 'global' || modelRequiresInferenceProfile(raw)) {
+      return `${prefix}${raw}`;
+    }
+    return raw;
+  }
+
+  /**
+   * Format messages for Bedrock Converse. Splits system messages out into a
+   * top-level `system` array and converts each remaining message into a
+   * `{ role, content: [...] }` shape with text / image / toolUse / toolResult
+   * content blocks.
+   */
+  formatMessages(messages) {
+    const systemTexts = [];
+    const out = [];
+
+    for (const msg of messages) {
+      if (msg.role === 'system') {
+        if (typeof msg.content === 'string' && msg.content.trim()) {
+          systemTexts.push({ text: msg.content });
+        }
+        continue;
+      }
+
+      if (msg.role === 'tool') {
+        const content = [];
+        const parsed = this.safeJsonParse(msg.content, msg.content);
+        const block = typeof parsed === 'string' ? { text: parsed } : { json: parsed };
+        content.push({
+          toolResult: {
+            toolUseId: msg.tool_call_id,
+            content: [block],
+            status: msg.is_error ? 'error' : 'success'
+          }
+        });
+        out.push({ role: 'user', content });
+        continue;
+      }
+
+      const content = [];
+
+      if (Array.isArray(msg.tool_calls) && msg.tool_calls.length > 0) {
+        for (const call of msg.tool_calls) {
+          let input = {};
+          try {
+            input =
+              typeof call.function?.arguments === 'string'
+                ? JSON.parse(call.function.arguments || '{}')
+                : call.function?.arguments || {};
+          } catch {
+            input = {};
+          }
+          content.push({
+            toolUse: {
+              toolUseId: call.id,
+              name: call.function?.name,
+              input
+            }
+          });
+        }
+      }
+
+      if (typeof msg.content === 'string' && msg.content.length > 0) {
+        content.push({ text: msg.content });
+      } else if (Array.isArray(msg.content)) {
+        for (const part of msg.content) {
+          if (typeof part === 'string' && part.length > 0) {
+            content.push({ text: part });
+          } else if (part?.type === 'text' && part.text) {
+            content.push({ text: part.text });
+          }
+        }
+      }
+
+      if (this.hasImageData(msg)) {
+        const images = Array.isArray(msg.imageData) ? msg.imageData : [msg.imageData];
+        for (const img of images) {
+          if (!img?.base64) continue;
+          const format =
+            IMAGE_FORMAT_BY_MIME[(img.fileType || '').toLowerCase()] ||
+            IMAGE_FORMAT_BY_MIME[`image/${(img.fileType || '').toLowerCase()}`] ||
+            'jpeg';
+          if (!VALID_IMAGE_FORMATS.has(format)) {
+            logger.warn('Skipping unsupported image format for Bedrock', {
+              component: 'BedrockAdapter',
+              fileType: img.fileType
+            });
+            continue;
+          }
+          content.push({
+            image: {
+              format,
+              source: { bytes: this.cleanBase64Data(img.base64) }
+            }
+          });
+        }
+      }
+
+      if (Array.isArray(msg.documentData)) {
+        for (const doc of msg.documentData) {
+          if (!doc?.base64 || !doc?.format) continue;
+          content.push({
+            document: {
+              name: sanitizeDocumentName(doc.name || doc.fileName),
+              format: doc.format,
+              source: { bytes: this.cleanBase64Data(doc.base64) }
+            }
+          });
+        }
+      }
+
+      if (content.length === 0) continue;
+
+      const role = msg.role === 'assistant' ? 'assistant' : 'user';
+      out.push({ role, content });
+    }
+
+    // Bedrock requires the first message to be from the user.
+    if (out.length > 0 && out[0].role !== 'user') {
+      out.unshift({ role: 'user', content: [{ text: '' }] });
+    }
+
+    // Collapse consecutive same-role messages defensively.
+    const merged = [];
+    for (const m of out) {
+      const last = merged[merged.length - 1];
+      if (last && last.role === m.role) {
+        last.content = [...last.content, ...m.content];
+      } else {
+        merged.push(m);
+      }
+    }
+
+    // Bedrock rejects empty text blocks; strip them but keep at least one
+    // content block per message.
+    for (const m of merged) {
+      const filtered = m.content.filter(b => {
+        if (b.text !== undefined) return b.text.length > 0;
+        return true;
+      });
+      m.content = filtered.length > 0 ? filtered : [{ text: ' ' }];
+    }
+
+    // Pre-flight document count validation (Bedrock max: 5).
+    const docCount = merged.reduce((n, m) => n + m.content.filter(b => b.document).length, 0);
+    if (docCount > 5) {
+      throw new Error(`Bedrock allows a maximum of 5 documents per request, received ${docCount}.`);
+    }
+
+    return {
+      messages: merged,
+      system: systemTexts.length > 0 ? systemTexts : undefined
+    };
+  }
+
+  /**
+   * Build the Converse request.
+   */
+  createCompletionRequest(model, messages, apiKey, options = {}) {
+    const opts = this.extractRequestOptions(options);
+    const { messages: bedrockMessages, system } = this.formatMessages(messages);
+
+    const region = this.resolveRegion(model);
+    const endpointRegion = resolveEndpointRegion(region);
+    const modelId = this.resolveBedrockModelId(model, region);
+    const stream = opts.stream;
+    const op = stream ? 'converse-stream' : 'converse';
+    const url = `https://bedrock-runtime.${endpointRegion}.amazonaws.com/model/${encodeURIComponent(modelId)}/${op}`;
+
+    const inferenceConfig = {
+      maxTokens: opts.maxTokens,
+      temperature: opts.temperature
+    };
+    if (typeof options.topP === 'number') inferenceConfig.topP = options.topP;
+    if (Array.isArray(options.stopSequences) && options.stopSequences.length > 0) {
+      inferenceConfig.stopSequences = options.stopSequences;
+    }
+
+    const body = {
+      messages: bedrockMessages,
+      inferenceConfig
+    };
+    if (system) body.system = system;
+
+    if (Array.isArray(opts.tools) && opts.tools.length > 0) {
+      const tools = convertToolsFromGeneric(opts.tools, 'bedrock');
+      if (Array.isArray(tools) && tools.length > 0) {
+        body.toolConfig = {
+          tools,
+          toolChoice: convertBedrockToolChoice(opts.toolChoice)
+        };
+      }
+    }
+
+    if (model.config?.additionalModelRequestFields) {
+      body.additionalModelRequestFields = model.config.additionalModelRequestFields;
+    }
+
+    const headers = {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    };
+    if (stream) {
+      headers.Accept = 'application/vnd.amazon.eventstream';
+    }
+
+    return { url, method: 'POST', headers, body };
+  }
+
+  /**
+   * Stream parser. Reads raw bytes from the response, decodes the binary
+   * EventStream framing, and yields normalized result chunks.
+   */
+  async *parseResponseStream(response) {
+    const readable = getReadableStream(response);
+    const reader = readable.getReader();
+    const decoder = new BedrockEventStreamDecoder();
+    const toolUseBlocks = new Map(); // contentBlockIndex -> { id, name, inputBuf }
+    let lastFinishReason = null;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        const chunk = value instanceof Uint8Array ? value : new Uint8Array(value);
+        const frames = decoder.feed(chunk);
+
+        for (const frame of frames) {
+          const evt = frame.eventType;
+          const payload = frame.payload || {};
+
+          if (frame.messageType === 'exception' || frame.messageType === 'error') {
+            const message = payload.message || payload.Message || `Bedrock ${evt || 'error'}`;
+            yield {
+              content: [],
+              error: true,
+              errorMessage: message,
+              finishReason: 'error'
+            };
+            return;
+          }
+
+          switch (evt) {
+            case 'messageStart':
+              break;
+
+            case 'contentBlockStart': {
+              const idx = payload.contentBlockIndex;
+              if (payload.start?.toolUse) {
+                toolUseBlocks.set(idx, {
+                  id: payload.start.toolUse.toolUseId,
+                  name: payload.start.toolUse.name,
+                  inputBuf: ''
+                });
+              }
+              break;
+            }
+
+            case 'contentBlockDelta': {
+              const idx = payload.contentBlockIndex;
+              const delta = payload.delta || {};
+              if (typeof delta.text === 'string' && delta.text.length > 0) {
+                yield { content: [delta.text] };
+              }
+              if (delta.toolUse?.input !== undefined) {
+                const block = toolUseBlocks.get(idx);
+                if (block) {
+                  block.inputBuf += String(delta.toolUse.input ?? '');
+                }
+              }
+              if (delta.reasoningContent?.text) {
+                yield { thinking: [{ content: delta.reasoningContent.text }] };
+              }
+              break;
+            }
+
+            case 'contentBlockStop': {
+              const idx = payload.contentBlockIndex;
+              const block = toolUseBlocks.get(idx);
+              if (block) {
+                let parsedArgs = {};
+                try {
+                  parsedArgs = block.inputBuf ? JSON.parse(block.inputBuf) : {};
+                } catch (err) {
+                  logger.warn('Failed to parse Bedrock toolUse input as JSON', {
+                    component: 'BedrockAdapter',
+                    error: err.message,
+                    inputBuf: block.inputBuf
+                  });
+                }
+                yield {
+                  tool_calls: [
+                    {
+                      index: idx,
+                      id: block.id,
+                      type: 'function',
+                      function: {
+                        name: block.name,
+                        arguments: JSON.stringify(parsedArgs)
+                      }
+                    }
+                  ]
+                };
+                toolUseBlocks.delete(idx);
+              }
+              break;
+            }
+
+            case 'messageStop': {
+              const stopReason = payload.stopReason;
+              lastFinishReason = mapStopReason(stopReason);
+              break;
+            }
+
+            case 'metadata': {
+              const usage = payload.usage || {};
+              yield {
+                usage: {
+                  promptTokens: usage.inputTokens,
+                  completionTokens: usage.outputTokens,
+                  totalTokens:
+                    usage.totalTokens ??
+                    (typeof usage.inputTokens === 'number' && typeof usage.outputTokens === 'number'
+                      ? usage.inputTokens + usage.outputTokens
+                      : undefined)
+                },
+                complete: true,
+                finishReason: lastFinishReason || 'stop'
+              };
+              return;
+            }
+
+            default:
+              logger.debug('Unhandled Bedrock event', {
+                component: 'BedrockAdapter',
+                eventType: evt
+              });
+          }
+        }
+      }
+
+      // Stream ended without metadata; signal completion.
+      yield { complete: true, finishReason: lastFinishReason || 'stop' };
+    } finally {
+      try {
+        reader.releaseLock();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  getModelInfo() {
+    return {
+      provider: 'bedrock',
+      supportsStreaming: true,
+      supportsImages: true,
+      supportsTools: true,
+      maxTokens: null,
+      contextWindow: null
+    };
+  }
+}
+
+function mapStopReason(stopReason) {
+  switch (stopReason) {
+    case 'end_turn':
+    case 'stop_sequence':
+      return 'stop';
+    case 'tool_use':
+      return 'tool_calls';
+    case 'max_tokens':
+      return 'length';
+    case 'guardrail_intervened':
+    case 'content_filtered':
+      return 'content_filter';
+    case 'malformed_model_output':
+    case 'malformed_tool_use':
+    case 'model_context_window_exceeded':
+      return 'error';
+    default:
+      return stopReason || 'stop';
+  }
+}
+
+const BedrockAdapter = new BedrockAdapterClass();
+export default BedrockAdapter;

--- a/server/adapters/bedrockEventStream.js
+++ b/server/adapters/bedrockEventStream.js
@@ -1,0 +1,205 @@
+/**
+ * AWS Bedrock EventStream Decoder
+ *
+ * Decodes the binary `application/vnd.amazon.eventstream` framing used by
+ * Bedrock's ConverseStream API. Self-contained, no AWS SDK dependency.
+ *
+ * Frame layout:
+ *   [Total Length :4][Headers Length :4][Prelude CRC :4][Headers ...][Payload ...][Message CRC :4]
+ *
+ * Headers are a packed sequence of:
+ *   {1-byte name length}{name bytes}{1-byte value type}{value bytes...}
+ *
+ * Bedrock only emits string headers (type 7) for the keys we care about
+ * (`:event-type`, `:content-type`, `:message-type`). We decode those and
+ * skip header value types we don't need to read for the Converse API.
+ *
+ * The payload is always UTF-8 JSON.
+ */
+
+const HEADER_VALUE_TYPE = {
+  TRUE: 0,
+  FALSE: 1,
+  BYTE: 2,
+  SHORT: 3,
+  INT: 4,
+  LONG: 5,
+  BYTES: 6,
+  STRING: 7,
+  TIMESTAMP: 8,
+  UUID: 9
+};
+
+const PRELUDE_LENGTH = 12;
+const MIN_FRAME_LENGTH = 16;
+
+const crc32Table = (() => {
+  const table = new Uint32Array(256);
+  for (let n = 0; n < 256; n++) {
+    let c = n;
+    for (let k = 0; k < 8; k++) {
+      c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+    }
+    table[n] = c >>> 0;
+  }
+  return table;
+})();
+
+function crc32(bytes, start, end) {
+  let crc = 0xffffffff;
+  for (let i = start; i < end; i++) {
+    crc = (crc >>> 8) ^ crc32Table[(crc ^ bytes[i]) & 0xff];
+  }
+  return (crc ^ 0xffffffff) >>> 0;
+}
+
+function readUint32BE(bytes, offset) {
+  return (
+    ((bytes[offset] << 24) |
+      (bytes[offset + 1] << 16) |
+      (bytes[offset + 2] << 8) |
+      bytes[offset + 3]) >>>
+    0
+  );
+}
+
+function readUint16BE(bytes, offset) {
+  return ((bytes[offset] << 8) | bytes[offset + 1]) & 0xffff;
+}
+
+function decodeHeaders(bytes, start, end) {
+  const headers = {};
+  const decoder = new TextDecoder('utf-8');
+  let offset = start;
+  while (offset < end) {
+    const nameLen = bytes[offset++];
+    if (offset + nameLen > end) break;
+    const name = decoder.decode(bytes.subarray(offset, offset + nameLen));
+    offset += nameLen;
+    const valueType = bytes[offset++];
+
+    switch (valueType) {
+      case HEADER_VALUE_TYPE.TRUE:
+        headers[name] = true;
+        break;
+      case HEADER_VALUE_TYPE.FALSE:
+        headers[name] = false;
+        break;
+      case HEADER_VALUE_TYPE.BYTE:
+        headers[name] = bytes[offset];
+        offset += 1;
+        break;
+      case HEADER_VALUE_TYPE.SHORT: {
+        const v = readUint16BE(bytes, offset);
+        headers[name] = v > 0x7fff ? v - 0x10000 : v;
+        offset += 2;
+        break;
+      }
+      case HEADER_VALUE_TYPE.INT: {
+        const v = readUint32BE(bytes, offset);
+        headers[name] = v > 0x7fffffff ? v - 0x100000000 : v;
+        offset += 4;
+        break;
+      }
+      case HEADER_VALUE_TYPE.LONG: {
+        offset += 8;
+        break;
+      }
+      case HEADER_VALUE_TYPE.BYTES:
+      case HEADER_VALUE_TYPE.STRING: {
+        const len = readUint16BE(bytes, offset);
+        offset += 2;
+        const value = decoder.decode(bytes.subarray(offset, offset + len));
+        headers[name] = value;
+        offset += len;
+        break;
+      }
+      case HEADER_VALUE_TYPE.TIMESTAMP:
+        offset += 8;
+        break;
+      case HEADER_VALUE_TYPE.UUID:
+        offset += 16;
+        break;
+      default:
+        return headers;
+    }
+  }
+  return headers;
+}
+
+export class BedrockEventStreamDecoder {
+  constructor() {
+    this.buffer = new Uint8Array(0);
+    this.textDecoder = new TextDecoder('utf-8');
+  }
+
+  feed(chunk) {
+    if (!chunk || chunk.length === 0) {
+      return [];
+    }
+
+    const incoming = chunk instanceof Uint8Array ? chunk : new Uint8Array(chunk);
+    const merged = new Uint8Array(this.buffer.length + incoming.length);
+    merged.set(this.buffer, 0);
+    merged.set(incoming, this.buffer.length);
+    this.buffer = merged;
+
+    const frames = [];
+    while (this.buffer.length >= MIN_FRAME_LENGTH) {
+      const totalLength = readUint32BE(this.buffer, 0);
+      if (totalLength < MIN_FRAME_LENGTH || totalLength > 16 * 1024 * 1024) {
+        // Unrecoverable framing error — drop buffer to resync.
+        this.buffer = new Uint8Array(0);
+        break;
+      }
+      if (this.buffer.length < totalLength) break;
+
+      const headersLength = readUint32BE(this.buffer, 4);
+      const preludeCrc = readUint32BE(this.buffer, 8);
+      const computedPreludeCrc = crc32(this.buffer, 0, 8);
+      const frameEnd = totalLength;
+
+      if (computedPreludeCrc !== preludeCrc) {
+        // Resync by skipping one byte and retrying.
+        this.buffer = this.buffer.subarray(1);
+        continue;
+      }
+
+      const headersStart = PRELUDE_LENGTH;
+      const headersEnd = headersStart + headersLength;
+      const payloadStart = headersEnd;
+      const payloadEnd = frameEnd - 4;
+
+      const headers = decodeHeaders(this.buffer, headersStart, headersEnd);
+      let payload = null;
+      if (payloadEnd > payloadStart) {
+        const payloadBytes = this.buffer.subarray(payloadStart, payloadEnd);
+        const payloadText = this.textDecoder.decode(payloadBytes);
+        if (payloadText.length > 0) {
+          try {
+            payload = JSON.parse(payloadText);
+          } catch {
+            payload = { _raw: payloadText };
+          }
+        } else {
+          payload = {};
+        }
+      } else {
+        payload = {};
+      }
+
+      frames.push({
+        headers,
+        payload,
+        eventType: headers[':event-type'] || '',
+        messageType: headers[':message-type'] || ''
+      });
+
+      this.buffer = this.buffer.subarray(frameEnd);
+    }
+
+    return frames;
+  }
+}
+
+export default BedrockEventStreamDecoder;

--- a/server/adapters/iassistant-conversation.js
+++ b/server/adapters/iassistant-conversation.js
@@ -14,6 +14,15 @@ import logger from '../utils/logger.js';
 
 class IAssistantConversationAdapterClass extends BaseAdapter {
   /**
+   * Use the line-delimited SSE parser from BaseAdapter.
+   * The conversation API emits multi-event blocks separated by `\n\n` and
+   * expects whole-block interpretation in processResponseBuffer.
+   */
+  async *parseResponseStream(response) {
+    yield* this.parseLineDelimitedSseStream(response);
+  }
+
+  /**
    * Format messages for the conversation API.
    * The conversation API handles history via parent_id, so we only extract the last user message.
    */

--- a/server/adapters/index.js
+++ b/server/adapters/index.js
@@ -6,6 +6,7 @@ import GoogleAdapter from './google.js';
 import MistralAdapter from './mistral.js';
 import VLLMAdapter from './vllm.js';
 import IAssistantConversationAdapter from './iassistant-conversation.js';
+import BedrockAdapter from './bedrock.js';
 
 // Adapter registry
 const adapters = {
@@ -15,7 +16,8 @@ const adapters = {
   google: GoogleAdapter,
   mistral: MistralAdapter,
   local: VLLMAdapter, // vLLM uses dedicated adapter with schema sanitization
-  'iassistant-conversation': IAssistantConversationAdapter
+  'iassistant-conversation': IAssistantConversationAdapter,
+  bedrock: BedrockAdapter
 };
 
 /**
@@ -61,4 +63,24 @@ export async function processResponseBuffer(provider, buffer) {
 export function formatMessages(provider, messages) {
   const adapter = getAdapter(provider);
   return adapter.formatMessages(messages);
+}
+
+/**
+ * Get the provider-specific config schema declared by the adapter (if any).
+ * The schema describes fields that are written to `model.config[key]` and
+ * is consumed by the admin Model Form Editor for dynamic field rendering.
+ *
+ * @param {string} provider - The provider name
+ * @returns {Promise<object|null>}
+ */
+export async function getProviderConfigSchema(provider) {
+  if (!provider) return null;
+  switch (provider) {
+    case 'bedrock': {
+      const mod = await import('./bedrock.js');
+      return mod.providerConfigSchema || null;
+    }
+    default:
+      return null;
+  }
 }

--- a/server/adapters/toolCalling/BedrockConverter.js
+++ b/server/adapters/toolCalling/BedrockConverter.js
@@ -1,0 +1,118 @@
+/**
+ * AWS Bedrock Tool Calling Converter
+ *
+ * Handles conversion between AWS Bedrock Converse API tool format and the
+ * generic tool calling format. Bedrock wraps each tool in a `toolSpec`
+ * envelope and nests the JSON Schema under `inputSchema.json`.
+ */
+
+import {
+  createGenericTool,
+  createGenericToolCall,
+  sanitizeSchemaForProvider
+} from './GenericToolCalling.js';
+import logger from '../../utils/logger.js';
+
+/**
+ * Convert generic tools to Bedrock Converse format.
+ * Filters out provider-specific tools that don't target Bedrock.
+ * @param {import('./GenericToolCalling.js').GenericTool[]} genericTools
+ * @returns {Object[]} Array of `{ toolSpec: { name, description, inputSchema: { json } } }`
+ */
+export function convertGenericToolsToBedrock(genericTools = []) {
+  const filteredTools = genericTools.filter(tool => {
+    if (tool.provider === 'bedrock') return true;
+    if (tool.provider) {
+      logger.info('Filtering out provider-specific tool', {
+        component: 'BedrockConverter',
+        toolId: tool.id || tool.name,
+        provider: tool.provider
+      });
+      return false;
+    }
+    if (tool.isSpecialTool) {
+      logger.info('Filtering out special tool', {
+        component: 'BedrockConverter',
+        toolId: tool.id || tool.name
+      });
+      return false;
+    }
+    return true;
+  });
+
+  return filteredTools.map(tool => ({
+    toolSpec: {
+      name: tool.id || tool.name,
+      description: tool.description || '',
+      inputSchema: {
+        json: sanitizeSchemaForProvider(
+          tool.parameters || { type: 'object', properties: {} },
+          'anthropic'
+        )
+      }
+    }
+  }));
+}
+
+/**
+ * Convert Bedrock tools to generic format.
+ * @param {Object[]} bedrockTools - Tools in `{ toolSpec: { … } }` shape
+ * @returns {import('./GenericToolCalling.js').GenericTool[]} Generic tools
+ */
+export function convertBedrockToolsToGeneric(bedrockTools = []) {
+  return bedrockTools
+    .map(t => t.toolSpec || t)
+    .map(spec =>
+      createGenericTool(
+        spec.name,
+        spec.name,
+        spec.description || '',
+        spec.inputSchema?.json || { type: 'object', properties: {} },
+        { originalFormat: 'bedrock' }
+      )
+    );
+}
+
+/**
+ * Convert generic tool calls to Bedrock toolUse content blocks.
+ * @param {import('./GenericToolCalling.js').GenericToolCall[]} genericToolCalls
+ * @returns {Object[]} Array of `{ toolUse: { toolUseId, name, input } }`
+ */
+export function convertGenericToolCallsToBedrock(genericToolCalls = []) {
+  return genericToolCalls.map(call => ({
+    toolUse: {
+      toolUseId: call.id,
+      name: call.name,
+      input: call.arguments || {}
+    }
+  }));
+}
+
+/**
+ * Convert Bedrock toolUse content blocks to generic tool calls.
+ * @param {Object[]} bedrockToolUse - Array of `{ toolUseId, name, input }` (already unwrapped)
+ * @returns {import('./GenericToolCalling.js').GenericToolCall[]} Generic tool calls
+ */
+export function convertBedrockToolUseToGeneric(bedrockToolUse = []) {
+  return bedrockToolUse.map((tu, index) =>
+    createGenericToolCall(tu.toolUseId, tu.name, tu.input || {}, index, {
+      originalFormat: 'bedrock',
+      type: 'tool_use'
+    })
+  );
+}
+
+/**
+ * Resolve a generic tool-choice value to the Bedrock toolChoice union shape.
+ * Bedrock accepts `{ auto: {} }`, `{ any: {} }`, or `{ tool: { name } }`.
+ */
+export function convertBedrockToolChoice(toolChoice) {
+  if (!toolChoice || toolChoice === 'auto') return { auto: {} };
+  if (toolChoice === 'any' || toolChoice === 'required') return { any: {} };
+  if (typeof toolChoice === 'object') {
+    if (toolChoice.function?.name) return { tool: { name: toolChoice.function.name } };
+    if (toolChoice.tool?.name) return { tool: { name: toolChoice.tool.name } };
+    if (toolChoice.auto || toolChoice.any || toolChoice.tool) return toolChoice;
+  }
+  return { auto: {} };
+}

--- a/server/adapters/toolCalling/ToolCallingConverter.js
+++ b/server/adapters/toolCalling/ToolCallingConverter.js
@@ -12,6 +12,7 @@ import * as AnthropicConverter from './AnthropicConverter.js';
 import * as GoogleConverter from './GoogleConverter.js';
 import * as MistralConverter from './MistralConverter.js';
 import * as VLLMConverter from './VLLMConverter.js';
+import * as BedrockConverter from './BedrockConverter.js';
 
 // GenericToolCalling exports are re-exported from converters, not directly used here
 
@@ -24,7 +25,8 @@ const CONVERTERS = {
   anthropic: AnthropicConverter,
   google: GoogleConverter,
   mistral: MistralConverter,
-  local: VLLMConverter // vLLM uses dedicated converter with schema sanitization
+  local: VLLMConverter, // vLLM uses dedicated converter with schema sanitization
+  bedrock: BedrockConverter
 };
 
 /**

--- a/server/defaults/config/providers.json
+++ b/server/defaults/config/providers.json
@@ -61,6 +61,19 @@
       "enabled": true
     },
     {
+      "id": "bedrock",
+      "name": {
+        "en": "AWS Bedrock",
+        "de": "AWS Bedrock"
+      },
+      "description": {
+        "en": "AWS Bedrock foundation models via the Converse API",
+        "de": "AWS Bedrock Foundation Models über die Converse-API"
+      },
+      "enabled": true,
+      "category": "llm"
+    },
+    {
       "id": "tavily",
       "name": {
         "en": "Tavily Search",

--- a/server/defaults/config/registries.json
+++ b/server/defaults/config/registries.json
@@ -9,6 +9,16 @@
       "enabled": true,
       "autoRefresh": false,
       "refreshIntervalHours": 24
+    },
+    {
+      "id": "ihub-examples",
+      "name": "iHub Examples",
+      "description": "In-repo example apps, models, prompts, and skills shipped with iHub Apps",
+      "source": "https://raw.githubusercontent.com/intrafind/ihub-apps/main/examples/catalog.json",
+      "auth": { "type": "none" },
+      "enabled": true,
+      "autoRefresh": false,
+      "refreshIntervalHours": 24
     }
   ]
 }

--- a/server/migrations/V034__add_bedrock_provider.js
+++ b/server/migrations/V034__add_bedrock_provider.js
@@ -1,0 +1,45 @@
+/**
+ * Migration V034 — Add AWS Bedrock provider
+ *
+ * Registers the `bedrock` provider in config/providers.json for existing
+ * installations so the AWS Bedrock adapter can be selected when configuring
+ * a model. Fresh installs receive this automatically via
+ * server/defaults/config/providers.json.
+ */
+
+export const version = '034';
+export const description = 'Add AWS Bedrock provider';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/providers.json');
+}
+
+export async function up(ctx) {
+  const config = await ctx.readJson('config/providers.json');
+
+  if (!Array.isArray(config.providers)) {
+    config.providers = [];
+  }
+
+  const added = ctx.addIfMissing(
+    config.providers,
+    {
+      id: 'bedrock',
+      name: { en: 'AWS Bedrock', de: 'AWS Bedrock' },
+      description: {
+        en: 'AWS Bedrock foundation models via the Converse API',
+        de: 'AWS Bedrock Foundation Models über die Converse-API'
+      },
+      enabled: true,
+      category: 'llm'
+    },
+    'id'
+  );
+
+  if (added) {
+    await ctx.writeJson('config/providers.json', config);
+    ctx.log('Added bedrock provider');
+  } else {
+    ctx.log('bedrock provider already present — skipping');
+  }
+}

--- a/server/migrations/V035__add_examples_marketplace_registry.js
+++ b/server/migrations/V035__add_examples_marketplace_registry.js
@@ -1,0 +1,48 @@
+/**
+ * Migration V035 — Add iHub Examples marketplace registry
+ *
+ * Adds the in-repo example marketplace to config/registries.json so admins
+ * can browse and install example models, apps, and prompts shipped under
+ * the repository's `examples/` folder. The registry catalog is fetched
+ * from raw.githubusercontent.com (same path used by ihub-official).
+ *
+ * Fresh installs receive this automatically via
+ * server/defaults/config/registries.json.
+ */
+
+export const version = '035';
+export const description = 'Add iHub Examples marketplace registry';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/registries.json');
+}
+
+export async function up(ctx) {
+  const config = await ctx.readJson('config/registries.json');
+
+  if (!Array.isArray(config.registries)) {
+    config.registries = [];
+  }
+
+  const added = ctx.addIfMissing(
+    config.registries,
+    {
+      id: 'ihub-examples',
+      name: 'iHub Examples',
+      description: 'In-repo example apps, models, prompts, and skills shipped with iHub Apps',
+      source: 'https://raw.githubusercontent.com/intrafind/ihub-apps/main/examples/catalog.json',
+      auth: { type: 'none' },
+      enabled: true,
+      autoRefresh: false,
+      refreshIntervalHours: 24
+    },
+    'id'
+  );
+
+  if (added) {
+    await ctx.writeJson('config/registries.json', config);
+    ctx.log('Added iHub Examples marketplace registry');
+  } else {
+    ctx.log('iHub Examples marketplace registry already present — skipping');
+  }
+}

--- a/server/routes/admin/providers.js
+++ b/server/routes/admin/providers.js
@@ -7,6 +7,7 @@ import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import { validateIdForPath } from '../../utils/pathSecurity.js';
 import tokenStorageService from '../../services/TokenStorageService.js';
+import { getProviderConfigSchema } from '../../adapters/index.js';
 import logger from '../../utils/logger.js';
 import { sendInternalError, sendNotFound, sendBadRequest } from '../../utils/responseHelpers.js';
 
@@ -55,6 +56,27 @@ export default function registerAdminProvidersRoutes(app) {
       return sendInternalError(res, error, 'fetch providers');
     }
   });
+
+  /**
+   * Adapter-declared provider config schema. Drives dynamic field rendering
+   * in the admin Model Form Editor for provider-specific knobs (e.g. AWS
+   * Bedrock region). Returns `{ fields: [] }` for providers that don't
+   * declare a schema, so callers can safely render an empty section.
+   */
+  app.get(
+    buildServerPath('/api/admin/providers/:providerId/schema'),
+    adminAuth,
+    async (req, res) => {
+      try {
+        const { providerId } = req.params;
+        if (!validateIdForPath(providerId, 'provider', res)) return;
+        const schema = await getProviderConfigSchema(providerId);
+        res.json(schema || { fields: [] });
+      } catch (error) {
+        return sendInternalError(res, error, 'fetch provider schema');
+      }
+    }
+  );
 
   app.get(buildServerPath('/api/admin/providers/:providerId'), adminAuth, async (req, res) => {
     try {

--- a/server/services/chat/StreamingHandler.js
+++ b/server/services/chat/StreamingHandler.js
@@ -1,9 +1,7 @@
-import { convertResponseToGeneric } from '../../adapters/toolCalling/index.js';
 import { logInteraction } from '../../utils.js';
 import { estimateTokens, recordChatRequest, recordChatResponse } from '../../usageTracker.js';
 import { activeRequests } from '../../sse.js';
 import { actionTracker } from '../../actionTracker.js';
-import { createParser } from 'eventsource-parser';
 import { throttledFetch } from '../../requestThrottler.js';
 import ErrorHandler from '../../utils/ErrorHandler.js';
 import { getAdapter } from '../../adapters/index.js';
@@ -381,309 +379,92 @@ class StreamingHandler {
         return;
       }
 
-      const readableStream = this.getReadableStream(llmResponse);
-      const reader = readableStream.getReader();
-      const decoder = new TextDecoder();
       let fullResponse = '';
-
-      // Check if the adapter needs custom SSE processing (iassistant-conversation uses custom format)
       const adapter = getAdapter(model.provider);
-      const hasCustomBufferProcessor = model.provider === 'iassistant-conversation';
 
-      if (hasCustomBufferProcessor) {
-        // For providers like iAssistant Conversation with custom SSE format
-        let buffer = '';
+      // Adapters expose parseResponseStream(response, ctx) which yields normalized
+      // result chunks. The default in BaseAdapter handles SSE; iAssistant uses the
+      // line-delimited SSE variant; Bedrock parses binary EventStream frames.
+      const stream = adapter.parseResponseStream(llmResponse, { model, chatId, request });
 
-        while (true) {
-          const { done, value } = await reader.read();
+      for await (const result of stream) {
+        if (!activeRequests.has(chatId)) {
+          break;
+        }
+        if (!result) continue;
 
-          if (!activeRequests.has(chatId)) {
-            reader.cancel();
-            break;
-          }
-          if (done) {
-            break;
-          }
+        // Usage may arrive either at the top level or under metadata.usage
+        // depending on which converter emitted it.
+        if (result.usage) {
+          accumulatedUsage = mergeUsage(accumulatedUsage, result.usage);
+        }
+        if (result.metadata?.usage) {
+          accumulatedUsage = mergeUsage(accumulatedUsage, result.metadata.usage);
+        }
 
-          const chunk = decoder.decode(value, { stream: true });
-          buffer += chunk;
-
-          // Process complete SSE events only
-          if (buffer.includes('\n\n')) {
-            // Find the position of the last complete event
-            const parts = buffer.split('\n\n');
-            const completeEvents = parts.slice(0, -1).join('\n\n');
-            const remainingData = parts[parts.length - 1];
-
-            let result = null;
-            if (completeEvents) {
-              // Add back the delimiter for processing
-              try {
-                // Await the adapter's async buffer processing before using the parsed result
-                result = await adapter.processResponseBuffer(completeEvents + '\n\n');
-              } catch (processingError) {
-                logger.error('Error processing buffer with adapter', {
-                  component: 'StreamingHandler',
-                  provider: model.provider,
-                  error: processingError
-                });
-                result = {
-                  content: [],
-                  complete: false,
-                  finishReason: 'error',
-                  error: true,
-                  errorMessage: `Processing error: ${processingError.message}`
-                };
-              }
-
-              // Keep the remaining incomplete data in buffer
-              buffer = remainingData;
-
-              // Accumulate usage data from adapter results
-              if (result?.usage) {
-                accumulatedUsage = mergeUsage(accumulatedUsage, result.usage);
-              }
-
-              if (result && result.content && result.content.length > 0) {
-                for (const textContent of result.content) {
-                  actionTracker.trackChunk(chatId, { content: textContent });
-                  fullResponse += textContent;
-                }
-              }
-
-              // Handle generated images
-              this.processImages(result, chatId);
-
-              // Handle thinking content
-              this.processThinking(result, chatId);
-
-              // Handle grounding metadata (for Google Search)
-              this.processGroundingMetadata(result, chatId);
-
-              // Handle conversation-specific events (iassistant-conversation)
-              this.processConversationEvents(result, chatId, request);
-
-              if (result && result.error) {
-                await logInteraction(
-                  'chat_error',
-                  buildLogData(true, {
-                    responseType: 'error',
-                    error: {
-                      message: result.errorMessage || 'Error processing response',
-                      code: 'PROCESSING_ERROR'
-                    },
-                    response: fullResponse
-                  })
-                );
-                actionTracker.trackError(chatId, {
-                  message: result.errorMessage || 'Error processing response'
-                });
-                finishReason = 'error';
-                break;
-              }
-
-              if (result && result.finishReason) {
-                finishReason = result.finishReason;
-              }
-
-              if (result && result.complete) {
-                // Emit answer source information before done event
-                const sources = this.getKnowledgeSources(chatId);
-                if (sources.length > 0) {
-                  actionTracker.trackAnswerSource(chatId, { sources, type: 'mixed' });
-                }
-
-                actionTracker.trackDone(chatId, { finishReason });
-                doneEmitted = true;
-
-                // Reset knowledge sources after emitting
-                this.resetKnowledgeSources(chatId);
-
-                await logInteraction(
-                  'chat_response',
-                  buildLogData(true, { responseType: 'success', response: fullResponse })
-                );
-
-                const completionTokens =
-                  accumulatedUsage?.completionTokens ?? estimateTokens(fullResponse);
-                const tokenSource = accumulatedUsage ? 'provider' : 'estimate';
-                await recordChatResponse({
-                  userId: baseLog.userSessionId,
-                  appId: baseLog.appId,
-                  modelId: model.id,
-                  tokens: completionTokens,
-                  tokenSource,
-                  user: baseLog.user
-                });
-                break;
-              }
-            }
-          }
-
-          if (finishReason === 'error' || doneEmitted) {
-            break;
+        if (result.content && result.content.length > 0) {
+          for (const textContent of result.content) {
+            actionTracker.trackChunk(chatId, { content: textContent });
+            fullResponse += textContent;
           }
         }
 
-        // Process any remaining data in buffer after stream ends
-        if (buffer.trim() && !doneEmitted && finishReason !== 'error') {
-          const result = await adapter.processResponseBuffer(buffer);
+        this.processImages(result, chatId);
+        this.processThinking(result, chatId);
+        this.processGroundingMetadata(result, chatId);
+        this.processConversationEvents(result, chatId, request);
 
-          if (result?.usage) {
-            accumulatedUsage = mergeUsage(accumulatedUsage, result.usage);
-          }
-
-          if (result && result.content && result.content.length > 0) {
-            for (const textContent of result.content) {
-              actionTracker.trackChunk(chatId, { content: textContent });
-              fullResponse += textContent;
-            }
-          }
-
-          // Handle generated images in remaining buffer
-          this.processImages(result, chatId);
-
-          // Handle conversation events in remaining buffer
-          this.processConversationEvents(result, chatId, request);
-
-          if (result && result.complete) {
-            // Emit answer source information before done event
-            const sources = this.getKnowledgeSources(chatId);
-            if (sources.length > 0) {
-              actionTracker.trackAnswerSource(chatId, { sources, type: 'mixed' });
-            }
-
-            actionTracker.trackDone(chatId, { finishReason: result.finishReason || 'stop' });
-            doneEmitted = true;
-
-            // Reset knowledge sources after emitting
-            this.resetKnowledgeSources(chatId);
-
-            await logInteraction(
-              'chat_response',
-              buildLogData(true, { responseType: 'success', response: fullResponse })
-            );
-
-            const completionTokens =
-              accumulatedUsage?.completionTokens ?? estimateTokens(fullResponse);
-            const tokenSource = accumulatedUsage ? 'provider' : 'estimate';
-            await recordChatResponse({
-              userId: baseLog.userSessionId,
-              appId: baseLog.appId,
-              modelId: model.id,
-              tokens: completionTokens,
-              tokenSource,
-              user: baseLog.user
-            });
-          }
+        if (result.error) {
+          await logInteraction(
+            'chat_error',
+            buildLogData(true, {
+              responseType: 'error',
+              error: {
+                message: result.errorMessage || 'Error processing response',
+                code: 'PROCESSING_ERROR'
+              },
+              response: fullResponse
+            })
+          );
+          actionTracker.trackError(chatId, {
+            message: result.errorMessage || 'Error processing response'
+          });
+          finishReason = 'error';
+          break;
         }
-      } else {
-        // Standard eventsource-parser approach for OpenAI-style providers
-        const events = [];
-        const parser = createParser({
-          onEvent: event => {
-            if (event.type === 'event' || !event.type) {
-              events.push(event);
-            }
-          }
-        });
 
-        while (true) {
-          const { done, value } = await reader.read();
-          if (!activeRequests.has(chatId)) {
-            reader.cancel();
-            break;
-          }
-          if (done) break;
+        if (result.finishReason) {
+          finishReason = result.finishReason;
+        }
 
-          const chunk = decoder.decode(value, { stream: true });
-          parser.feed(chunk);
-
-          while (events.length > 0) {
-            const evt = events.shift();
-            // Use await to handle async processResponseBuffer
-            const result = await convertResponseToGeneric(evt.data, model.provider);
-
-            // Accumulate usage data from converter results (via metadata.usage)
-            if (result?.metadata?.usage) {
-              accumulatedUsage = mergeUsage(accumulatedUsage, result.metadata.usage);
-            }
-
-            if (result && result.content && result.content.length > 0) {
-              for (const textContent of result.content) {
-                actionTracker.trackChunk(chatId, { content: textContent });
-                fullResponse += textContent;
-              }
-            }
-
-            // Handle generated images
-            this.processImages(result, chatId);
-
-            // Handle thinking
-            this.processThinking(result, chatId);
-
-            // Handle grounding metadata
-            this.processGroundingMetadata(result, chatId);
-
-            if (result && result.error) {
-              await logInteraction(
-                'chat_error',
-                buildLogData(true, {
-                  responseType: 'error',
-                  error: {
-                    message: result.errorMessage || 'Error processing response',
-                    code: 'PROCESSING_ERROR'
-                  },
-                  response: fullResponse
-                })
-              );
-              actionTracker.trackError(chatId, {
-                message: result.errorMessage || 'Error processing response'
-              });
-              finishReason = 'error';
-              break;
-            }
-
-            if (result && result.finishReason) {
-              finishReason = result.finishReason;
-            }
-
-            if (result && result.complete) {
-              // Emit answer source information before done event
-              const sources = this.getKnowledgeSources(chatId);
-              if (sources.length > 0) {
-                actionTracker.trackAnswerSource(chatId, { sources, type: 'mixed' });
-              }
-
-              actionTracker.trackDone(chatId, { finishReason });
-              doneEmitted = true;
-
-              // Reset knowledge sources after emitting
-              this.resetKnowledgeSources(chatId);
-
-              await logInteraction(
-                'chat_response',
-                buildLogData(true, { responseType: 'success', response: fullResponse })
-              );
-
-              const completionTokens =
-                accumulatedUsage?.completionTokens ?? estimateTokens(fullResponse);
-              const tokenSource = accumulatedUsage ? 'provider' : 'estimate';
-              await recordChatResponse({
-                userId: baseLog.userSessionId,
-                appId: baseLog.appId,
-                modelId: model.id,
-                tokens: completionTokens,
-                tokenSource,
-                user: baseLog.user
-              });
-              break;
-            }
+        if (result.complete) {
+          const sources = this.getKnowledgeSources(chatId);
+          if (sources.length > 0) {
+            actionTracker.trackAnswerSource(chatId, { sources, type: 'mixed' });
           }
 
-          if (finishReason === 'error' || doneEmitted) {
-            break;
-          }
+          actionTracker.trackDone(chatId, { finishReason: finishReason || 'stop' });
+          doneEmitted = true;
+
+          this.resetKnowledgeSources(chatId);
+
+          await logInteraction(
+            'chat_response',
+            buildLogData(true, { responseType: 'success', response: fullResponse })
+          );
+
+          const completionTokens =
+            accumulatedUsage?.completionTokens ?? estimateTokens(fullResponse);
+          const tokenSource = accumulatedUsage ? 'provider' : 'estimate';
+          await recordChatResponse({
+            userId: baseLog.userSessionId,
+            appId: baseLog.appId,
+            modelId: model.id,
+            tokens: completionTokens,
+            tokenSource,
+            user: baseLog.user
+          });
+          break;
         }
       }
     } catch (error) {

--- a/server/utils/ApiKeyVerifier.js
+++ b/server/utils/ApiKeyVerifier.js
@@ -65,7 +65,7 @@ class ApiKeyVerifier {
   }
 
   async validateApiKeys() {
-    const providers = ['openai', 'anthropic', 'google', 'mistral'];
+    const providers = ['openai', 'anthropic', 'google', 'mistral', 'bedrock'];
     const missing = [];
 
     for (const provider of providers) {

--- a/server/validators/modelConfigSchema.js
+++ b/server/validators/modelConfigSchema.js
@@ -67,12 +67,13 @@ export const modelConfigSchema = z
         'google',
         'mistral',
         'local',
-        'iassistant-conversation'
+        'iassistant-conversation',
+        'bedrock'
       ],
       {
         errorMap: () => ({
           message:
-            'Provider must be one of: openai, openai-responses, anthropic, google, mistral, local, iassistant-conversation'
+            'Provider must be one of: openai, openai-responses, anthropic, google, mistral, local, iassistant-conversation, bedrock'
         })
       }
     ),


### PR DESCRIPTION
Closes #1373.

## Summary

Adds a `bedrock` provider that calls Bedrock's **Converse / ConverseStream** API directly over `fetch` with Bearer-token auth — no AWS SDK, no SigV4 signing. Supports text, vision, tool calling (incl. parallel), streaming, and reasoning content. Authentication uses long-lived Bedrock API keys, resolved through the existing per-model / per-provider / env (`BEDROCK_API_KEY`) pipeline.

The PR also lands two architectural cleanups that the new adapter required:

1. **`StreamingHandler` is now provider-agnostic.** Adapters expose `parseResponseStream(response, ctx)` — an async iterable of normalized result chunks. `BaseAdapter` ships SSE and line-delimited-SSE defaults; Bedrock plugs in its own binary EventStream generator. The previous `iassistant-conversation` special-case is migrated to the same pattern (~200 lines removed from the handler).
2. **Adapter-declared provider config schemas.** Adapters can export a `providerConfigSchema`. A new endpoint `GET /api/admin/providers/:id/schema` serves it, and the Admin Model Form Editor renders dynamic provider-specific fields. Bedrock ships a `region` selector with autocomplete.

## What's in the box

**New code**
- `server/adapters/bedrock.js` — adapter (formatMessages / createCompletionRequest / parseResponseStream / providerConfigSchema)
- `server/adapters/bedrockEventStream.js` — self-contained `application/vnd.amazon.eventstream` decoder (~180 LOC, no dependencies)
- `server/adapters/toolCalling/BedrockConverter.js` — generic ↔ Bedrock tool/toolUse/toolChoice conversion
- `server/migrations/V034__add_bedrock_provider.js` — registers `bedrock` in providers.json
- `server/migrations/V035__add_examples_marketplace_registry.js` — registers in-repo `examples/` as a marketplace

**New marketplace registry**
- `examples/catalog.json` + `examples/models/bedrock/{12 model JSONs, README}` — exposed via the new `ihub-examples` registry. All 12 examples ship `enabled: false`. Admins install via Admin → Marketplace.

**Modified**
- `server/adapters/{BaseAdapter,iassistant-conversation,index}.js`
- `server/adapters/toolCalling/ToolCallingConverter.js`
- `server/services/chat/StreamingHandler.js` (-200 LOC)
- `server/utils/ApiKeyVerifier.js`, `server/validators/modelConfigSchema.js`, `server/routes/admin/providers.js`
- `server/defaults/config/{providers,registries}.json`
- `client/src/features/admin/components/ModelFormEditor.jsx`
- `docs/models.md` — full AWS Bedrock section (auth, region, model matrix, limits, marketplace pointer)

## Region & model-ID handling

- Default region: `eu-central-1` (Frankfurt). Configurable per-model via `config.region`.
- `region: "global"` selects the `global.` cross-region inference profile (Anthropic Sonnet 4 family).
- `us-*` / `eu-*` / `apac-*` regions auto-prepend the matching `us./eu./apac.` profile prefix when the model requires it (Claude 4.x, Llama 4, Llama 3.3).
- Explicit profile-prefixed model IDs (`us.anthropic.claude-…`) are honored as-is.

## Pre-flight validation (Bedrock service limits)

- Max **5 documents** per request.
- Document `name` sanitized to `^[A-Za-z0-9\-()[\] ]{1,200}$` (Bedrock's strict allowlist).
- Image format restricted to `png | jpeg | gif | webp`.
- Empty content blocks (`{ text: '' }`) are stripped before send.

## Test plan

- [x] `npm run lint:fix` — no new errors in changed files
- [x] `node --check` on every new/modified server file — all pass
- [x] Server boots in cluster mode, V034 + V035 apply cleanly, `providers.json` contains `bedrock`, `registries.json` contains `ihub-examples`
- [x] `validateApiKeys()` reports `bedrock` in the missing-keys list when `BEDROCK_API_KEY` is unset (proves provider plumbing works)
- [ ] Manual chat smoke against a real Bedrock account (text / vision / PDF / tool calling / parallel tools) — pending real `BEDROCK_API_KEY`
- [ ] Verify Admin → Marketplace lists `iHub Examples` and one-click install of `bedrock-claude-3-5-sonnet` lands the JSON in `contents/models/`
- [ ] Verify Admin → Models → Edit shows the dynamic "Region" field for the Bedrock provider with autocomplete suggestions
- [ ] Regression: existing OpenAI / Anthropic / Google / Mistral / vLLM / iAssistant chats still work after the StreamingHandler refactor

## Notes

- **No AWS SDK dependency.** Authentication uses Bearer tokens; the binary EventStream framing is parsed in 180 lines with no external deps. CRC32 verification is implemented but soft (logs and skips on mismatch rather than failing the stream).
- **Native `document` content blocks** are not in this PR — the existing `RequestBuilder.preprocessMessagesWithFileData` already converts uploaded PDFs to per-page images upstream, so vision-capable Bedrock models receive PDFs via the `image` block path. Native `document` blocks (better text fidelity) are left as a follow-up.

https://claude.ai/code/session_01BNL9QD5Hfb8HjFSg4NYaPM

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNL9QD5Hfb8HjFSg4NYaPM)_