### PR TITLE
fix(ifinder): guard empty JWT subject and log payload for debugging

### DIFF
--- a/server/utils/iFinderJwt.js
+++ b/server/utils/iFinderJwt.js
@@ -122,17 +122,45 @@ function getIFinderPrivateKey(iFinderConfig) {
 function resolveJwtSubject(user, config) {
   const field = config.jwtSubjectField || 'email';
 
+  let resolved;
   switch (field) {
     case 'email':
-      return user.email || user.username || user.id;
+      resolved = user.email || user.username || user.id;
+      break;
     case 'username':
-      return user.username || user.email || user.id;
+      resolved = user.username || user.email || user.id;
+      break;
     case 'domain\\username':
-      return user.domain ? `${user.domain}\\${user.username || user.id}` : user.username || user.id;
+      resolved = user.domain
+        ? `${user.domain}\\${user.username || user.id}`
+        : user.username || user.id;
+      break;
     default:
-      // Custom template: replace ${field} placeholders
-      return field.replace(/\$\{(\w+)\}/g, (_, key) => user[key] || '');
+      // Custom template: replace ${field} placeholders. Warn on missing keys so
+      // misconfigurations surface in logs instead of producing an empty `sub`.
+      resolved = field.replace(/\$\{(\w+)\}/g, (_, key) => {
+        const value = user[key];
+        if (value === undefined || value === null || value === '') {
+          logger.warn(
+            `iFinder JWT subject template placeholder \${${key}} resolved to empty for user ${user.id || user.username || '<unknown>'}`,
+            { component: 'iFinderJwt', jwtSubjectField: field }
+          );
+          return '';
+        }
+        return value;
+      });
   }
+
+  if (typeof resolved !== 'string' || resolved.trim() === '') {
+    throw new Error(
+      `iFinder JWT subject could not be resolved (jwtSubjectField="${field}"). ` +
+        `User is missing the required field(s). ` +
+        `Check the "JWT Subject Field" setting in Admin > iFinder Integration and ensure ` +
+        `the authenticated user has a non-empty value for it.`
+    );
+  }
+
+  return resolved;
 }
 
 /**
@@ -184,6 +212,19 @@ export function generateIFinderJWT(user, options = {}) {
     const kid = computeOidcKid();
     if (kid) signOptions.keyid = kid;
   }
+
+  logger.debug('iFinder JWT payload and sign options', {
+    component: 'iFinderJwt',
+    payload,
+    signOptions: {
+      algorithm: signOptions.algorithm,
+      expiresIn: signOptions.expiresIn,
+      issuer: signOptions.issuer,
+      audience: signOptions.audience,
+      keyid: signOptions.keyid
+    },
+    jwtSubjectField: iFinderConfig.jwtSubjectField
+  });
 
   return jwt.sign(payload, privateKey, signOptions);
 }


### PR DESCRIPTION
## Summary

Diagnoses and prevents the iFinder error `IllegalStateException: Name could not be resolved for principal: org.springframework.security.oauth2.jwt.Jwt@…`.

Root cause: when iHub's `jwtSubjectField` resolves to an empty string (e.g. a custom template like `${email}` for an OIDC user without an email claim, or a placeholder referencing a key that doesn't exist on the user object), the generated JWT carries an empty `sub`. iFinder's Spring Security uses `sub` as the default `principal-claim-name`, so an empty value blows up at request time.

## Changes (`server/utils/iFinderJwt.js`)

- **Hard guard:** `resolveJwtSubject()` now throws a descriptive error pointing at the admin setting when the resolved subject is missing/blank, instead of silently signing a bad token.
- **Custom-template warning:** when a `${field}` placeholder resolves to empty, log a `warn` with the failing key and the user identifier — so misconfigurations show up in logs without trial-and-error.
- **Debug payload log:** before signing, emit a `debug` line with the full JWT payload and sign options (`algorithm`, `issuer`, `audience`, `keyid`, `jwtSubjectField`) so the exact contents of the token can be inspected without decoding the wire bytes.

## Test plan

- [ ] Configure iFinder integration with `jwtSubjectField` set to a custom template referencing a missing user claim (e.g. `${preferred_username}`); creating a conversation should fail fast in iHub with a clear error and a `warn` log line, instead of producing a 500 from iFinder.
- [ ] Configure with `jwtSubjectField: email` for a user that has an email — verify the conversation still works and the `debug` log shows `sub` populated.
- [ ] Enable debug logging and confirm the new `iFinder JWT payload and sign options` line appears with expected `payload.sub`, `issuer`, `audience`, and (when `useOidcKeyPair` is true) `keyid`.

https://claude.ai/code/session_019vtFaepNLFLcVYqFFf216A

---
_Generated by [Claude Code](https://claude.ai/code/session_019vtFaepNLFLcVYqFFf216A)_