### PR TITLE
fix(ReactComponentRenderer): resolve eslint static-components build errors

### DIFF
--- a/client/src/shared/components/ReactComponentRenderer.jsx
+++ b/client/src/shared/components/ReactComponentRenderer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo, useRef } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
 // Error fallback component
@@ -267,26 +267,20 @@ UserComponent;
     };
   }, [jsxCode]);
 
-  // Build a stable wrapper around the compiled function. Only gets a new
-  // identity when the compiled function itself changes (i.e. jsxCode changed).
-  // Props are always read from the ref so they are never stale.
-  const CompiledComponent = useMemo(() => {
-    if (!ComponentFunction) return null;
-    return props => {
-      const combinedProps = {
-        ...componentPropsRef.current,
-        ...props,
-        React,
-        useState: React.useState,
-        useEffect: React.useEffect,
-        useMemo: React.useMemo,
-        useCallback: React.useCallback,
-        useRef: React.useRef,
-        useId: React.useId
-      };
-      return React.createElement(ComponentFunction, combinedProps);
-    };
-  }, [ComponentFunction]);
+  // Build the props the compiled component should receive. Recomputed on
+  // every render so the user component always sees the latest external
+  // props; React's reconciliation keeps the compiled component's state
+  // stable as long as ComponentFunction's identity is unchanged.
+  const compiledChildProps = {
+    ...componentPropsRef.current,
+    React,
+    useState: React.useState,
+    useEffect: React.useEffect,
+    useMemo: React.useMemo,
+    useCallback: React.useCallback,
+    useRef: React.useRef,
+    useId: React.useId
+  };
 
   if (isLoading) {
     return <LoadingComponent t={t} />;
@@ -320,7 +314,7 @@ UserComponent;
     );
   }
 
-  if (!CompiledComponent) {
+  if (!ComponentFunction) {
     return (
       <div className="text-center py-8 text-gray-500">
         {t('errors.noComponentToRender', 'No component to render')}
@@ -331,14 +325,14 @@ UserComponent;
   return (
     <div className={`react-component-container ${className}`}>
       <ErrorBoundary
-        FallbackComponent={props => <ErrorFallback {...props} t={t} />}
+        fallbackRender={fallbackProps => <ErrorFallback {...fallbackProps} t={t} />}
         onReset={() => {
           // Force recompilation on reset
           setComponentFunction(null);
           setIsLoading(true);
         }}
       >
-        <CompiledComponent />
+        {React.createElement(ComponentFunction, compiledChildProps)}
       </ErrorBoundary>
     </div>
   );


### PR DESCRIPTION
## Summary

The `Auto Lint & Format` workflow ([run 25499176581](https://github.com/intrafind/ihub-apps/actions/runs/25499176581)) was failing the final `npm run lint` step with two `@eslint-react/static-components` errors in `client/src/shared/components/ReactComponentRenderer.jsx`:

```
273:29  error  The component is created during render here
341:10  error  Cannot create components during render. Components created during render
               will reset their state each time they are created. Declare components
               outside of render
```

These come from the upgraded `@eslint-react/eslint-plugin` (3.0.0 → 5.7.2, #1372), which now flags inline component definitions.

## Fix

`client/src/shared/components/ReactComponentRenderer.jsx`:

1. **Removed the `useMemo`-wrapped inner component.** Previously the compiled JSX was wrapped in `props => React.createElement(ComponentFunction, combinedProps)` inside `useMemo`, which the rule flagged as a component-during-render. Now the renderer calls `React.createElement(ComponentFunction, compiledChildProps)` directly inside the JSX. State of the user component is still preserved across parent re-renders because React uses the same `ComponentFunction` reference until `jsxCode` changes.
2. **Switched `FallbackComponent` → `fallbackRender`.** `react-error-boundary` accepts both, but `fallbackRender` is documented as a render function (not a component constructor), so the rule does not treat the inline arrow as a component definition.
3. Removed the now-unused `useMemo` import.

Verified locally:

```
✖ 453 problems (0 errors, 453 warnings)   # was 2 errors before
prettier --check .                         # All matched files use Prettier code style!
```

The remaining 453 warnings are pre-existing `no-unused-vars` warnings (e.g. unused `error` in `catch` blocks) and do not fail the build.

## Test plan

- [ ] CI `Auto Lint & Format` workflow passes the final `npm run lint` and `npm run format` steps.
- [ ] Verify dynamic JSX pages still render — open a page using `ReactComponentRenderer` (e.g. `contents/pages/en/qr-generator.jsx`) and confirm:
  - [ ] The compiled component renders without an `ErrorBoundary` fallback.
  - [ ] Internal component state (e.g. inputs, counters) is preserved across parent re-renders that don't change `jsxCode`.
  - [ ] Triggering an error inside the user component shows the `ErrorFallback` and the "Try Again" button still resets it.

https://claude.ai/code/session_01T7w6XpkMu6bvzsbJ2gH6Kc

---
_Generated by [Claude Code](https://claude.ai/code/session_01T7w6XpkMu6bvzsbJ2gH6Kc)_