### PR TITLE
fix(oidc): read groups claim from ID token

### DIFF
--- a/server/middleware/oidcAuth.js
+++ b/server/middleware/oidcAuth.js
@@ -9,6 +9,7 @@ import authDebugService from '../utils/authDebugService.js';
 import logger from '../utils/logger.js';
 import { buildServerPath } from '../utils/basePath.js';
 import { getAuthCookieOptions } from '../utils/cookieSettings.js';
+import { decodeIdTokenClaims } from '../utils/oidcIdToken.js';
 
 // Store configured providers
 const configuredProviders = new Map();
@@ -69,7 +70,7 @@ export function configureOidcProviders() {
           customHeaders: {},
           skipUserProfile: false // We'll fetch user info manually
         },
-        async (accessToken, _refreshToken, _profile, done) => {
+        async (accessToken, _refreshToken, params, _profile, done) => {
           const sessionId = authDebugService.generateSessionId();
 
           try {
@@ -93,11 +94,49 @@ export function configureOidcProviders() {
                 provider: provider.name,
                 hasAccessToken: !!accessToken,
                 hasRefreshToken: !!_refreshToken,
+                hasIdToken: !!params?.id_token,
                 accessTokenLength: accessToken?.length || 0,
                 tokenType: 'Bearer'
               },
               sessionId
             );
+
+            // Decode ID token claims (if present). Some IdPs (notably
+            // Microsoft Entra) emit `groups` only in the ID token and not in
+            // the userinfo endpoint response, so we read it here and merge it
+            // into userInfo before normalization.
+            const idTokenClaims = decodeIdTokenClaims(params?.id_token);
+            if (idTokenClaims) {
+              const groupsAttr = provider.groupsAttribute || 'groups';
+              const overage = !!(
+                idTokenClaims._claim_names?.[groupsAttr] || idTokenClaims.hasgroups
+              );
+              authDebugService.log(
+                'oidc',
+                'debug',
+                'id_token_claims_decoded',
+                {
+                  provider: provider.name,
+                  claimKeys: Object.keys(idTokenClaims),
+                  hasGroupsClaim: Array.isArray(idTokenClaims[groupsAttr]),
+                  groupsCount: Array.isArray(idTokenClaims[groupsAttr])
+                    ? idTokenClaims[groupsAttr].length
+                    : 0,
+                  hasOverageIndicator: overage
+                },
+                sessionId
+              );
+              if (overage) {
+                logger.warn(
+                  'OIDC ID token signaled groups overage; the groups claim list is incomplete. ' +
+                    'Consider configuring a Microsoft Graph fallback or an Entra group filter.',
+                  {
+                    component: 'OidcAuth',
+                    providerName: provider.name
+                  }
+                );
+              }
+            }
 
             // Get user info from OIDC provider
             const userInfo = await fetchUserInfo(
@@ -106,6 +145,29 @@ export function configureOidcProviders() {
               provider.name,
               sessionId
             );
+
+            // If the userinfo response lacks the configured groups attribute
+            // but the ID token carries it, fill it in so downstream extraction
+            // picks the groups up unchanged.
+            const groupsAttr = provider.groupsAttribute || 'groups';
+            if (
+              idTokenClaims &&
+              userInfo[groupsAttr] === undefined &&
+              Array.isArray(idTokenClaims[groupsAttr])
+            ) {
+              userInfo[groupsAttr] = idTokenClaims[groupsAttr];
+              authDebugService.log(
+                'oidc',
+                'info',
+                'groups_merged_from_id_token',
+                {
+                  provider: provider.name,
+                  groupsAttribute: groupsAttr,
+                  groupsCount: idTokenClaims[groupsAttr].length
+                },
+                sessionId
+              );
+            }
 
             // Log user info if includeRawData is enabled
             authDebugService.log(

--- a/server/utils/oidcIdToken.js
+++ b/server/utils/oidcIdToken.js
@@ -1,0 +1,26 @@
+/**
+ * Decode the JWT payload of an OIDC ID token without verifying its signature.
+ *
+ * Signature verification is intentionally skipped: the token came directly from
+ * the IdP's token endpoint over TLS to passport-oauth2 in this same process, so
+ * its claims are used here only as a side-channel alongside userinfo (e.g., to
+ * pick up a `groups` claim that some IdPs put only in the ID token).
+ *
+ * @param {string} idToken - The serialized JWT.
+ * @returns {object|null} The decoded payload, or null if the token is missing,
+ *   malformed, or unparseable.
+ */
+export function decodeIdTokenClaims(idToken) {
+  if (!idToken || typeof idToken !== 'string') return null;
+  const parts = idToken.split('.');
+  if (parts.length !== 3) return null;
+  try {
+    const b64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = b64 + '='.repeat((4 - (b64.length % 4)) % 4);
+    const json = Buffer.from(padded, 'base64').toString('utf8');
+    const claims = JSON.parse(json);
+    return claims && typeof claims === 'object' ? claims : null;
+  } catch {
+    return null;
+  }
+}

--- a/tests/unit/server/oidcAuth.test.js
+++ b/tests/unit/server/oidcAuth.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect } from '@jest/globals';
+import { decodeIdTokenClaims } from '../../../server/utils/oidcIdToken.js';
+
+function encodeJwt(header, payload, signature = 'sig') {
+  const b64 = obj =>
+    Buffer.from(JSON.stringify(obj))
+      .toString('base64')
+      .replace(/=+$/, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_');
+  return `${b64(header)}.${b64(payload)}.${signature}`;
+}
+
+describe('decodeIdTokenClaims', () => {
+  it('decodes a base64url-encoded JWT payload', () => {
+    const token = encodeJwt(
+      { alg: 'RS256', typ: 'JWT' },
+      {
+        sub: 'user-123',
+        email: 'a@b.com',
+        groups: ['11111111-1111-1111-1111-111111111111']
+      }
+    );
+    const claims = decodeIdTokenClaims(token);
+    expect(claims).toMatchObject({
+      sub: 'user-123',
+      email: 'a@b.com',
+      groups: ['11111111-1111-1111-1111-111111111111']
+    });
+  });
+
+  it('handles payloads requiring base64 padding', () => {
+    const token = encodeJwt({ alg: 'RS256' }, { a: 1 });
+    expect(decodeIdTokenClaims(token)).toEqual({ a: 1 });
+  });
+
+  it('preserves the Entra overage indicator', () => {
+    const token = encodeJwt(
+      { alg: 'RS256' },
+      {
+        sub: 'user-456',
+        _claim_names: { groups: 'src1' },
+        _claim_sources: {
+          src1: {
+            endpoint: 'https://graph.microsoft.com/v1.0/users/abc/getMemberObjects'
+          }
+        }
+      }
+    );
+    expect(decodeIdTokenClaims(token)).toMatchObject({
+      _claim_names: { groups: 'src1' }
+    });
+  });
+
+  it('returns null for falsy or non-string input', () => {
+    expect(decodeIdTokenClaims(null)).toBeNull();
+    expect(decodeIdTokenClaims(undefined)).toBeNull();
+    expect(decodeIdTokenClaims('')).toBeNull();
+    expect(decodeIdTokenClaims(123)).toBeNull();
+  });
+
+  it('returns null for tokens that are not three dot-separated parts', () => {
+    expect(decodeIdTokenClaims('not.a.jwt.token')).toBeNull();
+    expect(decodeIdTokenClaims('header.payload')).toBeNull();
+  });
+
+  it('returns null when the payload is not valid base64-encoded JSON', () => {
+    expect(decodeIdTokenClaims('aaa.!!!.sig')).toBeNull();
+    const notJson = Buffer.from('hello world').toString('base64url');
+    expect(decodeIdTokenClaims(`aaa.${notJson}.sig`)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Some OIDC providers — most notably **Microsoft Entra** — emit the `groups` claim only in the ID token, not in the userinfo endpoint response. Today the verify callback in `server/middleware/oidcAuth.js` declares 4 arguments, so [passport-oauth2 dispatches](https://github.com/jaredhanson/passport-oauth2/blob/master/lib/strategy.js#L194-L205) without the `params` argument and `id_token` is silently dropped on the floor. Result: even with `groupsAttribute: "groups"` configured, no group ever reaches `user.externalGroups`, so the `groups.json` mapping never fires and every authenticated user effectively shares the same role.

This change makes the OIDC middleware also read groups from the ID token claims.

## What changes

- `server/middleware/oidcAuth.js`
  - Verify callback signature: `(accessToken, _refreshToken, _profile, done)` → `(accessToken, _refreshToken, params, _profile, done)`.
  - Decode `params.id_token` via the new `decodeIdTokenClaims()` helper.
  - When `userInfo[provider.groupsAttribute]` is missing but the ID token has it, merge the array into `userInfo` so the existing extraction at the bottom of the callback stays unchanged.
  - Log a structured `id_token_claims_decoded` debug event and a `WARN` when Entra's `_claim_names.groups` / `hasgroups` overage indicator is present (so we notice it instead of silently truncating).
- `server/utils/oidcIdToken.js` (new): tiny dependency-free `decodeIdTokenClaims()` helper. Signature verification is intentionally skipped — the token came from the IdP token endpoint over TLS to passport-oauth2 in this same process and is used here only as a side-channel alongside userinfo.
- `tests/unit/server/oidcAuth.test.js` (new): unit tests for the decoder, including the Entra overage shape and malformed-input cases.

No config schema or migration needed — all the levers (`scope`, `groupsAttribute`, `defaultGroups`) already exist in `oidcProviderSchema`. For Entra specifically, the App Registration still needs **Token configuration → Add groups claim** to actually emit groups in the ID token.

## Why no signature verification on the ID token

Doing it properly requires fetching the IdP's JWKS, picking a JWS verifier, and handling key rotation — all out of scope for this fix. The token reaches us directly from `passport-oauth2` after a TLS exchange with the token endpoint, so for the purpose of populating `externalGroups` (which is then run through the existing `groups.json` allow-list anyway), unverified decoding is acceptable. A follow-up could swap in `openid-client` or `passport-openidconnect` for full verification.

## Out of scope (deliberate)

- **Microsoft Graph fallback for the overage case.** When a user is in >200 security groups, Entra emits `_claim_names` instead of the full `groups` array. We log a warning so it's visible in pod logs, but we don't yet call `/me/transitiveMemberOf`. Reference scripts already exist outside the repo (`entra-test.js`) and a follow-up PR can wire this in if any tenant actually hits the limit.
- **Tightening default group permissions.** `users` and `authenticated` currently both grant `apps: ["*"]`, so even after groups start flowing, every user keeps seeing every app. That's a configuration change, not a code change, and belongs in `groups.json` per deployment.

## Test plan

- [x] `npm run test:unit -- tests/unit/server/oidcAuth.test.js` — 6/6 passing locally
- [x] `npx eslint server/middleware/oidcAuth.js server/utils/oidcIdToken.js tests/unit/server/oidcAuth.test.js` — clean
- [x] `npx prettier --check` on the same files — clean
- [x] `node server/server.js` boots without errors
- [ ] **Manual on a real Entra tenant**: add the groups claim in App Registration → Token configuration, log in, watch pod logs for `groups_merged_from_id_token` with a non-zero count, and confirm a non-admin user that's added to an `admins`-mapped Entra group via GUID flips to admin in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)