### PR TITLE
fix: initialize selected model from app-compatible models (#1418)

### DIFF
--- a/client/src/shared/hooks/useAppSettings.js
+++ b/client/src/shared/hooks/useAppSettings.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { saveAppSettings, loadAppSettings } from '../../utils/appSettings';
 import { fetchModels, fetchStyles } from '../../api/api';
+import { filterModelsForApp, pickInitialModelForApp } from '../../utils/modelFiltering';
 import { useUIConfig } from '../contexts/UIConfigContext';
 
 /**
@@ -68,12 +69,15 @@ function useAppSettings(appId, app) {
       setHeaderColor(app.color);
     }
 
-    const defaultModel = models.find(m => m.default);
-
-    let initialModel = app.preferredModel;
-    if (!models.some(m => m.id === initialModel)) {
-      initialModel = defaultModel ? defaultModel.id : models[0]?.id || null;
-    }
+    // Pick the initial model from the set of models that are actually
+    // compatible with the app (allowedModels, tools requirement, settings
+    // filter). Without this filter the initial selection could land on a
+    // model that's excluded by the app — and since the model selector
+    // auto-hides when only one compatible model remains, the user would
+    // never see the mismatch but the chat would behave as if the wrong
+    // model was selected (e.g. image generation controls and vision
+    // uploads disappear because the resolved model doesn't support them).
+    const initialModel = pickInitialModelForApp(models, app);
 
     // Initialize with app defaults
     const initialState = {
@@ -108,7 +112,15 @@ function useAppSettings(appId, app) {
     // Load saved settings and override defaults if available
     const savedSettings = loadAppSettings(appId);
     if (savedSettings) {
-      if (savedSettings.selectedModel && models.some(m => m.id === savedSettings.selectedModel))
+      // Only restore the saved model if it's still compatible with the
+      // current app config — otherwise we'd resurrect a stale selection
+      // (e.g. after the admin tightened allowedModels) and bypass the
+      // initial-model logic above.
+      const compatibleModels = filterModelsForApp(models, app);
+      if (
+        savedSettings.selectedModel &&
+        compatibleModels.some(m => m.id === savedSettings.selectedModel)
+      )
         setSelectedModel(savedSettings.selectedModel);
       if (savedSettings.selectedStyle) setSelectedStyle(savedSettings.selectedStyle);
       if (savedSettings.selectedOutputFormat)

--- a/client/src/utils/modelFiltering.js
+++ b/client/src/utils/modelFiltering.js
@@ -1,0 +1,66 @@
+/**
+ * Filter models based on app requirements.
+ * Mirrors the server-side filterModelsForApp logic in
+ * server/services/chat/RequestBuilder.js so client and server agree on
+ * which models are valid for a given app.
+ *
+ * Applies, in order:
+ *   1. app.allowedModels — restrict to listed model IDs
+ *   2. app.tools / app.websearch.enabled — require model.supportsTools
+ *   3. app.settings.model.filter — match arbitrary model properties
+ *
+ * @param {Array<Object>} models - Full list of available models
+ * @param {Object} app - App configuration
+ * @returns {Array<Object>} Filtered models compatible with the app
+ */
+export function filterModelsForApp(models, app) {
+  if (!Array.isArray(models)) return [];
+  let filtered = models;
+
+  if (app?.allowedModels && app.allowedModels.length > 0) {
+    filtered = filtered.filter(model => app.allowedModels.includes(model.id));
+  }
+
+  if ((app?.tools && app.tools.length > 0) || app?.websearch?.enabled) {
+    filtered = filtered.filter(model => model.supportsTools);
+  }
+
+  if (app?.settings?.model?.filter) {
+    const filter = app.settings.model.filter;
+    filtered = filtered.filter(model => {
+      for (const [key, value] of Object.entries(filter)) {
+        if (model[key] !== value) return false;
+      }
+      return true;
+    });
+  }
+
+  return filtered;
+}
+
+/**
+ * Pick the initial model ID for an app from a list of available models.
+ * Prefers, in order: app.preferredModel (if compatible), a compatible model
+ * flagged default, then the first compatible model. Falls back to the full
+ * list's default or first entry when no compatible model exists, to avoid
+ * leaving the chat without any selection.
+ *
+ * @param {Array<Object>} models - Full list of available models
+ * @param {Object} app - App configuration
+ * @returns {string|null} Initial model ID, or null if no models exist
+ */
+export function pickInitialModelForApp(models, app) {
+  if (!Array.isArray(models) || models.length === 0) return null;
+
+  const compatible = filterModelsForApp(models, app);
+  const pool = compatible.length > 0 ? compatible : models;
+
+  if (app?.preferredModel && pool.some(m => m.id === app.preferredModel)) {
+    return app.preferredModel;
+  }
+
+  const defaultModel = pool.find(m => m.default);
+  if (defaultModel) return defaultModel.id;
+
+  return pool[0]?.id || null;
+}


### PR DESCRIPTION
## Summary

Fixes #1418: image generation settings and image (JPG/PNG) uploads disappear when the model selector is hidden.

## Root cause

`useAppSettings` initialised `selectedModel` from the full `models` list, ignoring `app.allowedModels`, the tools/websearch requirement, and `app.settings.model.filter`. When those restrictions narrow the compatible set to a single model the `ModelSelector` correctly auto-hides — but the selected model could still resolve to an unrelated model from the unfiltered list (typically the global default).

Downstream UI is then gated on the wrong model:
- `client/src/features/chat/components/ChatInput.jsx:518` hides the image generation controls because `model.supportsImageGeneration` is false on the resolved (wrong) model.
- `client/src/shared/hooks/useFileUploadHandler.js:58-71` disables image uploads (JPG/PNG fall out of `supportedImageFormats`) because `selectedModel.supportsVision` is false.

This matches the reporter's observation: with two image models the selector renders, the user picks one explicitly, and uploads work; with one allowed model the selector hides and image controls/uploads disappear.

## Fix

- Add `client/src/utils/modelFiltering.js` with `filterModelsForApp` (mirrors the server's `filterModelsForApp` in `server/services/chat/RequestBuilder.js`) and `pickInitialModelForApp`.
- Use `pickInitialModelForApp` in `useAppSettings` so the initial selection is always one of the app-compatible models (preferring `app.preferredModel`, then a compatible `default`, then the first compatible entry).
- Validate the restored saved model against the compatible set so a stale localStorage entry (e.g. after the admin tightened `allowedModels`) no longer bypasses the new initial-model logic.

No new abstractions beyond the bug fix; the existing duplicated filter logic in `ModelSelector`, `AppConfigForm`, and `ChatMessage` is left untouched to keep the change minimal.

## Test plan

- [ ] App with a single `allowedModels` entry that supports image generation (e.g. `gemini-2.5-flash-image`): model selector hides, aspect ratio + quality dropdowns appear, JPG/PNG accepted by the uploader.
- [ ] App with a single `allowedModels` entry that only supports image generation (no vision, e.g. `dall-e-3`): selector hides, image generation controls appear, image upload correctly stays disabled.
- [ ] App with two compatible models: selector renders, switching between models updates controls/upload accept-list as before.
- [ ] App with no restrictions: initial selection still respects `app.preferredModel` → global default → first model (no regression).
- [ ] App with saved `selectedModel` in localStorage that is no longer in `allowedModels`: the saved value is ignored and the new initial-model logic runs.

https://claude.ai/code/session_01HqifpQ4wKMLVL5w1rrqRU8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqifpQ4wKMLVL5w1rrqRU8)_