### PR TITLE
fix(sse): abort fetch on done/error to release HTTP/1.1 connection slot

### DIFF
--- a/client/src/shared/hooks/useEventSource.js
+++ b/client/src/shared/hooks/useEventSource.js
@@ -200,6 +200,15 @@ function useEventSource({ appId, chatId, timeoutDuration = 60000, onEvent, onPro
           if (name === 'done' || name === 'error') {
             abortControllerRef.current = null;
             if (onProcessingChange) onProcessingChange(false);
+            // Release the browser's HTTP/1.1 connection slot. Without this the
+            // fetch sits in the pool until TCP keep-alive times out; opening 2
+            // streams per round in compare mode hits the 6-connection limit by
+            // the third message and the whole UI appears to hang.
+            try {
+              ac.abort();
+            } catch {
+              // already aborted — nothing to do
+            }
           }
         };
 

--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -347,27 +347,30 @@ export default function registerSessionRoutes(
         res.setHeader('Cache-Control', 'no-cache');
         res.setHeader('Connection', 'keep-alive');
         clients.set(chatId, { response: res, lastActivity: new Date(), appId });
+        // Pin this registration so a stale close handler from a previous SSE on the
+        // same chatId can't delete a fresh entry (or abort a fresh active request)
+        // after the client reconnects.
+        const myEntry = clients.get(chatId);
         actionTracker.trackConnected(chatId);
 
         req.on('close', () => {
-          if (clients.has(chatId)) {
-            if (activeRequests.has(chatId)) {
-              try {
-                const controller = activeRequests.get(chatId);
-                controller.abort();
-                activeRequests.delete(chatId);
-                logger.info('Aborted request', { component: 'sessionRoutes', chatId });
-              } catch (error) {
-                logger.error('Error aborting request', {
-                  component: 'sessionRoutes',
-                  chatId,
-                  error: error.message
-                });
-              }
+          if (clients.get(chatId) !== myEntry) return;
+          if (activeRequests.has(chatId)) {
+            try {
+              const controller = activeRequests.get(chatId);
+              controller.abort();
+              activeRequests.delete(chatId);
+              logger.info('Aborted request', { component: 'sessionRoutes', chatId });
+            } catch (error) {
+              logger.error('Error aborting request', {
+                component: 'sessionRoutes',
+                chatId,
+                error: error.message
+              });
             }
-            clients.delete(chatId);
-            logger.info('Client disconnected', { component: 'sessionRoutes', chatId });
           }
+          clients.delete(chatId);
+          logger.info('Client disconnected', { component: 'sessionRoutes', chatId });
         });
       } catch (error) {
         logger.error('Error establishing SSE connection', { component: 'sessionRoutes', error });


### PR DESCRIPTION
Follow-up to #1417 (the compare-mode refactor). Root-causes the third-message hang the user reported.

## Symptom

In compare mode (which opens two parallel SSE streams per round), the third user message never returns and the entire app stops responding to other navigation / requests from the same browser. Reproducible.

## Root cause

`useEventSource.initEventSource` uses `fetch` (not the native `EventSource`) for SSE, so each open stream sits in the browser's HTTP/1.1 per-origin connection pool (max 6).

When the server emits a `done` (or `error`) event:
- **Client** (`useEventSource.js:200-203`): nulls `abortControllerRef.current` but **never calls `ac.abort()`**. `parseSseStream`'s `await reader.read()` keeps blocking — the underlying `fetch` connection stays open in the pool.
- **Server** (`sse.js` fire-sse handler + `actionTracker.trackDone`): writes the `done` event but never calls `res.end()` — the response stays open server-side too.

Math: compare mode opens 2 streams/round. After 3 rounds: 6 held connections = browser limit. Round 4's opening fetch can never get a slot; neither can any other UI fetch — that's the "server appears down" symptom.

The same bug affects **single-chat mode** too — it just takes ~6 rounds to hit (1 leak per round), so it hadn't been reported.

## Fix

**Client** (`client/src/shared/hooks/useEventSource.js`): call `ac.abort()` on `done`/`error`. The abort trips `signal.aborted` in `parseSseStream`, the fetch tears down, the browser releases the connection slot. `ac` is already in scope (the AbortController from the enclosing `initEventSource` closure).

**Server** (`server/routes/chat/sessionRoutes.js`): make the SSE GET's `req.on('close')` cleanup identity-aware. Aborting on `done` now triggers a disconnect on every round, so a stale close handler from message N could otherwise run after message N+1 has already registered its SSE for the same chatId — the blind `clients.delete(chatId)` / `activeRequests.get(chatId).abort()` would clobber the live entry / abort the live request. Pin the registered entry at GET time, skip cleanup if a fresh entry has replaced it.

## What I deliberately did **not** change

- **No server-side `res.end()` on `trackDone`**: tempting, but `trackError` is called at non-terminal mid-stream sites (e.g. per-tool errors in `ToolExecutor.js` that continue the loop). Ending the response there would close streams that are still producing chunks. The client abort gets us out of the woods today; introducing a true "terminal" signal is its own refactor.
- **No HTTP/2 / connection-pool config changes**: orthogonal.

## Test plan

- [ ] Repro the bug on `main` first — compare mode, 3 messages → hang.
- [ ] With this branch: compare mode, send 5+ messages, every round completes. DevTools → Network shows previous SSE requests as `(canceled)` after their `done` event, not perpetually `(pending)`.
- [ ] Single-chat mode: send 10+ messages, same observation.
- [ ] Stop button mid-stream still cancels.
- [ ] "New chat" button in compare mode regenerates `chatId`s, no orphaned sockets.
- [ ] Server logs show one "Client disconnected" per panel per round, with no spurious "Aborted request" against the new round's request.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZGkL13cPaW5XrT98rrXDo)_