### PR TITLE
fix(sources): collision-resistant chatId + regression tests for PR #1406

### DIFF
--- a/server/routes/admin/sources.js
+++ b/server/routes/admin/sources.js
@@ -1,3 +1,4 @@
+import crypto from 'crypto';
 import { join } from 'path';
 import { getRootDir } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
@@ -1066,7 +1067,7 @@ export default function registerAdminSourcesRoutes(app) {
           const testConfig = {
             ...source.config,
             user: req.user,
-            chatId: `admin-source-test-${id}-${Date.now()}`
+            chatId: `admin-source-test-${id}-${crypto.randomUUID()}`
           };
 
           // Test source connection
@@ -1188,7 +1189,7 @@ export default function registerAdminSourcesRoutes(app) {
           const previewConfig = {
             ...source.config,
             user: req.user,
-            chatId: `admin-source-preview-${id}-${Date.now()}`
+            chatId: `admin-source-preview-${id}-${crypto.randomUUID()}`
           };
 
           const content = await manager.loadContent(source.type, previewConfig);

--- a/server/routes/admin/sources.js
+++ b/server/routes/admin/sources.js
@@ -1058,8 +1058,19 @@ export default function registerAdminSourcesRoutes(app) {
         const startTime = Date.now();
 
         try {
+          // Inject runtime context required by handlers that need user identity.
+          // The IFinderHandler validates `user` and `chatId` before issuing any
+          // HTTP call and would otherwise abort with "requires authenticated user
+          // in sourceConfig". Other handlers (filesystem, url, page) ignore these
+          // extra fields, so adding them unconditionally is safe.
+          const testConfig = {
+            ...source.config,
+            user: req.user,
+            chatId: `admin-source-test-${id}-${Date.now()}`
+          };
+
           // Test source connection
-          const result = await manager.testSource(source.type, source.config);
+          const result = await manager.testSource(source.type, testConfig);
           const duration = Date.now() - startTime;
 
           res.json({
@@ -1172,7 +1183,15 @@ export default function registerAdminSourcesRoutes(app) {
         const manager = getSourceManager();
 
         try {
-          const content = await manager.loadContent(source.type, source.config);
+          // Same context injection as the test endpoint — handlers like
+          // IFinderHandler require `user` and `chatId` before any HTTP call.
+          const previewConfig = {
+            ...source.config,
+            user: req.user,
+            chatId: `admin-source-preview-${id}-${Date.now()}`
+          };
+
+          const content = await manager.loadContent(source.type, previewConfig);
           const preview = content.substring(0, parseInt(limit));
 
           res.json({

--- a/server/tests/admin-sources-user-context.test.js
+++ b/server/tests/admin-sources-user-context.test.js
@@ -1,0 +1,217 @@
+/**
+ * Admin Sources User Context Test Suite
+ *
+ * Regression tests for the admin source `test` and `preview` endpoints to
+ * ensure that runtime context (the authenticated `user` plus a generated
+ * `chatId`) is injected into the source configuration before it is handed
+ * to the `SourceManager`.
+ *
+ * Without this context, handlers such as `IFinderHandler` abort with
+ * "requires authenticated user in sourceConfig" / "requires chatId in
+ * sourceConfig" and the admin UI surfaces a confusing error. The
+ * regression these tests protect against is documented in PR #1406 /
+ * issue #1404.
+ *
+ * Note: The repo's source is native ESM (uses `import.meta.url`), so this
+ * file uses `jest.unstable_mockModule` + dynamic imports rather than the
+ * CommonJS-only `jest.mock` API. Run with
+ * `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+
+// Captures the most recent invocations of the mocked SourceManager methods so
+// each test can inspect what the route handler passed in.
+const sourceManagerCalls = {
+  testSource: [],
+  loadContent: []
+};
+
+const mockAdminUser = {
+  id: 'admin-user',
+  username: 'admin',
+  email: 'admin@example.com',
+  groups: ['admin', 'authenticated']
+};
+
+const mockGroups = {
+  admin: {
+    id: 'admin',
+    permissions: {
+      apps: ['*'],
+      prompts: ['*'],
+      models: ['*'],
+      adminAccess: true
+    }
+  }
+};
+
+const mockIFinderSource = {
+  id: 'test-ifinder-source',
+  name: { en: 'Test iFinder Source' },
+  description: { en: 'Test iFinder source for regression coverage' },
+  type: 'ifinder',
+  enabled: true,
+  exposeAs: 'prompt',
+  config: {
+    query: 'test query',
+    searchProfile: 'default'
+  }
+};
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: {
+    getPlatform: () => ({ data: {} }),
+    getSources: () => ({ data: [mockIFinderSource], etag: 'test-etag' }),
+    getFeatures: () => ({}),
+    getGroups: () => ({ data: mockGroups, etag: 'test-etag' })
+  }
+}));
+
+jest.unstable_mockModule('../utils/authorization.js', () => ({
+  loadGroupsConfiguration: () => ({ groups: mockGroups }),
+  enhanceUserWithPermissions: user => user,
+  isAnonymousAccessAllowed: () => false
+}));
+
+// Replace the real source manager with one that records its inputs and
+// emulates IFinderHandler's strict precondition checks. If the route handler
+// ever stops injecting `user` / `chatId` again, the simulated handler throws
+// — surfacing the regression as a 400 with the exact production error.
+jest.unstable_mockModule('../sources/index.js', () => {
+  const fakeManager = {
+    testSource: async (type, config) => {
+      sourceManagerCalls.testSource.push({ type, config });
+      if (type === 'ifinder') {
+        if (!config.user) {
+          throw new Error('IFinderHandler requires authenticated user in sourceConfig');
+        }
+        if (!config.chatId) {
+          throw new Error('IFinderHandler requires chatId in sourceConfig');
+        }
+      }
+      return { accessible: true, testQuery: config.query };
+    },
+    loadContent: async (type, config) => {
+      sourceManagerCalls.loadContent.push({ type, config });
+      if (type === 'ifinder') {
+        if (!config.user) {
+          throw new Error('IFinderHandler requires authenticated user in sourceConfig');
+        }
+        if (!config.chatId) {
+          throw new Error('IFinderHandler requires chatId in sourceConfig');
+        }
+      }
+      return 'mocked source content';
+    }
+  };
+
+  return {
+    createSourceManager: () => fakeManager,
+    validateSourceConfig: () => ({ success: true }),
+    getAvailableHandlerTypes: () => ['filesystem', 'url', 'ifinder', 'page']
+  };
+});
+
+// Dynamic import after mocks are registered.
+const { default: registerAdminSourcesRoutes } = await import('../routes/admin/sources.js');
+
+function createTestApp({ user = mockAdminUser } = {}) {
+  const app = express();
+  app.use(express.json());
+  // Stub auth middleware: populate req.user so adminAuth (which the route
+  // chains on) sees an admin and lets the request through.
+  app.use((req, res, next) => {
+    req.user = user;
+    next();
+  });
+  registerAdminSourcesRoutes(app);
+  return app;
+}
+
+describe('Admin Sources Endpoints - User Context Injection (regression for PR #1406)', () => {
+  let app;
+
+  beforeEach(() => {
+    sourceManagerCalls.testSource.length = 0;
+    sourceManagerCalls.loadContent.length = 0;
+    app = createTestApp();
+  });
+
+  describe('POST /api/admin/sources/:id/test', () => {
+    test('injects req.user and a chatId into the iFinder source config', async () => {
+      const response = await request(app)
+        .post(`/api/admin/sources/${mockIFinderSource.id}/test`)
+        .send();
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+
+      expect(sourceManagerCalls.testSource).toHaveLength(1);
+      const { type, config } = sourceManagerCalls.testSource[0];
+      expect(type).toBe('ifinder');
+      expect(config.user).toEqual(mockAdminUser);
+      expect(typeof config.chatId).toBe('string');
+      expect(config.chatId).toMatch(
+        new RegExp(
+          `^admin-source-test-${mockIFinderSource.id}-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`
+        )
+      );
+      // Original source config is preserved alongside the injected context.
+      expect(config.query).toBe(mockIFinderSource.config.query);
+      expect(config.searchProfile).toBe(mockIFinderSource.config.searchProfile);
+    });
+
+    test('generates a unique chatId per request (collision-resistant)', async () => {
+      const responses = await Promise.all([
+        request(app).post(`/api/admin/sources/${mockIFinderSource.id}/test`).send(),
+        request(app).post(`/api/admin/sources/${mockIFinderSource.id}/test`).send()
+      ]);
+
+      responses.forEach(res => expect(res.status).toBe(200));
+      expect(sourceManagerCalls.testSource).toHaveLength(2);
+
+      const [first, second] = sourceManagerCalls.testSource;
+      expect(first.config.chatId).not.toBe(second.config.chatId);
+    });
+  });
+
+  describe('POST /api/admin/sources/:id/preview', () => {
+    test('injects req.user and a chatId into the iFinder source config', async () => {
+      const response = await request(app)
+        .post(`/api/admin/sources/${mockIFinderSource.id}/preview`)
+        .send();
+
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+      expect(response.body.preview).toBe('mocked source content');
+
+      expect(sourceManagerCalls.loadContent).toHaveLength(1);
+      const { type, config } = sourceManagerCalls.loadContent[0];
+      expect(type).toBe('ifinder');
+      expect(config.user).toEqual(mockAdminUser);
+      expect(typeof config.chatId).toBe('string');
+      expect(config.chatId).toMatch(
+        new RegExp(
+          `^admin-source-preview-${mockIFinderSource.id}-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`
+        )
+      );
+      expect(config.query).toBe(mockIFinderSource.config.query);
+    });
+
+    test('generates a unique chatId per request (collision-resistant)', async () => {
+      const responses = await Promise.all([
+        request(app).post(`/api/admin/sources/${mockIFinderSource.id}/preview`).send(),
+        request(app).post(`/api/admin/sources/${mockIFinderSource.id}/preview`).send()
+      ]);
+
+      responses.forEach(res => expect(res.status).toBe(200));
+      expect(sourceManagerCalls.loadContent).toHaveLength(2);
+
+      const [first, second] = sourceManagerCalls.loadContent;
+      expect(first.config.chatId).not.toBe(second.config.chatId);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #1406 addressing the [Copilot review feedback](https://github.com/intrafind/ihub-apps/pull/1406#pullrequestreview-4252355070):

- Replace `Date.now()` with `crypto.randomUUID()` for the generated `chatId` on the admin `POST /api/admin/sources/:id/test` and `POST /api/admin/sources/:id/preview` endpoints. The previous timestamp-only ID could collide on concurrent admin runs and mix iFinder telemetry (`actionTracker.trackAction(chatId, ...)`).
- Add a regression test (`server/tests/admin-sources-user-context.test.js`) that mounts the admin sources routes against a mocked `SourceManager` whose `testSource` / `loadContent` emulate `IFinderHandler`'s strict precondition checks. The test asserts that:
  - `req.user` is forwarded into the source config for both endpoints.
  - The generated `chatId` matches the expected `admin-source-{test,preview}-{id}-<uuid>` shape.
  - Two concurrent invocations get distinct `chatId`s.
  - The handler-style precondition checks return success (i.e. the regression — missing `user` / `chatId` — would otherwise surface as a 400).

This builds on top of @ifjoergi's original commit from #1406 (cherry-picked here) so the branch is self-contained.

## Test plan

- [x] `npx jest tests/admin-sources-user-context.test.js` — 4/4 pass (using `NODE_OPTIONS=--experimental-vm-modules` since the source is native ESM; the repo's existing jest preset has separate, pre-existing setup issues)
- [x] `npm run lint` — no new errors or warnings introduced by these changes
- [x] `npm run format` — clean
- [ ] Manual exercise of `POST /api/admin/sources/:id/test` against a real iFinder source (cannot do from here)

https://claude.ai/code/session_01BcwQezACfm2rNGwFhD6R4j

---
_Generated by [Claude Code](https://claude.ai/code/session_01BcwQezACfm2rNGwFhD6R4j)_