### PR TITLE
fix(upload): show cloud storage actions when local file upload is disabled

### DIFF
--- a/client/src/features/chat/components/ChatInput.jsx
+++ b/client/src/features/chat/components/ChatInput.jsx
@@ -10,6 +10,7 @@ import ModelSelector from './ModelSelector';
 import ModelHintBanner from './ModelHintBanner';
 import { VoiceInputComponent } from '../../voice/components';
 import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
+import { usePlatformConfig } from '../../../shared/contexts/PlatformConfigContext';
 import MagicPromptLoader from '../../../shared/components/MagicPromptLoader';
 
 /**
@@ -74,6 +75,7 @@ function ChatInput({
 }) {
   const { t, i18n } = useTranslation();
   const { uiConfig } = useUIConfig();
+  const { platformConfig } = usePlatformConfig();
   const localInputRef = useRef(null);
   const actualInputRef = inputRef || localInputRef;
   const workflowSearchRef = useRef(null);
@@ -156,13 +158,26 @@ function ChatInput({
   // Calculate if single-action optimization is active in ChatInputActionsMenu
   // This logic mirrors the calculation in ChatInputActionsMenu.jsx
   const hasTools = app?.tools && app.tools.length > 0;
+  // Local upload (paper-clip + dropzone) is independent from cloud storage
+  // upload, which is rendered as separate entries in the actions menu.
+  const localUploadEnabled = uploadConfig?.localUploadEnabled === true;
+  // Match ChatInputActionsMenu's hasCloudProviders calculation so the
+  // single-action optimization stays in sync (issue #1426).
+  const cloudStorageEnabledForApp = uploadConfig?.cloudStorageUpload?.enabled === true;
+  const platformCloudStorage = platformConfig?.cloudStorage;
+  const hasCloudProviders =
+    cloudStorageEnabledForApp &&
+    platformCloudStorage?.enabled === true &&
+    Array.isArray(platformCloudStorage?.providers) &&
+    platformCloudStorage.providers.some(p => p.enabled);
   const quickActionCount =
-    (uploadConfig?.enabled === true ? 1 : 0) +
+    (localUploadEnabled ? 1 : 0) +
     (magicPromptEnabled && !showUndoMagicPrompt ? 1 : 0) +
     (showUndoMagicPrompt ? 1 : 0) +
     (onVoiceInput ? 1 : 0);
   const totalActions = quickActionCount + (hasTools ? 1 : 0);
-  const isSingleActionOptimization = totalActions === 1 && quickActionCount === 1 && !hasTools;
+  const isSingleActionOptimization =
+    totalActions === 1 && quickActionCount === 1 && !hasTools && !hasCloudProviders;
 
   // Handler to trigger file upload dialog via ref
   const handleAttachFile = useCallback(() => {
@@ -462,7 +477,7 @@ function ChatInput({
 
             {/* Upload icon - show directly on desktop if enabled and NOT in single-action mode */}
             {/* When single action, ChatInputActionsMenu shows it directly without a menu */}
-            {uploadConfig?.enabled === true && !isSingleActionOptimization && (
+            {localUploadEnabled && !isSingleActionOptimization && (
               <button
                 type="button"
                 onClick={handleAttachFile}
@@ -609,7 +624,7 @@ function ChatInput({
         />
       )}
 
-      {uploadConfig?.enabled === true ? (
+      {localUploadEnabled ? (
         <UnifiedUploader
           onFileSelect={handleLocalFileSelect}
           disabled={isInputDisabled || isProcessing}

--- a/client/src/features/chat/components/ChatInputActionsMenu.jsx
+++ b/client/src/features/chat/components/ChatInputActionsMenu.jsx
@@ -222,16 +222,23 @@ function ChatInputActionsMenu({
   const enabledCount = hasTools ? app.tools.filter(t => enabledTools.includes(t)).length : 0;
   const hasWebsearch = app?.websearch?.enabled === true && onWebsearchEnabledChange !== null;
 
+  // Local upload covers the paper-clip / drop-zone affordance. Cloud storage
+  // providers are rendered separately so they must remain available even when
+  // local upload is disabled (issue #1426).
+  const localUploadEnabled = uploadConfig?.localUploadEnabled === true;
+  const hasCloudProviders = enabledCloudProviders.length > 0;
+
   // Count quick actions (non-tools actions)
   const quickActionCount =
-    (uploadConfig?.enabled === true ? 1 : 0) +
+    (localUploadEnabled ? 1 : 0) +
     (magicPromptEnabled && !showUndoMagicPrompt ? 1 : 0) +
     (showUndoMagicPrompt ? 1 : 0) +
     (onVoiceInput ? 1 : 0);
 
   // Check if we have any actions to show
   const hasHostContextToggles = hostContextToggles.length > 0;
-  const hasActions = hasTools || hasWebsearch || hasHostContextToggles || quickActionCount > 0;
+  const hasActions =
+    hasTools || hasWebsearch || hasHostContextToggles || hasCloudProviders || quickActionCount > 0;
 
   if (!hasActions) return null;
 
@@ -243,9 +250,9 @@ function ChatInputActionsMenu({
     (hasWebsearch ? 1 : 0) +
     (hasHostContextToggles ? 1 : 0);
 
-  if (totalActions === 1 && quickActionCount === 1 && !hasTools) {
+  if (totalActions === 1 && quickActionCount === 1 && !hasTools && !hasCloudProviders) {
     // Render the single action directly
-    if (uploadConfig?.enabled === true) {
+    if (localUploadEnabled) {
       return (
         <button
           type="button"
@@ -306,7 +313,7 @@ function ChatInputActionsMenu({
   // getNavigableElements discovers, so React-controlled tabIndex agrees with the
   // hook's activeIndex (prevents roving tabindex from being overwritten on re-render).
   const menuNavItems = [];
-  if (uploadConfig?.enabled === true && !(disabled || isProcessing)) menuNavItems.push('upload');
+  if (localUploadEnabled && !(disabled || isProcessing)) menuNavItems.push('upload');
   if (magicPromptEnabled && !showUndoMagicPrompt && !(disabled || isProcessing))
     menuNavItems.push('magic');
   if (showUndoMagicPrompt && !(disabled || isProcessing)) menuNavItems.push('undo');
@@ -354,7 +361,7 @@ function ChatInputActionsMenu({
               {t('chatActions.quickActions', 'Quick Actions')}
             </h3>
             <div className="flex flex-wrap gap-2">
-              {uploadConfig?.enabled === true && (
+              {localUploadEnabled && (
                 <button
                   type="button"
                   role="menuitem"

--- a/client/src/shared/hooks/useFileUploadHandler.js
+++ b/client/src/shared/hooks/useFileUploadHandler.js
@@ -39,17 +39,33 @@ export function useFileUploadHandler() {
     const audioConfig = uploadConfig?.audioUpload || {};
     const videoConfig = uploadConfig?.videoUpload || {};
     const fileConfig = uploadConfig?.fileUpload || {};
+    const cloudStorageConfig = uploadConfig?.cloudStorageUpload || {};
 
-    // Check if upload is enabled at all
-    const uploadEnabled =
+    // Local upload covers paper-clip / drag-and-drop file selection
+    const localUploadEnabled =
       uploadConfig?.enabled !== false &&
       (imageConfig?.enabled === true ||
         audioConfig?.enabled === true ||
         videoConfig?.enabled === true ||
         fileConfig?.enabled === true);
 
-    if (!uploadEnabled) {
-      return { enabled: false };
+    // Cloud storage is offered through the actions menu and can be enabled
+    // independently from local file upload (issue #1426).
+    const cloudStorageUploadEnabled =
+      uploadConfig?.enabled !== false && cloudStorageConfig?.enabled === true;
+
+    if (!localUploadEnabled && !cloudStorageUploadEnabled) {
+      return { enabled: false, localUploadEnabled: false };
+    }
+
+    if (!localUploadEnabled) {
+      // Only cloud storage uploads are available — skip local-upload specific
+      // computations and return a minimal config that still exposes cloud info.
+      return {
+        enabled: true,
+        localUploadEnabled: false,
+        cloudStorageUpload: { ...cloudStorageConfig, enabled: true }
+      };
     }
 
     // Determine if image upload should be disabled based on model capabilities
@@ -75,6 +91,7 @@ export function useFileUploadHandler() {
 
     return {
       enabled: true,
+      localUploadEnabled: true,
       imageUploadEnabled,
       audioUploadEnabled,
       videoUploadEnabled,
@@ -181,7 +198,7 @@ export function useFileUploadHandler() {
           ]
         : [],
       // Cloud storage upload settings
-      cloudStorageUpload: uploadConfig?.cloudStorageUpload || { enabled: false }
+      cloudStorageUpload: { ...cloudStorageConfig, enabled: cloudStorageUploadEnabled }
     };
   };
 


### PR DESCRIPTION
## Summary

Fixes #1426: when an app disabled all local upload types (image/audio/video/file) but kept `cloudStorageUpload.enabled = true`, the user could not attach anything because the attach UI disappeared entirely.

## Root cause

`useFileUploadHandler.createUploadConfig` short-circuited with `{ enabled: false }` whenever no local upload type was enabled, dropping the `cloudStorageUpload` config. Downstream, `ChatInputActionsMenu` then computed `enabledCloudProviders = []`, `hasActions = false`, and returned `null` — so neither the paper-clip nor the cloud storage entries were rendered.

## Fix

- **`client/src/shared/hooks/useFileUploadHandler.js`** — separate `localUploadEnabled` (paper-clip / drag-and-drop) from cloud storage availability, and always preserve `cloudStorageUpload` info on the returned config when any upload pathway is active.
- **`client/src/features/chat/components/ChatInputActionsMenu.jsx`** — use the new `localUploadEnabled` flag for the paper-clip affordance, include `hasCloudProviders` in `hasActions`, and skip the single-action optimization when cloud providers will render in the menu.
- **`client/src/features/chat/components/ChatInput.jsx`** — mirror the menu's `hasCloudProviders` check (via `usePlatformConfig`) so the desktop paper-clip and `UnifiedUploader` wrapper stay in sync, and only render the dropzone wrapper when local upload is actually enabled.

## Test plan

- [ ] Configure an app with `upload.fileUpload.enabled = false` and `upload.cloudStorageUpload.enabled = true` while platform has at least one enabled cloud provider — verify the `+` actions menu shows the cloud provider entry and no paper-clip.
- [ ] Configure an app with both local file upload and cloud storage enabled — verify paper-clip and cloud provider entries both appear (no duplicates on desktop).
- [ ] Configure an app with only local file upload enabled — verify the legacy single-action optimization still renders the paper-clip directly.
- [ ] Configure an app with all upload types disabled — verify no attach UI appears.
- [ ] `npm run lint:fix && npm run format:fix` clean.

Fixes #1426

https://claude.ai/code/session_013sg8kMF7k1kS9W4uGoozp7

---
_Generated by [Claude Code](https://claude.ai/code/session_013sg8kMF7k1kS9W4uGoozp7)_