### PR TITLE
fix(client): prevent infinite reload loop after version update (#1421)

### DIFF
--- a/client/src/utils/forceRefresh.js
+++ b/client/src/utils/forceRefresh.js
@@ -6,12 +6,51 @@
  * 2. Comparing it with the stored salt in localStorage
  * 3. If salt has changed, clearing all caches and forcing a full reload
  * 4. Preserving the disclaimer acceptance flag during refresh
+ *
+ * Loop safety:
+ * Triggers like a version update (e.g. 5.2.10-RC4 → 5.3.11) intentionally bump
+ * `computedRefreshSalt`, which is what fires this flow in the first place. If
+ * anything goes wrong while storing the new salt — empty server response,
+ * blocked localStorage, etc. — a naive "reload anyway" would loop forever.
+ * `REFRESH_ATTEMPT_KEY` caps consecutive force-refresh attempts so the user
+ * lands on the app instead of a reload storm. The counter is cleared once the
+ * salt matches.
  */
 
 import { fetchUIConfig } from '../api/api';
 
 const REFRESH_SALT_KEY = 'ihub-refresh-salt';
 const DISCLAIMER_KEY = 'ihub-disclaimer-acknowledged';
+const REFRESH_ATTEMPT_KEY = 'ihub-refresh-attempt';
+const REFRESH_PARAM = '_refresh';
+const MAX_REFRESH_ATTEMPTS = 2;
+
+const readAttemptCount = () => {
+  const raw = sessionStorage.getItem(REFRESH_ATTEMPT_KEY);
+  const parsed = raw ? parseInt(raw, 10) : 0;
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+};
+
+const clearAttemptCount = () => {
+  sessionStorage.removeItem(REFRESH_ATTEMPT_KEY);
+};
+
+/**
+ * Strip the `_refresh` cache-busting param from the current URL without
+ * triggering navigation. Keeps the address bar clean after a successful
+ * refresh and prevents the param from snowballing across reloads.
+ */
+export const stripRefreshParamFromUrl = () => {
+  try {
+    const url = new URL(window.location.href);
+    if (!url.searchParams.has(REFRESH_PARAM)) return;
+    url.searchParams.delete(REFRESH_PARAM);
+    const newUrl = url.pathname + (url.search ? url.search : '') + url.hash;
+    window.history.replaceState(window.history.state, '', newUrl);
+  } catch (error) {
+    console.warn('Could not strip _refresh param from URL:', error);
+  }
+};
 
 /**
  * Checks if a force refresh is needed by comparing the current salt with the stored salt
@@ -37,6 +76,7 @@ export const checkForceRefresh = async () => {
     // If no stored salt (first run), store current salt and continue
     if (!storedSalt) {
       localStorage.setItem(REFRESH_SALT_KEY, currentSalt);
+      clearAttemptCount();
       console.log('✅ First run - stored initial salt');
       return false;
     }
@@ -47,6 +87,9 @@ export const checkForceRefresh = async () => {
       return true;
     }
 
+    // Salts match: we're on the version the server expects. Reset the loop
+    // guard so a *future* legitimate version change can refresh again.
+    clearAttemptCount();
     console.log('✅ Salt matches - no force refresh needed');
     return false;
   } catch (error) {
@@ -57,58 +100,95 @@ export const checkForceRefresh = async () => {
 };
 
 /**
- * Performs a force refresh by clearing all caches and reloading the page
+ * Performs a force refresh by clearing all caches and reloading the page.
+ *
+ * Reloads only when the new salt was successfully fetched AND written to
+ * localStorage, and only while the attempt counter is under the cap. Any
+ * other branch logs and returns without navigating, so the user always
+ * lands on a usable app instead of in a reload loop.
  */
 export const performForceRefresh = async () => {
+  const attempts = readAttemptCount();
+  if (attempts >= MAX_REFRESH_ATTEMPTS) {
+    console.warn(
+      `Force refresh attempted ${attempts} times in a row; aborting to avoid a loop. ` +
+        'Continuing with the current page state.'
+    );
+    clearAttemptCount();
+    return;
+  }
+  sessionStorage.setItem(REFRESH_ATTEMPT_KEY, String(attempts + 1));
+
+  let newSalt = null;
   try {
     console.log('🔄 Performing force refresh...');
 
     // Get current UI configuration to get the new salt
     const uiConfig = await fetchUIConfig({ skipCache: true });
-    const newSalt = uiConfig?.computedRefreshSalt;
+    newSalt = uiConfig?.computedRefreshSalt || null;
 
-    if (newSalt) {
-      // Preserve disclaimer acceptance
-      const disclaimerAcknowledged = localStorage.getItem(DISCLAIMER_KEY);
-
-      // Clear all localStorage
-      localStorage.clear();
-
-      // Clear all sessionStorage
-      sessionStorage.clear();
-
-      // Restore disclaimer acceptance
-      if (disclaimerAcknowledged) {
-        localStorage.setItem(DISCLAIMER_KEY, disclaimerAcknowledged);
-      }
-
-      // Store new salt
-      localStorage.setItem(REFRESH_SALT_KEY, newSalt);
-
-      console.log('✅ Cleared all caches and storage');
+    if (!newSalt) {
+      console.warn('Force refresh: server response missing computedRefreshSalt; not reloading.');
+      return;
     }
 
-    // Force reload the page with cache busting
-    // Using window.location.reload(true) is deprecated, so we use a different approach
-    const url = new URL(window.location.href);
-    url.searchParams.set('_refresh', Date.now().toString());
-    window.location.href = url.toString();
+    // Preserve disclaimer acceptance
+    const disclaimerAcknowledged = localStorage.getItem(DISCLAIMER_KEY);
+
+    // Clear all localStorage / sessionStorage, then restore the keys we need
+    // to survive a refresh. We restore the attempt counter so a follow-up
+    // load can still detect a runaway loop.
+    const attemptCounter = sessionStorage.getItem(REFRESH_ATTEMPT_KEY);
+    localStorage.clear();
+    sessionStorage.clear();
+    if (disclaimerAcknowledged) {
+      localStorage.setItem(DISCLAIMER_KEY, disclaimerAcknowledged);
+    }
+    if (attemptCounter) {
+      sessionStorage.setItem(REFRESH_ATTEMPT_KEY, attemptCounter);
+    }
+    localStorage.setItem(REFRESH_SALT_KEY, newSalt);
+
+    // Verify the write actually took effect. Some browser modes (Safari
+    // private mode, storage quota, blocked storage) silently drop writes,
+    // which would put us in a loop on reload.
+    if (localStorage.getItem(REFRESH_SALT_KEY) !== newSalt) {
+      console.warn('Force refresh: could not persist new salt to localStorage; not reloading.');
+      return;
+    }
+
+    console.log('✅ Cleared all caches and storage');
   } catch (error) {
     console.error('Error during force refresh:', error);
-    // Fallback to simple reload
-    window.location.reload();
+    // Do NOT reload here. A reload without storing the new salt would loop;
+    // the user can manually retry or the next genuine version change will
+    // pick this up.
+    return;
   }
+
+  // Force reload the page with cache busting. Drop any existing `_refresh`
+  // param first so it doesn't accumulate across reloads.
+  const url = new URL(window.location.href);
+  url.searchParams.delete(REFRESH_PARAM);
+  url.searchParams.set(REFRESH_PARAM, Date.now().toString());
+  window.location.href = url.toString();
 };
 
 /**
- * Initializes the force refresh check and performs refresh if needed
- * This should be called early in the application startup
+ * Initializes the force refresh check and performs refresh if needed.
+ * This should be called early in the application startup.
  */
 export const initializeForceRefresh = async () => {
+  // Strip any leftover ?_refresh=... from a previous reload so the URL stays
+  // clean and a manual reload doesn't carry it forward.
+  stripRefreshParamFromUrl();
+
   const needsRefresh = await checkForceRefresh();
 
   if (needsRefresh) {
     await performForceRefresh();
-    // This will reload the page, so code after this won't execute
+    // If we get here without a reload, performForceRefresh decided it was
+    // unsafe to continue (loop guard, write failure, missing salt). The app
+    // continues to render with the stale stored salt.
   }
 };


### PR DESCRIPTION
Fixes #1421.

## How this relates to the update

The `Admin → System Administration → Version Information → Update` flow replaces `version.txt` and the `public/` client bundle but leaves `contents/config/platform.json` untouched. The UI-config endpoint builds the client-facing salt as:

```js
// server/routes/chat/dataRoutes.js:802
const computedSalt = `${appVersion}.${refreshSalt.salt}`;
```

So the version bump from `5.2.10-RC4` → `5.3.11` flips that salt from `5.2.10-RC4.N` to `5.3.11.N`. That mismatch with the browser's stored salt is **the intended trigger** for the one-shot client force-refresh — clients should reload after a deploy. The bug isn't in the trigger; it's in how the client handler reacts when something goes wrong while completing the refresh.

## Root cause

`client/src/utils/forceRefresh.js` had three structural problems that turned a single intended reload into a loop with `?_refresh=<timestamp>` accumulating in the URL:

1. **Unconditional reload.** `performForceRefresh` reloaded the page even when it failed to fetch or persist a new salt — so the next load saw the same mismatch and re-triggered.
2. **No loop guard.** Unlike `lazyWithRetry.js` (which uses `RELOAD_GUARD_KEY` for the chunk-error reload), the salt-refresh path had no attempt cap.
3. **`_refresh` was never cleaned up.** It piled up in the address bar and survived manual reloads.

## Fix

- Cap consecutive force-refresh attempts via a `sessionStorage` counter (`ihub-refresh-attempt`, max 2) — pattern borrowed from `lazyWithRetry.js`. The counter resets once `checkForceRefresh` sees matching salts.
- Reload only when the new salt has been fetched **and** its write to `localStorage` is verified (catches silent failures from private mode / storage quota / blocked storage).
- On error, log and return instead of falling back to `window.location.reload()`.
- Strip `?_refresh=` on every init via `history.replaceState`, and delete-then-set the param when reloading so it doesn't snowball.

No server-side or API changes.

## Test plan

- [ ] Manually verify: set `localStorage['ihub-refresh-salt'] = 'old-version.0'`, reload, expect exactly one reload with `?_refresh=…`, then a clean URL and a working app.
- [ ] Manually verify loop guard: force `fetchUIConfig` to return `{}` (DevTools override), reload — expect at most 2 reloads then a console warning + working app.
- [ ] Admin force-refresh button (`/admin/system` → Force Refresh) still triggers a one-shot refresh in other tabs.
- [ ] `npm run lint:fix && npm run format:fix` clean.
- [ ] Server startup smoke test: `timeout 10s node server/server.js`.

https://claude.ai/code/session_01HXGPofN2m3s9dD6nP5EE3B

---
_Generated by [Claude Code](https://claude.ai/code/session_01HXGPofN2m3s9dD6nP5EE3B)_