### PR TITLE
fix(tools): surface proxy/network failures instead of swallowing them

### DIFF
--- a/server/services/WebSearchService.js
+++ b/server/services/WebSearchService.js
@@ -100,7 +100,8 @@ class BraveSearchProvider extends SearchProvider {
       // surface here as a thrown Error from node-fetch. Without this branch the upstream
       // wrapper only sees `error.message` and drops the code/cause, making proxy issues
       // impossible to diagnose from the logs.
-      const causeMsg = error?.cause?.message || (typeof error?.cause === 'string' ? error.cause : undefined);
+      const causeMsg =
+        error?.cause?.message || (typeof error?.cause === 'string' ? error.cause : undefined);
       logger.error('Brave search network request failed', {
         component: 'WebSearch',
         provider: 'brave',
@@ -114,7 +115,9 @@ class BraveSearchProvider extends SearchProvider {
       const detailParts = [error?.message];
       if (error?.code) detailParts.push(`code=${error.code}`);
       if (causeMsg) detailParts.push(`cause=${causeMsg}`);
-      const wrapped = new Error(`Brave search request failed: ${detailParts.filter(Boolean).join(' ')}`);
+      const wrapped = new Error(
+        `Brave search request failed: ${detailParts.filter(Boolean).join(' ')}`
+      );
       wrapped.code = error?.code || error?.cause?.code || 'NETWORK_ERROR';
       wrapped.cause = error;
       throw wrapped;

--- a/server/services/WebSearchService.js
+++ b/server/services/WebSearchService.js
@@ -87,15 +87,59 @@ class BraveSearchProvider extends SearchProvider {
       actionTracker.trackAction(chatId, { action: 'search', query, provider: 'brave' });
     }
 
-    const res = await throttledFetch('braveSearch', `${endpoint}?q=${encodeURIComponent(query)}`, {
-      headers: {
-        'X-Subscription-Token': apiKey,
-        Accept: 'application/json'
-      }
-    });
+    let res;
+    try {
+      res = await throttledFetch('braveSearch', `${endpoint}?q=${encodeURIComponent(query)}`, {
+        headers: {
+          'X-Subscription-Token': apiKey,
+          Accept: 'application/json'
+        }
+      });
+    } catch (error) {
+      // Network/proxy failures (ECONNREFUSED, ETIMEDOUT, TLS errors, proxy unreachable, ...)
+      // surface here as a thrown Error from node-fetch. Without this branch the upstream
+      // wrapper only sees `error.message` and drops the code/cause, making proxy issues
+      // impossible to diagnose from the logs.
+      const causeMsg = error?.cause?.message || (typeof error?.cause === 'string' ? error.cause : undefined);
+      logger.error('Brave search network request failed', {
+        component: 'WebSearch',
+        provider: 'brave',
+        endpoint,
+        errorName: error?.name,
+        errorCode: error?.code || error?.cause?.code,
+        errorMessage: error?.message,
+        errorCause: causeMsg,
+        hint: 'If a proxy is configured, verify HTTPS_PROXY/HTTP_PROXY, ssl.domainWhitelist, and proxy.urlPatterns in platform.json.'
+      });
+      const detailParts = [error?.message];
+      if (error?.code) detailParts.push(`code=${error.code}`);
+      if (causeMsg) detailParts.push(`cause=${causeMsg}`);
+      const wrapped = new Error(`Brave search request failed: ${detailParts.filter(Boolean).join(' ')}`);
+      wrapped.code = error?.code || error?.cause?.code || 'NETWORK_ERROR';
+      wrapped.cause = error;
+      throw wrapped;
+    }
 
     if (!res.ok) {
-      throw new Error(`Brave search failed with status ${res.status}`);
+      let bodyPreview = '';
+      try {
+        bodyPreview = (await res.text()).slice(0, 500);
+      } catch {
+        // ignore body read errors
+      }
+      logger.error('Brave search returned non-OK status', {
+        component: 'WebSearch',
+        provider: 'brave',
+        status: res.status,
+        statusText: res.statusText,
+        bodyPreview
+      });
+      const err = new Error(
+        `Brave search failed with status ${res.status}${res.statusText ? ` (${res.statusText})` : ''}`
+      );
+      err.code = `HTTP_${res.status}`;
+      err.status = res.status;
+      throw err;
     }
 
     const data = await res.json();
@@ -280,7 +324,20 @@ class WebSearchService {
     try {
       return await provider.search(query, options);
     } catch (error) {
-      throw new Error(`Search failed with ${providerName}: ${error.message}`);
+      logger.error('Web search provider failed', {
+        component: 'WebSearch',
+        provider: providerName,
+        errorName: error?.name,
+        errorCode: error?.code,
+        errorMessage: error?.message,
+        errorCause: error?.cause?.message || error?.cause
+      });
+      const wrapped = new Error(`Search failed with ${providerName}: ${error.message}`);
+      // Preserve original code/cause so admins (and the ToolExecutor error report)
+      // can see proxy/network/TLS specifics instead of a generic "Search failed" line.
+      if (error?.code) wrapped.code = error.code;
+      wrapped.cause = error;
+      throw wrapped;
     }
   }
 }

--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -491,9 +491,19 @@ class ToolExecutor {
         message
       };
     } catch (toolError) {
+      const causeMessage =
+        toolError?.cause?.message ||
+        (typeof toolError?.cause === 'string' ? toolError.cause : undefined);
+      const causeCode = toolError?.cause?.code;
+
       logger.error('Tool execution failed', {
         component: 'ToolExecutor',
         toolId,
+        toolInput: args,
+        errorName: toolError?.name,
+        errorCode: toolError?.code || causeCode,
+        errorMessage: toolError?.message,
+        errorCause: causeMessage,
         error: toolError
       });
 
@@ -501,13 +511,17 @@ class ToolExecutor {
         error: true,
         message: `Tool execution failed: ${toolError.message || 'Unknown error'}`,
         toolId,
+        code: toolError?.code || causeCode,
+        cause: causeMessage,
         details: toolError.stack || toolError.toString()
       };
 
       actionTracker.trackToolCallEnd(chatId, {
         toolName: toolId,
         toolOutput: errorResult,
-        error: true
+        error: true,
+        errorCode: errorResult.code,
+        errorMessage: errorResult.message
       });
 
       await logInteraction(

--- a/server/toolLoader.js
+++ b/server/toolLoader.js
@@ -600,7 +600,15 @@ export async function runTool(toolId, params = {}) {
 
     return await fn(params);
   } catch (error) {
-    logger.error('Failed to execute tool', { component: 'ToolLoader', toolId, error: err });
-    throw err;
+    logger.error('Failed to execute tool', {
+      component: 'ToolLoader',
+      toolId,
+      errorName: error?.name,
+      errorMessage: error?.message,
+      errorCode: error?.code,
+      errorCause: error?.cause?.message || error?.cause,
+      error
+    });
+    throw error;
   }
 }


### PR DESCRIPTION
Fixes #1432.

A customer hit a proxy issue with Brave search and saw no error at all in the UI or in the logs. Two bugs combined to produce the silent failure:

1. **`toolLoader.runTool` typo** — the catch block referenced an undefined `err` instead of the caught `error`, so any tool that threw caused a `ReferenceError: err is not defined` to be thrown in place of the real error, and the `logger.error` call inside the catch was never reached (the ReferenceError fired while evaluating the log object).
2. **`BraveSearchProvider` only handled non‑OK responses.** A node‑fetch transport error (proxy unreachable, `ECONNREFUSED`, TLS handshake failure, etc.) bubbled up as a bare `Error`. The outer `WebSearchService.search` wrapper then re‑threw it as `Search failed with brave: <message>`, dropping `error.code` and `error.cause` — so admins had no way to tell a proxy/TLS issue apart from a generic tool failure.

## Changes

- **`server/toolLoader.js`** — fix the `err`/`error` typo and log full diagnostics (name, message, code, cause) before re‑throwing.
- **`server/services/WebSearchService.js`**
  - `BraveSearchProvider.search` now catches transport errors, logs the endpoint plus `errorCode`/`errorCause`, and includes a hint pointing admins at `HTTPS_PROXY` / `ssl.domainWhitelist` / `proxy.urlPatterns` in `platform.json`. The thrown error preserves `code` (defaulting to `NETWORK_ERROR`) and `cause`.
  - Non‑OK responses log a body preview and attach `HTTP_<status>` as the code.
  - The outer `WebSearchService.search` wrapper preserves `error.code` and `error.cause` when re‑throwing.
- **`server/services/chat/ToolExecutor.js`** — the catch in `executeToolCall` now logs `errorName`/`errorCode`/`errorMessage`/`errorCause`, includes `code` and `cause` in the JSON returned to the LLM as the tool result, and emits them on the `TOOL_CALL_END` SSE event so the UI can distinguish a proxy/TLS/HTTP failure from a generic tool error.

## Test plan

- [ ] Configure an unreachable HTTPS proxy and trigger a Brave search; verify the server logs a `Brave search network request failed` entry with `errorCode` and the proxy hint, and the chat surfaces a `TOOL_CALL_END` with a non‑empty `errorCode`/`errorMessage` instead of silently completing.
- [ ] Trigger a Brave search with an invalid API key (HTTP 401/403); verify the body preview is logged and the tool result carries `code: HTTP_401`.
- [ ] Trigger a tool that throws synchronously (e.g. missing required argument); verify the logs now show the actual error message instead of `err is not defined`.
- [ ] Happy path: Brave search still returns results unchanged.

https://claude.ai/code/session_01CmRASuiS6NPZaXYWuNbDoh

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmRASuiS6NPZaXYWuNbDoh)_