### PR TITLE
fix(connections): close remaining HTTP/1.1 slot leaks across SSE + polling

### DIFF
--- a/client/src/api/adminApi.js
+++ b/client/src/api/adminApi.js
@@ -475,9 +475,9 @@ export const updateToolScript = async (toolId, content) => {
  * @param {number} [params.offset] - Number of results to skip
  * @returns {Promise<Object>} Response containing executions array, total count, and stats
  */
-export const fetchAdminExecutions = async params => {
+export const fetchAdminExecutions = async (params, { signal } = {}) => {
   const queryString = params ? '?' + new URLSearchParams(params).toString() : '';
-  const response = await makeAdminApiCall(`/admin/workflows/executions${queryString}`);
+  const response = await makeAdminApiCall(`/admin/workflows/executions${queryString}`, { signal });
   return response.data;
 };
 

--- a/client/src/features/admin/pages/AdminSystemPage.jsx
+++ b/client/src/features/admin/pages/AdminSystemPage.jsx
@@ -33,6 +33,12 @@ function AdminSystemPage() {
   const [updateActionMessageType, setUpdateActionMessageType] = useState('success');
   const updatePollIntervalRef = useRef(null);
   const rollbackPollIntervalRef = useRef(null);
+  // Abort prior in-flight /admin/version polls when a new tick starts (or on
+  // unmount). On a slow network, 3s ticks with 30s axios timeouts could
+  // otherwise stack ~10 pending requests and saturate the browser's
+  // 6-connection HTTP/1.1 pool.
+  const updatePollAbortRef = useRef(null);
+  const rollbackPollAbortRef = useRef(null);
 
   // Fetch version information on mount
   useEffect(() => {
@@ -86,11 +92,19 @@ function AdminSystemPage() {
     fetchUpdateStatus();
   }, []);
 
-  // Clean up polling intervals on unmount
+  // Clean up polling intervals (and any in-flight version-poll requests) on unmount
   useEffect(() => {
     return () => {
       if (updatePollIntervalRef.current) clearInterval(updatePollIntervalRef.current);
       if (rollbackPollIntervalRef.current) clearInterval(rollbackPollIntervalRef.current);
+      if (updatePollAbortRef.current) {
+        updatePollAbortRef.current.abort();
+        updatePollAbortRef.current = null;
+      }
+      if (rollbackPollAbortRef.current) {
+        rollbackPollAbortRef.current.abort();
+        rollbackPollAbortRef.current = null;
+      }
     };
   }, []);
 
@@ -115,11 +129,22 @@ function AdminSystemPage() {
 
       // Poll until server comes back
       updatePollIntervalRef.current = setInterval(async () => {
+        // Abort any previous tick's request still in flight — otherwise slow
+        // (non-refused) failures could pile up and saturate the connection pool.
+        if (updatePollAbortRef.current) {
+          updatePollAbortRef.current.abort();
+        }
+        const controller = new AbortController();
+        updatePollAbortRef.current = controller;
         try {
-          const response = await makeAdminApiCall('/admin/version', { method: 'GET' });
+          const response = await makeAdminApiCall('/admin/version', {
+            method: 'GET',
+            signal: controller.signal
+          });
           if (response.data) {
             clearInterval(updatePollIntervalRef.current);
             updatePollIntervalRef.current = null;
+            updatePollAbortRef.current = null;
             setUpdateActionMessage(
               t('admin.system.updateSuccess', 'Update complete! Now running version {{version}}.', {
                 version: response.data.app
@@ -138,7 +163,11 @@ function AdminSystemPage() {
             }
           }
         } catch {
-          // Server not ready yet, keep polling
+          // Server not ready yet (or our own abort), keep polling
+        } finally {
+          if (updatePollAbortRef.current === controller) {
+            updatePollAbortRef.current = null;
+          }
         }
       }, 3000);
 
@@ -193,11 +222,20 @@ function AdminSystemPage() {
 
       // Poll until server comes back
       rollbackPollIntervalRef.current = setInterval(async () => {
+        if (rollbackPollAbortRef.current) {
+          rollbackPollAbortRef.current.abort();
+        }
+        const controller = new AbortController();
+        rollbackPollAbortRef.current = controller;
         try {
-          const response = await makeAdminApiCall('/admin/version', { method: 'GET' });
+          const response = await makeAdminApiCall('/admin/version', {
+            method: 'GET',
+            signal: controller.signal
+          });
           if (response.data) {
             clearInterval(rollbackPollIntervalRef.current);
             rollbackPollIntervalRef.current = null;
+            rollbackPollAbortRef.current = null;
             setUpdateActionMessage(
               t(
                 'admin.system.rollbackSuccess',
@@ -218,7 +256,11 @@ function AdminSystemPage() {
             }
           }
         } catch {
-          // Server not ready yet
+          // Server not ready yet (or our own abort)
+        } finally {
+          if (rollbackPollAbortRef.current === controller) {
+            rollbackPollAbortRef.current = null;
+          }
         }
       }, 3000);
 

--- a/client/src/features/admin/pages/AdminWorkflowExecutionsPage.jsx
+++ b/client/src/features/admin/pages/AdminWorkflowExecutionsPage.jsx
@@ -124,6 +124,12 @@ function AdminWorkflowExecutionsPage() {
 
   /** @type {React.MutableRefObject<NodeJS.Timeout|null>} */
   const pollTimerRef = useRef(null);
+  // Tracks the AbortController for the current in-flight loadExecutions request.
+  // Each new tick (or unmount) aborts the previous one so slow responses don't
+  // accumulate and saturate the browser's 6-connection-per-origin HTTP/1.1 pool
+  // — a steady 5s poll with 30s axios timeout could otherwise stack ~6 pending
+  // requests on a slow network and freeze the rest of the UI.
+  const inFlightAbortRef = useRef(null);
 
   /**
    * Loads executions from the admin API with current filter parameters.
@@ -133,6 +139,13 @@ function AdminWorkflowExecutionsPage() {
    */
   const loadExecutions = useCallback(
     async (showLoadingSpinner = false) => {
+      // Abort any prior in-flight request before issuing a new one.
+      if (inFlightAbortRef.current) {
+        inFlightAbortRef.current.abort();
+      }
+      const controller = new AbortController();
+      inFlightAbortRef.current = controller;
+
       try {
         if (showLoadingSpinner) {
           setLoading(true);
@@ -144,15 +157,21 @@ function AdminWorkflowExecutionsPage() {
           params.search = searchTerm.trim();
         }
 
-        const data = await fetchAdminExecutions(params);
+        const data = await fetchAdminExecutions(params, { signal: controller.signal });
 
         setExecutions(Array.isArray(data.executions) ? data.executions : []);
         setStats(data.stats || null);
         setTotal(data.total || 0);
       } catch (err) {
+        // Don't surface our own aborts — they're expected when a new tick
+        // supersedes the previous one or the component unmounts.
+        if (err.name === 'CanceledError' || err.name === 'AbortError') return;
         console.error('Error loading executions:', err);
         setError(err.message);
       } finally {
+        if (inFlightAbortRef.current === controller) {
+          inFlightAbortRef.current = null;
+        }
         if (showLoadingSpinner) {
           setLoading(false);
         }
@@ -181,6 +200,16 @@ function AdminWorkflowExecutionsPage() {
       }
     };
   }, [autoRefresh, loadExecutions]);
+
+  // Abort any in-flight request on unmount.
+  useEffect(() => {
+    return () => {
+      if (inFlightAbortRef.current) {
+        inFlightAbortRef.current.abort();
+        inFlightAbortRef.current = null;
+      }
+    };
+  }, []);
 
   /**
    * Handles cancelling a workflow execution with confirmation dialog.

--- a/client/src/features/tools/pages/JobListPage.jsx
+++ b/client/src/features/tools/pages/JobListPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { buildApiUrl } from '../../../utils/runtimeBasePath';
 import { apiClient } from '../../../api/client';
@@ -45,14 +45,28 @@ function ProgressBar({ value, max }) {
 export default function JobListPage() {
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(true);
+  // Abort the previous in-flight fetch when a new poll tick starts (or on
+  // unmount) so slow responses don't pile up against the browser's 6-connection
+  // HTTP/1.1 limit.
+  const inFlightAbortRef = useRef(null);
 
   const fetchJobs = useCallback(async () => {
+    if (inFlightAbortRef.current) {
+      inFlightAbortRef.current.abort();
+    }
+    const controller = new AbortController();
+    inFlightAbortRef.current = controller;
+
     try {
-      const res = await apiClient.get('/tools-service/jobs');
+      const res = await apiClient.get('/tools-service/jobs', { signal: controller.signal });
       setJobs(res.data);
-    } catch {
-      // Silently fail
+    } catch (err) {
+      if (err.name === 'CanceledError' || err.name === 'AbortError') return;
+      // Silently fail other errors
     } finally {
+      if (inFlightAbortRef.current === controller) {
+        inFlightAbortRef.current = null;
+      }
       setLoading(false);
     }
   }, []);
@@ -65,7 +79,13 @@ export default function JobListPage() {
       fetchJobs();
     }, 5000);
 
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      if (inFlightAbortRef.current) {
+        inFlightAbortRef.current.abort();
+        inFlightAbortRef.current = null;
+      }
+    };
   }, [fetchJobs]);
 
   const handleDownload = jobId => {

--- a/client/src/features/workflows/hooks/useMyExecutions.js
+++ b/client/src/features/workflows/hooks/useMyExecutions.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { apiClient } from '../../../api/client';
 import useFeatureFlags from '../../../shared/hooks/useFeatureFlags';
 
@@ -25,6 +25,10 @@ function useMyExecutions(options = {}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const featureFlags = useFeatureFlags();
+  // Abort the previous in-flight request whenever a new one starts, and on
+  // unmount. Polling pages call this on a 5s interval; without aborting, slow
+  // responses could stack up to the browser's 6-connection HTTP/1.1 limit.
+  const inFlightAbortRef = useRef(null);
 
   const fetchExecutions = useCallback(async () => {
     // Don't fetch if workflows feature is disabled
@@ -33,6 +37,12 @@ function useMyExecutions(options = {}) {
       setLoading(false);
       return;
     }
+
+    if (inFlightAbortRef.current) {
+      inFlightAbortRef.current.abort();
+    }
+    const controller = new AbortController();
+    inFlightAbortRef.current = controller;
 
     setLoading(true);
     setError(null);
@@ -43,13 +53,19 @@ function useMyExecutions(options = {}) {
       params.append('limit', String(limit));
       params.append('offset', String(offset));
 
-      const response = await apiClient.get(`/workflows/my-executions?${params.toString()}`);
+      const response = await apiClient.get(`/workflows/my-executions?${params.toString()}`, {
+        signal: controller.signal
+      });
       setExecutions(response.data || []);
     } catch (err) {
+      if (err.name === 'CanceledError' || err.name === 'AbortError') return;
       console.error('Failed to fetch executions:', err);
       setError(err.response?.data?.error || err.message || 'Failed to load executions');
       setExecutions([]);
     } finally {
+      if (inFlightAbortRef.current === controller) {
+        inFlightAbortRef.current = null;
+      }
       setLoading(false);
     }
   }, [status, limit, offset, featureFlags]);
@@ -57,6 +73,16 @@ function useMyExecutions(options = {}) {
   useEffect(() => {
     fetchExecutions();
   }, [fetchExecutions]);
+
+  // Abort any in-flight request on unmount.
+  useEffect(() => {
+    return () => {
+      if (inFlightAbortRef.current) {
+        inFlightAbortRef.current.abort();
+        inFlightAbortRef.current = null;
+      }
+    };
+  }, []);
 
   // Calculate running/paused count for badge display
   const runningCount = executions.filter(

--- a/client/src/features/workflows/hooks/useWorkflowExecution.js
+++ b/client/src/features/workflows/hooks/useWorkflowExecution.js
@@ -25,6 +25,11 @@ function useWorkflowExecution(executionId) {
   const [error, setError] = useState(null);
   const eventSourceRef = useRef(null);
   const reconnectTimeoutRef = useRef(null);
+  // Tracks whether the hook is still mounted. Used by the reconnect setTimeout
+  // to bail out if the component unmounted while the timer was pending —
+  // otherwise the reconnect creates a fresh EventSource that no cleanup path
+  // will ever close (per-page-visit leak).
+  const mountedRef = useRef(true);
   const featureFlags = useFeatureFlags();
 
   // Fetch initial execution state
@@ -226,6 +231,7 @@ function useWorkflowExecution(executionId) {
             }
           }));
           eventSource.close();
+          eventSourceRef.current = null;
           setConnected(false);
           // Refetch state after completion to ensure all data is loaded
           // (SSE event may have truncated data, server has the full state)
@@ -239,6 +245,7 @@ function useWorkflowExecution(executionId) {
             errors: [...(prev?.errors || []), data.error]
           }));
           eventSource.close();
+          eventSourceRef.current = null;
           setConnected(false);
           break;
 
@@ -248,6 +255,7 @@ function useWorkflowExecution(executionId) {
             status: 'cancelled'
           }));
           eventSource.close();
+          eventSourceRef.current = null;
           setConnected(false);
           break;
 
@@ -279,17 +287,17 @@ function useWorkflowExecution(executionId) {
       }
 
       reconnectTimeoutRef.current = setTimeout(() => {
+        // Bail out if the component unmounted while we were waiting — without
+        // this guard, the reconnect creates a brand-new EventSource that no
+        // cleanup function references, leaking the connection for the rest of
+        // the page session.
+        if (!mountedRef.current) return;
         // Only reconnect if execution is still running/paused
         if (state?.status === 'running' || state?.status === 'paused') {
           console.log('Attempting SSE reconnection...');
           connectSSE();
         }
       }, 3000);
-    };
-
-    return () => {
-      eventSource.close();
-      eventSourceRef.current = null;
     };
   }, [executionId, state?.status, featureFlags]);
 
@@ -360,6 +368,15 @@ function useWorkflowExecution(executionId) {
     fetchState();
   }, [fetchState]);
 
+  // Track mount status so the reconnect setTimeout in connectSSE can bail out
+  // if the component has unmounted before its 3s timer fires.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   // Connect SSE when execution is running or paused
   useEffect(() => {
     if (state && (state.status === 'running' || state.status === 'paused') && state.canReconnect) {
@@ -373,6 +390,7 @@ function useWorkflowExecution(executionId) {
       }
       if (reconnectTimeoutRef.current) {
         clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
       }
     };
   }, [state?.status, state?.canReconnect, connectSSE]);

--- a/client/src/shared/hooks/useEventSource.js
+++ b/client/src/shared/hooks/useEventSource.js
@@ -28,47 +28,50 @@ function useEventSource({ appId, chatId, timeoutDuration = 60000, onEvent, onPro
   const heartbeatIntervalRef = useRef(null);
   const fullContentRef = useRef('');
 
-  const cleanupEventSource = useCallback(async () => {
+  // Synchronously release the connection slot: abort the fetch and clear timers.
+  // Kept separate from cleanupEventSource so callers (and initEventSource) can
+  // tear the slot down without awaiting a 30s axios round-trip — that delay
+  // re-opened the original leak window (an in-flight fetch keeps holding its
+  // HTTP/1.1 slot until ac.abort() actually runs).
+  const abortAndClearTimers = useCallback(() => {
     const ac = abortControllerRef.current;
-    if (!ac) return;
-
     abortControllerRef.current = null;
 
-    // Clear timers
-    try {
-      if (heartbeatIntervalRef.current) {
-        clearInterval(heartbeatIntervalRef.current);
-        heartbeatIntervalRef.current = null;
-      }
-    } catch (err) {
-      console.error('Error clearing heartbeat interval:', err);
+    if (heartbeatIntervalRef.current) {
+      clearInterval(heartbeatIntervalRef.current);
+      heartbeatIntervalRef.current = null;
+    }
+    if (connectionTimeoutRef.current) {
+      clearTimeout(connectionTimeoutRef.current);
+      connectionTimeoutRef.current = null;
     }
 
-    try {
-      if (connectionTimeoutRef.current) {
-        clearTimeout(connectionTimeoutRef.current);
-        connectionTimeoutRef.current = null;
+    if (ac) {
+      try {
+        ac.abort();
+      } catch {
+        // already aborted — nothing to do
       }
-    } catch (err) {
-      console.error('Error clearing connection timeout:', err);
     }
 
-    // Tell the server to stop streaming
-    try {
-      if (appId && chatId) {
+    return !!ac;
+  }, []);
+
+  const cleanupEventSource = useCallback(async () => {
+    const wasActive = abortAndClearTimers();
+
+    // Best-effort notification to the server. Fire-and-forget — the server
+    // detects the disconnect via req.on('close') regardless, and we don't want
+    // a slow /stop call to delay the next stream the caller may immediately
+    // open (rapid send-button clicks would otherwise race; see B2 in audit).
+    if (wasActive && appId && chatId) {
+      try {
         await stopAppChatStream(appId, chatId);
+      } catch (err) {
+        console.warn('Failed to stop chat stream:', err);
       }
-    } catch (err) {
-      console.warn('Failed to stop chat stream:', err);
     }
-
-    // Abort the fetch
-    try {
-      ac.abort();
-    } catch (err) {
-      console.error('Error aborting SSE fetch:', err);
-    }
-  }, [appId, chatId]);
+  }, [appId, chatId, abortAndClearTimers]);
 
   const startHeartbeat = useCallback(() => {
     if (heartbeatIntervalRef.current) {
@@ -108,9 +111,17 @@ function useEventSource({ appId, chatId, timeoutDuration = 60000, onEvent, onPro
    */
   const initEventSource = useCallback(
     async url => {
-      // Clean up any existing stream first
-      if (abortControllerRef.current) {
-        await cleanupEventSource();
+      // Synchronously tear down any prior stream first. We deliberately do NOT
+      // `await cleanupEventSource()` here — that awaits stopAppChatStream
+      // (axios, 30s timeout), and during that window a re-entrant call would
+      // see abortControllerRef.current === null and proceed in parallel,
+      // orphaning the first controller (no ref left to abort it on unmount).
+      const hadPrior = abortAndClearTimers();
+      if (hadPrior && appId && chatId) {
+        // Notify the server in the background; do not block the new stream.
+        stopAppChatStream(appId, chatId).catch(err =>
+          console.warn('Failed to stop prior chat stream:', err)
+        );
       }
 
       fullContentRef.current = '';
@@ -227,6 +238,17 @@ function useEventSource({ appId, chatId, timeoutDuration = 60000, onEvent, onPro
         }
         if (onProcessingChange) onProcessingChange(false);
       } finally {
+        // Always abort the controller — release the HTTP/1.1 connection slot.
+        // The handleSseEvent 'done'/'error' path already aborts on the happy
+        // path; this finally covers the failure paths (mid-stream network
+        // error, malformed event, exception thrown by the consumer's onEvent
+        // callback) that would otherwise leave the fetch hanging in the
+        // browser's connection pool until TCP keep-alive expires.
+        try {
+          ac.abort();
+        } catch {
+          // already aborted — nothing to do
+        }
         // Ensure we don't hold a stale abort controller after the stream ends
         if (abortControllerRef.current === ac) {
           abortControllerRef.current = null;
@@ -242,6 +264,9 @@ function useEventSource({ appId, chatId, timeoutDuration = 60000, onEvent, onPro
       }
     },
     [
+      abortAndClearTimers,
+      appId,
+      chatId,
       cleanupEventSource,
       onProcessingChange,
       onEvent,
@@ -251,14 +276,19 @@ function useEventSource({ appId, chatId, timeoutDuration = 60000, onEvent, onPro
     ]
   );
 
-  // Cleanup on unmount
+  // Cleanup on unmount — release the slot synchronously, then notify the server
+  // in the background. Awaiting the public async cleanup here would race the
+  // browser navigation; abortAndClearTimers is enough to free the connection.
   useEffect(() => {
     return () => {
-      cleanupEventSource();
-      if (heartbeatIntervalRef.current) clearInterval(heartbeatIntervalRef.current);
-      if (connectionTimeoutRef.current) clearTimeout(connectionTimeoutRef.current);
+      abortAndClearTimers();
+      if (appId && chatId) {
+        stopAppChatStream(appId, chatId).catch(() => {
+          // server may be unreachable on tab close — best effort only
+        });
+      }
     };
-  }, [cleanupEventSource]);
+  }, [abortAndClearTimers, appId, chatId]);
 
   return {
     initEventSource,

--- a/client/src/shared/utils/parseSseStream.js
+++ b/client/src/shared/utils/parseSseStream.js
@@ -74,6 +74,7 @@ export async function parseSseStream(body, onEvent, signal) {
     // id: and retry: fields are intentionally ignored here
   };
 
+  let completedCleanly = false;
   try {
     while (true) {
       if (signal?.aborted) {
@@ -109,7 +110,23 @@ export async function parseSseStream(body, onEvent, signal) {
         processLine(line);
       }
     }
+    completedCleanly = true;
   } finally {
-    reader.releaseLock();
+    // If we exited via an exception (e.g. consumer's onEvent threw), the
+    // underlying body stream is still flowing — releaseLock alone won't
+    // close the socket. Cancel the reader so the browser releases the
+    // HTTP/1.1 connection slot.
+    if (!completedCleanly) {
+      try {
+        await reader.cancel();
+      } catch {
+        // already cancelled — nothing to do
+      }
+    }
+    try {
+      reader.releaseLock();
+    } catch {
+      // already released (cancel() releases the lock on some implementations)
+    }
   }
 }

--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -346,6 +346,7 @@ export default function registerSessionRoutes(
         res.setHeader('Content-Type', 'text/event-stream');
         res.setHeader('Cache-Control', 'no-cache');
         res.setHeader('Connection', 'keep-alive');
+        res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
         clients.set(chatId, { response: res, lastActivity: new Date(), appId });
         // Pin this registration so a stale close handler from a previous SSE on the
         // same chatId can't delete a fresh entry (or abort a fresh active request)
@@ -353,7 +354,24 @@ export default function registerSessionRoutes(
         const myEntry = clients.get(chatId);
         actionTracker.trackConnected(chatId);
 
+        // Heartbeat: write an SSE comment every 30s so reverse proxies (nginx
+        // default idle timeout is 60s) don't silently kill the connection.
+        // If the write throws, the socket is dead — clear the interval and
+        // let req.on('close') handle the rest of the cleanup.
+        const heartbeatInterval = setInterval(() => {
+          if (clients.get(chatId) !== myEntry) {
+            clearInterval(heartbeatInterval);
+            return;
+          }
+          try {
+            res.write(': heartbeat\n\n');
+          } catch {
+            clearInterval(heartbeatInterval);
+          }
+        }, 30000);
+
         req.on('close', () => {
+          clearInterval(heartbeatInterval);
           if (clients.get(chatId) !== myEntry) return;
           if (activeRequests.has(chatId)) {
             try {
@@ -751,8 +769,15 @@ export default function registerSessionRoutes(
             user: req.user
           });
         } else {
-          const clientRes = clients.get(chatId).response;
-          clients.set(chatId, { ...clients.get(chatId), lastActivity: new Date() });
+          // Mutate the existing entry in place rather than replacing it. The SSE
+          // GET handler pins this object reference via `myEntry` to identify a
+          // stale `req.on('close')` after a reconnect; replacing the entry here
+          // would defeat that check, letting a dead socket's close handler bail
+          // out and leak the Map entry + activeRequests controller for up to
+          // 5 minutes until cleanupInactiveClients evicts it.
+          const clientEntry = clients.get(chatId);
+          const clientRes = clientEntry.response;
+          clientEntry.lastActivity = new Date();
           const prep = await chatService.prepareChatRequest({
             appId,
             modelId,

--- a/server/routes/openaiProxy.js
+++ b/server/routes/openaiProxy.js
@@ -250,6 +250,23 @@ export default function registerOpenAIProxyRoutes(app, { basePath = '' } = {}) {
       });
     }
 
+    // Track client disconnection so we can abort the upstream LLM call instead
+    // of streaming tokens into a dead socket for the full generation duration.
+    // Without this, a closed browser tab silently wastes provider tokens AND
+    // any errors after headers were sent leave the response in an inconsistent
+    // state (the JSON-error fallback at the bottom throws ERR_HTTP_HEADERS_SENT).
+    const upstreamAbort = new AbortController();
+    let clientDisconnected = false;
+    const onClientClose = () => {
+      clientDisconnected = true;
+      try {
+        upstreamAbort.abort();
+      } catch {
+        // already aborted — nothing to do
+      }
+    };
+    req.on('close', onClientClose);
+
     try {
       const request = createCompletionRequest(model, messages, apiKey, {
         stream,
@@ -264,7 +281,8 @@ export default function registerOpenAIProxyRoutes(app, { basePath = '' } = {}) {
       const llmResponse = await throttledFetch(model.id, request.url, {
         method: 'POST',
         headers: request.headers,
-        body: JSON.stringify(request.body)
+        body: JSON.stringify(request.body),
+        signal: upstreamAbort.signal
       });
 
       res.status(llmResponse.status);
@@ -313,6 +331,7 @@ export default function registerOpenAIProxyRoutes(app, { basePath = '' } = {}) {
 
         try {
           while (true) {
+            if (clientDisconnected) break;
             const { done, value } = await reader.read();
             if (done) break;
 
@@ -485,11 +504,17 @@ export default function registerOpenAIProxyRoutes(app, { basePath = '' } = {}) {
             }
           }
         } finally {
-          reader.releaseLock();
+          try {
+            reader.releaseLock();
+          } catch {
+            // already released
+          }
         }
 
-        res.write('data: [DONE]\n\n');
-        res.end();
+        if (!clientDisconnected && !res.writableEnded) {
+          res.write('data: [DONE]\n\n');
+          res.end();
+        }
       } else {
         const data = await llmResponse.text();
 
@@ -549,19 +574,39 @@ export default function registerOpenAIProxyRoutes(app, { basePath = '' } = {}) {
         }
       }
     } catch (error) {
-      logger.error('[OpenAI Proxy] Error occurred', {
-        component: 'OpenAIProxy',
-        error: error,
-        modelId,
-        provider: model?.provider,
-        stream
-      });
-      const lang =
-        req.headers['accept-language']?.split(',')[0] ||
-        configCache.getPlatform()?.defaultLanguage ||
-        'en';
-      const msg = await getLocalizedError('internalError', {}, lang);
-      res.status(500).json({ error: msg });
+      // Aborts triggered by client disconnect are expected, not real errors.
+      const isAbort =
+        clientDisconnected || error?.name === 'AbortError' || error?.code === 'ERR_ABORTED';
+      if (!isAbort) {
+        logger.error('[OpenAI Proxy] Error occurred', {
+          component: 'OpenAIProxy',
+          error: error,
+          modelId,
+          provider: model?.provider,
+          stream
+        });
+      }
+      // If headers were already sent (mid-stream failure), we can't send a
+      // JSON error — that throws ERR_HTTP_HEADERS_SENT and leaves the response
+      // dangling. End the stream cleanly instead.
+      if (res.headersSent) {
+        if (!res.writableEnded) {
+          try {
+            res.end();
+          } catch {
+            // already closed
+          }
+        }
+      } else if (!isAbort) {
+        const lang =
+          req.headers['accept-language']?.split(',')[0] ||
+          configCache.getPlatform()?.defaultLanguage ||
+          'en';
+        const msg = await getLocalizedError('internalError', {}, lang);
+        res.status(500).json({ error: msg });
+      }
+    } finally {
+      req.off('close', onClientClose);
     }
   });
 }

--- a/server/routes/toolsService/jobStore.js
+++ b/server/routes/toolsService/jobStore.js
@@ -90,6 +90,11 @@ export function listJobs(userId, isAdmin, filters = {}) {
 
 /**
  * Send SSE update to all connected clients for a job.
+ *
+ * Wraps each client's write/end in its own try/catch — without this, the first
+ * dead socket throws and aborts iteration, so every later client misses the
+ * update AND the `job.clients = []` reset below is skipped (causing repeated
+ * notifyClients() calls to spam errors against the same dead sockets).
  */
 export function notifyClients(job) {
   if (!job.clients || job.clients.length === 0) return;
@@ -102,15 +107,23 @@ export function notifyClients(job) {
     model: job.model || null
   };
   const message = `data: ${JSON.stringify(payload)}\n\n`;
+  const isTerminal =
+    job.status === 'completed' || job.status === 'error' || job.status === 'cancelled';
 
+  const survivors = [];
   for (const res of job.clients) {
-    res.write(message);
-    if (job.status === 'completed' || job.status === 'error' || job.status === 'cancelled') {
-      res.end();
+    try {
+      res.write(message);
+      if (isTerminal) {
+        res.end();
+      } else {
+        survivors.push(res);
+      }
+    } catch {
+      // Dead socket — drop this client. The HTTP layer will reclaim the
+      // connection slot on its own; we just stop trying to write to it.
     }
   }
 
-  if (job.status === 'completed' || job.status === 'error' || job.status === 'cancelled') {
-    job.clients = [];
-  }
+  job.clients = isTerminal ? [] : survivors;
 }

--- a/server/routes/workflow/workflowRoutes.js
+++ b/server/routes/workflow/workflowRoutes.js
@@ -1272,6 +1272,13 @@ export default function registerWorkflowRoutes(app, deps = {}) {
         response: res,
         lastActivity: new Date()
       });
+      // Pin this registration: if a fresh SSE GET reconnects on the same
+      // executionId, the Map entry is replaced. We don't want this connection's
+      // close handler to then delete the new entry (or remove the new
+      // listener) and we don't want the new connection to delete THIS entry
+      // when it registers. Identity-pinning lets the close handler bail out
+      // when it's stale.
+      const myEntry = workflowClients.get(executionId);
 
       // Send initial connection event
       res.write(`event: connected\ndata: ${JSON.stringify({ executionId })}\n\n`);
@@ -1356,23 +1363,11 @@ export default function registerWorkflowRoutes(app, deps = {}) {
       // Register event handler
       actionTracker.on('fire-sse', handleWorkflowEvent);
 
-      // Handle client disconnect
-      req.on('close', () => {
-        // Remove event listener
-        actionTracker.off('fire-sse', handleWorkflowEvent);
-
-        // Remove client from map
-        workflowClients.delete(executionId);
-
-        logger.info('SSE connection closed for workflow execution', {
-          component: 'WorkflowRoutes',
-          executionId
-        });
-      });
-
       // Send periodic heartbeat to keep connection alive
       const heartbeatInterval = setInterval(() => {
-        if (!workflowClients.has(executionId)) {
+        // Only this connection's heartbeat operates on its own entry — if a
+        // newer SSE replaced us, stop heartbeating (the new one has its own).
+        if (workflowClients.get(executionId) !== myEntry) {
           clearInterval(heartbeatInterval);
           return;
         }
@@ -1381,13 +1376,33 @@ export default function registerWorkflowRoutes(app, deps = {}) {
           res.write(`: heartbeat\n\n`);
         } catch (_err) {
           clearInterval(heartbeatInterval);
-          workflowClients.delete(executionId);
+          // Only delete if this is still our entry — don't wipe a successor.
+          if (workflowClients.get(executionId) === myEntry) {
+            workflowClients.delete(executionId);
+          }
         }
       }, 30000); // 30 second heartbeat
 
-      // Clean up heartbeat on disconnect
+      // Handle client disconnect. Combined into one handler so cleanup is
+      // atomic — both the actionTracker listener removal and the Map deletion
+      // are gated by the identity check.
       req.on('close', () => {
         clearInterval(heartbeatInterval);
+        // Always remove THIS connection's listener — it's tied to this closure
+        // and would otherwise leak with each reconnect.
+        actionTracker.off('fire-sse', handleWorkflowEvent);
+
+        // Only remove the Map entry if it's still ours. A fresh SSE GET on
+        // the same executionId would have already replaced it; deleting now
+        // would orphan the new connection.
+        if (workflowClients.get(executionId) === myEntry) {
+          workflowClients.delete(executionId);
+        }
+
+        logger.info('SSE connection closed for workflow execution', {
+          component: 'WorkflowRoutes',
+          executionId
+        });
       });
     }
   );

--- a/server/serverHelpers.js
+++ b/server/serverHelpers.js
@@ -65,11 +65,22 @@ export function cleanupInactiveClients() {
             logger.error('Error aborting request for chat', {
               component: 'SSE',
               chatId,
-              error: e
+              error: error?.message || String(error)
             });
           }
         }
-        client.response.end();
+        try {
+          client.response.end();
+        } catch (endErr) {
+          // The socket may already be dead — end() can throw on an already
+          // destroyed stream. We're cleaning up anyway, so just log and
+          // continue.
+          logger.warn('Error ending inactive client response', {
+            component: 'SSE',
+            chatId,
+            error: endErr?.message || String(endErr)
+          });
+        }
         clients.delete(chatId);
         logger.info('Removed inactive client', { component: 'SSE', chatId });
       }

--- a/server/sse.js
+++ b/server/sse.js
@@ -17,7 +17,34 @@ actionTracker.on('fire-sse', step => {
     try {
       sendSSE(clientEntry.response, event, step);
     } catch (error) {
-      logger.error('Error sending SSE action event', { component: 'SSE', error: err });
+      // The socket is most likely dead (peer closed, write-after-end, etc.).
+      // Without this cleanup, every subsequent fire-sse event would re-throw
+      // and the Map entry would linger until cleanupInactiveClients evicts it
+      // 5 minutes later — meanwhile the LLM keeps streaming into a void and
+      // the activeRequests controller leaks.
+      logger.error('Error sending SSE action event; tearing down dead client', {
+        component: 'SSE',
+        chatId,
+        error: error?.message || String(error)
+      });
+      try {
+        const controller = activeRequests.get(chatId);
+        if (controller) {
+          controller.abort();
+          activeRequests.delete(chatId);
+        }
+      } catch (abortErr) {
+        logger.error('Error aborting activeRequest after SSE write failure', {
+          component: 'SSE',
+          chatId,
+          error: abortErr?.message || String(abortErr)
+        });
+      }
+      // Only delete the entry if it's still the one we just wrote to — avoids
+      // wiping out a freshly-reconnected entry on the same chatId.
+      if (clients.get(chatId) === clientEntry) {
+        clients.delete(chatId);
+      }
     }
   }
 });


### PR DESCRIPTION
## Summary

Follow-up audit of the customer-reported "frozen webclient" symptom that commit 57ce55d only partially addressed. That fix released the slot on the SSE happy path (`done`/`error` events); this PR closes every other path I could find that can hold an HTTP/1.1 connection slot open until TCP keep-alive expires.

Each leak below could on its own saturate the browser's **6-connection-per-origin** pool and make every subsequent `fetch` (page navigation, watchdog pings, SSE reconnect) queue forever — the exact "server appears down from this browser" symptom customers reported.

## A. HIGH-severity leaks — actively causing the symptom

### A1. `server/routes/chat/sessionRoutes.js:755` — POST silently defeated the recent fix
```js
clients.set(chatId, { ...clients.get(chatId), lastActivity: new Date() });
```
Replaced the Map entry with a fresh object literal on every chat message. After the first POST, the SSE GET's `myEntry` identity check no longer matched the live entry, so `req.on('close')` always bailed — leaking the entry **and** the `activeRequests` controller for up to 5 minutes until `cleanupInactiveClients` evicted them. Now mutates in place.

### A2. `client/src/shared/hooks/useEventSource.js` — catch block didn't abort
The previous fix added `ac.abort()` on the `done`/`error` SSE event path. The mid-stream error path (network blip, parse error, exception thrown by consumer's `onEvent`) still only nulled `abortControllerRef`. Same bug class, different code path. Now aborts in `finally` so every termination releases the slot.

Also split cleanup into a synchronous `abortAndClearTimers` + fire-and-forget `stopAppChatStream`:
- the previous `await stopAppChatStream(...)` delayed `ac.abort()` by up to 30 s (axios timeout) when the server's `/stop` endpoint hung;
- a re-entrant `initEventSource` (rapid send-button clicks) could orphan the first controller during that await window.

### A3. `client/src/features/workflows/hooks/useWorkflowExecution.js` — reconnect outlived unmount
`onerror` scheduled a 3 s reconnect `setTimeout`; if the component unmounted before it fired, the timer created a fresh `EventSource` that no cleanup path referenced. Added `mountedRef` guard. Also null `eventSourceRef.current` after `close()` in each `workflow.*` terminal event handler.

## B. MEDIUM-severity amplifiers

### B1. Four polling pages stacked axios requests on slow networks
`AdminSystemPage`, `AdminWorkflowExecutionsPage`, `MyExecutionsTab`, `JobListPage` — all poll every 3–5 s with axios (30 s timeout) without aborting the previous tick's in-flight request. On slow networks this can stack ~6 requests by itself and hit the 6-connection limit. Each poll now creates its own `AbortController`, aborts the prior, and aborts on unmount. `fetchAdminExecutions` and `makeAdminApiCall` plumb a `signal` option through.

### B3. `server/sse.js` — `fire-sse` handler logged ReferenceError, didn't clean dead clients
```js
} catch (error) {
  logger.error('Error sending SSE action event', { component: 'SSE', error: err }); // ← err undefined
}
```
On `res.write` failure, neither aborted `activeRequests` nor removed the dead `clients` entry — every subsequent `fire-sse` re-threw and the entry lingered until 5-min cleanup. Now logs the actual `error`, aborts the controller, and deletes the entry (identity-checked so a fresh reconnect isn't wiped).

### B4. `server/routes/openaiProxy.js` — no `req.on('close')`, leaked upstream LLM
A closed browser tab silently wasted provider tokens for the full generation duration, and mid-stream errors *after* headers were sent threw `ERR_HTTP_HEADERS_SENT` trying to send a JSON error. Added `AbortController` wired to the upstream `throttledFetch` + a `clientDisconnected` flag that breaks the read loop, end the response cleanly on headers-sent errors, and remove the listener in `finally`.

## C. Defense-in-depth

- **`server/routes/workflow/workflowRoutes.js`** — apply identity pinning so reconnect on the same `executionId` doesn't leak the prior `actionTracker` listener or delete the new entry via the old close handler. Consolidate the two `req.on('close')` handlers.
- **`server/routes/toolsService/jobStore.js`** — `notifyClients` now wraps each client's write/end in its own try/catch. Previously the first dead socket threw and aborted iteration, so every later client missed the update AND the `job.clients = []` terminal reset was skipped (causing repeated calls to spam errors against the same dead sockets).
- **`server/serverHelpers.js`** — fix the parallel ReferenceError (`e` instead of `error`) in `cleanupInactiveClients`'s catch; wrap `client.response.end()` for already-destroyed sockets.
- **`server/routes/chat/sessionRoutes.js`** — add a 30 s heartbeat to the SSE channel so reverse proxies (nginx default 60 s idle timeout) don't silently sever the connection. Also added `X-Accel-Buffering: no` to disable nginx response buffering.
- **`client/src/shared/utils/parseSseStream.js`** — call `reader.cancel()` in `finally` when the read loop exited abnormally (consumer's `onEvent` threw). `releaseLock` alone doesn't tear down the body stream — pairs with A2.

## Why the recent fix wasn't enough

The recent fix (57ce55d) correctly identified the leak mechanism (HTTP/1.1 slot held until TCP keep-alive expires) and fixed the most visible path (`done`/`error` SSE events). But:

1. **`sessionRoutes.js:755` silently re-opened the leak window** on the same chatId after the first message — the identity check that the fix relied on was being invalidated by a spread-replace one screen down in the same file.
2. **Several other code paths produce the same class of leak**: the catch block of `useEventSource`, polling pages without abort, the openaiProxy streaming endpoint, the workflow reconnect timer.

This PR closes all of them.

## Test plan

- [x] `npm run lint:fix` — 0 errors, all warnings pre-existing in unrelated files
- [x] `npm run format:fix` — no formatting changes needed in modified files
- [x] Server boot smoke check — all 4 cluster workers start, `/api/health` returns 200
- [ ] **Manual browser reproduction (needs human verification)**: open compare mode with a working LLM key, send 6+ rounds, watch DevTools Network panel — no pending streams should accumulate. Repeat in single-chat mode. Repeat with a "Stop" mid-generation to exercise the error path.
- [ ] **Workflow page**: navigate away during a running execution, return, repeat 5+ times — workflow SSE connection count in DevTools should stay at 1.
- [ ] **Admin → System → "Check for updates"**: trigger an update while the network is throttled to slow-3G; the admin page should still respond and not freeze.

## Risk

All changes are additive cleanups around existing call sites. Notable behavioral changes:
- `useEventSource.cleanupEventSource` no longer awaits `stopAppChatStream` before aborting. The server still detects the disconnect via `req.on('close')`, so the only externally observable change is faster slot release. The fire-and-forget POST still runs, just unblocked.
- `openaiProxy` now ends the response on mid-stream failure instead of trying (and failing) to send a JSON error. Clients receive a truncated stream instead of an `ERR_HTTP_HEADERS_SENT` from the proxy.
- The chat SSE now emits `: heartbeat\n\n` every 30 s. Existing clients already ignore SSE comment lines per spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpDWqsTVmay6NwByAVh3UU)_