### PR TITLE
feat(logging): auto-inject userId, oauthClientId, ip per request

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -218,6 +218,45 @@ Use descriptive component names that identify the source of the log:
 - **RequestBuilder**: Request building
 - **[RouteName]**: Route-specific logs (e.g., DataRoutes, AdminRoutes)
 
+### Automatic Request Context (`userId`, `oauthClientId`, `ip`)
+
+Every log entry emitted while handling an HTTP request automatically carries three additional fields, so logs can be filtered by who triggered them and from where:
+
+| Field | Source | Notes |
+|-------|--------|-------|
+| `userId` | `req.user.id` | The authenticated user. For OAuth client_credentials tokens this equals the OAuth client id (the token has no human subject). `'anonymous'` for unauthenticated traffic. |
+| `oauthClientId` | OAuth metadata on `req.user` | Set when the request was authenticated via an OAuth client — either client_credentials / static API key (`req.user.isOAuthClient`) or user-delegated authorization_code (`req.user.clientId`). Omitted for non-OAuth requests. |
+| `ip` | `req.ip` | Calling IP address, resolved via Express `trust proxy` so `X-Forwarded-For` is honoured behind a reverse proxy. |
+
+**How it works:** A middleware installed early in `server/middleware/setup.js` opens an `AsyncLocalStorage` scope per request (see `server/utils/requestContext.js`). The logger reads from this store on every call and merges the fields in. Caller-supplied fields always win — e.g. if you explicitly log `{ userId: 'audited-subject' }` for an admin action, that value is not overwritten.
+
+**Example output for an authenticated request:**
+
+```json
+{"component":"AppsRoutes","level":"info","timestamp":"...","message":"App started","appId":"chat","userId":"alice@example.com","oauthClientId":"web-spa","ip":"203.0.113.7"}
+```
+
+**Example output for an anonymous request:**
+
+```json
+{"component":"AppsRoutes","level":"info","timestamp":"...","message":"App started","appId":"chat","userId":"anonymous","ip":"203.0.113.7"}
+```
+
+**Filtering by user / client / IP with `jq`:**
+
+```bash
+# All actions by a specific user
+cat logs/app.log | jq 'select(.userId == "alice@example.com")'
+
+# All traffic from a specific OAuth client
+cat logs/app.log | jq 'select(.oauthClientId == "ci-pipeline")'
+
+# All actions from a specific IP
+cat logs/app.log | jq 'select(.ip == "203.0.113.7")'
+```
+
+Logs emitted outside a request (server startup, scheduled background jobs, cluster master) do not have these fields — the context store is unset in those code paths.
+
 ### Log Format
 
 #### JSON Format (Default)

--- a/server/middleware/setup.js
+++ b/server/middleware/setup.js
@@ -17,6 +17,7 @@ import config from '../config.js';
 import configCache from '../configCache.js';
 import tokenStorageService from '../services/TokenStorageService.js';
 import logger from '../utils/logger.js';
+import { runWithContext, setContext } from '../utils/requestContext.js';
 import activityTracker from '../telemetry/ActivityTracker.js';
 
 /**
@@ -398,6 +399,22 @@ export function setupMiddleware(app, platformConfig = {}) {
   // Trust proxy for proper IP and protocol detection
   app.set('trust proxy', 1);
 
+  // Open the per-request logging context. Subsequent middleware and route
+  // handlers run inside an AsyncLocalStorage scope, so every logger call on
+  // the request's async chain gets userId / oauthClientId / ip merged in
+  // automatically. The store is a mutable object: the auth chain below
+  // mutates it with user/client info once authentication has resolved.
+  app.use((req, res, next) => {
+    runWithContext(
+      {
+        ip: req.ip,
+        userId: undefined,
+        oauthClientId: undefined
+      },
+      () => next()
+    );
+  });
+
   // CORS options are resolved per-request from the live platform config so
   // changes saved via /api/admin/cors/config take effect without a server
   // restart. The cors() middleware accepts a (req, callback) -> options
@@ -584,6 +601,25 @@ export function setupMiddleware(app, platformConfig = {}) {
       platformConfig // Pass platform config to respect NTLM requirements
     )
   );
+
+  // Populate the request logging context with the authenticated identity so
+  // every subsequent log line carries userId / oauthClientId. The store was
+  // opened earlier in the middleware chain (right after trust proxy) with a
+  // mutable object — see runWithContext above.
+  app.use((req, res, next) => {
+    if (req.user) {
+      const updates = { userId: req.user.id };
+      // OAuth client_credentials / static API key: req.user.id IS the client id.
+      // OAuth authorization_code (user-delegated): req.user.clientId is set.
+      if (req.user.isOAuthClient) {
+        updates.oauthClientId = req.user.id;
+      } else if (req.user.clientId) {
+        updates.oauthClientId = req.user.clientId;
+      }
+      setContext(updates);
+    }
+    next();
+  });
 
   // Enhance user with permissions after authentication
   app.use((req, res, next) => {

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -1,4 +1,5 @@
 import winston from 'winston';
+import { getContext } from './requestContext.js';
 
 // Default log level and format (fallback if not configured)
 const DEFAULT_LOG_LEVEL = 'info';
@@ -286,8 +287,38 @@ function processLogArgs(args) {
     }
   }
 
+  // Merge per-request context (userId, oauthClientId, ip) so logs are
+  // attributable without each call site having to pass them through.
+  // Caller-provided fields always win.
+  logData = mergeRequestContext(logData);
+
   // Redact sensitive information from the log data
   return redactSensitiveData(logData);
+}
+
+/**
+ * Merge fields from the active request context into the log data without
+ * overriding fields explicitly set by the caller. Returns the data unchanged
+ * when called outside a request (e.g. server startup, background jobs).
+ *
+ * @param {Object} logData - Structured log data.
+ * @returns {Object} Log data with request context fields merged in.
+ */
+function mergeRequestContext(logData) {
+  const ctx = getContext();
+  if (!ctx) return logData;
+
+  const merged = { ...logData };
+  if (ctx.userId !== undefined && merged.userId === undefined) {
+    merged.userId = ctx.userId;
+  }
+  if (ctx.oauthClientId !== undefined && merged.oauthClientId === undefined) {
+    merged.oauthClientId = ctx.oauthClientId;
+  }
+  if (ctx.ip !== undefined && merged.ip === undefined) {
+    merged.ip = ctx.ip;
+  }
+  return merged;
 }
 
 /**

--- a/server/utils/requestContext.js
+++ b/server/utils/requestContext.js
@@ -1,0 +1,57 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+/**
+ * Per-request context propagated through async boundaries via AsyncLocalStorage.
+ *
+ * Fields:
+ *   - userId          The authenticated user id (or 'anonymous' / null). For
+ *                     OAuth client_credentials tokens this is the client id.
+ *   - oauthClientId   The OAuth client id when the request was authenticated
+ *                     via an OAuth client (client_credentials, static API key,
+ *                     or user-delegated authorization code).
+ *   - ip              The calling IP address as resolved by Express (respects
+ *                     trust proxy).
+ *
+ * The logger reads from this store on every log call and merges these fields
+ * into the structured log entry, so log filtering by user / OAuth client / IP
+ * works without touching every individual log site.
+ */
+const storage = new AsyncLocalStorage();
+
+/**
+ * Run the given callback inside a request context. Any subsequent log calls
+ * made on the same async chain see the provided fields.
+ *
+ * @param {Object} initialContext - Initial context fields (mutable object).
+ * @param {Function} callback - Function invoked inside the context.
+ */
+export function runWithContext(initialContext, callback) {
+  storage.run(initialContext || {}, callback);
+}
+
+/**
+ * Get the current request context, or undefined when called outside a request.
+ * @returns {Object|undefined}
+ */
+export function getContext() {
+  return storage.getStore();
+}
+
+/**
+ * Merge updates into the current request context. No-op when called outside
+ * a request (which is intentional — background tasks have no context).
+ *
+ * @param {Object} updates - Fields to merge into the context.
+ */
+export function setContext(updates) {
+  const store = storage.getStore();
+  if (store && updates && typeof updates === 'object') {
+    Object.assign(store, updates);
+  }
+}
+
+export default {
+  runWithContext,
+  getContext,
+  setContext
+};


### PR DESCRIPTION
## Summary

Closes #1439.

Every log entry emitted while handling an HTTP request now carries three extra fields so logs can be filtered by who triggered an action and from where:

| Field | Source |
|-------|--------|
| `userId` | `req.user.id` (the user, or the OAuth client id for client_credentials tokens, or `'anonymous'`) |
| `oauthClientId` | OAuth metadata on `req.user` — set for client_credentials, static API key, and user-delegated authorization_code flows |
| `ip` | `req.ip` (respects `trust proxy`, so `X-Forwarded-For` is honoured behind a reverse proxy) |

Implementation uses Node's `AsyncLocalStorage` so individual log call sites do not need to be edited — the logger merges the context fields in automatically. Caller-supplied fields always win (e.g. an admin audit log that explicitly passes `userId: 'audited-subject'` is not overwritten).

## Changes

- New `server/utils/requestContext.js` exposing `runWithContext` / `getContext` / `setContext`.
- `server/utils/logger.js` merges context fields into structured log data inside `processLogArgs`.
- `server/middleware/setup.js`:
  - Opens the context right after `app.set('trust proxy', 1)` with `req.ip`.
  - Fills in `userId` / `oauthClientId` after the auth chain, handling all three OAuth identity shapes (`isOAuthClient`, `clientId`, plain user).
- `docs/logging.md`: new "Automatic Request Context" section with field reference, example output, and `jq` filtering recipes.

Logs emitted outside a request (server startup, background jobs, cluster master) are unchanged — the context store is unset in those code paths.

## Test plan

- [x] Unit-style smoke test for `requestContext.js`: outside / inside / async-boundary / post-run all behave correctly.
- [x] End-to-end logger smoke test confirms `userId` / `oauthClientId` / `ip` appear in JSON output inside the context, that caller-supplied fields override context, and that logs outside the context are unaffected.
- [x] `npx eslint` and `npx prettier --check` pass on all changed files.
- [ ] Manual verification against a running server with anonymous, local-auth, OAuth client_credentials, and OAuth authorization_code requests (could not run full server in sandbox due to unrelated `pdfjs-dist` / `@napi-rs/canvas` issue).


---
_Generated by [Claude Code](https://claude.ai/code/session_01X7i8CjQg4dVova7rMUoLus)_