### PR TITLE
fix: add uuid as explicit server dependency

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -51,6 +51,7 @@
         "selenium-webdriver": "^4.20.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1",
+        "uuid": "^11.1.0",
         "winston": "^3.19.0",
         "yauzl": "^3.2.1",
         "zod": "^3.25.74",
@@ -13945,6 +13946,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/server/package.json
+++ b/server/package.json
@@ -60,7 +60,8 @@
     "yauzl": "^3.2.1",
     "zod": "^3.25.74",
     "zod-to-json-schema": "^3.24.6",
-    "html-to-text": "^9.0.5"
+    "html-to-text": "^9.0.5",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",


### PR DESCRIPTION
## Summary

- `uuid` was imported by 6 server files but never declared in `server/package.json`
- This caused `ERR_MODULE_NOT_FOUND: Cannot find package 'uuid'` on startup in 5.3.13
- Fix: add `uuid: ^11.1.0` to `server/package.json` dependencies (matching the version already present in `package-lock.json`)

## Affected files

All of these import `{ v4 as uuidv4 } from 'uuid'`:
- `server/utils/userManager.js`
- `server/utils/oauthClientManager.js`
- `server/routes/admin/auth.js`
- `server/services/workflow/WorkflowEngine.js`
- `server/services/workflow/StateManager.js`
- `server/services/workflow/executors/HumanNodeExecutor.js`

## Test plan

- [ ] Run `npm install` in `server/` and verify `uuid` is installed
- [ ] Start the server and confirm no `ERR_MODULE_NOT_FOUND` for `uuid`
- [ ] Verify user creation (which calls `uuidv4()`) still works

https://claude.ai/code/session_01Wae7DmnsSHdFaYNyVTUHHo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wae7DmnsSHdFaYNyVTUHHo)_