### PR TITLE
docs: rewrite upload feature documentation to cover all upload types

### DIFF
--- a/docs/file-upload-feature.md
+++ b/docs/file-upload-feature.md
@@ -1,251 +1,308 @@
-# File Upload Feature Documentation
+# Upload Feature Documentation
 
 ## Overview
 
-The file upload feature allows users to upload text files, PDF documents, Microsoft Office documents (.docx), OpenOffice/LibreOffice documents (.odt, .ods, .odp), and email files (.msg, .eml) to the iHub Apps chat interface. The uploaded content is automatically processed and included in the AI conversation.
+iHub Apps supports a unified upload system that enables users to attach files, images, audio recordings, and cloud storage documents to their AI conversations. All upload types are configured together under the `upload` key in the app configuration.
+
+## Upload Types
+
+Four upload sub-types are available, each independently enabled:
+
+| Type | Description | Default size limit |
+|------|-------------|--------------------|
+| `fileUpload` | Text documents, PDFs, Office files, email files | 5 MB |
+| `imageUpload` | JPEG, PNG, GIF, WebP, TIFF images | 10 MB |
+| `audioUpload` | MP3, WAV, FLAC, OGG, MP4 audio | 20 MB |
+| `cloudStorageUpload` | Google Drive, OneDrive, Nextcloud | — |
+
+## Configuration
+
+All upload types share a single `upload` object in the app configuration:
+
+```json
+{
+  "upload": {
+    "enabled": true,
+    "allowMultiple": false,
+    "fileUpload": { "enabled": true },
+    "imageUpload": { "enabled": true },
+    "audioUpload": { "enabled": true },
+    "cloudStorageUpload": { "enabled": true }
+  }
+}
+```
+
+### Top-Level Options
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Master switch — must be `true` for any upload to work |
+| `allowMultiple` | boolean | `false` | Allow selecting multiple files at once (applies to all types) |
+
+### `fileUpload` Options
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable document/file attachment |
+| `maxFileSizeMB` | number (1–100) | `5` | Maximum file size in megabytes |
+| `supportedFormats` | string[] | See below | MIME types accepted for upload |
+
+Default `supportedFormats` for `fileUpload`:
+
+```
+text/plain, text/markdown, text/csv, application/json, text/html, text/css,
+text/javascript, application/javascript, text/xml, message/rfc822,
+application/pdf,
+application/vnd.openxmlformats-officedocument.wordprocessingml.document,
+application/vnd.ms-outlook, application/x-msg,
+application/vnd.oasis.opendocument.text,
+application/vnd.oasis.opendocument.spreadsheet,
+application/vnd.oasis.opendocument.presentation
+```
+
+### `imageUpload` Options
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable image attachment |
+| `resizeImages` | boolean | `true` | Resize to max 1024 px and convert to JPEG before sending |
+| `maxFileSizeMB` | number (1–100) | `10` | Maximum file size in megabytes |
+| `supportedFormats` | string[] | `['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']` | Must match `image/*` |
+
+TIFF images (`image/tiff`, `image/tif`) are supported when added to `supportedFormats` — they are converted to PNG before being sent to the model. Multi-page TIFFs produce one image per page.
+
+### `audioUpload` Options
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Enable audio attachment |
+| `maxFileSizeMB` | number (1–100) | `20` | Maximum file size in megabytes |
+| `supportedFormats` | string[] | `['audio/mpeg', 'audio/wav', 'audio/mp3', 'audio/flac', 'audio/ogg', 'audio/mp4']` | Must match `audio/*` |
+
+The system can also extract the audio track from video files using the Web Audio API.
+
+> **Note:** Audio upload requires a model that supports audio input. OpenAI (GPT-4o Audio models) and Google Gemini support audio; Anthropic Claude does not.
+
+### `cloudStorageUpload` Options
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | boolean | `false` | Show the cloud storage file picker |
+
+Supported providers (configured at the platform level):
+
+- Google Drive
+- Microsoft OneDrive / Office 365
+- Nextcloud
 
 ## Supported File Types
 
-### Text Files
+### Documents and Text Files
 
-- `.txt` - Plain text files
-- `.md` - Markdown files
-- `.csv` - Comma-separated values
-- `.json` - JSON files
-- `.html` - HTML files
-- `.css` - CSS files
-- `.js` - JavaScript files
-- `.xml` - XML files
+| Extension | MIME Type | Processing library |
+|-----------|-----------|-------------------|
+| `.txt`, `.md`, `.csv`, `.json`, `.html`, `.css`, `.js`, `.xml` | `text/*` / `application/json` | Read directly as text |
+| `.pdf` | `application/pdf` | Text extracted via `pdfjs-dist`; falls back to rendering each page as an image |
+| `.docx` | `application/vnd.openxmlformats-officedocument.wordprocessingml.document` | Converted to text via `mammoth` |
+| `.xlsx` | `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` | Cell content extracted via `xlsx` |
+| `.xls` | `application/vnd.ms-excel` | Cell content extracted via `xlsx` |
+| `.pptx` | `application/vnd.openxmlformats-officedocument.presentationml.presentation` | Slide text extracted via `xlsx` |
+| `.ppt` | `application/vnd.ms-powerpoint` | Slide text extracted via `xlsx` |
+| `.odt` | `application/vnd.oasis.opendocument.text` | XML text extracted via `jszip` |
+| `.ods` | `application/vnd.oasis.opendocument.spreadsheet` | XML text extracted via `jszip` |
+| `.odp` | `application/vnd.oasis.opendocument.presentation` | XML text extracted via `jszip` |
+| `.msg` | `application/vnd.ms-outlook`, `application/x-msg` | Subject, sender, recipients, body extracted via `@kenjiuno/msgreader` |
+| `.eml` | `message/rfc822` | Read as-is (RFC 822 format) |
 
-### PDF Files
+> `.xlsx`, `.xls`, `.pptx`, and `.ppt` are fully supported by the processing engine but are not included in the default `supportedFormats` list. Add their MIME types explicitly to enable them.
 
-- `.pdf` - PDF documents (automatically converted to text)
+### Images
 
-### Microsoft Office Documents
+| Extension | MIME Type | Notes |
+|-----------|-----------|-------|
+| `.jpg`, `.jpeg` | `image/jpeg` | |
+| `.png` | `image/png` | |
+| `.gif` | `image/gif` | |
+| `.webp` | `image/webp` | |
+| `.tiff`, `.tif` | `image/tiff` | Converted to PNG; multi-page supported |
 
-- `.docx` - Microsoft Word documents (automatically converted to text)
+### Audio
 
-### OpenOffice/LibreOffice Documents
+| Extension | MIME Type |
+|-----------|-----------|
+| `.mp3` | `audio/mpeg`, `audio/mp3` |
+| `.wav` | `audio/wav` |
+| `.flac` | `audio/flac` |
+| `.ogg` | `audio/ogg` |
+| `.mp4` (audio) | `audio/mp4` |
 
-- `.odt` - OpenDocument Text (Writer documents, automatically converted to text)
-- `.ods` - OpenDocument Spreadsheet (Calc spreadsheets, text content extracted)
-- `.odp` - OpenDocument Presentation (Impress presentations, text content extracted)
+## LLM Provider Support
 
-### Email Files
+| Provider | Images | Audio | Files (text) |
+|----------|:------:|:-----:|:------------:|
+| OpenAI (GPT-4o, GPT-4 Vision, etc.) | ✅ | ✅ (GPT-4o Audio) | ✅ |
+| Anthropic (Claude) | ✅ | ❌ | ✅ |
+| Google Gemini | ✅ | ✅ | ✅ |
+| Mistral | ✅ | ❌ | ✅ |
+| Local (vLLM, LM Studio, Jan.ai) | ✅ | ❌ | ✅ |
 
-- `.msg` - Microsoft Outlook email messages (subject, sender, recipients, and body extracted)
-- `.eml` - Standard email format (RFC 822)
-
-## File Size Limits
-
-- Maximum file size: 10MB
+File content (text documents, PDFs, etc.) is always converted to plain text and prepended to the message, so it works with any text-capable model regardless of multimodal support.
 
 ## How It Works
 
-1. **File Selection**: Users click the paper-clip icon to open the file uploader
-2. **File Processing**:
-   - Text files are read directly
-   - PDF files are converted to text using `pdfjs-dist`
-   - DOCX files are converted to text using `mammoth`
-   - MSG files are parsed using `@kenjiuno/msgreader` to extract subject, sender, recipients, and body
-   - EML files are read as text (RFC 822 format)
-   - OpenOffice/LibreOffice files (ODT, ODS, ODP) are processed using `jszip` to extract text from the XML content
-3. **Preview**: The first 200 characters of the file content are shown as a preview
-4. **AI Integration**: File content is prepended to the user's message and sent to the AI
-5. **Content Format**: Files are formatted as `[File: filename.ext (type)] content`
+### Processing Pipeline
 
-## Technical Implementation
+All file processing happens **client-side** before content is sent to the server.
 
-### Frontend Components
+1. **Selection** — User clicks the paperclip (files), camera (images), or microphone icon (audio).
+2. **Validation** — MIME type and file size are checked against the app's upload configuration. File extension is used as a fallback when the browser reports an incorrect MIME type.
+3. **Processing** (type-specific):
+   - **Text files** — Read directly as UTF-8 text.
+   - **PDF** — Text extracted via PDF.js. If the extracted text is empty or minimal (e.g. a scanned document), each page is rendered as an image instead.
+   - **DOCX** — Converted to plain text via mammoth.
+   - **XLSX / XLS** — Cell content extracted as text via the xlsx library.
+   - **PPTX / PPT** — Slide text extracted via the xlsx library.
+   - **ODT / ODS / ODP** — XML parsed and text content extracted via jszip.
+   - **MSG** — Subject, sender, recipients, and body extracted via msgreader.
+   - **EML** — Read as-is.
+   - **Images** — Optionally resized to max 1024 px and converted to JPEG; TIFF images converted to PNG first.
+   - **Audio** — Base64-encoded and sent natively to the model.
+   - **Video** — Audio track extracted via the Web Audio API, then processed as audio.
+4. **Preview** — Attached files are displayed with a preview before sending.
+5. **Sending** — File content is packed into the message:
+   - Text file content → prepended to `message.content` as `[File: filename.ext (type)]\n<content>`
+   - Image data → `imageData` property (base64)
+   - Audio data → `audioData` property (base64)
+6. **Provider formatting** — The server reformats data per provider:
+   - **OpenAI** — `image_url` content parts (images) or `input_audio` parts (audio)
+   - **Anthropic** — `image` source blocks with base64 data
+   - **Google** — `inlineData` parts with MIME type and base64
 
-- `FileUploader.jsx` - Handles file selection and processing
-- `ChatInput.jsx` - Integrates file upload with chat input
-- `AppChat.jsx` - Manages file upload state
+### Size Limits
 
-### Frontend Libraries
+| Type | Default | Configurable range | Server ceiling |
+|------|---------|--------------------|----------------|
+| Files | 5 MB | 1–100 MB | 50 MB |
+| Images | 10 MB | 1–100 MB | 50 MB |
+| Audio | 20 MB | 1–100 MB | 50 MB |
 
-- `pdfjs-dist` - PDF text extraction
-- `mammoth` - DOCX to HTML/text conversion
-- `@kenjiuno/msgreader` - MSG file parsing
-- `jszip` - OpenOffice/LibreOffice document processing (ODT, ODS, ODP)
+The server-wide request body limit is set by `requestBodyLimitMB` in `platform.json` (default: 50 MB). Per-type limits must stay within this ceiling.
 
-### Backend Processing
+## Example Configurations
 
-- File content is processed in `processMessageTemplates()`
-- All AI adapters (OpenAI, Anthropic, Google) handle file content
-- Content is automatically included in AI prompts
-- Server configured with the `requestBodyLimitMB` setting in `platform.json` (default 50MB) to handle file uploads
-
-### Configuration
-
-Enable file upload for an app by adding to the app configuration:
-
-```json
-{
-  "settings": {
-    "fileUpload": {
-      "enabled": true
-    }
-  },
-  "fileUpload": {
-    "maxFileSizeMB": 15,
-    "supportedFormats": [
-      "text/plain",
-      "text/markdown",
-      "text/csv",
-      "application/json",
-      "text/html",
-      "text/css",
-      "text/javascript",
-      "application/javascript",
-      "text/xml",
-      "application/pdf",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "application/vnd.ms-outlook"
-    ]
-  }
-}
-```
-
-#### Configuration Options
-
-**settings.fileUpload.enabled** (boolean)
-
-- Enables or disables the file upload feature for the app
-- Default: `false`
-
-**upload.allowMultiple** (boolean)
-
-- When `true`, allows users to select and upload multiple files/images at once
-- Default: `false`
-- All selected files will be processed individually and sent with the message
-- This setting applies to both image and file uploads
-
-**fileUpload.maxFileSizeMB** (number)
-
-- Maximum file size in megabytes
-- Default: `10`
-- Range: 1-50 (limited by the `requestBodyLimitMB` setting)
-
-**fileUpload.supportedFormats** (array)
-
-- List of supported MIME types for file uploads
-- Default: All supported formats including text, PDF, DOCX, and MSG files
-- The system automatically selects the appropriate processing tool based on the MIME type
-- Common values:
-  - `"text/plain"` - .txt files
-  - `"text/markdown"` - .md files
-  - `"text/csv"` - .csv files
-  - `"application/json"` - .json files
-  - `"text/html"` - .html files
-  - `"text/css"` - .css files
-  - `"text/javascript"` or `"application/javascript"` - .js files
-  - `"text/xml"` - .xml files
-  - `"message/rfc822"` - .eml files (standard email format)
-  - `"application/pdf"` - .pdf files (processed with PDF.js)
-  - `"application/vnd.openxmlformats-officedocument.wordprocessingml.document"` - .docx files (processed with mammoth)
-  - `"application/vnd.ms-outlook"` - .msg files (processed with msgreader)
-  - `"application/vnd.oasis.opendocument.text"` - .odt files (processed with jszip)
-  - `"application/vnd.oasis.opendocument.spreadsheet"` - .ods files (processed with jszip)
-  - `"application/vnd.oasis.opendocument.presentation"` - .odp files (processed with jszip)
-
-#### Example Configurations
-
-**Full-featured file upload (AI Chat app):**
+### Full-featured (all upload types)
 
 ```json
 {
   "upload": {
     "enabled": true,
-    "allowMultiple": false
-  },
-  "fileUpload": {
-    "maxFileSizeMB": 15,
-    "supportedFormats": [
-      "text/plain",
-      "text/markdown",
-      "text/csv",
-      "application/json",
-      "text/html",
-      "text/css",
-      "text/javascript",
-      "application/javascript",
-      "text/xml",
-      "application/pdf",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "application/vnd.ms-outlook"
-    ]
-  }
-}
-```
-
-**Multiple file upload enabled:**
-
-```json
-{
-  "upload": {
-    "enabled": true,
-    "allowMultiple": true
-  },
-  "fileUpload": {
-    "maxFileSizeMB": 10,
-    "supportedFormats": [
-      "text/plain",
-      "text/markdown",
-      "text/html",
-      "application/pdf",
-      "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-      "application/vnd.ms-outlook"
-    ]
-  }
-}
-```
-
-**Text and PDF only (Summarizer app):**
-
-```json
-{
-  "upload": {
-    "enabled": true
-  },
-  "fileUpload": {
-    "maxFileSizeMB": 5,
-    "supportedFormats": ["text/plain", "text/markdown", "text/html", "application/pdf"]
-  }
-}
-```
-
-**Minimal configuration (uses defaults):**
-
-```json
-{
-  "settings": {
+    "allowMultiple": true,
+    "imageUpload": {
+      "enabled": true,
+      "resizeImages": true,
+      "maxFileSizeMB": 10,
+      "supportedFormats": [
+        "image/jpeg", "image/jpg", "image/png",
+        "image/gif", "image/webp", "image/tiff"
+      ]
+    },
+    "audioUpload": {
+      "enabled": true,
+      "maxFileSizeMB": 20
+    },
     "fileUpload": {
+      "enabled": true,
+      "maxFileSizeMB": 5
+    },
+    "cloudStorageUpload": {
       "enabled": true
     }
   }
 }
 ```
 
-## Example Usage
+### Document summarizer (PDF and Office files only)
 
-1. Navigate to the AI Chat app
-2. Click the paper-clip icon in the input area
-3. Select a text file or PDF
-4. Review the file preview
-5. Type a message (optional) and send
-6. The AI will have access to the file content for analysis
+```json
+{
+  "upload": {
+    "enabled": true,
+    "fileUpload": {
+      "enabled": true,
+      "maxFileSizeMB": 10,
+      "supportedFormats": [
+        "application/pdf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+      ]
+    }
+  }
+}
+```
 
-## Error Handling
+### Audio transcription
 
-- File size validation (10MB limit)
-- File type validation (supported formats only)
-- PDF processing error handling
-- User-friendly error messages
+```json
+{
+  "upload": {
+    "enabled": true,
+    "audioUpload": {
+      "enabled": true,
+      "maxFileSizeMB": 20,
+      "supportedFormats": [
+        "audio/mpeg", "audio/mp3", "audio/wav",
+        "audio/flac", "audio/ogg", "audio/mp4"
+      ]
+    }
+  }
+}
+```
+
+### Image analysis (no resizing)
+
+```json
+{
+  "upload": {
+    "enabled": true,
+    "allowMultiple": true,
+    "imageUpload": {
+      "enabled": true,
+      "resizeImages": false,
+      "maxFileSizeMB": 10
+    }
+  }
+}
+```
+
+### Minimal (file upload with all defaults)
+
+```json
+{
+  "upload": {
+    "enabled": true,
+    "fileUpload": { "enabled": true }
+  }
+}
+```
+
+## Frontend Components
+
+| Component | Purpose |
+|-----------|---------|
+| `UnifiedUploader.jsx` | Main upload coordinator; auto-detects file type and routes to the correct handler |
+| `ImageUploader.jsx` | Image resizing, TIFF-to-PNG conversion, base64 encoding |
+| `Uploader.jsx` | Generic file handling with drag-and-drop and MIME validation |
+| `AttachedFilesList.jsx` | Preview display for attached files; allows individual removal |
+| `CloudStoragePicker.jsx` | Cloud storage provider selection dialog |
+| `GoogleDriveFileBrowser.jsx` | Google Drive file browser |
+| `Office365FileBrowser.jsx` | OneDrive / SharePoint file browser |
+| `NextcloudFileBrowser.jsx` | Nextcloud file browser |
 
 ## Security Considerations
 
-- Files are processed client-side
-- Content is only sent to the AI service
-- No files are stored on the server
-- Content is included in conversation logs (if logging is enabled)
+- All file processing happens client-side; only extracted text or base64-encoded data is transmitted to the server.
+- No files are stored on the server; content exists only for the duration of the conversation session.
+- File content is included in conversation logs if server-side logging is enabled.
+- MIME type and file size are validated before processing begins.
+- File extension is used as a secondary validation when the browser reports an incorrect MIME type.

--- a/docs/image-upload-feature.md
+++ b/docs/image-upload-feature.md
@@ -9,13 +9,15 @@ The image upload feature allows users to attach images to their chat messages. I
 Enable the feature in an app by adding an `imageUpload` object with an `enabled` flag and optional settings:
 
 ```json
-"upload": {
-  "enabled": true,
-  "allowMultiple": false
-},
-"imageUpload": {
-  "enabled": true,
-  "resizeImages": true
+{
+  "upload": {
+    "enabled": true,
+    "allowMultiple": false,
+    "imageUpload": {
+      "enabled": true,
+      "resizeImages": true
+    }
+  }
 }
 ```
 
@@ -28,7 +30,7 @@ Enable the feature in an app by adding an `imageUpload` object with an `enabled`
 - All selected images will be processed individually and sent with the message
 - This setting applies to both image and file uploads
 
-**imageUpload.resizeImages** (boolean)
+**upload.imageUpload.resizeImages** (boolean)
 
 - When `true` (default) the uploaded image is resized to a maximum dimension of 1024 px and converted to JPEG before being sent.
 - Set to `false` to use the original image without resizing or format conversion.


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Rewrites `docs/file-upload-feature.md` from scratch to accurately document the full unified upload system (file, image, audio, cloud storage)
- Fixes a config example bug in `docs/image-upload-feature.md` where `imageUpload` was shown as a top-level key instead of nested inside `upload`

## What changed in `file-upload-feature.md`

The previous version had several inaccuracies and gaps:

- **Wrong config schema** — used legacy top-level `fileUpload` / `settings.fileUpload.enabled` keys; the correct structure nests everything under `upload.fileUpload`, `upload.imageUpload`, etc.
- **Missing upload types** — image upload, audio upload, and cloud storage upload were not documented at all
- **Missing file formats** — Excel (`.xlsx`/`.xls`) and PowerPoint (`.pptx`/`.ppt`) are supported but were not listed
- **Missing TIFF support** and the PDF-to-image fallback behaviour (scanned documents)
- **Wrong default size limit** — claimed 10 MB; the schema default for `fileUpload` is 5 MB
- **No LLM provider support matrix** — audio upload only works with OpenAI GPT-4o Audio and Google Gemini; this was undocumented
- **Outdated component names** — referenced `FileUploader.jsx` which no longer exists; replaced by `UnifiedUploader.jsx`

## Test plan

- [ ] Review the new doc for accuracy against `server/validators/appConfigSchema.js`
- [ ] Verify example configs are valid against the schema
- [ ] Check that the `image-upload-feature.md` config fix matches the actual schema structure

https://claude.ai/code/session_011z4ByHwccykX8HFxwTNyLA
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_011z4ByHwccykX8HFxwTNyLA)_