### PR TITLE
docs: astron-agent vs ihub-apps gap analysis

### DIFF
--- a/concepts/astron-comparison/00-roadmap.md
+++ b/concepts/astron-comparison/00-roadmap.md
@@ -1,0 +1,376 @@
+# Astron-Agent vs iHub-Apps — Master Roadmap
+
+Synthesis of the six area reports in this folder. Read this first; drill into
+the per-area files for evidence, file/line citations, and detailed
+implementation outlines.
+
+| # | Area | File |
+|---|---|---|
+| 01 | Workflow engine | [`01-workflow-engine.md`](./01-workflow-engine.md) |
+| 02 | Model abstraction & MaaS | [`02-model-abstraction.md`](./02-model-abstraction.md) |
+| 03 | Agent / tools / plugins / RPA | [`03-agent-tools-plugins-rpa.md`](./03-agent-tools-plugins-rpa.md) |
+| 04 | Knowledge / RAG / memory | [`04-knowledge-memory-rag.md`](./04-knowledge-memory-rag.md) |
+| 05 | Interfaces / console / APIs | [`05-interfaces-console-api.md`](./05-interfaces-console-api.md) |
+| 06 | Tenant / collab / observability / eval | [`06-tenant-collab-observability.md`](./06-tenant-collab-observability.md) |
+
+---
+
+## TL;DR
+
+Astron-agent is broader in surface area than iHub-apps, but a meaningful
+fraction of that breadth is **integration with iFLYTEK's own cloud** (Spark,
+Xinghuo Knowledge Base, AIUI, MaaS gateway) rather than original engineering
+we should copy verbatim. The genuinely missing capabilities — and the ones
+worth investing in — are concentrated in four areas:
+
+1. **Knowledge / RAG / memory.** iHub has _no_ embeddings, vector store,
+   chunking, or persistent conversation memory. This is the largest single
+   technical gap.
+2. **Workflow ergonomics.** The engine exists and is solid, but lacks a visual
+   builder, parallel execution, and the Iteration / Loop / Code / Sub-workflow
+   node primitives that make workflows usable for non-developers.
+3. **MCP, both directions.** Our "MCP client" is a one-line URL stub
+   ([`server/toolLoader.js:203`](../../server/toolLoader.js)); we expose
+   nothing over MCP. Astron has full bidirectional MCP.
+4. **Enterprise plumbing.** Spaces / workspaces, structured audit log, quotas,
+   versioning, and an evaluation harness are all missing.
+
+iHub is **ahead of astron** on five fronts that we should consciously preserve:
+multi-adapter LLM layer (8 vs 3), OpenAI-compatible inference proxy, GenAI
+OTel semantic conventions, breadth of external shells (browser ext, Electron,
+Teams, Nextcloud, Office), and authentication options (5 modes vs Casdoor-only).
+
+---
+
+## 1. iHub's existing strengths (don't reinvent)
+
+Verified across all six reports — these are areas where copying astron would
+be a regression.
+
+| Strength | Evidence (file:line) | Astron's posture |
+|---|---|---|
+| 8 first-class LLM adapters incl. Bedrock + GPT-5 Responses + iAssistant | `server/adapters/index.js:12-21`, see report 02 §2.1 | 3 generic adapters + Spark Java path |
+| Cross-provider tool-calling normalization (8 converters) | `server/adapters/toolCalling/` (~3200 LoC), report 02 §2.2 | Implicit at runner level only |
+| OpenAI-compatible inference proxy w/ tools + SSE + permissions | `server/routes/openaiProxy.js:1-612`, report 05 §2.3 | None |
+| OTel GenAI semantic conventions + cardinality-safe metrics | `server/telemetry/GenAIInstrumentation.js:24`, report 06 §2.3 | OTel present but plain attributes |
+| Mature usage tracking (daily/monthly rollups, JSONL, pseudonymisation) | `server/services/UsageAggregator.js`, `UsageEventLog.js`, report 06 §2.4 | Kafka events; no rollup pipeline shown |
+| 5 auth modes + own OAuth2 server | `server/routes/{auth.js,oauth.js,wellKnown.js}`, report 06 §2.1 | Casdoor only |
+| External shells (browser ext / Electron / Teams / Nextcloud / Office) | `browser-extension/`, `electron/`, `teams/`, `nextcloud-app/`, report 05 §2.6 | Console only |
+| Group inheritance w/ circular detection | `server/utils/authorization.js:15`, report 06 §2.1 | Implicit per-space scoping |
+| Agent skills lazy-loading via `activate_skill` | `server/toolLoader.js:437-475`, report 03 §2.1 | Not first-class |
+| First-party `ask_user` clarification tool w/ rate limits | `server/tools/askUser.js`, report 03 §2.1 | Not first-class |
+| Marketplace installer (multi-format incl. Claude Code, Anthropic skills, native) | `server/services/marketplace/RegistryService.js`, `ContentInstaller.js`, report 03 §2.3 | Plugin Square (in-platform only) |
+| Per-model concurrency / requestDelayMs throttling | `server/requestThrottler.js:25,37,43`, report 02 §2.7 | None (delegated upstream) |
+| Multimodal breadth (audio + docs + image gen) | report 02 §2.5 | Mostly Spark domain mapping |
+| Feedback storage (1-5 stars + comments) | `server/feedbackStorage.js`, report 06 §2.2 | Not surfaced |
+| Per-execution SSE channel with reconnect for workflows | `server/routes/workflow/workflowRoutes.js:1257-1408`, report 01 §2.5 | SSE via SseEmitter, simpler |
+| First-class human-in-the-loop checkpoint node | `executors/HumanNodeExecutor.js`, report 01 §2.3 | Implicit via Q/A node |
+| Workflow-as-tool bridge | `server/tools/workflowRunner.js`, report 01 §2.5 | Workflows are first-class; not exposed as tools |
+
+---
+
+## 2. Cross-cutting findings (consolidated across reports)
+
+### 2.1 Same feature mentioned by two reports — single project, not two
+
+| Project | Appears in | Resolution |
+|---|---|---|
+| **Visual workflow builder** (React Flow) | 01 §4 #12, 05 §4 #1 | One project. Designed in report 05 §5.1; benefits from workflow-engine improvements in report 01. |
+| **MCP server endpoint** | 03 §4 #3, 05 §4 #2 | One project. Use report 03 §5.3 outline; expose apps + workflows + tools. |
+| **Real MCP client (multi-server)** | 03 §4 #1 — touches workflow's MCP node potential in 01 §3 | One project. Outline in report 03 §5.1. |
+| **Sub-workflow / call-flow node** | 01 §4 #7 — also unblocks multi-agent supervisor in 03 §4 #8 | Same primitive serves both. |
+| **Persistent state store** | 01 §4 #13 (workflow), 04 §4 #2 (conversations), 06 §4 #4 (audit log) | One persistence-layer decision (sqlite vs postgres) covers all three. |
+| **Quotas / per-user rate limits** | 06 §4 #3 — built on `UsageAggregator` from 06 §2.4 | Single project. |
+| **Code node (sandboxed)** | 01 §4 #4 — and "out-of-process tool sandbox" in 03 §4 #5 | Same sandbox tech (worker thread / isolated-vm / sidecar) serves both. Decide once. |
+
+### 2.2 Things astron has that we should consciously NOT copy
+
+| Astron feature | Why skip |
+|---|---|
+| Multi-tenant SQL data service (Xingchen DB) | Not "memory" despite the name — it's a tenant-scoped SQL gateway, niche. Report 04 §1.6. |
+| iFLYTEK content-safety audit (`audit_system/`) | Domain-specific moderation, not user-action audit. Report 06 §1.4. |
+| iFLYTEK MaaS HTTP gateway as shipped | Proprietary, points at `xingchen-api.xf-yun.com`. The _abstraction_ (control plane delegating to operator) is worth copying; the _implementation_ is not. Report 02 §1.4. |
+| Knowledge Graph flag | Astron only exposes a passthrough flag to RAGFlow's KG; minimal product value without RAGFlow. Report 04 §4 #8. |
+| Wechat/Feishu publish channels | Not relevant for iHub's market. Report 05 §1.3. |
+| Bespoke iFLYTEK SDKs as client integration model | iHub's OpenAI-compatible proxy is strictly better. Report 05 §2.3. |
+| `metrology_auth` native SDK (C headers) | Closed-source, iFLYTEK-internal licensing. Build an open Node equivalent instead. Report 06 §1.5. |
+
+### 2.3 Areas where neither platform has anything (greenfield)
+
+These are differentiator opportunities, not parity work.
+
+- **Evaluation / regression harness** — neither has one (report 06 §1.6, §2.6).
+- **Long-term user memory** (extracted facts, preferences) — astron's "memory"
+  module is a SQL gateway, not this (report 04 §1.6).
+- **Conversation summarisation** to extend context budget (report 04 §3 #17).
+- **Cohesive content-safety audit** with admin policy (report 06 §1.4).
+- **Multi-agent supervisor with first-class agent-as-tool wrapper** — both
+  realise it via workflow chaining only (report 03 §1.1, §4 #8).
+- **In-product trace viewer** — astron uses Elasticsearch + `WorkflowTraceEsClient`
+  but the viewer is theirs; iHub ships no trace UI (report 06 §4 #6).
+
+---
+
+## 3. Master priority matrix
+
+Aggregated from §4 of each area report. Scope: S < M < L < XL. Risk: L / M / H.
+"Cumulative" effort is a rough order-of-magnitude in dev-weeks for a single
+senior engineer.
+
+### Tier A — Quick wins (S, low risk, ship in weeks not quarters)
+
+| # | Feature | Area | Scope | Risk | Why now |
+|---|---|---|---|---|---|
+| A1 | Honour `errorHandler: continue` + `customReturn` strategy | 01 §4 #5 | S | L | Schema declares it; engine fails anyway. Quick correctness win. |
+| A2 | Fail-branch edge routing (`sourceHandle: "fail"`) | 01 §4 #6 | S | L | Pairs with A1; tiny scheduler change. |
+| A3 | LLM-based decision routing (already stubbed) | 01 §4 #9 | S | L | `DecisionNodeExecutor.js:413-429` is a stub. |
+| A4 | Connection validation on model save | 02 §5.1 | S | L | Eliminates "wrong URL" footgun. |
+| A5 | Workflow/app integrity cleanup on model removal | 02 §5.3 | S | L | Sweep apps/workflows for dangling `preferredModel`. |
+| A6 | SSRF guard for admin-supplied URLs | 02 §4 #6 | S | L | Security hardening. |
+| A7 | Cost (price/currency) metrics in `executionMetrics` | 01 §4 #15 | S | L | Pair with existing model-pricing config. |
+| A8 | OCR-as-tool — expose existing `toolsService/ocrRoutes.js` to agents | 03 §4 #10 | S | L | Reuses code already shipped. |
+| A9 | Tool usage analytics surfacing ("heat") | 03 §4 #11 | S | L | `usageTracker.js` already counts; just expose. |
+| A10 | Generated client SDKs (Python / TS / Java) from Swagger | 05 §4 #8 | S | L | `openapi-generator-cli` over existing specs. |
+| A11 | Per-provider declarative capability matrix | 02 §4 #8 | S | L | Centralizes scattered adapter capability flags. |
+
+**Tier A cumulative:** ~6-8 dev-weeks for the lot.
+
+### Tier B — Mid bets (M, low-medium risk, 2-6 weeks each)
+
+| # | Feature | Area | Scope | Risk | Dependencies |
+|---|---|---|---|---|---|
+| B1 | **Real MCP client** (multi-server, SSE+stdio+ws, schema-validated, encrypted creds) | 03 §5.1 | M | L | none |
+| B2 | **Generic OpenAPI HTTP tool runner** | 03 §5.2 | M | L | none |
+| B3 | **MCP server endpoint** (expose apps/workflows/tools) | 03 §5.3, 05 §5.2 | M | L-M | B1 (shared transport code) |
+| B4 | **Parallel execution in `WorkflowEngine`** | 01 §5.1 | M | M | none — unblocks B5 |
+| B5 | **Iteration node** (subgraph per list item) | 01 §5.2 | L | M | B4 |
+| B6 | **Loop node** with declarative termination conditions | 01 §5.3 | M | L | none |
+| B7 | **Sub-workflow / call-flow node** | 01 §4 #7 | M | M | none |
+| B8 | **Structured user-action audit log** | 06 §4 #4 | M | L | none |
+| B9 | **Webhook framework (in + out, HMAC-signed)** | 05 §5.3 | M | L-M | none |
+| B10 | **Quotas / credits / per-user rate limits** | 06 §5.3 | M | M | builds on `UsageAggregator`; nicer scoped per-space (G2) |
+| B11 | **First-class knowledge/RAG node** in workflow | 01 §4 #8 | M | L | C1 (vector RAG) ideal but not strictly required |
+| B12 | **Persistent conversation memory** (SQLite/Postgres-backed) | 04 §5.2 | L | L-M | C1 nice-to-have for semantic recall |
+| B13 | **Model categorization / "shelf" + admin marketplace polish** | 02 §4 #2 | M | L | none |
+| B14 | **iFLYTEK Spark adapter** (`spark.js`, OpenAI-compatible HTTP) | 02 §4 #5 | M | M | only if Spark/CN-market relevant |
+| B15 | **Code node** (sandboxed JS first, Python via sidecar later) | 01 §4 #4 | L | H | sandbox decision (§4) |
+| B16 | **Browser-automation tool** (Playwright DSL: click/type/screenshot/extract) | 03 §4 #4 | M | M | none — Playwright already a dep |
+| B17 | **Reranker + hybrid (BM25 + vector) retrieval** | 04 §4 #4 | M | L | C1 |
+| B18 | **In-product trace viewer** (proxy OTLP collector or ship Tempo/CH) | 06 §4 #6 | M | M | storage decision |
+| B19 | **App-scoped Bot API keys** (per-app keyed REST endpoint) | 05 §4 #5 | M | L | existing OAuth client store |
+| B20 | **End-user marketplace browse UI** (atop existing admin marketplace) | 03 §4 #6, 05 §4 #6 | S-M | L | none |
+| B21 | **DB-backed workflow state for horizontal scaling** | 01 §4 #13 | L | M | persistence decision (§4) |
+| B22 | **Token-level streaming from agent nodes to client** | 01 §4 #14 | M | L | none |
+
+**Tier B cumulative:** ~30-40 dev-weeks, parallelisable.
+
+### Tier C — Strategic bets (L–XL, high reward, quarter-scale)
+
+| # | Feature | Area | Scope | Risk | Dependencies |
+|---|---|---|---|---|---|
+| C1 | **In-process vector RAG** (chunk → embed → retrieve) | 04 §5.1 | XL | M | A11 helpful |
+| C2 | **Visual workflow builder** (React Flow) | 01 §4 #12, 05 §5.1 | L–XL | M | DSL stability — pin schema before starting |
+| C3 | **Long-term user memory + summarisation** | 04 §5.3 | L | M | C1, B12 |
+| C4 | **Eval / regression harness for apps & workflows** | 06 §5.2 | L | M | none; opt-in cost guard |
+| C5 | **App / workflow versioning + share-with-user/group** | 06 §4 #5 | L | M | C6 (sharing scope) |
+| C6 | **Spaces / workspaces / per-space membership** | 06 §5.1 | XL | H | foundational; design carefully |
+| C7 | **MaaS deployment lifecycle (pluggable inference operator)** | 02 §5.2 | XL | H | product decision (§4) |
+
+### Won't-do (for v1)
+
+| Feature | Why not |
+|---|---|
+| Desktop RPA suite à la astron-rpa | XL effort, OS-level automation, niche audience for iHub. Defer or partner. |
+| Knowledge Graph | Only valuable atop external RAGFlow; revisit if customer demand emerges. |
+| Multi-tenant SQL data service (Xingchen DB clone) | iFinder / Jira / Office already cover structured data via tools. |
+| WeChat / Feishu publish channels | Not in target audience. |
+| Multi-agent supervisor as separate class | Workflow + sub-workflow node (B7) gives 80% of value at 20% of cost. |
+
+---
+
+## 4. Decision points that gate the work
+
+Each decision below unblocks one or more Tier-B/C items. **Resolve before
+starting** the dependent project, not during.
+
+| ID | Decision | Affects | Default recommendation |
+|---|---|---|---|
+| D1 | **Persistence substrate** — keep `contents/*.json` only, add SQLite, or add Postgres | B8, B12, B21, C1, C3, C5, C6 | Start SQLite-by-default, `pgvector`/Postgres opt-in via `platform.json` |
+| D2 | **Sandbox tech** for Code node and out-of-process tool execution | B15, B16, future plugins | Try `isolated-vm` first (sync, mature); fall back to worker_threads for portability; sidecar Python via subprocess for D3 follow-up |
+| D3 | **Vector store backend** | C1 | `sqlite-vss` default (file per KB), `pgvector` opt-in for scale, `lancedb` follow-up |
+| D4 | **Embedding model strategy** | C1 | Pluggable: provider adapter (OpenAI/Bedrock/Cohere) + bundled `@xenova/transformers BGE-small` for air-gapped |
+| D5 | **MaaS scope** — own data plane, thin proxy to KServe/Ollama/vLLM-operator, or skip | C7 | Thin proxy (control plane only); document operator compliance |
+| D6 | **Spaces scope** — per-space resource catalogs, or one global catalog + per-space ACL | C5, C6 | Per-space catalogs; gate behind `features.spaces` flag, default off |
+| D7 | **MCP auth model for our server** | B3 | API keys v1 (per-key tool ACL via existing groups); OAuth 2.1 v2 |
+| D8 | **Workflow versioning persistence** | C5 | Sidecar `versions/<workflow-id>/<semver>.json` with `current.json` pointer; promote later to DB |
+| D9 | **In-product trace viewer storage** | B18 | Proxy configured OTLP collector via API v1; ClickHouse-backed embedded reader v2 |
+| D10 | **Spark / Chinese-market priority** | B14 | Skip unless explicit customer demand; HTTP-only adapter is M effort |
+
+---
+
+## 5. Suggested phased sequence
+
+This is one valid ordering; reshuffle to taste. Numbers reference the IDs
+above. "Track" lets two engineers work in parallel without stepping on each
+other.
+
+### Phase 1 — "Make it correct" (≈ 6–10 weeks)
+
+Goal: close advertised-but-broken features; raise security floor; ship MCP
+properly.
+
+- **Track 1 (correctness):** A1, A2, A3, A4, A5, A6, A7
+- **Track 2 (MCP + tools):** B1 → B2 → B3 → B20
+- **Track 3 (ops):** A8, A9, A10, A11, B8 (audit log)
+
+Outcomes: real MCP client + server, generic OpenAPI tools, end-user
+marketplace browse, model save validation, integrity sweeps, audit trail.
+
+### Phase 2 — "Make it powerful" (≈ 8–12 weeks)
+
+Goal: workflow ergonomics + persistent memory.
+
+- **Track 1 (workflow):** B4 → B5 → B6 → B7 → B22
+- **Track 2 (model + interfaces):** B9 (webhooks), B13 (model marketplace), B19 (bot API keys), optionally B14 (Spark)
+- **Track 3 (persistence):** D1 decision → B12 (persistent conversations) → B21 (DB-backed workflow state). Same store unblocks Phase 3.
+
+Outcomes: parallel workflow execution, Iteration/Loop/Sub-workflow nodes,
+webhooks, persistent conversations, optional Spark.
+
+### Phase 3 — "Make it smart" (≈ 10–14 weeks)
+
+Goal: knowledge layer.
+
+- **Track 1 (RAG):** D3+D4 decisions → C1 (vector RAG) → B11 (RAG node in workflow) → B17 (rerank + hybrid)
+- **Track 2 (visual builder):** D8 schema freeze → C2 (visual workflow builder) → B18 (trace viewer)
+- **Track 3 (control):** B10 (quotas), B15 (Code node — D2 decision)
+
+Outcomes: real RAG with citation; visual workflow editor; quota
+enforcement; sandboxed Code node.
+
+### Phase 4 — "Make it enterprise" (≈ 12–20 weeks)
+
+Goal: multi-tenancy, evaluation, lifecycle.
+
+- **Track 1 (eval):** C4 (eval harness — can start earlier, cheap to prototype)
+- **Track 2 (memory):** C3 (long-term user memory + summarisation)
+- **Track 3 (tenant):** D6 decision → C6 (spaces) → C5 (versioning + sharing)
+- **Track 4 (model lifecycle):** D5 decision → C7 (MaaS lifecycle, only if D5 = "yes")
+
+Outcomes: per-space catalogs and quotas, app/workflow versioning,
+evaluation harness, ChatGPT-style long-term memory.
+
+---
+
+## 6. Risk register (top 5)
+
+| Risk | Mitigation |
+|---|---|
+| **Visual builder (C2) creates a schema fork** between admin-edited JSON and the engine's expected shape | Freeze workflow DSL before C2 starts (D8); preserve presentation metadata under `viewport`; keep Monaco "raw JSON" fallback tab. |
+| **Spaces (C6) becomes a breaking-change retrofit** across every loader and route | Default-space alias; feature flag `features.spaces`; ship with all-or-nothing migration. Pair with CLAUDE.md migration system (`server/migrations/`). |
+| **Vector RAG (C1) leaks proprietary docs** if multi-tenancy lands before isolation rules | Tie KB ACL to groups initially (matches today's model); revisit when C6 lands. |
+| **MaaS lifecycle (C7) implies an inference operator we don't own** | Stay control-plane only; document KServe/Ollama compatibility; never bundle an operator. |
+| **MCP server (B3) exposes more tools than intended** | Per-API-key tool allowlist; reuse `enhanceUserWithPermissions` for ACL; default-deny new tools until enabled. |
+
+---
+
+## 7. Effort + value snapshot
+
+Rough one-line summary for each Tier-B/C item. Use for prioritisation
+conversations.
+
+```
+A1  errorHandler:continue/customReturn  S/L  HIGH  schema already lies; fix
+A2  fail-branch edge routing            S/L  MED   pairs with A1
+A3  LLM decision routing                S/L  MED   stubbed; finish it
+A4  model save: connection validation   S/L  HIGH  eliminates wrong-URL footguns
+A5  model removal integrity sweep       S/L  HIGH  prevents dangling refs
+A6  SSRF guard on admin URLs            S/L  HIGH  security floor
+A7  cost in executionMetrics            S/L  MED   token→cost mapping exists
+A8  OCR-as-tool                         S/L  MED   reuses shipped route
+A9  tool heat / favourites              S/L  LOW   discoverability
+A10 generated SDKs                      S/L  MED   one-shot generator job
+A11 capability matrix                   S/L  MED   unblocks B14 + caching
+
+B1  real MCP client                     M/L  HIGH  closes #1 platform fib
+B2  OpenAPI HTTP tool runner            M/L  HIGH  zero-code integrations
+B3  MCP server endpoint                 M/L-M HIGH MCP gateway story
+B4  parallel workflow execution         M/M  HIGH  unblocks B5
+B5  Iteration node                      L/M  HIGH  big UX win
+B6  Loop node w/ termination            M/L  HIGH  declarative loops
+B7  Sub-workflow node                   M/M  MED   composition + multi-agent stand-in
+B8  user-action audit log               M/L  HIGH  compliance floor
+B9  webhook framework (in+out)          M/L-M MED  enterprise integration
+B10 quotas / credits / per-user RL      M/M  HIGH  cost control
+B11 first-class RAG node                M/L  MED   when C1 lands
+B12 persistent conversations            L/L-M HIGH multi-replica safe
+B13 model marketplace polish            M/L  LOW   nice-to-have
+B14 Spark adapter                       M/M  LOW   only if CN demand
+B15 Code node (sandboxed JS)            L/H  MED   power-user feature
+B16 Playwright DSL tool                 M/M  MED   beyond screenshots
+B17 rerank + hybrid retrieval           M/L  HIGH  big quality lever atop C1
+B18 in-product trace viewer             M/M  MED   support productivity
+B19 app-scoped Bot API keys             M/L  MED   external integrations
+B20 marketplace browse UI               S-M/L MED  end-user discoverability
+B21 DB-backed workflow state            L/M  MED   horizontal scale
+B22 token-level streaming               M/L  MED   perceived latency
+
+C1  in-process vector RAG               XL/M  CRIT  headline parity feature
+C2  visual workflow builder             L-XL/M HIGH adoption blocker today
+C3  long-term user memory               L/M   MED  differentiator
+C4  eval / regression harness           L/M   HIGH differentiator (neither has)
+C5  app/workflow versioning + share     L/M   MED  enterprise asks
+C6  spaces / workspaces                 XL/H  HIGH every enterprise deal eventually
+C7  MaaS lifecycle                      XL/H  LOW  product-strategy call (D5)
+```
+
+---
+
+## 8. Open questions (rolled up from area reports)
+
+Listed by area for traceability; resolution unblocks the corresponding Tier
+item.
+
+- **01 §6:** workflow persistence model (D1), Code-node sandbox (D2),
+  JSON-files vs DB workflows (D1), streaming protocol for token-level
+  output (B22 design), sub-workflow permission inheritance.
+- **02 §6:** MaaS scope decision (D5), Spark demand (D10), in-transit
+  encryption of admin-submitted API keys (Astron's RSA flow vs current
+  TLS+AES-at-rest), where to mount MaaS UI in admin.
+- **03 §6:** astron's exact agent-loop semantics (CoT-only vs ReAct), Plugin
+  Square packaging format, SkillHub package spec compatibility with
+  Anthropic Skills, RPA host requirements (Electron client vs headless),
+  out-of-process sandbox technology (D2), MCP auth standard (D7).
+- **04 §6:** vector backend (D3), embedding model licensing (D4), KB
+  multi-tenancy scope (depends on D6), iAssistant vs internal RAG strategy,
+  reranker bundling in `build:binary`, memory-extraction cost guardrails,
+  citation enforcement approach.
+- **05 §6:** astron MCP server channel scope, gRPC publicness, webhook
+  framework completeness, plugin store openness, embed widget existence,
+  marketplace registry topology, Bot API auth (OAuth client vs new API
+  keys — B19/D7), visual builder schema strategy (D8), MCP-server token model (D7).
+- **06 §6:** astron tenant member storage (informational only), quota
+  schema (D5 adjacent), product decision on per-space catalogs vs global +
+  ACL (D6), persistence direction (D1), workflow versioning scheme (D8),
+  audit retention requirements, eval CI integration, in-product trace
+  storage (D9).
+
+---
+
+## 9. What to do with this
+
+1. **Treat each per-area report as a working PRD.** Each §4 is a ranked
+   backlog; each §5 is an implementation outline detailed enough to start.
+2. **Resolve D1–D10 first.** Many Tier-B/C items branch on these decisions.
+3. **Don't sequence by area report — sequence by phase.** Phases 1–4 in §5
+   intentionally interleave area reports because real value lands in
+   cross-area combinations (e.g. MCP server + tool runner + marketplace
+   browse, or RAG + RAG node in workflow + visual builder).
+4. **Convert tracked items to concept docs.** Each Tier-B/C item should
+   graduate into its own `concepts/YYYY-MM-DD …` file when it's about to be
+   built, citing the area report.
+
+---
+
+_Word count: ~2300. Cross-references are intentional; the area reports
+remain the authoritative evidence._

--- a/concepts/astron-comparison/01-workflow-engine.md
+++ b/concepts/astron-comparison/01-workflow-engine.md
@@ -1,0 +1,529 @@
+# Workflow Engine — astron-agent vs ihub-apps
+
+Research date: 2026-05-13. Sources:
+- astron-agent: `https://github.com/iflytek/astron-agent/tree/main/core/workflow` (Python, FastAPI-style)
+- ihub-apps: `/home/user/ihub-apps/server/services/workflow/` (Node.js/ES modules)
+
+---
+
+## 1. astron-agent: what it offers
+
+### 1.1 Project layout
+
+`core/workflow/` is a full Python micro-service with the following modules
+([tree](https://github.com/iflytek/astron-agent/tree/main/core/workflow)):
+
+- `alembic/` — DB migrations
+- `api/v1/` — FastAPI router; namespaces `/workflow/v1`, `/sparkflow/v1`, `/v1`; sub-routers
+  `layout`, `auth`, `node_debug`, `file`, `sse_debug_chat`, `sse_openapi`
+- `engine/` — execution engine (`dsl_engine.py`, `node.py`, `callbacks/`, `entities/`, `nodes/`)
+- `repository/` — DAO layer (`flow_dao.py`, `license_dao.py`) — DB-backed persistence
+- `service/` — business orchestration
+- `cache/`, `configs/`, `consts/`, `domain/`, `exception/`, `extensions/`, `infra/`, `utils/`
+
+### 1.2 Execution model
+
+- **Async DFS over a DAG** orchestrated by `WorkflowEngine.async_run()` in
+  `engine/dsl_engine.py`. `_depth_first_search_execution()` walks the graph;
+  `_wait_predecessor_nodes()` enforces dependencies; `_get_next_nodes()` selects
+  successors after each completion.
+- **Per-node strategy** via `NodeExecutionStrategyManager`:
+  `DefaultNodeExecutionStrategy` for async parallel-capable nodes,
+  `QuestionAnswerNodeStrategy` for serial-only nodes (locking).
+- **Compiled nodes**: `SparkFlowEngineNode.async_call()` wraps each DSL node;
+  nodes are cached in `built_nodes`.
+- **Branching**: outgoing edges include `sourceHandle` (e.g. fail-branch). Error
+  strategies can route to a dedicated `FailBranch` instead of failing the whole
+  flow.
+
+### 1.3 Node types (28 total, from `engine/entities/node_entities.py` enum)
+
+| Category | Node types |
+|---|---|
+| Core | START, END, FLOW, MESSAGE, AGENT |
+| Processing | LLM, CODE, PLUGIN, DATABASE, RPA, MCP |
+| Knowledge | KNOWLEDGE_BASE, KNOWLEDGE_EXPERT, KNOWLEDGE_PRO |
+| Control flow | IF_ELSE, DECISION_MAKING, ITERATION (start/end), LOOP (start/end/exit) |
+| Data | PARAMETER_EXTRACTOR, TEXT_JOINER, VARIABLE_AGGREGATION |
+| Advanced | QUESTION_ANSWER, MEMORY_ADD, MEMORY_SEARCH |
+
+Notable nodes:
+- **LLM** (`engine/nodes/llm/spark_llm_node.py`) — multimodal inputs (image/audio/video),
+  format-specific parsers (text/markdown/json), reasoning content, tool calling,
+  token/price tracking.
+- **Code** (`engine/nodes/code/code_node.py`) — Python only; `main()` function;
+  pluggable `CodeExecutorFactory` (`CODE_EXEC_TYPE` env: local, sandbox, remote);
+  typed I/O validated against schema.
+- **Iteration** (`engine/nodes/iteration/iteration_node.py`) — executes a
+  **subgraph** per batch item; sequential or **parallel** (`isParallel`,
+  `maxConcurrency`, `asyncio.Semaphore`); error strategies `fail_fast`,
+  `continue`, `ignore_error_output`; each parallel batch gets an isolated
+  child engine + deep-copied `VariablePool`.
+- **Loop** (`engine/nodes/loop/loop_node.py`) — stateful loop with `loopVariables`,
+  multi-condition termination (`and`/`or`, operators `eq`, `gt`, `contains`,
+  `regex_contains`, …), `maxLoopCount` (default 10, bounded 1-100).
+- **Knowledge / Knowledge Pro / Expert** — RAG nodes with adaptive prompting
+  (`adaptive_search_prompt.py`) and a knowledge client.
+- **MCP** — Model Context Protocol integration node.
+- **RPA** — robotic process automation.
+- **Plugin/Tool** — external plug-in integration with versioning (`tool_id`, `version`).
+- **Question/Answer** — serial-locked user-Q node.
+- **Variable Aggregation / Text Joiner / Params Extractor** — pure data nodes.
+- **Memory Add/Search** — persistent memory ops.
+
+### 1.4 State and persistence
+
+- `WorkflowEngineCtx` holds `variable_pool`, `node_run_status`,
+  `msg_or_end_node_deps`, `built_nodes`, `callback`, `event_log_trace`.
+- **`VariablePool`** (`engine/entities/variable_pool.py`) — `input_variable_mapping`
+  & `output_variable_mapping` keyed `"{node_id}-{var_name}"`; resolves references
+  via `NodeRef`; literals vs references; `deepcopy()` for parallel isolation;
+  chat history (`history_mapping`, `history_v2`).
+- **DSL schema** (`engine/entities/workflow_dsl.py`): top-level `nodes`,
+  `edges`; node id pattern `^.*::[0-9a-zA-Z-]+`; `data.inputs`, `outputs`,
+  `nodeParam`, `nodeMeta`, `retryConfig`.
+- **Persistence**: DAO layer (`repository/flow_dao.py`) + Alembic migrations;
+  flows stored in database (not flat files).
+
+### 1.5 Streaming, retries, error handling
+
+- **Streaming**: `support_stream_node_ids` set; per-node `stream_data` queue;
+  `StreamOutputMsg` with `exception_occurred` flag. LLM/Agent/Knowledge Pro/Flow
+  nodes are streaming-capable; the engine forwards tokens to callbacks while
+  the DAG runs.
+- **Retries (`RetryConfig`, `engine/entities/retry_config.py`)**:
+  `timeout` (float, default 60), `should_retry` (bool, default False),
+  `max_retries` (int, default 0), `error_strategy` (int — `Interrupted`,
+  `CustomReturn`, `FailBranch`), `custom_output` (dict).
+- **`ErrorHandlerChain`** (Chain of Responsibility) —
+  `TimeoutErrorHandler` → `CustomExceptionInterruptHandler` →
+  `RetryableErrorHandler` → `GeneralErrorHandler`. Mid-stream retries are
+  blocked by `_stream_node_has_sent_first_token()` to avoid double-output.
+- **Error continuation by node type**: some nodes can return a custom value and
+  continue (DATABASE/PLUGIN/CODE/DECISION_MAKING/KB/PARAMETER_EXTRACTOR/MCP/RPA/MEMORY);
+  streaming nodes (LLM/AGENT/KP/FLOW) emit an error message and continue.
+
+### 1.6 Observability & debugging
+
+- Per-node `WorkflowLog` event trace (`event_log_trace`).
+- Token & price metrics tracked per node (`TOTAL_TOKENS`, `TOTAL_PRICE`,
+  `CURRENCY`, `TOOL_INFO`, `ITERATION_ID`, `ITERATION_INDEX`).
+- Dedicated `node_debug_router` (`/workflow/v1/...`) for single-node
+  debug runs.
+- SSE debug chat router (`sse_debug_chat_router`) and OpenAPI SSE router
+  (`sse_openapi_router`).
+
+### 1.7 Builder UI
+
+- `layout_router` returns canvas layout for the frontend visual editor.
+- Repository has `console-frontend/` (React) implementing the workflow builder
+  (not in scope for this analysis).
+
+---
+
+## 2. ihub-apps: current state
+
+### 2.1 Module layout
+
+`/home/user/ihub-apps/server/services/workflow/`:
+- `WorkflowEngine.js` — orchestrator
+- `DAGScheduler.js` — DAG ops, condition evaluation
+- `StateManager.js` — in-memory + disk checkpoints
+- `ExecutionRegistry.js` — user → executions index
+- `WorkflowLLMHelper.js` — adapter-option filter & streaming helper
+- `executors/`: `BaseNodeExecutor`, `StartNodeExecutor`, `EndNodeExecutor`,
+  `AgentNodeExecutor`, `ToolNodeExecutor`, `DecisionNodeExecutor`,
+  `TransformNodeExecutor`, `HumanNodeExecutor`, `index.js`
+
+Routes: `/home/user/ihub-apps/server/routes/workflow/workflowRoutes.js`
+Schema: `/home/user/ihub-apps/server/validators/workflowConfigSchema.js`
+Loader: `/home/user/ihub-apps/server/workflowsLoader.js`
+Chat bridge: `/home/user/ihub-apps/server/tools/workflowRunner.js`
+
+### 2.2 Execution model
+
+- **Sequential MVP loop** (`WorkflowEngine.js:268-535`). Iterates with
+  `MAX_EXECUTION_ITERATIONS = 100`, picks the first executable node from
+  `state.currentNodes`, runs it, then computes next nodes
+  (`DAGScheduler.getNextNodes`). Parallel execution is **explicitly TODO**
+  (`DAGScheduler.js:239-241`).
+- **Cycle handling**: opt-in via `workflow.config.allowCycles` (default true).
+  Strict-DAG mode rejects cycles using Kahn’s algorithm. Looping is bounded by
+  `maxIterations` per node (`WorkflowEngine.js:649-664`).
+- **Edge conditions** (`DAGScheduler.js:363-409`): `always`, `never`,
+  `expression` (using `===`/`!==`), `equals`, `contains`, `exists`, `llm`
+  (placeholder — not implemented).
+
+### 2.3 Node types (7 implemented)
+
+| Type | File | Purpose |
+|---|---|---|
+| `start` | `executors/StartNodeExecutor.js` | input mapping/defaults |
+| `end` | `executors/EndNodeExecutor.js` | output mapping, custom statusCode |
+| `agent` | `executors/AgentNodeExecutor.js` | LLM call w/ tools, sources, files |
+| `tool` | `executors/ToolNodeExecutor.js` | deterministic tool invocation |
+| `decision` | `executors/DecisionNodeExecutor.js` | expression / switch / LLM (TODO) |
+| `transform` | `executors/TransformNodeExecutor.js` | pure state ops: set, copy, increment, push, merge, arrayGet, lengthOf, conditional |
+| `human` | `executors/HumanNodeExecutor.js` | pause for user input / approval |
+
+Schema also enumerates `parallel`, `join`, `memory` (`workflowConfigSchema.js:106-117`)
+but **no executors** exist for them — they would throw `EXECUTOR_NOT_FOUND`.
+
+### 2.4 State & persistence
+
+- `StateManager` singleton (`StateManager.js:68-73`) keeps `activeStates` Map
+  in memory.
+- Per-execution disk checkpoints under
+  `contents/data/workflow-state/{executionId}/latest.json` via
+  `atomicWriteJSON` (`StateManager.js:259-303`).
+- 50 MB state size cap (`StateManager.js:23`).
+- `ExecutionRegistry` keeps a JSON index of executions per user
+  (`workflow-state/execution-registry.json`), recoverable on restart
+  (`ExecutionRegistry.js:357-406`).
+- State carries `currentNodes`, `completedNodes`, `failedNodes`, `data`,
+  `data.nodeResults`, `data.executionMetrics`, `_nodeIterations`,
+  `_pausedAt`, `_pauseReason`. Loop iteration outputs are keyed
+  `{nodeId}_iter{N}` (`StateManager.js:458-465`).
+- Workflows are **flat JSON files** under `contents/workflows/{id}.json`
+  with no DB. Loader: `workflowsLoader.js` + `configCache`.
+
+### 2.5 Streaming, retries, errors
+
+- **SSE**: `workflowRoutes.js:1257-1408` per-execution SSE channel,
+  identity-pinned for reconnect safety, 30 s heartbeat. Events:
+  `workflow.start`, `workflow.iteration`, `workflow.node.{start,complete,error}`,
+  `workflow.paused`, `workflow.human.{required,responded}`,
+  `workflow.{complete,failed,cancelled}`, `workflow.checkpoint.saved`.
+- **Chat bridge** (`tools/workflowRunner.js`) re-emits workflow events
+  on the chat SSE channel and exposes workflows as tools.
+- **Retry per node**: `node.execution.retries` / `retryDelay` /
+  `errorHandler ∈ {fail, continue, llm_recovery}` in schema
+  (`workflowConfigSchema.js:60-71`). Engine implements `retries` + `retryDelay`
+  (`WorkflowEngine.js:399-456`) but `continue` and `llm_recovery` are
+  **schema-declared only** — engine always fails the workflow after all retries
+  (`WorkflowEngine.js:820-844`).
+- **Workflow-level deadline**: `config.maxExecutionTime` (default 5 min, cap
+  10 min) checked every loop iteration (`WorkflowEngine.js:312-343`).
+- **Cancellation**: `AbortController` per execution.
+
+### 2.6 Observability
+
+- Per-node `tokens` and `metrics.duration` aggregated into
+  `state.data.executionMetrics` (`StateManager.js:467-481`).
+- Step history (`state.history`) for every `node_start` / `node_complete` /
+  `node_error`.
+- Admin endpoint `GET /api/admin/workflows/executions` with status/search/pagination
+  (`workflowRoutes.js:1809-1883`).
+- Per-execution export (`/executions/:id/export`) of full state JSON.
+- No per-node debug runner; no built-in single-node debug API.
+
+### 2.7 Builder UI
+
+- Client lives at `/home/user/ihub-apps/client/src/features/workflows/` and
+  contains list, execution, human-checkpoint, and live progress components but
+  **no visual graph editor** — workflows are authored as raw JSON.
+- The `canvas/` feature (`client/src/features/canvas/`) is a Quill-based text
+  canvas, **not** a graph workflow editor.
+
+### 2.8 Variable resolution
+
+Two co-existing syntaxes:
+- JSONPath-ish `$.data.field`, `${$.path}` — `BaseNodeExecutor.resolveVariable`
+  / `resolveVariables` (`BaseNodeExecutor.js:120-217`).
+- Handlebars-ish `{{var}}`, `{{#if}}`, `{{#each}}`, `{{#compare}}`, `{{this}}`,
+  `{{@index}}` — `AgentNodeExecutor.resolveTemplateVariables` /
+  `processEachBlocks` (`AgentNodeExecutor.js:383-623`).
+
+Decision expressions use a sanitized `new Function()` evaluator
+(`DecisionNodeExecutor.js:243-288`) with deny-list patterns and helpers
+(`exists()`, `empty()`, `length()`).
+
+---
+
+## 3. Gap matrix
+
+| Capability | astron-agent | ihub-apps | Severity | Notes |
+|---|---|---|---|---|
+| Parallel node execution | Yes (asyncio + strategy) | No (MVP sequential, TODO) | **High** | Major perf gap; iteration-style parallelism missing |
+| Iteration over a list (subgraph per item) | Iteration node (serial+parallel) | No | **High** | Common pattern (e.g., per-query research) |
+| Stateful loop with conditions | Loop node (`and`/`or`, regex, `eq`, `gt`, …) | Cycles + `maxIterations` only | **High** | No declarative loop termination |
+| LLM/agent node | Spark LLM + Agent (separate) | Combined `agent` node | Low | Functional parity |
+| Code node (sandboxed Python) | Yes (`CodeExecutorFactory`) | No | **High** | Big feature for power users / RPA |
+| Knowledge / RAG node | Yes (Knowledge / Pro / Expert + adaptive prompts) | Via `sources` in `agent` config | Med | iHub does have sources, but no first-class RAG node with reranking |
+| Tool / Plugin node with versioning | Yes | `tool` node, no versioning | Low | Adequate today |
+| MCP node | Yes | No | Med | MCP momentum is growing |
+| RPA node | Yes | No | Low | Niche |
+| Memory add/search nodes | Yes | No | Med | iHub has chat memory but no node primitives |
+| Decision / If-Else | Decision + If/Else nodes | `decision` (expression / switch / LLM TODO) | Low | LLM routing not implemented |
+| Parameter extractor | Dedicated node | Done in `agent` w/ schema | Med | Reusable pattern is convenient |
+| Variable aggregation / text joiner | Dedicated nodes | Doable via `transform` | Low | OK for now |
+| Question/Answer node (in-flow user Q) | Yes (with serial lock) | `human` covers it | Low | Similar |
+| Human-in-the-loop checkpoints | Implicit (Q/A) | First-class `human` node | None | iHub is ahead here |
+| Edge conditions / branches | DAG edges + `sourceHandle`, fail-branch | Multiple condition types | Low | Parity-ish |
+| Error strategy per node | `Interrupted` / `CustomReturn` / `FailBranch` | Schema enums declared but only `fail` works | **High** | `continue`/`llm_recovery` are stubs |
+| Per-node retry config | Yes (timeout/maxRetries/strategy/customOutput) | Yes (retries/retryDelay/errorHandler) | Low | Implementation gap on errorHandler |
+| Streaming intermediate output to client | Per-node streaming queue + token-aware retries | SSE per execution; no token-level streaming from agent nodes to UI | Med | LLM tokens are accumulated, not streamed |
+| Persistence | Database (DAO + Alembic) | JSON files + checkpoint dir | Med | OK at small scale; weak for multi-instance |
+| Multi-instance / horizontal scale | DB-backed state | Singleton in-memory `StateManager` | **High** | One process owns running executions |
+| Node debug API (single-node run) | Yes (`node_debug_router`) | No | Med | Big DX win for builders |
+| Versioned DSL (semver, schema versioning) | Workflow DSL with explicit DB schema | semver field in JSON | Low | Both have versions, no migration tooling on either side |
+| Visual graph editor | Yes (console-frontend) | No (JSON only) | **High** | Adoption blocker for non-developers |
+| Token / cost metrics | Per-node tokens + price + currency | Tokens + duration; no price | Med | Cost reporting missing |
+| Observability log trace | `WorkflowLog` event trace + structured callbacks | `state.history`, SSE events | Low | Comparable |
+| Cycle/loop safety | maxLoopCount per loop node | maxIterations per workflow + per-node | Low | Parity |
+| Schema validation | Pydantic at boot + runtime | Zod at boot + runtime | None | OK |
+| Sub-workflows / call-flow node | `FLOW` node | No | Med | Composition is currently impossible |
+
+---
+
+## 4. What we should reimplement (ranked)
+
+Each row: rationale · scope (S/M/L/XL) · risk · key dependencies.
+
+1. **Parallel execution in `DAGScheduler` / `WorkflowEngine`**
+   *Rationale*: Unblocks every other parallel feature (iteration, branch fan-out).
+   The current MVP picks one node per iteration — devastating for any non-linear
+   graph.
+   *Scope*: M · *Risk*: Med (state-merge races, error fan-in) · *Deps*: none — already
+   gated by `workflow.config.parallel` flag we can add.
+
+2. **Iteration node (subgraph per list item, serial + parallel modes)**
+   *Rationale*: The biggest user-facing missing primitive. Today users hand-roll
+   cycles to iterate, which is brittle. Astron’s `IterationNode` is the obvious
+   blueprint.
+   *Scope*: L · *Risk*: Med (deep-cloning state, isolated metrics) · *Deps*: #1.
+
+3. **Loop node with declarative termination conditions**
+   *Rationale*: Replaces the current “cycles + maxIterations” crutch. Cleaner
+   semantics, safer, easier to validate, supports common patterns (until-converged,
+   while-not-found).
+   *Scope*: M · *Risk*: Low · *Deps*: none.
+
+4. **Code node (sandboxed JavaScript/Python execution)**
+   *Rationale*: Power-user requirement; enables data wrangling, custom validators,
+   small adapters without writing a tool.
+   *Scope*: L · *Risk*: High (sandboxing — recommend `isolated-vm` or sidecar)
+   · *Deps*: none.
+
+5. **Honour `errorHandler: continue` and add `customReturn` strategy**
+   *Rationale*: Schema already promises it. Today it silently fails the workflow.
+   *Scope*: S · *Risk*: Low · *Deps*: none. Quick win.
+
+6. **Fail-branch routing on edges (`sourceHandle: "fail"`)**
+   *Rationale*: Lets workflows recover gracefully without a separate decision node.
+   *Scope*: S · *Risk*: Low · *Deps*: #5.
+
+7. **Sub-workflow node (`flow` / `call_workflow`)**
+   *Rationale*: Enables composition and reuse — today there’s no way to factor
+   common sequences.
+   *Scope*: M · *Risk*: Med (recursion budget, output mapping) · *Deps*: none.
+
+8. **First-class knowledge/RAG node**
+   *Rationale*: Sources are wired into `agent` nodes only. A dedicated RAG node
+   that returns ranked chunks (and feeds into other nodes) is more flexible.
+   *Scope*: M · *Risk*: Low · *Deps*: existing `SourceResolutionService`.
+
+9. **LLM-based decision routing**
+   *Rationale*: `decision.type === 'llm'` is declared and stubbed
+   (`DecisionNodeExecutor.js:413-429`).
+   *Scope*: S · *Risk*: Low · *Deps*: `WorkflowLLMHelper`.
+
+10. **Memory add/search nodes**
+    *Rationale*: Standard pattern for long-running agents.
+    *Scope*: M · *Risk*: Med (persistence model) · *Deps*: new memory store.
+
+11. **Single-node debug API + UI**
+    *Rationale*: Builder productivity. Execute one node with synthetic input
+    without running the rest.
+    *Scope*: M · *Risk*: Low · *Deps*: existing executors.
+
+12. **Visual graph editor (canvas)**
+    *Rationale*: Major adoption blocker. Likely reuse React Flow + existing
+    component infra.
+    *Scope*: XL · *Risk*: High (UX surface) · *Deps*: stable DSL.
+
+13. **DB-backed state & cross-instance execution**
+    *Rationale*: Today `StateManager` is an in-memory singleton — only one
+    process can own an execution. Blocks horizontal scaling.
+    *Scope*: L · *Risk*: Med · *Deps*: choose store (SQLite/Postgres).
+
+14. **Token-level streaming from agent nodes to client**
+    *Rationale*: Today agent output is buffered and emitted on completion;
+    astron streams tokens. Improves perceived latency in chat bridge.
+    *Scope*: M · *Risk*: Low · *Deps*: actionTracker plumbing.
+
+15. **Cost (price/currency) metrics in `executionMetrics`**
+    *Rationale*: We track tokens but not cost. Easy add given model registry.
+    *Scope*: S · *Risk*: Low · *Deps*: model pricing config.
+
+---
+
+## 5. Implementation outline (top 3)
+
+### 5.1 Parallel execution
+
+**Files to touch**
+- `server/services/workflow/DAGScheduler.js` —
+  `getExecutableNodes()` currently returns `[firstNode]`
+  (`DAGScheduler.js:244`). Return **all** current nodes whose `incomingEdges`
+  are satisfied; respect a new `workflow.config.parallel` and per-node
+  `node.execution.sequential` opt-out (Q/A-style).
+- `server/services/workflow/WorkflowEngine.js` —
+  in `_runExecutionLoop`, replace the `for (const nodeId of executableNodes)`
+  loop with `await Promise.all(executableNodes.map(...))` when parallel; gather
+  results, then call `getNextNodes` for each. Wrap `markNodeCompleted` and
+  state updates so concurrent writes go through a queue per execution to
+  avoid `deepMerge` races.
+- `server/services/workflow/StateManager.js` — add a small per-execution
+  async mutex (or serialize via a `Promise` chain) around `update` /
+  `markNodeCompleted`.
+
+**API/module names**
+- `WorkflowEngine._runParallelTier(executableNodes, …)`
+- `StateManager._withLock(executionId, fn)`
+
+**Schema changes** (`workflowConfigSchema.js`)
+- Add `config.parallel: boolean` (default `false` for backward compat).
+- Add `node.execution.sequential: boolean` to force serial.
+
+**Migration**
+- New `server/migrations/V0NN__workflow_parallel_default.js` setting
+  `config.parallel = false` on existing workflow JSON files (no-op semantics).
+
+**UI**
+- `ExecutionProgress.jsx` already renders one node-card per result —
+  no major change, but show concurrent nodes side-by-side in the same tier
+  row.
+
+**Tests**
+- New unit tests in `server/tests/services/workflow/DAGScheduler.test.js`
+  (parallel tier resolution).
+- Engine integration test running a fan-out → fan-in diamond.
+- Stress test ensuring `state.data.nodeResults` is consistent under
+  10-way fan-out.
+
+---
+
+### 5.2 Iteration node (subgraph per item)
+
+**Files to add**
+- `server/services/workflow/executors/IterationNodeExecutor.js`
+- (Optional) `server/services/workflow/SubExecutionRunner.js` —
+  helper that re-uses `WorkflowEngine` to run a list of nodes as a
+  sub-workflow with an isolated `StateManager` scope (or namespaced
+  `state.data._iter[itemIdx]`).
+
+**Files to touch**
+- `executors/index.js` — register `iteration`.
+- `WorkflowEngine.js` — accept a callback to spawn nested executions;
+  share `actionTracker` so SSE events bubble.
+- `DAGScheduler.js` — treat iteration node as a single scheduling unit
+  (its inner subgraph runs inside the executor).
+
+**Schema changes** (`workflowConfigSchema.js`)
+- Extend `nodeTypeEnum` with `iteration`.
+- Inside `config` (passthrough already allows it), document the contract:
+  ```
+  config: {
+    items: "$.data.queries",            // JSONPath to iterable
+    itemVariable: "query",              // exposed inside subgraph
+    indexVariable: "i",
+    subgraph: { nodes: [...], edges: [...] },
+    isParallel: false,
+    maxConcurrency: 5,
+    errorStrategy: "fail_fast" | "continue" | "ignore",
+    outputVariable: "results"
+  }
+  ```
+
+**Migration**
+- No backfill — additive.
+
+**UI**
+- `client/src/features/workflows/components/ExecutionProgress.jsx` —
+  render iteration sub-results as a nested collapsible per index
+  (we already key by iteration: `state.data.nodeResults` uses
+  `{nodeId}_iter{N}` — extend with `{nodeId}_iter{N}_sub_{subNodeId}`).
+- `WorkflowExecutionPage.jsx` — surface iteration progress (e.g. "3/10").
+
+**Tests**
+- Unit: executor with serial + parallel + each error strategy.
+- E2E: workflow that iterates over a list of search queries and
+  aggregates into a final report (mirrors `iterative-research-auto.json`
+  but cleaner).
+
+**Migration considerations**
+- Existing `iterative-research-*` workflows use cycles. After landing,
+  publish a new `iterative-research-iteration.json` example; do **not**
+  auto-rewrite existing workflows (they may rely on per-cycle state).
+
+---
+
+### 5.3 Loop node with declarative termination
+
+**Files to add**
+- `server/services/workflow/executors/LoopNodeExecutor.js`
+
+**Files to touch**
+- `executors/index.js` — register `loop`.
+- `workflowConfigSchema.js` — add `loop` to `nodeTypeEnum`. Inside `config`:
+  ```
+  config: {
+    loopVariables: [
+      { name: "counter", initial: 0 },
+      { name: "results", initial: [] }
+    ],
+    termination: {
+      operator: "or",
+      conditions: [
+        { field: "$.data.counter", op: "gt", value: 10 },
+        { field: "$.data.shouldStop", op: "eq", value: true }
+      ]
+    },
+    maxIterations: 50,
+    subgraph: { nodes: [...], edges: [...] }
+  }
+  ```
+
+**Schema validation**
+- Add discriminated-union refinements for the `op` field
+  (`eq | neq | gt | gte | lt | lte | contains | regex_contains | in | exists`).
+
+**Migration**
+- New migration `V0NN__deprecate_cycles_default.js`: optional, leaves
+  `allowCycles=true` (existing workflows unaffected). When we deprecate,
+  bump again to `false` by default.
+
+**UI**
+- Show loop iteration count in `ExecutionProgress`.
+- Surface termination condition that fired (engine emits a new
+  `workflow.loop.terminated` event with `reason`).
+
+**Tests**
+- Termination on each operator.
+- `maxLoopCount` safety net.
+- Pre/post loop variable propagation.
+
+---
+
+## 6. Open questions
+
+1. **What persistence model do we want long-term?** Astron uses a DB. iHub uses
+   JSON files. Adopting a DB unlocks multi-instance execution but is a larger
+   architectural change. Resolution: prototype with SQLite first; measure.
+2. **Sandbox technology for the Code node** — `vm2` is deprecated; `isolated-vm`
+   needs native build; `quickjs-emscripten` is portable. Need a decision.
+3. **Should we keep JSON-file workflows or migrate to DB?** Could keep both
+   (file = source-of-truth in repo, DB = runtime cache + execution state).
+4. **Multi-language code node** — Python via sidecar process? Or JS-only first?
+5. **Exact mapping from astron’s 28 node types to ihub’s `transform`** —
+   how many of `text_joiner`, `variable_aggregation`, `params_extractor` can be
+   served by `transform` vs needing dedicated nodes for clearer DX?
+6. **Streaming protocol changes** — token-level streaming from agent nodes
+   to the chat bridge needs a contract between `actionTracker`,
+   `workflowRunner.js`, and the SSE channel; needs design before code.
+7. **Sub-workflow security/permissions** — does the called workflow inherit
+   the caller’s user/groups? Need explicit policy.
+8. **Could not fetch** complete `dsl_engine.py`, `node_debug_router`, `flow_dao.py`
+   contents (rate limits / size). Findings on those are from WebFetch summaries
+   and may miss subtleties — verify before final implementation.

--- a/concepts/astron-comparison/02-model-abstraction.md
+++ b/concepts/astron-comparison/02-model-abstraction.md
@@ -1,0 +1,477 @@
+# Model Abstraction & MaaS — astron-agent vs ihub-apps
+
+Research conducted 2026-05-13 against `iflytek/astron-agent` (main branch) and the local
+`ihub-apps` working tree at `/home/user/ihub-apps`. References to astron-agent files cite
+the `main` branch path; references to ihub-apps cite `path:line`.
+
+## 1. astron-agent
+
+### Architecture at a glance
+
+Astron is a polyglot microservices platform. The model layer is split across two main
+runtimes:
+
+- **`console/backend`** (Java / Spring Boot 3, MyBatis-Plus, MySQL) — the *control plane*.
+  Manages model metadata, validation, encrypted API keys, model marketplace ("shelf"),
+  and the MaaS deployment lifecycle. Source: `console/backend/toolkit/src/main/java/com/iflytek/astron/console/toolkit/`.
+- **`core/agent`** + **`core/workflow`** (Python / FastAPI, httpx) — the *data plane*.
+  Hosts `BaseLLMModel` and provider-specific subclasses (`AnthropicLLMModel`,
+  `GoogleLLMModel`) plus per-workflow-node LLM execution (`core/workflow/engine/nodes/llm/spark_llm_node.py`).
+- **`console/backend/hub`** — a Java module dedicated to the iFLYTEK Spark chat path
+  (`SparkChatService.java`, uses the proprietary `cn.xfyun.api.SparkChatClient`).
+
+### Provider adapters
+
+The Python data plane has three concrete adapters in `core/agent/domain/models/base.py`:
+
+| Adapter | Endpoint family | HTTP client | Streaming |
+| --- | --- | --- | --- |
+| `BaseLLMModel` (the OpenAI client) | OpenAI Chat Completions | `openai` SDK | yes, `ChatCompletionChunk` |
+| `AnthropicLLMModel` | `/v1/messages` | `httpx.AsyncClient` | SSE |
+| `GoogleLLMModel` | `generateContent` (Gemini) | `httpx.AsyncClient` | SSE |
+
+The Java control plane in `service/model/LLMService.java` declares mappings for a much
+broader registry — OpenAI, Anthropic, Google, DeepSeek, Minimax, Zhipu, Qwen, Moonshot,
+Doubao, ChatGPT — but those are *configuration entries*, not runtime adapters; they are
+all served through the OpenAI-compatible base adapter at inference time.
+
+For iFLYTEK Spark, Astron carries a separate Java-only path through
+`console/backend/hub/service/SparkChatService.java` which uses the proprietary
+`SparkChatClient`, SDK enum `SparkModel` (e.g. `SPARK_X1`, `SPARK_4_0_ULTRA`), and
+signature-based HTTP authentication, returning a Spring `SseEmitter`.
+
+### Model registry & metadata
+
+Model metadata lives in MySQL tables, exposed through the Spring controller
+`controller/model/ModelController.java`. Endpoints (all under `/api/model`):
+
+- `POST /api/model` — create/update a model definition (validates via reflection of the
+  remote provider before persisting).
+- `GET /api/model/delete` — soft-delete a model (with workflow cleanup via `ShelfModelService`).
+- `POST /api/model/list` — paginated browse.
+- `GET /api/model/detail` — fetch one entity.
+- `GET /api/model/rsa/public-key` — fetch the RSA public key used by the client to
+  encrypt API keys before they are sent to the server.
+- `GET /api/model/check-model-base` — ownership/permission check.
+- `GET /api/model/category-tree` — category hierarchy used by the model marketplace UI.
+- `GET /api/model/{option}` — toggle a model on/off.
+- `GET /api/model/off-model` — remove from "shelf" and unwire from dependent workflows.
+- `POST /api/model/local-model` — register a local model definition.
+- `GET /api/model/local-model/list` — enumerate local model files.
+
+Permissions are enforced via `@SpacePreAuth` annotations.
+
+### MaaS lifecycle (deploy / start / stop / status)
+
+The MaaS control plane is `handler/LocalModelHandler.java`:
+
+- `deployModel(ModelDeployVo)` — POST a new deployment, returns `serviceId`.
+- `deployModelUpdate(ModelDeployVo, serviceId)` — PUT changes to a running service.
+- `checkDeployStatus(serviceId)` — GET status, returns `{status, endpoint, updateTime}`.
+  States: `running | pending | failed | initializing | terminating`.
+- `deleteModel(serviceId)` — DELETE the service.
+- `getLocalModelList()` — list deployable files.
+
+The deployment request shape (`entity/vo/model/ModelDeployVo.java`) is intentionally
+minimal — Astron delegates to a separate, opaque "MaaS service" microservice via HTTP:
+
+```java
+@Data public class ModelDeployVo {
+  private String modelName;
+  private ResourceRequirements resourceRequirements; // { acceleratorCount }
+  private Integer replicaCount;
+  private Integer contextLength;
+}
+```
+
+Astron itself does **not** ship the underlying k8s/Helm operator — the
+`README` only mentions "one-click deployment" and the `MAAS_*` env vars in
+`docs/CONFIGURATION_zh.md` show that all MaaS API URLs default to an external
+iFLYTEK Xingchen endpoint (`https://xingchen-api.xf-yun.com`) with credential triples
+(`MAAS_APP_ID/API_KEY/API_SECRET`, `MAAS_CONSUMER_*`). Local self-hosted MaaS plugs in by
+swapping the `ApiUrl` config. The status enum and minimal VO suggest the platform
+expects a Kubernetes-backed inference operator (replicas + GPU count + context window).
+
+### API key management
+
+API keys are encrypted client-side with RSA — the public key is fetched via
+`GET /api/model/rsa/public-key`, encrypted, sent to the server, persisted in the model
+row, and decrypted at request time by `ModelService.decryptApiKey()`. SSRF protection is
+applied via `SsrfParamGuard` with IP blacklisting before any outbound call.
+
+### Streaming
+
+All adapters stream:
+- OpenAI: native `openai` SDK chunk iterator.
+- Anthropic / Google: manual SSE parsing inside `BaseLLMModel` subclasses.
+- Spark (Java path): `SseEmitter` driven by `cn.xfyun.api.SparkChatClient`.
+- The workflow engine surfaces the stream as `AgentResponse` chunks; the runner
+  (`core/agent/engine/nodes/chat/chat_runner.py`) calls `self.model_general_stream()`
+  which yields normalized `delta` + `usage` chunks.
+
+### Multimodal, tool calling, prompt caching, fine-tune
+
+- **Multimodal**: Spark LLM node has explicit `input_to_filetype_map` for image / audio /
+  video and a "xaipersonality" domain. Other adapters inherit OpenAI-style content arrays.
+- **Tool calling**: surfaced via MCP (Model Context Protocol) — MCP servers are stored
+  in the `tool_base` MySQL table. Tool integration is *plugin-based* (`service/plugin/mcp.py`,
+  `skill.py`, `knowledge.py`, `link.py`, `workflow.py`), not per-adapter normalization.
+- **Prompt caching**: not surfaced in any model-layer code observed.
+- **Fine-tune hooks**: `LLMService.switchFinetuneModel()` exists, plus an
+  `entity/finetune` package — the platform tracks finetuned model state in Redis,
+  but the actual fine-tuning job is delegated to the external Xingchen platform.
+
+### Per-model rate limits / billing
+
+No per-model concurrency or rate-limit field surfaced in any adapter — billing and rate
+limits are delegated to the upstream provider (iFLYTEK enforces them at the Xingchen
+gateway via the `MAAS_CONSUMER_*` credentials).
+
+### Sources
+
+- README + `docs/CONFIGURATION.md` + `docs/PROJECT_MODULES.md` on <https://github.com/iflytek/astron-agent>
+- `console/backend/hub/.../service/SparkChatService.java`,
+  `console/backend/toolkit/.../service/model/` (`LLMService`, `ModelService`, `ShelfModelService`,
+  `ModelCommonService`), `.../handler/LocalModelHandler.java`,
+  `.../controller/model/ModelController.java`, `.../entity/vo/model/ModelDeployVo.java`
+- `core/agent/domain/models/base.py`, `core/agent/engine/nodes/chat/chat_runner.py`,
+  `core/workflow/engine/nodes/llm/spark_llm_node.py`
+- <https://deepwiki.com/iflytek/astron-agent/1-astron-agent-platform-overview>
+
+## 2. ihub-apps
+
+### Adapter registry
+
+The runtime is single-process Node.js (Express). All adapters live in
+`/home/user/ihub-apps/server/adapters/` and are registered as a flat object in
+`adapters/index.js:12-21`:
+
+| Key | Module | Notes |
+| --- | --- | --- |
+| `openai` | `openai.js` | Chat Completions, images + audio multipart |
+| `openai-responses` | `openai-responses.js` | GPT-5 Responses API, reasoning + verbosity |
+| `anthropic` | `anthropic.js` | `/v1/messages`, tool_use, image tool results |
+| `google` | `google.js` | `streamGenerateContent` + thinking + image generation |
+| `mistral` | `mistral.js` | La Plateforme, JSON schema strict mode |
+| `local` | `vllm.js` | vLLM, schema sanitization, autoDiscovery |
+| `bedrock` | `bedrock.js` | Converse + EventStream + cross-region profiles |
+| `iassistant-conversation` | `iassistant-conversation.js` | iFinder Conversation API, JWT, citations |
+
+All adapters extend `BaseAdapter` (`server/adapters/BaseAdapter.js:9`) which provides
+shared SSE parsing (`parseSseStream`), line-delimited SSE parsing
+(`parseLineDelimitedSseStream`), debug logging, base64 cleaning, and tool-response
+normalization.
+
+### Generic tool-calling layer
+
+A separate, non-trivial subsystem in `server/adapters/toolCalling/` (cited counts):
+
+- `ToolCallingConverter.js:1` (330 lines) — cross-provider routing.
+- `GenericToolCalling.js:1` (281 lines) — normalized tool/tool-call/streaming shapes.
+- Provider converters: `OpenAIConverter.js` (502), `OpenAIResponsesConverter.js` (580),
+  `AnthropicConverter.js` (416), `GoogleConverter.js` (524), `MistralConverter.js` (302),
+  `BedrockConverter.js` (224), `VLLMConverter.js` (504).
+- Public surface in `toolCalling/index.js:24-39` exports `convertToolsToGeneric`,
+  `convertToolsFromGeneric`, `convertResponseToGeneric`, etc.
+
+This converter layer is **richer than astron-agent's** — astron normalizes only at the
+agent-runner level (`AgentResponse`), whereas ihub-apps round-trips every provider's
+streaming chunk into a single intermediate shape, enabling the OpenAI-compatible
+inference proxy (`server/routes/openaiProxy.js:1`).
+
+### Model registry & metadata
+
+`contents/models/*.json` (one file per model). Defaults shipped in
+`server/defaults/models/` (17 files, including Claude 4 Opus/Sonnet, Gemini 3.x, GPT-5,
+Mistral Large/Medium/Small, GPT-OSS vLLM, iAssistant Conversation, Local vLLM).
+Loading goes through `server/modelsLoader.js:45-51` (uses a generic
+`createResourceLoader` factory) with `ensureOneDefaultModel` post-processing.
+
+Schema is enforced by Zod in `server/validators/modelConfigSchema.js:41-127`. Fields
+include `id`, `modelId`, localized `name`/`description`, `url`, `provider` (closed enum
+of 8 values, `:62-78`), `tokenLimit`, `default`, `supportsTools`, `concurrency`,
+`requestDelayMs`, `thinking`, multimodal flags (`supportsImages`, `supportsVision`,
+`supportsAudio`), `supportsStructuredOutput`, `supportsImageGeneration`,
+`imageGeneration`, free-form `config` (provider-specific), `hint` (UI banner),
+encrypted `apiKey`, `autoDiscovery`.
+
+Provider-level metadata lives in a separate `config/providers.json`
+(`server/defaults/config/providers.json:1`) with `enabled`, localized name/description,
+and `category`. Bedrock declares a `providerConfigSchema` in `bedrock.js:25-59` consumed
+by the admin Model Form Editor.
+
+### Runtime selection
+
+`server/routes/modelRoutes.js:75-113` exposes `GET /api/models` with permission filtering
+(`configCache.getModelsForUser`) and ETag-based caching. The chat flow goes through
+`server/services/chat/RequestBuilder.js:79` (`filterModelsForApp`) which picks the
+model from app `preferredModel`/`allowedModels`/user preference, then
+`server/adapters/index.js:42-44` dispatches via `getAdapter(model.provider)`. The
+streaming pipeline is `ChatService → RequestBuilder → StreamingHandler → adapter SSE
+parser` (`server/services/chat/ChatService.js:97-120`).
+
+### OpenAI-compatible inference proxy
+
+`server/routes/openaiProxy.js:21` mounts a parallel `/api/inference/v1/{models,chat/completions}`
+that translates inbound OpenAI requests to the generic format, dispatches via the
+provider-specific adapter, then re-encodes the response back to OpenAI format using
+`convertResponseFromGeneric`. This makes ihub-apps usable as a drop-in OpenAI proxy for
+external clients (handles permissions, client-disconnect abort, telemetry, tool
+conversion). No equivalent surfaces in astron-agent.
+
+### Model auto-discovery
+
+`server/services/ModelDiscoveryService.js:1` — calls the `/v1/models` endpoint on
+OpenAI-compatible providers (vLLM, LM Studio, Jan.ai), 5-minute cache TTL,
+deduped concurrent fetches, falls back to configured `modelId`. Triggered when
+`autoDiscovery: true` (`modelConfigSchema.js:122-124`).
+
+### Multimodal, thinking, structured output
+
+- **Images** in every adapter; multi-image arrays supported, per-provider media-type
+  handling (`anthropic.js:39-62`, `google.js:194-218`, `openai.js:58-79`, `bedrock.js:227-249`).
+- **Audio**: OpenAI multipart input_audio (`openai.js:83-105`), Gemini inlineData.
+- **Documents**: Bedrock-only document blocks (`bedrock.js:251-262`, 5-doc cap enforced).
+- **Thinking**: Gemini thinkingConfig (`google.js:353-372`), GPT-5 Responses reasoning
+  effort (`openai-responses.js:143-167`), Bedrock reasoningContent stream (`bedrock.js:423-425`).
+- **Structured output**: per-provider JSON-schema strict modes
+  (`openai.js:142-176`, `anthropic.js:172-180` via tool, `google.js:319-345`,
+  `mistral.js:73-83`).
+- **Image generation**: Gemini with aspect-ratio table (`google.js:13-64`, `:374-421`).
+- **Grounding metadata**: Gemini Search grounding (`google.js:518-521`).
+
+### API key management
+
+Per-model encrypted `apiKey` field (`modelConfigSchema.js:120`) — stored in the model
+JSON, decrypted at request time by `TokenStorageService` (AES-256-GCM, key in
+`contents/.encryption-key`). Provider-level fallback through env vars
+(`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) handled by `getApiKeyForModel`.
+
+### Streaming, throttling
+
+- SSE through `BaseAdapter.parseSseStream` (`BaseAdapter.js:155-188`).
+- Bedrock binary EventStream parsed by `bedrockEventStream.js`.
+- iAssistant uses line-delimited multi-event blocks (`BaseAdapter.js:201-249`).
+- Per-model concurrency + delay enforced by `server/requestThrottler.js:25,37,43`
+  using `concurrency` and `requestDelayMs` from the model schema.
+
+### Fine-tune, prompt caching, MaaS, billing
+
+- **Fine-tune**: none.
+- **Prompt caching**: not exposed (Anthropic `cache_control`, Gemini implicit, OpenAI
+  Responses cache — none surfaced; `grep` confirms zero occurrences).
+- **MaaS / model deployment lifecycle**: none — ihub-apps assumes models are pre-deployed
+  and consumed by URL. Local LLM is supported via vLLM as a configured upstream.
+- **Billing / credits**: not implemented at the model layer (telemetry counts tokens
+  via the adapter `usage` field but no quota / billing enforcement).
+
+## 3. Gap matrix
+
+| Capability | astron-agent | ihub-apps | Gap severity | Notes |
+| --- | --- | --- | --- | --- |
+| Provider count (runtime adapters) | 3 generic + 1 Spark | 8 (incl. Bedrock, vLLM, GPT-5 Responses, iAssistant) | astron lags | ihub-apps is ahead |
+| iFLYTEK Spark adapter | dedicated `SparkChatService` | none | medium (only if Spark targeted) | needs `SparkChatClient` Java→Node port or REST translation |
+| Tool-calling normalization | implicit (AgentResponse chunks) | dedicated 8-converter generic layer | astron lags | ihub-apps is ahead |
+| OpenAI-compatible inference proxy | none | `/api/inference/v1/*` | astron lags | ihub-apps is ahead |
+| Model registry CRUD UI | full Spring CRUD with categories & shelf | admin model edit + provider config | medium | ihub-apps lacks category tree, shelf, model marketplace |
+| Model categorization / "shelf" / marketplace | yes | partial (hint + enabled flag) | medium | useful for tenants browsing |
+| RSA-encrypted client-side key submission | yes (`/rsa/public-key` flow) | server-side AES-256-GCM at rest | low | different threat model; ihub's is good but key never crosses transport unencrypted only via HTTPS |
+| **MaaS deployment lifecycle (deploy/update/status/delete)** | **yes (`LocalModelHandler`)** | **none** | **HIGH** | core differentiator of astron's pitch |
+| GPU / replica / context-length sizing | yes (`ModelDeployVo`) | none | high | requires k8s operator backend |
+| Local model file management | `/local-model/list`, `LocalModelDto` | partial (vLLM auto-discovery only) | medium | upload + register from disk path |
+| Workflow cleanup on model removal | yes (`ShelfModelService.offShelfModel`) | manual | medium | when admin deletes a model, ihub leaves dangling refs |
+| SSRF guard on outbound provider URLs | yes (`SsrfParamGuard`) | none documented | medium | risk surface in admin-supplied URLs |
+| Connection validation before save | yes (`ModelService.validateModel` reflects to provider) | client/server-side smoke test only | medium | low-effort win |
+| Per-model rate limits / quotas | none (delegated upstream) | `concurrency` + `requestDelayMs` | astron lags | ihub-apps is ahead |
+| Fine-tune state management | yes (`switchFinetuneModel`, Redis) | none | low | likely not relevant to ihub's deployment story |
+| Prompt caching | none | none | n/a | both lack |
+| Multi-tenancy at model level | yes (`space` ownership in MyBatis) | groups-based ACL via `permissions.models` | low | semantically equivalent for most use cases |
+| Multimodal (image/audio/video/doc) | partial (Spark domain mapping) | extensive (Bedrock docs, OpenAI audio, Gemini image gen) | astron lags | ihub-apps is ahead |
+| Streaming + cancellation | yes (SSE) | yes + client-disconnect abort | comparable | ihub slightly better |
+| Auto-discovery from `/v1/models` | none | yes | astron lags | ihub-apps is ahead |
+| Cost / usage telemetry per model | none (delegated) | OTEL token metrics | astron lags | ihub-apps is ahead |
+| MCP servers in model selection UI | yes (via `tool_base`) | tools admin UI | comparable | different surface |
+
+## 4. What we should reimplement (ranked)
+
+Ranked by user value × differentiation × tractability.
+
+1. **Connection validation on model save (validateConnection endpoint)** — S, low risk.
+   Astron's `ModelService.validateModel()` reflects a probe request against the provider
+   before persisting. Adding this to ihub-apps' admin model save closes a common foot-gun
+   ("admin saves wrong URL, users get 502"). Already partially there client-side but no
+   server-side reflection.
+
+2. **Model categorization / marketplace ("shelf") + category tree** — M, low risk.
+   `ModelCategoryService.getTree()` powers a hierarchical model picker in astron's UI.
+   Maps neatly onto an optional `category` field plus a `config/model-categories.json`
+   in ihub. Useful as iHub grows past 20 models. Pairs with admin polish.
+
+3. **MaaS deployment lifecycle abstraction** — XL, high risk, high reward.
+   This is astron's headline feature. The right scope for ihub-apps depends on the
+   deployment story we want to commit to (see open questions). Concretely: an admin
+   surface that, given a vLLM/Ollama/TGI/LMStudio backend URL or a Kubernetes-aware
+   operator URL, lets users `deploy/update/status/delete` model serving instances. The
+   minimal viable shape mirrors `LocalModelHandler`: HTTP delegation to an external
+   "inference operator" — ihub becomes the control plane, the operator is pluggable.
+
+4. **Workflow / app integrity cleanup on model removal** — S, low risk.
+   Today `DELETE` of a model leaves `preferredModel` references dangling in
+   `contents/apps/*.json`. Port `ShelfModelService.offShelfModel` logic: when a model is
+   disabled/deleted, sweep apps + workflows and either auto-disable or surface a warning.
+
+5. **iFLYTEK Spark provider adapter** — M, medium risk.
+   Astron is iFLYTEK's flagship product; if we want to compete on Chinese-market parity,
+   a `spark.js` adapter that speaks the OpenAI-compatible Spark v3.x HTTP API (X1 /
+   4.0 Ultra) is straightforward. The non-compatible WebSocket flow (`wss://spark-openapi.cn-huabei-1.xf-yun.com`)
+   would only be necessary for legacy Spark v2.x and is not recommended.
+
+6. **SSRF guard for admin-supplied model URLs** — S, low risk.
+   Astron's `SsrfParamGuard` blacklists internal IPs before any outbound model call.
+   ihub-apps currently trusts admin-entered URLs implicitly — a meaningful hardening
+   given the admin Model Form Editor accepts arbitrary URLs.
+
+7. **Prompt caching primitives** — M, low risk.
+   Neither system has it, but Anthropic `cache_control`, Gemini implicit caching, and
+   OpenAI Responses caching are all becoming standard. Adding `supportsPromptCaching`
+   + per-message `cacheable: true` would put ihub-apps ahead.
+
+8. **Per-provider declarative metadata (capability matrix)** — S, low risk.
+   Astron carries this in `LLMService`'s provider mappings (auth header style, endpoint
+   path). ihub-apps' equivalent is scattered across adapter files. Centralizing into
+   `server/adapters/capabilities.js` would simplify documentation and unblock #2 and #3.
+
+## 5. Implementation outline (top 3)
+
+### 5.1 Connection validation on model save
+
+**Files**
+
+- New: `server/services/ModelValidationService.js` — exports `validateModelConnection(model, apiKey)`
+  which builds a tiny probe request via the matching adapter (e.g. one-token completion
+  with the model's `system` ping) and returns `{ok, latencyMs, errorCode, errorMessage}`.
+- Edit: `server/routes/admin/models.js` — add `POST /api/admin/models/validate` that calls
+  the service against a draft model object (without persisting).
+- Edit: `client/src/features/admin/models/ModelEditor.jsx` (or equivalent) — add "Test
+  connection" button before Save.
+
+**Schema delta**: none required. Optional: persist `lastValidatedAt` + `lastValidationStatus`
+on the model row for the admin list view.
+
+**Migration**: not required for the feature itself. If we persist validation status,
+create `server/migrations/V{NNN}__add_model_validation_status.js` to set defaults.
+
+**Tests**: unit tests against mocked `fetch` per provider; integration test against the
+admin endpoint with a deliberately bad URL → expects `502/timeout` classification.
+
+### 5.2 MaaS deployment lifecycle (pluggable inference operator)
+
+**Decision required** (Open Q1): commit to one of —
+(a) thin proxy to an external operator (mirror astron's `LocalModelHandler` design),
+(b) bundle our own k8s operator,
+(c) Docker-Compose local-only (good enough for self-hosters).
+
+Assuming (a) — the lowest-risk, highest-leverage choice.
+
+**Files**
+
+- New: `server/services/maas/MaasOperatorClient.js` — HTTP client to the configured
+  operator endpoint with `deploy/update/status/delete/list` methods. URL & creds in
+  `platform.json` → `maas` section.
+- New: `server/services/maas/MaasDeploymentRegistry.js` — persists `serviceId` ↔ model
+  config rows in `contents/maas-deployments.json`. Includes background poller that
+  refreshes status every 30s.
+- New: `server/routes/admin/maas.js` — `POST /api/admin/maas/deployments`,
+  `PUT /api/admin/maas/deployments/:id`, `DELETE`, `GET /api/admin/maas/deployments`,
+  `GET /api/admin/maas/files`.
+- New: `server/validators/maasDeploymentSchema.js` — Zod schema mirroring astron's
+  `ModelDeployVo` plus `image`, `env`, `ports`, `healthCheck` for operator flexibility.
+- Edit: `server/defaults/config/platform.json` — add encrypted `maas.{baseUrl, apiKey, kind}`.
+- New: `client/src/features/admin/maas/` — list view + deploy wizard + status badges
+  driven by the polling endpoint.
+- Edit: `client/src/utils/runtimeBasePath.js` — add `/admin/maas` to `knownRoutes`.
+
+**Config schema delta** (platform.json):
+
+```jsonc
+{
+  "maas": {
+    "enabled": false,
+    "operator": {
+      "baseUrl": "${MAAS_OPERATOR_URL}",
+      "apiKey": "${MAAS_OPERATOR_API_KEY}",  // encrypted at rest
+      "kind": "generic" // "generic" | "kserve" | "ollama" | "vllm-operator"
+    },
+    "defaults": { "replicaCount": 1, "contextLength": 8192, "acceleratorCount": 1 }
+  }
+}
+```
+
+**Migration**: `server/migrations/V{NNN}__add_maas_platform_section.js` that
+`ctx.setDefault(platform, 'maas.enabled', false)` and writes the operator shell.
+Secrets handled by the existing `encryptPlatformSecrets` path
+(add `maas.operator.apiKey` to the encrypted-fields list in `server/routes/admin/configs.js`).
+
+**UI hooks**: on successful `deploy`, materialize a model entry in `contents/models/`
+pointing at the operator-returned endpoint URL, with `provider: "openai"` (or "local")
+and `enabled: false` until status is `running`. Auto-flip to enabled on first healthy
+status poll.
+
+**Tests**:
+
+- Unit: `MaasOperatorClient` against a mock HTTP server covering all 5 verbs + error mapping.
+- Integration: full deploy → poll → auto-enable → chat → delete cycle using a fake operator.
+- E2E: admin UI flow with Playwright.
+
+**Risk callouts**: this is a control-plane feature without a data plane shipped — be
+explicit in docs that ihub-apps requires an external operator. Reference implementations
+(KServe, Ollama, vLLM-operator) should be documented but not bundled.
+
+### 5.3 Workflow / app integrity cleanup on model removal
+
+**Files**
+
+- Edit: `server/routes/admin/models.js` — wrap `DELETE /api/admin/models/:id` and
+  `PUT` (when `enabled: false`) with `await modelIntegrityService.cleanupReferences(modelId)`.
+- New: `server/services/ModelIntegrityService.js` —
+  - Scan `contents/apps/*.json` for `preferredModel`, `allowedModels` matches.
+  - Scan `contents/workflows/**/*.json` for embedded LLM-node model refs.
+  - Strategy per the request: `?strategy=warn` (default — return blocking diagnostics)
+    or `?strategy=cascade` (auto-unwire, write a back-up to
+    `contents/.deleted-model-backups/{modelId}/{timestamp}.json`).
+- Edit: client admin model delete dialog — show affected resources, choose strategy.
+
+**Schema delta**: none (operations are filesystem mutations on existing JSON).
+
+**Migration**: not needed.
+
+**Tests**: snapshot tests on a synthetic apps/workflows fixture; verify both warn and
+cascade strategies.
+
+## 6. Open questions
+
+- **Q1 (blocking for §5.2)**: Does the ihub-apps product want to own MaaS, or stay
+  control-plane only? Astron's pitch is "one-click on-prem MaaS"; ihub's current pitch is
+  app/agent surface over hosted models. Building a real k8s operator is XL effort; a
+  thin proxy to an existing operator (KServe, Ollama, vLLM-operator) is M effort and
+  arguably more in keeping with ihub's "we don't try to be infra" stance.
+- **Q2**: How real is the Spark / Chinese-market user demand? If non-trivial, a Node
+  port of `cn.xfyun.api.SparkChatClient` is doable; if not, an HTTP-only OpenAI-compatible
+  Spark X1 adapter (`spark.js`) is enough.
+- **Q3**: Encryption-in-transit for admin-submitted API keys. Astron's RSA-public-key
+  pattern protects against an HTTPS-terminating reverse proxy logging request bodies
+  with keys. ihub-apps relies on TLS + AES-at-rest. Worth adopting for compliance
+  scenarios (the public key endpoint is one extra route).
+- **Q4**: How does astron's `LocalModelHandler` HTTP API actually look on the wire? The
+  Java code calls it through `ApiUrl` config but we couldn't find the wire contract or
+  the operator implementation in the public repo — likely a separate iFLYTEK internal
+  service. We may need to define our own contract (and document operator compliance).
+- **Q5**: Should ihub-apps' future MaaS controller surface live in `server/routes/admin/`
+  alongside model routes, or as a sibling top-level admin area (`/admin/infra/`)? The
+  former keeps related concerns close; the latter scales better if we add embeddings /
+  reranker / TTS deployments.
+- **Q6**: Does the `BaseAdapter` design need rework before adding a real adapter count?
+  Currently every adapter manually re-implements `formatMessages`, `createCompletionRequest`,
+  `processResponseBuffer` — adding Spark + a refactor for prompt caching together might
+  be more efficient than two passes. Suggest doing #8 (capability matrix) before #5
+  (Spark) and #7 (caching).

--- a/concepts/astron-comparison/03-agent-tools-plugins-rpa.md
+++ b/concepts/astron-comparison/03-agent-tools-plugins-rpa.md
@@ -1,0 +1,352 @@
+# Agent Framework, Tools, Plugins, RPA — astron-agent vs ihub-apps
+
+**Date:** 2026-05-13
+**Focus areas:** Agent loop (planner/ReAct/multi-agent), tool calling, plugin marketplace, RPA, MCP support.
+**Status:** Research only — no code changes.
+
+---
+
+## 1. astron-agent (iFLYTEK)
+
+`astron-agent` is a multi-language polyglot platform: Java/Spring (console-backend), Python/FastAPI (core services), Vue/React frontends, Go (tenant). Agent / tool / plugin code lives under `core/agent` and `core/plugin/{aitools,link,rpa}`.
+
+### 1.1 Agent loop and engine
+
+- **Service layout** — `core/agent` is a FastAPI service (`main.py`) on **port 17870** with the layers `api/`, `domain/`, `engine/`, `service/`, `infra/`. The execution engine lives at `core/agent/engine/nodes/` and is organized around three node families: `chat/`, `cot/`, `cot_process/`, plus a `base.py` superclass.
+- **Loop semantics** — The `cot/` subtree (`cot_prompt.py`, `cot_runner.py`) and the parallel `cot_process/` subdirectory strongly indicate a **Chain-of-Thought / ReAct-style loop** (think → act → observe) implemented as a runner that drives the LLM through reasoning + tool steps. There is no explicit `react_node.py` or `planner_node.py`, so the framework appears to be a single-loop ReAct executor rather than a strict plan-and-execute split.
+- **Workflow vs. agent split** — Multi-step orchestration with branching, loops, parallel execution, human-in-the-loop checkpoints, and nested sub-workflows is provided by the separate `core-workflow` service (port 7880) using a visual DSL (ReactFlow). The agent engine drives the LLM step; the workflow engine drives node-graph execution.
+- **Multi-agent / supervisor** — Reviews ([kingy.ai](https://kingy.ai/uncategorized/astron-agent-review-iflyteks-open-source-enterprise-ai-workflow-platform-is-the-real-deal/), [jimmysong.io](https://jimmysong.io/ai/astron-agent/)) describe "orchestrated multi-agent workflows: define, schedule, and monitor coordinated agent tasks" and "shared context with task passing between agents," but multi-agent coordination is realised by chaining agents inside workflows rather than by a dedicated supervisor agent class.
+- **Knowledge** — A separate `core-knowledge` service provides RAG for grounding.
+- **Persistence** — MySQL + Redis + Kafka. Each LLM step / tool call is observable via Kafka and OpenTelemetry.
+
+### 1.2 Tool calling architecture
+
+- **Schema** — **OpenAPI** is the canonical tool description format. `ToolBoxService` (Java) converts simplified web-form schemas to full OpenAPI specs and validates via `OpenapiSchemaValidator`. Per [DeepWiki §6](https://deepwiki.com/iflytek/astron-agent/6-tool-and-plugin-integration).
+- **Tool execution bridge** — Tools are not run in-process. The agent calls **`core-link` (port 18888)** which handles "HTTP tool execution, MCP client." Two types are supported: **HTTP tools** (custom REST APIs, with parameter validation + auth injection + SSRF guards) and **MCP tools** (Server-Sent Events to remote MCP servers).
+- **Lifecycle** — Tools exist in a **Draft → Formal** dual-state; `tool_box_operate_history` tables track audit.
+- **Visibility filter** — `x-display` OpenAPI extension hides response fields from the LLM (e.g. internal IDs, secrets).
+- **AI tools service** — `core-aitools` (port 18668) is a dedicated service that exposes iFLYTEK Open Platform capabilities (translation, TTS, ASR, OCR, etc.) to agents.
+
+### 1.3 Plugin marketplace ("Plugin Square") & SkillHub
+
+- **Plugin Square** — In-platform marketplace UI with usage tracking ("heat" stored in Redis), favourites (`UserFavoriteToolMapper`), shared publishing across the platform. Plugins = tools published from Draft to Formal.
+- **SkillHub** ([github.com/iflytek/skillhub](https://github.com/iflytek/skillhub)) — Companion self-hosted **skill registry** with: semantic versioning, custom tags (`beta`, `stable`), automatic `latest` tracking, full-text search, team namespaces, RBAC (Owner/Admin/Member + Super Admin), starring/ratings/download counters. Storage is pluggable (filesystem / S3 / MinIO). CLI:
+  ```
+  skillhub login --token sk_xxx --registry [URL]
+  skillhub search [skill-name]
+  skillhub install [skill-name] --agent [agent-type]
+  skillhub list
+  ```
+- **Packaging format** — SkillHub readme references `SkillPackagePolicy.java` validator but does not nail down the exact schema; "skill package" is the unit, distributed via the registry, installable by CLI.
+
+### 1.4 MCP support
+
+- **Bidirectional** — Per [kingy.ai](https://kingy.ai/uncategorized/astron-agent-review-iflyteks-open-source-enterprise-ai-workflow-platform-is-the-real-deal/): "Astron's support for the Model Context Protocol (MCP) standard works bidirectionally — the platform can consume external MCP tools and serve as an MCP server."
+- **Client side** ([DeepWiki §6.3](https://deepwiki.com/iflytek/astron-agent/6.3-mcp-protocol-integration)):
+  - `core-link` is the SSE MCP client using the official `mcp` Python library.
+  - Registration via `register_mcp()` persists server metadata to MySQL (`tool_base` table).
+  - Discovery: `tool_list()` → MCP `list_tools()` per server; tools get IDs `mcp@{type}{id}`.
+  - SSRF protection: blocks `localhost`, `127.0.0.1`, private IP ranges; IP/domain/CIDR blacklists via env vars; HTTPS-only.
+- **Server side** — Exposing Astron workflows as an MCP server lets Claude / Cursor / other MCP-aware clients call them.
+
+### 1.5 RPA integration
+
+- **Sister project** — Astron-Agent's RPA bridge is `core/plugin/rpa` (FastAPI shim, no RPA libs in `pyproject.toml`), which talks to the standalone [iflytek/astron-rpa](https://github.com/iflytek/astron-rpa) suite.
+- **Astron-RPA stack**:
+  - Frontend: Vue 3 + TypeScript + Electron desktop client
+  - Backend: Java Spring Boot + Python FastAPI microservices
+  - Engine: Python, 20+ `astronverse.*` packages
+  - **Components**: `astronverse.system`, `.browser`, `.gui`, `.excel`, `.vision`, `.ai`, `.network`, `.email`, `.docx`, `.pdf`, `.encrypt`
+  - **Framework**: `astronverse.actionlib` (atomic ops), `.executor` (workflow engine), `.picker` (element picker), `.scheduler`, `.trigger`
+- **Coverage** — 300+ pre-built atomic capabilities; Windows desktop apps (Office, WPS, ERP/finance), web automation (IE/Edge/Chrome), document processing, computer vision.
+- **Integration** — Bi-directional: agents call RPA workflow nodes, RPA can call agent workflows.
+- **Enterprise** — Built-in "excellence centre" team marketplace, scheduling, robot team sharing.
+
+---
+
+## 2. ihub-apps (local repo)
+
+### 2.1 Agent loop and engine
+
+ihub-apps does **not** have a separate agent service. The "agent" is the chat completion loop running inside `server/services/chat/`.
+
+- **`ChatService.processChat`** (`server/services/chat/ChatService.js:138`) dispatches: non-streaming, streaming, or streaming-with-tools.
+- **`ToolExecutor.processChatWithTools`** (`server/services/chat/ToolExecutor.js:775`) is the first turn; tool calls collected from streamed deltas; tools executed; assistant turn pushed to message history.
+- **`ToolExecutor.continueWithToolExecution`** (`server/services/chat/ToolExecutor.js:1171`) implements the **multi-step loop** — `while (iteration < 10)`, hard cap `maxIterations = 10` (`ToolExecutor.js:1189`). Effectively a **vanilla function-calling loop**, not ReAct, not plan-execute, and no explicit "thought" channel. The LLM decides whether to keep calling tools or stop.
+- **No planner / supervisor / sub-agents** — There is no agent-of-agents, no dedicated planner step, no parallel branch evaluator. The closest thing is `workflowRunner.js` (workflows callable as tools) and `WorkflowEngine` (separate service for visual workflows with start/agent/condition/loop nodes).
+- **Ask-user clarification** — A first-party `ask_user` tool (`server/tools/askUser.js`) lets the model pause the loop to ask the user for input; tightly integrated into the executor (`ToolExecutor.js:143` `executeClarificationTool`) with rate limiting (10 clarifications / conversation).
+- **Passthrough / streaming tools** — Tools can opt-in to streaming their own output as the assistant message (`ToolExecutor.js:605` `executePassthroughTool`). Workflows use this.
+- **Skills as on-demand instructions** — `activate_skill` / `read_skill_resource` internal tools (`toolLoader.js:437-475`) let the model lazy-load skill markdown. This is the equivalent of Anthropic's Agent Skills spec.
+
+### 2.2 Tool calling architecture
+
+- **Schema** — **JSON Schema parameters** (OpenAI function-calling style). Tools are pure JavaScript modules under `server/tools/`. Definitions live in `server/defaults/config/tools.json` and the user's `contents/config/tools.json`.
+- **Tool loader** (`server/toolLoader.js`):
+  - `loadConfiguredTools` reads from cache → localizes multilingual fields
+  - `discoverMcpTools` (`toolLoader.js:203`) — **MCP CLIENT IS STUBBED**: GETs `{MCP_SERVER_URL}/tools` and merges into the tool list. Not a real MCP protocol client. No `list_tools`, no SSE, no auth, no multi-server registration, no schema validation.
+  - `getToolsForApp` builds the per-app tool set with: app.tools filter, source-generated tools (e.g. `source_<id>`), workflow-as-tool entries (`workflow:<id>`), websearch resolver, skill activation tools.
+  - `runTool` is the dispatcher; performs id validation, special-cases `activate_skill`, `read_skill_resource`, `workflow_*`, `source_*`, then dynamic-imports `./tools/<scriptName>.js`.
+- **Cross-provider** — `server/adapters/toolFormatter.js` + `server/adapters/toolCalling/` provide a unified "generic" tool format with bidirectional converters for OpenAI, Anthropic, Google, Mistral, Bedrock, VLLM, OpenAI Responses (`server/adapters/toolCalling/README.md`).
+- **Tool catalogue** (built-in): `askUser`, `braveSearch`, `tavilySearch`, `entraPeopleSearch`, `iFinder` (search/getContent/getMetadata), `jira` (searchTickets/getTicket and full CRUD via `JiraService`), `playwrightScreenshot` (chromium), `seleniumScreenshot` (selenium-webdriver), `webContentExtractor` (jsdom + pdfjs, with SSRF guard), `workflowRunner` (workflow-as-tool bridge).
+- **Integration services** (`server/services/integrations/`): Entra, GoogleDrive, Jira, Nextcloud, Office365, iFinder, iAssistant, ConversationApi — but only Jira, Entra, iFinder are exposed as agent-callable tools today.
+
+### 2.3 Marketplace / registry
+
+ihub-apps already has a **marketplace subsystem** (an under-publicised strength).
+
+- **`server/services/marketplace/RegistryService.js`** — Multi-registry catalog manager:
+  - Supports formats: native `catalog.json` (apps/models/prompts/skills/workflows), Claude Code `marketplace.json` (plugins/skills arrays), Anthropic plugin trees (auto-discovers `*/skills/*/SKILL.md` via GitHub Trees API)
+  - Authenticated registries: bearer / basic / custom header — encrypted at rest (AES-256-GCM via `TokenStorageService`)
+  - SSRF protection: HTTPS-only, host validation; GitHub blob→raw URL rewriting
+  - Caches catalogs to `contents/.registry-cache/{registryId}.json`
+- **`server/services/marketplace/ContentInstaller.js`** — Install/update/uninstall/detach. Dispatch table maps `{app|model|prompt|skill|workflow}` to dir/ext/cacheRefresh/validate. Skills are directory-based with companion files (`references/`, `scripts/`, `assets/`).
+- **Admin UI** — `client/src/features/admin/pages/AdminMarketplacePage.jsx` and `AdminMarketplaceRegistriesPage.jsx`. End-user marketplace UI not present.
+- **No versioning / tags / ratings / downloads / search ranking** — Items are identified by `{type}:{name}`; "version" is captured but not used for resolution. Installation manifest at `contents/config/installations.json`.
+
+### 2.4 MCP support
+
+- **One-line URL stub** (`toolLoader.js:203-221`): fetches `{MCP_SERVER_URL}/tools` once at load. Not the real MCP protocol; no JSON-RPC, no SSE/stdio transport, no tool invocation.
+- **No tool execution** — discovered tools land in the catalogue but `runTool` has no MCP code path, so they cannot be called.
+- **No MCP server side** — ihub-apps does not expose its tools/apps over MCP.
+
+### 2.5 RPA
+
+- **None.** The closest analogues:
+  - `playwrightScreenshot.js` (76 lines) — single-shot URL → PNG/PDF via Playwright `chromium.launch`.
+  - `seleniumScreenshot.js` (74 lines) — same but Selenium.
+  - Both lack multi-step UI scripting, recorders, element pickers, scheduling, OS-level (desktop) automation, or document/Office automation.
+- No `RpaService`, no script DSL, no robot scheduler, no triggers.
+
+---
+
+## 3. Gap matrix
+
+| # | Capability | astron-agent | ihub-apps | Gap severity | Notes |
+|---|---|---|---|---|---|
+| 1 | Agent loop type | ReAct-style CoT runner with explicit prompt+runner classes | Vanilla OpenAI-style function-call loop, cap 10 iters (`ToolExecutor.js:1189`) | **Medium** | Works today, but no thought trace, no plan, no replan-on-failure |
+| 2 | Planner / executor split | Implicit via cot_process subtree + workflow service | Not implemented | **Medium** | Could be added as a "planning" mode on apps |
+| 3 | Multi-agent / supervisor | Via workflow chaining, agent-to-agent task passing | Workflow agent nodes only; no agent → agent tool | **High** | Big gap for complex tasks |
+| 4 | Tool schema | OpenAPI (standardized, validatable) + JSON Schema | JSON Schema only | Low | OpenAPI nice-to-have; not blocking |
+| 5 | Tool execution sandbox | Out-of-process `core-link` HTTP service | In-process `import('./tools/<id>.js')` | **High** | Untrusted 3rd-party tools would run with full server privilege |
+| 6 | Tool catalogue breadth | Plugin Square (in-platform sharing + Plugin Marketplace) + iFLYTEK Open Platform | ~10 built-in tools + workflows + sources + skills | **High** | We're missing user-shareable plugin catalogue UX |
+| 7 | Tool ecosystem (3rd-party HTTP/REST) | Generic OpenAPI HTTP-tool runner with auth injection | None — every new HTTP tool needs a hand-rolled JS file | **High** | A `genericHttpTool` driven by OpenAPI would unlock dozens of integrations zero-code |
+| 8 | MCP client | Full SSE MCP client via official lib, multi-server registration, SSRF guards, persistent | URL stub (`toolLoader.js:203`); no invocation, no protocol | **CRITICAL** | We claim MCP support but it's a placeholder |
+| 9 | MCP server (expose own tools to other MCP clients) | Yes | No | **High** | Enables Claude/Cursor/etc. to call ihub-apps tools |
+| 10 | Plugin packaging | Skill packages via SkillHub CLI + semver + tags | Catalog items: JSON/MD files; no semver, no signing | **Medium** | Marketplace exists but is feature-light |
+| 11 | Marketplace UI (admin) | Plugin Square in-platform + SkillHub external | `AdminMarketplacePage.jsx`, `AdminMarketplaceRegistriesPage.jsx` | Low | We have it for admin; just needs end-user surface |
+| 12 | Marketplace UI (end-user) | Plugin Square (browse, install, favourite, rate, "heat") | None | **Medium** | Discovery surface for non-admins |
+| 13 | Versioning / updates of installed items | semver + `latest` tag + update-available checks | Single `version` field captured, no `update available` check | Medium | Already half-there in `ContentInstaller.update` |
+| 14 | RPA — browser automation | Full multi-step browser DSL with element picker, 300+ atoms | Single-shot screenshot only | **High** | Big differentiator — real RPA |
+| 15 | RPA — desktop automation | Yes (Win desktop, Office/WPS, ERP/finance) | None | **High** | Differentiator vs us |
+| 16 | RPA — OCR / vision | `astronverse.vision` | OCR routes exist (`toolsService/ocrRoutes.js`) standalone, not as agent tool | Medium | Already have OCR; need to expose as tool |
+| 17 | RPA — recorder | Picker engine implies recorder/inspector | None | High | Power-user feature; could come later |
+| 18 | RPA — scheduler / trigger | Yes (`astronverse.scheduler`, `astronverse.trigger`) | Task scheduling exists in concepts (`concepts/2025-07-20 Task Scheduling and Async Execution.md`) but not built | High | We have the design |
+| 19 | Tool usage analytics ("heat") | Redis-backed counters + favourites | `usageTracker.js` exists but tool-level surfacing is light | Low | Half-there |
+| 20 | OpenTelemetry / observability | Full OTLP stack | Has `telemetry.js`/`telemetry/` | Low | Comparable |
+| 21 | Agent skills lazy-loading | Not first-class | `activate_skill`, `read_skill_resource` (`toolLoader.js:437-475`) | **ihub-apps lead** | Mention as strength |
+| 22 | ask_user / clarification turn | Not first-class | First-party tool with rate limits (`tools/askUser.js`) | **ihub-apps lead** | Mention as strength |
+| 23 | Cross-provider tool format converters | Not advertised | `adapters/toolCalling/` (OpenAI/Anthropic/Google/Mistral/Bedrock/VLLM/OpenAI Responses) | **ihub-apps lead** | Solid engineering |
+
+---
+
+## 4. What we should reimplement (ranked)
+
+Ranking criteria: user value, strategic positioning (vs. closed competitors and astron), unblocks downstream features, and effort.
+
+| Rank | Feature | Scope | Risk | Dependencies |
+|---|---|---|---|---|
+| **1** | **Real MCP client (multi-server, SSE/stdio, schema-validated)** | M | Low | None — drop-in replacement of `discoverMcpTools` |
+| **2** | **Generic OpenAPI HTTP tool runner** (define a tool by OpenAPI URL + auth profile, no JS code) | M | Low | TokenStorageService (for encrypted creds), validator |
+| **3** | **MCP server endpoint** (expose ihub tools/apps over MCP) | M | Med | Needs auth model for clients (API keys); reuses tool registry |
+| 4 | Browser-automation tool (Playwright DSL: click/type/screenshot/extract, multi-step) | M | Med | Playwright already a dep; sandbox isolation |
+| 5 | Out-of-process tool sandbox (worker pool or container) for untrusted plugins | L | High | Need IPC protocol, resource quotas |
+| 6 | Plugin marketplace v2: ratings/favourites/version updates/end-user browse UI | L | Low | Marketplace backbone exists |
+| 7 | Planner / executor agent mode (toggle per app) | M | Med | Prompt templates; new app flag |
+| 8 | Multi-agent supervisor (delegate to sub-agent tool) | L | High | Needs "agent as tool" wrapper |
+| 9 | RPA-lite: scheduler + triggers for workflows-as-cron (uses existing workflow engine) | M | Med | Existing concept doc |
+| 10 | OCR-as-tool (expose existing `toolsService/ocrRoutes.js` to agents) | S | Low | None |
+| 11 | Tool usage analytics surfacing (heat / favourites) | S | Low | `usageTracker.js` |
+| 12 | Desktop RPA via remote agent (later — not worth in v1) | XL | Very high | New runtime |
+
+---
+
+## 5. Implementation outline (top 3)
+
+### 5.1 Real MCP client (rank #1)
+
+**Why first** — We *claim* MCP support but the implementation is a one-line URL stub (`server/toolLoader.js:203-221`). This is the lowest-effort, highest-impact gap to close. MCP is becoming the de-facto standard for tool sharing across Claude, Cursor, VS Code, ChatGPT, etc.
+
+**Module locations**
+- New: `server/services/mcp/McpClientManager.js` — top-level singleton, manages multiple connections
+- New: `server/services/mcp/McpServerConnection.js` — one per registered server, wraps the official `@modelcontextprotocol/sdk` client
+- New: `server/services/mcp/transports/` — `SseTransport.js`, `StdioTransport.js`, `WebSocketTransport.js`
+- New: `server/routes/admin/mcpServers.js` — CRUD for MCP server entries
+- Modify: `server/toolLoader.js:203-221` — replace `discoverMcpTools` with a call into the manager; add an MCP code path in `runTool` (~`server/toolLoader.js:495`)
+- Modify: `configCache.js` to load `config/mcpServers.json` and cache resolved tools
+
+**Config schema delta** — new `contents/config/mcpServers.json`:
+```jsonc
+{
+  "servers": [
+    {
+      "id": "github-mcp",
+      "name": { "en": "GitHub MCP" },
+      "enabled": true,
+      "transport": "sse",                // sse | stdio | websocket
+      "url": "https://mcp.example.com/sse",
+      "command": null,                   // for stdio
+      "args": [],
+      "env": {},
+      "auth": { "type": "bearer", "token": "ENC[...]" },
+      "toolPrefix": "github_",           // collision avoidance
+      "allowedTools": ["*"],             // or specific names
+      "timeoutMs": 30000
+    }
+  ],
+  "security": {
+    "blockPrivateIps": true,
+    "allowedHosts": [],
+    "blockedHosts": ["localhost", "127.0.0.1", "169.254.0.0/16"]
+  }
+}
+```
+
+**Packaging / distribution** — MCP servers are NOT packaged by us; they are run by their authors. We register *connections*, not packages. Admin pastes a URL or `stdio` command line, we test connectivity, persist (with encrypted token), and pull `list_tools` on startup + every hour. Cache invalidates automatically.
+
+**Security sandbox**
+- SSRF guards mirroring `RegistryService.sanitizeRegistrySourceUrl` and `webContentExtractor.assertNotPrivateIp`
+- Bearer/OAuth tokens encrypted at rest (use existing `TokenStorageService`)
+- Per-tool group ACL: which user groups can see which MCP tool (extend existing `enhanceUserWithPermissions`)
+- Hard timeout + cancellation token wired to existing `requestThrottler.js`
+- Stdio transport: spawned as a child process with `uid:gid` drop if running as root, no shell, restricted PATH
+
+**Tests** — `server/tests/mcp/`:
+- Mock SSE server with two tools, one with optional params; verify discovery, invocation, error mapping
+- Mock disconnection + reconnect path
+- SSRF: refuse `http://localhost:8000/sse`
+- Encrypted token round-trip
+- Tool name collision: prefix applied
+
+### 5.2 Generic OpenAPI HTTP tool runner (rank #2)
+
+**Why second** — Today every new HTTP integration (Jira, iFinder, Entra, …) costs hundreds of lines of JS. astron-agent's `core-link` lets admins paste an OpenAPI document and immediately get a callable tool. We can match this without their microservice architecture.
+
+**Module locations**
+- New: `server/services/tools/OpenApiToolRunner.js` — takes a parsed OpenAPI doc + operationId + params → builds and sends an HTTP request → returns JSON
+- New: `server/tools/openApiTool.js` — generic tool whose `runTool` path resolves the runner
+- New: `server/validators/openApiToolDefSchema.js` — Zod schema for tool definitions of `type: "openapi"`
+- Modify: `server/toolLoader.js` — when a tool entry has `type: "openapi"`, look up by operationId and dispatch through the runner
+- Modify: `client/src/features/admin/pages/AdminToolEditPage.jsx` — new editor pane: paste OpenAPI URL → preview operations → pick one → set auth profile
+
+**Config schema delta** — extend each tool entry in `contents/config/tools.json`:
+```jsonc
+{
+  "id": "github_listRepos",
+  "type": "openapi",
+  "openapi": {
+    "source": "https://api.github.com/openapi.json",   // url | inline | file
+    "operationId": "repos/list-for-authenticated-user",
+    "auth": {
+      "type": "oauth2",          // bearer | basic | apiKeyHeader | apiKeyQuery | oauth2
+      "credentialRef": "githubOAuth"   // → contents/config/credentials.json (encrypted)
+    },
+    "headers": { "Accept": "application/vnd.github+json" },
+    "xDisplay": { "hideFields": ["node_id", "url"] }   // mirror astron's x-display
+  },
+  "name": { "en": "List my GitHub repos" },
+  "description": { "en": "..." },
+  "parameters": { /* auto-derived from OpenAPI but overridable */ }
+}
+```
+
+**Packaging format** — A "tool plugin package" is a folder containing `tool.json` (the tool entry), optionally an `openapi.yaml` (inline source), and optional `README.md`. Marketplace `catalog.json` can list these with `type: "tool"`. `ContentInstaller` already has the dispatch table — extend with `tool` type pointing at `contents/tools/<name>.json`.
+
+**Security sandbox**
+- All outbound URLs run through SSRF guard (no private IPs, no `file:`, no `gopher:`)
+- Credentials never leaked into LLM response: `xDisplay.hideFields` strips before serialisation
+- Per-tool rate limit via existing `requestThrottler.js`
+- Response size cap (e.g. 256 KB before truncation)
+- Schema validation: every response validated against `responses.<status>.content` schema; oversized arrays auto-paginated
+
+**Tests**
+- Round-trip: OpenAPI doc → parameters JSON Schema → LLM call → HTTP request → response sanitisation
+- Auth: bearer, basic, OAuth refresh token rotation
+- Edge cases: required param missing → meaningful error to LLM; rate-limit 429 → retry-after
+- `xDisplay` field stripping
+
+### 5.3 MCP server endpoint (rank #3)
+
+**Why third** — Once we have a strong tool catalogue (via 5.1 + 5.2), exposing those tools over MCP is a small wrapper that turns ihub-apps into an **MCP gateway**. Users of Claude Desktop / Cursor / Continue.dev / VS Code can plug in our tools.
+
+**Module locations**
+- New: `server/routes/mcpServer.js` — exposes `/mcp/sse` (SSE transport) and `/mcp/v1/*` JSON-RPC endpoints
+- New: `server/services/mcp/McpServer.js` — wraps `@modelcontextprotocol/sdk/server`
+- New: `server/middleware/mcpAuth.js` — API-key-based auth (since OAuth in MCP is still maturing)
+- New admin page: `client/src/features/admin/pages/AdminMcpServerPage.jsx` to create API keys, set per-key tool ACLs, view usage
+- Modify: `server/toolLoader.js:loadTools` already returns the catalogue; reuse for `list_tools` handler
+- Reuse: `runTool` for `call_tool` handler
+
+**Config schema delta** — new `contents/config/mcpServer.json`:
+```jsonc
+{
+  "enabled": true,
+  "path": "/mcp",            // mounted as /<base>/mcp
+  "apiKeys": [
+    {
+      "id": "claude-desktop-andy",
+      "keyHash": "$2b$12$...",      // bcrypt
+      "userGroups": ["users"],      // ACL via existing groups
+      "allowedTools": ["braveSearch", "iFinder_search"],
+      "createdAt": "...",
+      "lastUsed": "..."
+    }
+  ],
+  "rateLimit": { "perMinute": 60 }
+}
+```
+
+**Packaging format** — N/A. This is a server-side endpoint, not a packageable item.
+
+**Security sandbox**
+- All `call_tool` requests dispatch through `runTool` which already enforces tool name validation, isolated `import()`, and adapter-level auth checks
+- Per-API-key rate limit via existing `requestThrottler.js`
+- Audit log: every `call_tool` invocation logged with API key id + tool id + status (uses existing `usageTracker.js`)
+- API keys hashed at rest (bcrypt) and shown plaintext exactly once at creation time
+- Optional client allowlist (IP CIDR / DNS name)
+
+**Tests**
+- Connect via `@modelcontextprotocol/sdk/client` — discover tools — invoke a tool — verify result shape matches MCP spec
+- Authn: bad API key → 401; expired key → 401; throttled key → 429
+- ACL: API key with `allowedTools: ['x']` cannot call `y`
+- SSE keepalive + reconnection
+
+---
+
+## 6. Open questions
+
+1. **astron-agent loop semantics** — The `cot_runner.py` source body was not accessible via the methods used here. We inferred CoT/ReAct from naming + file structure ([github.com/iflytek/astron-agent/tree/main/core/agent/engine/nodes](https://github.com/iflytek/astron-agent/tree/main/core/agent/engine/nodes)). Could be ChainOfThought-only with no act step, in which case real multi-step tool use lives in the **workflow** service. Worth a follow-up read of the actual Python.
+2. **astron Plugin Square packaging format** — DeepWiki describes OpenAPI as the schema and dual-state (Draft/Formal) lifecycle, but the actual artifact format (single OpenAPI yaml? zip? OCI image?) is undocumented in what was reachable. A peek at the `core/plugin/aitools` source would clarify.
+3. **SkillHub package spec** — Hinted at by `SkillPackagePolicy.java` but the actual SKILL spec (frontmatter? layout?) was not visible. Likely compatible with Anthropic Agent Skills, which is what ihub-apps already supports.
+4. **astron-rpa runtime requirement on the host** — Whether the desktop UI automation works headless inside Docker, or requires an Electron client + visible Windows session. If the latter, a server-side reimplementation in ihub-apps is unrealistic and we should partner / federate.
+5. **astron's multi-agent collaboration mechanics** — Marketing mentions "supervisor agent" but the OSS repo organises this as workflow chains; whether there is a first-class agent-as-tool wrapper remains unclear.
+6. **Should our marketplace go remote (SkillHub-style hosted registry) or stay GitHub-backed?** Trade-off: features (ratings/heat/RBAC namespaces) vs. infra burden. Worth a design doc before #6 above.
+7. **MCP authentication standard** — Where to land between API-key (today's pragma), OAuth 2.1 client (emerging MCP spec), and mTLS. Pick one for v1.
+8. **Out-of-process tool sandbox** (rank #5) — Worker threads vs. child processes vs. containers vs. WASM. Each has very different developer ergonomics and threat models.
+
+---
+
+## References (cited URLs)
+
+- [iflytek/astron-agent repo](https://github.com/iflytek/astron-agent) — root README
+- [iflytek/astron-agent/tree/main/core/agent](https://github.com/iflytek/astron-agent/tree/main/core/agent)
+- [iflytek/astron-agent/tree/main/core/agent/engine/nodes](https://github.com/iflytek/astron-agent/tree/main/core/agent/engine/nodes)
+- [iflytek/astron-agent/tree/main/core/plugin](https://github.com/iflytek/astron-agent/tree/main/core/plugin)
+- [iflytek/astron-agent/tree/main/core/plugin/rpa](https://github.com/iflytek/astron-agent/tree/main/core/plugin/rpa)
+- [iflytek/astron-rpa](https://github.com/iflytek/astron-rpa)
+- [iflytek/skillhub](https://github.com/iflytek/skillhub)
+- [DeepWiki: MCP Protocol Integration](https://deepwiki.com/iflytek/astron-agent/6.3-mcp-protocol-integration)
+- [DeepWiki: Tool and Plugin Integration](https://deepwiki.com/iflytek/astron-agent/6-tool-and-plugin-integration)
+- [DeepWiki: MCP Protocol and Plugin System](https://deepwiki.com/iflytek/astron-agent/9.4-mcp-protocol-and-plugin-system)
+- [kingy.ai review of Astron Agent](https://kingy.ai/uncategorized/astron-agent-review-iflyteks-open-source-enterprise-ai-workflow-platform-is-the-real-deal/)
+- [jimmysong.io on Astron Agent](https://jimmysong.io/ai/astron-agent/)
+- Local files cited inline above (`server/toolLoader.js`, `server/services/chat/ToolExecutor.js`, `server/services/marketplace/RegistryService.js`, etc.)

--- a/concepts/astron-comparison/04-knowledge-memory-rag.md
+++ b/concepts/astron-comparison/04-knowledge-memory-rag.md
@@ -372,14 +372,12 @@ system).
 
 **Embedding strategy**
 
-- Reuse the existing LLM adapter abstraction
-  (`server/adapters/index.js`) where the provider supports embeddings
-  (OpenAI, Bedrock-Titan, Cohere, etc.). Add an `embed()` method to
-  `BaseAdapter`.
-- Fallback: bundle `@xenova/transformers` BGE-small (Apache-2, runs in
-  Node) so air-gapped deployments work out-of-the-box.
-- Embedding model is per-KB (recorded in `index.sqlite` metadata table);
-  re-indexing required to change it.
+- Add `embed()` to `BaseAdapter`; reuse existing OpenAI / Bedrock-Titan /
+  Cohere paths in `server/adapters/`.
+- Fallback: bundle `@xenova/transformers` BGE-small (Apache-2,
+  Node-native) for air-gapped installs.
+- Per-KB embedding model recorded in metadata; changing it requires
+  re-indexing.
 
 **Ingestion pipeline**
 
@@ -399,16 +397,15 @@ Job is sync for files < 10 MB, queued (BullMQ / in-mem queue) above.
 `server/services/rag/RagService.search(kbId, query, {topK, filter,
 hybrid, rerank})` returns `[{ chunkId, text, score, doc, link, …meta }]`.
 
-Integration: extend `SourceHandler` with a new `KnowledgeBaseHandler`
-(`server/sources/KnowledgeBaseHandler.js`) — it implements `loadContent`
-by calling `RagService.search()` with the **user's last message** as
-the query (already plumbed via `chatId` + `userVariables`). This lets
-KBs slot into the existing `app.sources` config with **zero churn** in
-`PromptService` (`server/services/PromptService.js:276-346`).
+Integration: new `KnowledgeBaseHandler` extends `SourceHandler`; its
+`loadContent` calls `RagService.search()` with the user's last message
+as the query (`chatId` + `userVariables` already plumbed). KBs slot
+into the existing `app.sources` array with **zero churn** in
+`PromptService` (`PromptService.js:276-346`).
 
-**Tests:** unit for chunkers + embedder mocks; integration loading
-`contents/sources/faq.md` and verifying top-1 chunk includes the
-expected answer; perf test 10 k chunks @ p95 < 200 ms.
+**Tests:** chunker unit; embedder mocks; integration loads
+`contents/sources/faq.md` and asserts top-1; perf 10 k chunks
+p95 < 200 ms.
 
 ### 5.2 Persistent conversation memory (#2)
 

--- a/concepts/astron-comparison/04-knowledge-memory-rag.md
+++ b/concepts/astron-comparison/04-knowledge-memory-rag.md
@@ -1,0 +1,580 @@
+# Knowledge / RAG / Memory — astron-agent vs ihub-apps
+
+> Gap analysis comparing iFlytek's open-source **astron-agent**
+> (`core/knowledge`, `core/memory`) against **ihub-apps** (this repo).
+> Scope: doc ingestion, embeddings, vector retrieval, citation, knowledge
+> graph, and agent memory (short-term, long-term, episodic, semantic).
+> Research only — no code changed.
+
+---
+
+## 1. astron-agent
+
+`core/knowledge/` is a Python/FastAPI microservice (`main.py`, port 20010,
+pyproject lists `ragflow-sdk==0.13.0`, `openai>=2.7.1`, `redis`, `sqlmodel`,
+`boto3`) that exposes a RAG abstraction layer over **three pluggable
+backends**:
+
+- **RAGFlow** (default, OSS engine — embeddings + vector store + parser)
+- **iFLYTEK Xinghuo (Spark) Knowledge Base** (`XINGHUO_DATASET_ID`)
+- **AIUI** (iFlytek voice/dialog platform)
+- **SparkDesk / CBG** also wired
+
+Source: [`core/knowledge/service/`](https://github.com/iflytek/astron-agent/tree/main/core/knowledge/service)
+contains `rag_strategy.py` (abstract base) +
+[`rag_strategy_factory.py`](https://github.com/iflytek/astron-agent/blob/main/core/knowledge/service/rag_strategy_factory.py)
++ `impl/{aiui,cbg,ragflow,sparkdesk}_strategy.py`. Each strategy implements
+the same async contract.
+
+### 1.1 RAG strategy contract (`rag_strategy.py`)
+
+| Method            | Purpose                                                                   |
+| ----------------- | ------------------------------------------------------------------------- |
+| `query()`         | Semantic search; params: `doc_ids`, `repo_ids`, `top_k`, `threshold`      |
+| `split()`         | Chunk file/URL into fragments (length range, overlap, separators, titles) |
+| `chunks_save()`   | Persist chunks (doc/group/user IDs)                                       |
+| `chunks_update()` | Update chunk text/metadata                                                |
+| `chunks_delete()` | Remove by chunk ID                                                        |
+| `query_doc()`     | Retrieve all chunks for a document                                        |
+| `query_doc_name()`| Document metadata + chunk count                                           |
+
+All methods are async; `**kwargs` left open for backend-specific extras.
+
+### 1.2 Ingestion pipeline
+
+- File upload accepted as `UploadFile` or URL/path; routed to backend.
+- RAGFlow strategy: `_process_document_upload` →
+  `ragflow_client.upload_document_to_dataset` → `wait_for_parsing` (300 s
+  poll) → `fetch_all_document_chunks` (fail-closed multi-page paging).
+- Xinghuo: `upload` then `split` with Base64-encoded separators.
+- Per-dataset `asyncio.Lock` prevents race conditions when two requests
+  create the same KB.
+- "Blue-green" updates: new version uploaded + parsed + verified before
+  old version deleted.
+- File types: delegated to backend parsers (RAGFlow handles PDF, Office,
+  HTML, etc.; not enumerated in code).
+- OCR: not in `core/knowledge`; RAGFlow does it externally.
+
+### 1.3 Retrieval
+
+- RAGFlow query: `top_k` default **6**, `vector_similarity_weight`
+  default **0.2** (= hybrid: 80% BM25, 20% vector — keyword-leaning).
+- `RagflowQueryExt` extras: `vector_weight`, **reranking**,
+  **knowledge-graph traversal**, **highlighting** (passed straight to
+  RAGFlow API).
+- Xinghuo's `new_topk_search`: hybrid + overlap-chunk **context
+  reconstruction** (sorts neighbors by `dataIndex` to rebuild surrounding
+  prose), plus **image-reference extraction**.
+- Optional **LLM query rewriting** layer: an LLM generates search-optimised
+  variants of the user question before retrieval.
+
+### 1.4 Knowledge-enhanced chat flow
+
+(`deepwiki.com/iflytek/astron-agent/8.3-knowledge-enhanced-chat-flow`)
+
+- Bot config flag `supportDocument` toggles enhancement per-session.
+- `knowledgeService.getChuncksByBotId(botId, ask, 3)` retrieves chunks
+  via `KnowledgeV2ServiceCallHandler` (POST to knowledge-engine URL).
+- I18n prompt wrappers `loose.prefix.prompt` + `loose.suffix.prompt`
+  splice chunks around the user question.
+- **Chunks persisted to `req_knowledge_records` table keyed by request
+  ID** → on multi-turn, history reconstruction re-wraps the same chunks
+  so the context stays stable.
+- Token-budget guard `spark.chat.max.input.tokens` (default 8000) with
+  dynamic history truncation.
+
+### 1.5 Citation / grounding
+
+Not explicitly implemented in `core/knowledge`. Citations bubble up via
+RAGFlow's chunk metadata (doc ID, position, highlight) but there is no
+post-LLM citation verification. Knowledge-graph linking is delegated to
+RAGFlow's `use_kg` flag.
+
+### 1.6 Memory module
+
+[`core/memory/database/`](https://github.com/iflytek/astron-agent/tree/main/core/memory/database)
+— **important finding: this is _not_ a semantic/episodic memory engine.**
+It is the "Xingchen DB" service: a multi-tenant SQL-execution gateway.
+
+- Stack: FastAPI + SQLAlchemy 2 + SQLModel + Alembic;
+  drivers `asyncpg`, `psycopg2-binary`, `aiomysql`, `pymysql`;
+  Redis for cache; no vector libraries.
+- Routes (`api/router.py`, prefix `/xingchen-db/v1`):
+  - `create_db`, `drop_db`, `modify_db_description`
+  - `exec_ddl` (validated AST reconstruction)
+  - `exec_dml` (SQL rewriting injects `uid` filter)
+- Schema isolation: `{env}_{uid}_{database_id}` namespacing + row-level
+  `uid` filter + API-level ACL. Multi-tenant by construction.
+- It backs agent-authored facts/state — closer to a "tool that can read
+  and write its own tables" than to LLM-style long-term memory.
+
+### 1.7 Conversation history
+
+Lives in `core/agent` (Java/Spring Boot console + Python engine).
+`ChatHistoryServiceImpl.getSystemBotHistory` joins prior request pairs
+with `req_knowledge_records` to rebuild the historical RAG-augmented
+context. Storage = MySQL + Redis (per `docs/CONFIGURATION.md`).
+No explicit semantic-/episodic-memory layer; no summarisation pipeline
+documented.
+
+### 1.8 Embedding model
+
+Not implemented in-house — outsourced to RAGFlow (which ships its own
+embedder choice: e.g. BGE, BAAI, OpenAI). astron-agent calls `openai>=2.7.1`
+elsewhere but `core/knowledge` itself never calls `embeddings.create`.
+
+### Sources
+
+- [astron-agent README](https://github.com/iflytek/astron-agent)
+- [`core/knowledge`](https://github.com/iflytek/astron-agent/tree/main/core/knowledge)
+- [`core/knowledge/service/rag_strategy.py`](https://github.com/iflytek/astron-agent/blob/main/core/knowledge/service/rag_strategy.py)
+- [`core/knowledge/service/impl/ragflow_strategy.py`](https://github.com/iflytek/astron-agent/blob/main/core/knowledge/service/impl/ragflow_strategy.py)
+- [`core/knowledge/api/v1/api.py`](https://github.com/iflytek/astron-agent/blob/main/core/knowledge/api/v1/api.py)
+- [`core/memory/database`](https://github.com/iflytek/astron-agent/tree/main/core/memory/database)
+- [`docs/CONFIGURATION.md`](https://github.com/iflytek/astron-agent/blob/main/docs/CONFIGURATION.md)
+- DeepWiki: [Knowledge & RAG](https://deepwiki.com/iflytek/astron-agent/3.4-knowledge-service-and-rag),
+  [Memory DB](https://deepwiki.com/iflytek/astron-agent/7-memory-database-service),
+  [Knowledge-enhanced chat](https://deepwiki.com/iflytek/astron-agent/8.3-knowledge-enhanced-chat-flow),
+  [RAGFlow integration](https://deepwiki.com/iflytek/astron-agent/13.2-ragflow-knowledge-base-integration)
+
+---
+
+## 2. ihub-apps
+
+ihub-apps has **no vector store, no embeddings, no chunking, no rerank, no
+agent memory**. Verified by `grep -ri "embedding\|vector\|chroma\|qdrant\|
+pinecone\|weaviate" server/` — zero hits in product code (only telemetry
+attribute names and OCR comments).
+
+What ihub _does_ have is a **"sources" subsystem**: pluggable handlers
+that fetch whole documents from a few backends and dump them, verbatim,
+into the system prompt. It is closer to RAGFlow-without-the-RAG.
+
+### 2.1 Source handlers (`server/sources/`)
+
+| Handler             | File                                              | Backend                              |
+| ------------------- | ------------------------------------------------- | ------------------------------------ |
+| `SourceHandler`     | `server/sources/SourceHandler.js:1-131`           | Abstract base + in-memory TTL cache  |
+| `FileSystemHandler` | `server/sources/FileSystemHandler.js:1-419`       | Reads `contents/sources/*.{md,txt}`  |
+| `URLHandler`        | `server/sources/URLHandler.js:1-300`              | `webContentExtractor` tool / fetch   |
+| `IFinderHandler`    | `server/sources/IFinderHandler.js:1-278`          | IntraFind iFinder (external search)  |
+| `PageHandler`       | `server/sources/PageHandler.js:1-402`             | `contents/pages/{lang}/{id}.{md,jsx}`|
+| `SourceManager`     | `server/sources/SourceManager.js:1-793`           | Registry + tool generator            |
+
+Common shape: `loadContent(config) → { content: string, metadata: {…} }`.
+Caching is a per-process `Map` with TTL (default 3600 s) keyed off a
+JSON-stringified config (`SourceHandler.js:30-49`).
+
+### 2.2 Injection mechanism
+
+- `SourceManager.loadSources()` concatenates every source's full text
+  into one giant string and wraps each in `<source id=… type=… link=…>`
+  XML tags (`SourceManager.js:177-181`).
+- `PromptService.processMessageTemplates()`
+  (`server/services/PromptService.js:276-346`) replaces `{{sources}}`
+  (or legacy `{{source}}`) in the app's system prompt with that
+  concatenated content; otherwise it _appends_ a `Sources:\n<sources>…
+  </sources>` block to the system prompt.
+- `SourceResolutionService`
+  (`server/services/SourceResolutionService.js:31-108`) resolves admin-
+  configured source IDs (`contents/config/sources.json`) into runtime
+  handler configs, with a 5-minute resolution cache.
+- Sources can also be exposed `exposeAs: 'tool'`
+  (`SourceManager.js:230-251, 326-379`) — the LLM gets a `source_<id>`
+  function tool and decides when to call it. This is the closest thing
+  ihub has to dynamic retrieval, but the "tool" still returns the
+  entire pre-fetched document, not a vector-ranked passage.
+
+### 2.3 Config & schema
+
+- `server/validators/sourceConfigSchema.js:1-360`: Zod discriminated
+  union on `type ∈ {filesystem, url, ifinder, page}`. No chunk size,
+  embedding model, vector store, top-k, or rerank fields anywhere.
+- `server/defaults/config/sources.json`: example FAQ Markdown +
+  www.intrafind.com URL sources.
+- Admin CRUD: `server/routes/admin/sources.js`.
+
+### 2.4 Conversation persistence (= short-term "memory")
+
+- `server/services/integrations/ConversationStateManager.js:1-123`:
+  in-memory `Map<chatId, state>` with 24 h TTL and hourly cleanup.
+  Tracks `conversationId`, `lastParentId`, `title`, `baseUrl`,
+  `profileId`. **Single-process only — no Redis/DB.**
+- `server/routes/chat/conversationRoutes.js:1-268`: GET/DELETE
+  message-history endpoints that **proxy to the external iAssistant
+  API** (`/apps/:appId/conversations/:conversationId/messages`). ihub
+  itself never stores past messages.
+- `ConversationApiService` and `iAssistantService.js:1-46` are thin
+  wrappers; the iAssistant adapter
+  (`server/adapters/iassistant-conversation.js:117,153`) is the only
+  code path that ever round-trips a conversation ID — and only for
+  IntraFind's own RAG product.
+- For all _other_ providers (OpenAI, Anthropic, Google, Mistral,
+  Bedrock, vLLM, openai-responses), conversation history is rebuilt
+  client-side and re-sent on every request (`RequestBuilder.js:293-
+  304, 382-396`). `sendChatHistory: boolean` on each app config
+  (default `true`, see `CLAUDE.md` § "App Configuration Schema") just
+  toggles whether the client passes prior turns back.
+- `feedbackStorage.js:1-97` appends thumbs-up/down to
+  `contents/data/feedback.jsonl`. That's the only persistent
+  per-message store; it is **not** read back during chat — pure
+  analytics.
+
+### 2.5 User-fingerprint / per-user state
+
+`server/services/UserFingerprint.js:1-70`: pseudonymous SHA-256
+`usr_<16hex>` of `userId + pepper`. Used for usage tracking only — no
+user-profile / preference memory store.
+
+### 2.6 Where the LLM ends up
+
+`RequestBuilder.prepareChatRequest`
+(`server/services/chat/RequestBuilder.js:115-422`) calls
+`processMessageTemplates`, which substitutes sources into the system
+prompt, then ships the entire conversation + source text to the model
+adapter. Token budget = `min(app.tokenLimit, model.tokenLimit)`
+(`RequestBuilder.js:330-339`). There is **no chunk-level scoring**: if
+your three sources total 200 k tokens you'll blow the context window.
+
+### 2.7 Honest summary
+
+ihub treats "knowledge" the 2023 way: paste whole docs into the system
+prompt, lean on long-context models. Fine for FAQ-sized corpora; does
+not scale to thousands of docs, does not ground answers in citations,
+does not survive across sessions, does not learn about the user.
+
+---
+
+## 3. Gap matrix
+
+| #  | Capability                                | astron-agent                                       | ihub-apps                                 | Severity | Notes                                                                  |
+| -- | ----------------------------------------- | -------------------------------------------------- | ----------------------------------------- | -------- | ---------------------------------------------------------------------- |
+| 1  | Embedding generation                      | Via RAGFlow / Xinghuo (BGE, etc.)                  | None                                      | **High** | Foundational for anything below                                        |
+| 2  | Vector store                              | RAGFlow / Xinghuo                                  | None                                      | **High** | No backend wired                                                       |
+| 3  | Chunking pipeline                         | `split()` with length range, overlap, separators   | None — whole-document only                | **High** | All-or-nothing prompt bloat today                                      |
+| 4  | Document parsing (PDF/Office/HTML)        | RAGFlow                                            | Partial: `webContentExtractor`, OCR tool, DOCX/MSG/EPUB upload only | **Med-High** | Has the readers, lacks the indexing |
+| 5  | Top-k retrieval                           | `top_k`, `threshold` params                        | None                                      | **High** | n/a without vectors                                                    |
+| 6  | Hybrid search (BM25 + vector)             | `vector_similarity_weight` default 0.2             | None                                      | Med      | Most RAG wins come from hybrid                                         |
+| 7  | Reranker                                  | RAGFlow `rerank=true` flag                         | None                                      | Med      | Big quality lever once vectors exist                                   |
+| 8  | LLM query rewriting                       | Yes                                                | None                                      | Low-Med  | Cheap to add post-vectorisation                                        |
+| 9  | Citation / grounding (attribution)        | Chunk-level metadata (doc id, position)            | `<source link=…>` XML tag only            | Med      | ihub UI already renders the tag                                        |
+| 10 | Knowledge graph                           | RAGFlow `use_kg`                                   | None                                      | Low      | Niche; skip in v1                                                      |
+| 11 | Multi-backend RAG abstraction             | Strategy + factory (4 impls)                       | Source handler abstraction exists         | Low      | We can extend, not rebuild                                             |
+| 12 | Document CRUD API                         | `/dataset/create`, `/document/{upload,split,…}`    | Admin `routes/admin/sources.js` (CRUD source defs only) | High | Need ingestion endpoint                                |
+| 13 | Per-dataset locks (concurrent ingest)     | `asyncio.Lock` per dataset                         | n/a                                       | Low      | Easy in Node                                                           |
+| 14 | Conversation persistence (long-term)      | MySQL + Redis (`req_knowledge_records`, history)   | In-memory `Map`, 24 h TTL, single process | **High** | Breaks multi-replica deployments                                       |
+| 15 | Semantic / episodic / working memory      | None (out of scope for astron too)                 | None                                      | Med      | Greenfield opportunity                                                 |
+| 16 | Per-user profile memory                   | None                                               | None                                      | Med      | Pair with #15                                                          |
+| 17 | Conversation summarisation                | Token-budget truncation only                       | None                                      | Med      | Necessary as windows grow                                              |
+| 18 | Multi-tenant SQL data service             | Xingchen DB (`/xingchen-db/v1`)                    | None                                      | Low      | Reuse iFinder/Jira instead                                             |
+| 19 | Concurrent upload safety / blue-green     | Yes                                                | n/a                                       | Low      | Easy follow-up                                                         |
+| 20 | OpenTelemetry tracing of retrieval        | Spans + counters around every call                 | Has `recordSourceLoad` (`SourceManager.js:8,149`) | Low | Parity already                                                  |
+
+---
+
+## 4. What we should reimplement (ranked)
+
+### #1 — In-process vector RAG: chunk → embed → retrieve (XL, must-have)
+
+**Rationale:** every other gap (#1–#8) collapses into this one. Without
+a vector index ihub cannot serve corpora bigger than the model's context
+window. This is the headline parity feature with astron-agent.
+
+**Scope:** XL. **Risk:** medium (no embedding/vector dep today; needs
+careful backend selection). **Deps:** none (it bottoms-out the stack).
+
+### #2 — Persistent, recall-aware conversation memory (L, must-have)
+
+**Rationale:** `ConversationStateManager`'s in-memory `Map` already
+breaks the moment we run two server replicas. astron persists chat
+history in MySQL; we need at least SQLite/Postgres-backed conversation
+storage plus a recall API the chat builder can call.
+
+**Scope:** L. **Risk:** low-medium (touches auth + clustering).
+**Deps:** existing config/migration patterns; benefits from #1 for
+"semantic recall over prior turns."
+
+### #3 — Long-term memory (user-profile + episodic) with summarisation (L, should-have)
+
+**Rationale:** the genuinely _agentic_ leap astron-agent has _not_ made
+either. ChatGPT-style "memory" — derived facts ("user prefers German",
+"works at Acme, on Project X"), surfaced into future system prompts.
+Episodic summarisation compresses old turns to make room for new ones.
+
+**Scope:** L. **Risk:** medium (privacy/UX). **Deps:** #1 (semantic
+recall), #2 (storage substrate).
+
+### #4 — Reranker hook + hybrid retrieval (M, should-have)
+
+Once #1 lands, add BM25 alongside vector and a pluggable cross-encoder
+reranker (Cohere Rerank, BGE-reranker, local). Single biggest quality
+lever on top of vanilla top-k.
+
+### #5 — Citation/grounding UI + answer-verification pass (M)
+
+Already 80 % done in the system prompt (`<source link=…>` tags). Need
+a post-LLM step that asserts every claim cites a chunk, plus a chat-UI
+"jump to source" affordance.
+
+### #6 — Ingestion REST endpoints + admin UI (M)
+
+Parity with astron's `/document/upload` + `/document/split` + chunk CRUD.
+Lets non-developers feed PDFs/URLs/Confluence into a knowledge base
+without editing JSON.
+
+### #7 — Query rewriting + multi-query fan-out (S)
+
+Cheap LLM-side win; queue behind #4.
+
+### #8 — Knowledge graph (XL, won't-do for v1)
+
+Skip. astron-agent only exposes a flag; the heavy lifting lives in
+RAGFlow. Wait for evidence of demand.
+
+---
+
+## 5. Implementation outline (top 3)
+
+### 5.1 In-process vector RAG (#1)
+
+**Module layout**
+
+```
+server/services/rag/
+  index.js                  // public API: ingest, search, deleteDoc
+  RagService.js             // orchestrator
+  embedders/
+    BaseEmbedder.js
+    OpenAIEmbedder.js       // text-embedding-3-small/large
+    AnthropicEmbedder.js    // via Voyage when available
+    LocalEmbedder.js        // BGE-small via @xenova/transformers
+  vectorStores/
+    BaseVectorStore.js
+    SqliteVssStore.js       // default
+    PgVectorStore.js        // opt-in
+    LanceDbStore.js         // opt-in
+  chunkers/
+    RecursiveTextChunker.js // langchain-style
+    MarkdownChunker.js
+    HtmlChunker.js
+  parsers/
+    PdfParser.js            // pdf-parse / pdfjs
+    DocxParser.js           // mammoth (already in repo)
+    HtmlParser.js           // html-to-text (already in repo)
+contents/
+  knowledge/
+    {kbId}/
+      index.sqlite          // sqlite-vss DB
+      docs/                 // raw blobs
+```
+
+**Vector backend recommendation: `sqlite-vss` (better-sqlite3 +
+sqlite-vss extension), opt-in `pgvector`.**
+
+Tradeoffs:
+
+| Backend     | Pros                                                  | Cons                                  |
+| ----------- | ----------------------------------------------------- | ------------------------------------- |
+| **sqlite-vss** | Zero-install (ships with native bin), file-per-KB, fits ihub's existing "drop a JSON into `contents/`" mental model, works in Docker | Not great > 5 M vectors; single-writer |
+| pgvector    | Production-grade, multi-replica safe, SQL joins       | Adds Postgres dep, not in current stack |
+| lancedb     | Columnar/Arrow, multi-modal, JS-native                | Younger, smaller ecosystem            |
+| chroma      | Easy local mode                                       | Python-first; HTTP hop                |
+| qdrant      | Best filters + payload + perf                         | Extra service to operate              |
+| weaviate    | Hybrid out of the box                                 | Heavy                                 |
+
+**Recommendation:** ship `sqlite-vss` by default (matches the
+"single-folder install" ergonomics of `contents/`), expose a
+`platform.rag.vectorStore` enum so admins can switch to `pgvector` when
+they outgrow it. Schema lives in `server/migrations/V0??__add_rag_tables.js`
+(uses the existing Flyway-style migration system documented in
+`CLAUDE.md` § "Configuration Migration System").
+
+**Embedding strategy**
+
+- Reuse the existing LLM adapter abstraction
+  (`server/adapters/index.js`) where the provider supports embeddings
+  (OpenAI, Bedrock-Titan, Cohere, etc.). Add an `embed()` method to
+  `BaseAdapter`.
+- Fallback: bundle `@xenova/transformers` BGE-small (Apache-2, runs in
+  Node) so air-gapped deployments work out-of-the-box.
+- Embedding model is per-KB (recorded in `index.sqlite` metadata table);
+  re-indexing required to change it.
+
+**Ingestion pipeline**
+
+`POST /api/admin/knowledge/:kbId/documents` (multipart):
+
+1. Path-security check (reuse `utils/pathSecurity.js`).
+2. Parser → text (PDF / DOCX / HTML / MD / TXT).
+3. Chunker (default: recursive 800-token chunks, 100-token overlap;
+   configurable).
+4. Embed batches of 100 chunks.
+5. Upsert `(kb_id, doc_id, chunk_id, text, embedding, metadata)`.
+
+Job is sync for files < 10 MB, queued (BullMQ / in-mem queue) above.
+
+**Retrieval API**
+
+`server/services/rag/RagService.search(kbId, query, {topK, filter,
+hybrid, rerank})` returns `[{ chunkId, text, score, doc, link, …meta }]`.
+
+Integration: extend `SourceHandler` with a new `KnowledgeBaseHandler`
+(`server/sources/KnowledgeBaseHandler.js`) — it implements `loadContent`
+by calling `RagService.search()` with the **user's last message** as
+the query (already plumbed via `chatId` + `userVariables`). This lets
+KBs slot into the existing `app.sources` config with **zero churn** in
+`PromptService` (`server/services/PromptService.js:276-346`).
+
+**Tests:** unit for chunkers + embedder mocks; integration loading
+`contents/sources/faq.md` and verifying top-1 chunk includes the
+expected answer; perf test 10 k chunks @ p95 < 200 ms.
+
+### 5.2 Persistent conversation memory (#2)
+
+**Module layout**
+
+```
+server/services/memory/
+  ConversationStore.js      // persistent replacement
+  ChatMessageRepo.js        // CRUD on messages
+  RecallService.js          // semantic recall over prior turns
+```
+
+**Backend:** SQLite (default) → Postgres (opt-in), same dual-mode as
+RAG. Tables:
+
+```sql
+CREATE TABLE conversations (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  app_id TEXT NOT NULL,
+  title TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  metadata JSON
+);
+CREATE TABLE messages (
+  id TEXT PRIMARY KEY,
+  conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  tool_calls JSON,
+  embedding BLOB,           -- optional, fills #1's vector index
+  tokens INTEGER,
+  created_at INTEGER NOT NULL
+);
+```
+
+Migration: `server/migrations/V0??__add_conversation_persistence.js`.
+
+**Refactor:** `ConversationStateManager` (`server/services/integrations/
+ConversationStateManager.js:1-123`) keeps its in-memory map as an LRU
+cache fronting `ConversationStore`. Public surface unchanged → no client
+breakage.
+
+**Recall:** `RecallService.findRelevantTurns(conversationId, query, k)`
+runs a vector query over the per-conversation embedding column. Hooked
+into `PromptService` immediately after source resolution to inject a
+`<recalled_turns>` block when relevance > threshold. Behind feature flag
+`features.conversationRecall`.
+
+**Privacy:** per-user encryption at rest using the existing
+`TokenStorageService` (AES-256-GCM, see `CLAUDE.md` § "Secret encryption
+at rest"). Reuse `contents/.encryption-key`.
+
+**Tests:** clustering integration (two workers, one writes, the other
+reads); TTL eviction with persistence; embedding backfill for legacy
+in-memory conversations.
+
+### 5.3 Long-term memory + summarisation (#3)
+
+**Module layout**
+
+```
+server/services/memory/
+  UserMemoryStore.js        // append-only fact log per user
+  MemoryExtractor.js        // LLM job: chat → extracted facts
+  SummariserService.js      // rolling conversation summaries
+```
+
+**Data**
+
+```sql
+CREATE TABLE user_memories (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL,
+  scope TEXT,               -- 'global' | appId
+  kind TEXT,                -- 'preference' | 'fact' | 'event'
+  text TEXT NOT NULL,
+  embedding BLOB,
+  source_conversation_id TEXT,
+  source_message_id TEXT,
+  confidence REAL,
+  created_at INTEGER NOT NULL,
+  expires_at INTEGER,
+  metadata JSON
+);
+```
+
+**Flow**
+
+1. After every N turns or at conversation end, `MemoryExtractor`
+   prompts an LLM (cheap model, e.g. `gpt-4o-mini`) with a strict
+   JSON schema: `extracted: [{kind, text, confidence}]`.
+2. Apply de-dup + confidence threshold; embed; upsert.
+3. On new chat, `PromptService.resolveGlobalPromptVariables` (already
+   the right injection point — `PromptService.js:66-147`) calls
+   `UserMemoryStore.recall(userId, query, k=5)` and exposes the
+   matches as `{{user_memory}}` placeholders.
+
+**Summarisation**
+
+`SummariserService` collapses turns older than the sliding window into
+a `summary` row. Replaces astron's hard truncation. Triggered when
+estimated prompt-budget > `model.tokenLimit * 0.7`.
+
+**UI**
+
+- Settings page `/settings/memory` (add route in `App.jsx`; remember to
+  update `knownRoutes` in `client/src/utils/runtimeBasePath.js` per
+  `CLAUDE.md` "When Adding New Routes").
+- List, edit, delete user facts; toggle "memory off".
+- Per-app override: `app.memory: { enabled, scope, ttl }` (schema
+  extension in `server/validators/appConfigSchema.js`).
+
+**Privacy / consent**
+
+- Default **off**. Admin opt-in via `platform.json.features.userMemory`.
+- Migration `V0??__add_user_memory_feature_flag.js` adds the default.
+- GDPR export/delete endpoints reuse the auth + permissions framework.
+
+**Tests:** evaluator harness — script a 3-conversation arc, assert
+extracted facts, assert next conversation injects them, assert deletion
+removes them.
+
+---
+
+## 6. Open questions
+
+1. **Vector backend pick.** sqlite-vss vs pgvector vs lancedb hinges on
+   expected corpus size (1 k vs 1 M docs) and whether v1 must support
+   stateless replicas.
+2. **Embedding-model licensing.** Is bundling `Xenova/bge-small-en`
+   (Apache-2) acceptable for air-gapped installs, or provider-only?
+3. **KB multi-tenancy.** astron isolates by `uid`; ihub uses groups.
+   Do KBs belong to apps, users, or groups? Likely groups (matches
+   `groups.json` / `allowedModels`).
+4. **iAssistant overlap.** IntraFind's iAssistant already ships
+   `/public-api/rag/...` (`server/adapters/iassistant-conversation.js:
+   153`). Make our `RagService` _another_ source provider, parallel to
+   `iFinder` — so installs can choose either, both, or neither.
+5. **Reranker.** Cohere Rerank is external; can `@xenova/transformers`
+   cross-encoders ship inside `npm run build:binary`?
+6. **Memory-extraction cost.** Second LLM call per conversation doubles
+   spend; need budget guardrails and an opt-out.
+7. **Citation enforcement.** Force JSON-tagged citations or
+   post-process with embedding-similarity? Affects #5 scope.
+8. **KG / structured retrieval.** Defer to v2; no evidence yet.
+9. **Conversation API parity.** `conversationRoutes.js` proxies to
+   iAssistant today. Recommend a unified API with internal strategy
+   switch — mirrors astron's RAG strategy pattern.

--- a/concepts/astron-comparison/04-knowledge-memory-rag.md
+++ b/concepts/astron-comparison/04-knowledge-memory-rag.md
@@ -189,45 +189,34 @@ JSON-stringified config (`SourceHandler.js:30-49`).
 
 ### 2.4 Conversation persistence (= short-term "memory")
 
-- `server/services/integrations/ConversationStateManager.js:1-123`:
-  in-memory `Map<chatId, state>` with 24 h TTL and hourly cleanup.
-  Tracks `conversationId`, `lastParentId`, `title`, `baseUrl`,
-  `profileId`. **Single-process only — no Redis/DB.**
-- `server/routes/chat/conversationRoutes.js:1-268`: GET/DELETE
-  message-history endpoints that **proxy to the external iAssistant
-  API** (`/apps/:appId/conversations/:conversationId/messages`). ihub
-  itself never stores past messages.
-- `ConversationApiService` and `iAssistantService.js:1-46` are thin
-  wrappers; the iAssistant adapter
+- `ConversationStateManager.js:1-123`: in-memory `Map<chatId, state>`,
+  24 h TTL, hourly cleanup. **Single-process only — no Redis/DB.**
+- `conversationRoutes.js:1-268`: GET/DELETE message-history endpoints
+  that **proxy to the external iAssistant API**. ihub never stores past
+  messages itself.
+- The iAssistant adapter
   (`server/adapters/iassistant-conversation.js:117,153`) is the only
-  code path that ever round-trips a conversation ID — and only for
-  IntraFind's own RAG product.
-- For all _other_ providers (OpenAI, Anthropic, Google, Mistral,
-  Bedrock, vLLM, openai-responses), conversation history is rebuilt
-  client-side and re-sent on every request (`RequestBuilder.js:293-
-  304, 382-396`). `sendChatHistory: boolean` on each app config
-  (default `true`, see `CLAUDE.md` § "App Configuration Schema") just
-  toggles whether the client passes prior turns back.
-- `feedbackStorage.js:1-97` appends thumbs-up/down to
-  `contents/data/feedback.jsonl`. That's the only persistent
-  per-message store; it is **not** read back during chat — pure
-  analytics.
+  code path that round-trips a `conversationId` — IntraFind-only.
+- For all _other_ providers (OpenAI, Anthropic, Google, etc.) the
+  client rebuilds history and re-sends it every request
+  (`RequestBuilder.js:293-304, 382-396`). `sendChatHistory: boolean`
+  (app config, default `true`) just toggles client inclusion.
+- `feedbackStorage.js:1-97` appends ratings to
+  `contents/data/feedback.jsonl` — analytics only, never read back.
 
 ### 2.5 User-fingerprint / per-user state
 
-`server/services/UserFingerprint.js:1-70`: pseudonymous SHA-256
-`usr_<16hex>` of `userId + pepper`. Used for usage tracking only — no
-user-profile / preference memory store.
+`UserFingerprint.js:1-70`: pseudonymous SHA-256 `usr_<16hex>` of
+`userId + pepper`. Usage tracking only — no profile/preference store.
 
 ### 2.6 Where the LLM ends up
 
-`RequestBuilder.prepareChatRequest`
-(`server/services/chat/RequestBuilder.js:115-422`) calls
+`RequestBuilder.prepareChatRequest` (`RequestBuilder.js:115-422`) calls
 `processMessageTemplates`, which substitutes sources into the system
 prompt, then ships the entire conversation + source text to the model
 adapter. Token budget = `min(app.tokenLimit, model.tokenLimit)`
-(`RequestBuilder.js:330-339`). There is **no chunk-level scoring**: if
-your three sources total 200 k tokens you'll blow the context window.
+(`RequestBuilder.js:330-339`). **No chunk-level scoring**: three big
+sources will blow the context window.
 
 ### 2.7 Honest summary
 
@@ -375,12 +364,11 @@ Tradeoffs:
 | qdrant      | Best filters + payload + perf                         | Extra service to operate              |
 | weaviate    | Hybrid out of the box                                 | Heavy                                 |
 
-**Recommendation:** ship `sqlite-vss` by default (matches the
-"single-folder install" ergonomics of `contents/`), expose a
-`platform.rag.vectorStore` enum so admins can switch to `pgvector` when
-they outgrow it. Schema lives in `server/migrations/V0??__add_rag_tables.js`
-(uses the existing Flyway-style migration system documented in
-`CLAUDE.md` § "Configuration Migration System").
+**Recommendation:** ship `sqlite-vss` by default (matches `contents/`
+single-folder ergonomics); expose `platform.rag.vectorStore` enum to
+switch to `pgvector` at scale. Schema via
+`server/migrations/V0??__add_rag_tables.js` (existing Flyway-style
+system).
 
 **Embedding strategy**
 

--- a/concepts/astron-comparison/04-knowledge-memory-rag.md
+++ b/concepts/astron-comparison/04-knowledge-memory-rag.md
@@ -70,25 +70,21 @@ All methods are async; `**kwargs` left open for backend-specific extras.
 
 ### 1.4 Knowledge-enhanced chat flow
 
-(`deepwiki.com/iflytek/astron-agent/8.3-knowledge-enhanced-chat-flow`)
-
-- Bot config flag `supportDocument` toggles enhancement per-session.
-- `knowledgeService.getChuncksByBotId(botId, ask, 3)` retrieves chunks
-  via `KnowledgeV2ServiceCallHandler` (POST to knowledge-engine URL).
-- I18n prompt wrappers `loose.prefix.prompt` + `loose.suffix.prompt`
-  splice chunks around the user question.
-- **Chunks persisted to `req_knowledge_records` table keyed by request
-  ID** → on multi-turn, history reconstruction re-wraps the same chunks
-  so the context stays stable.
-- Token-budget guard `spark.chat.max.input.tokens` (default 8000) with
+- Bot flag `supportDocument` toggles enhancement per-session.
+- `knowledgeService.getChuncksByBotId(botId, ask, 3)` → POST to
+  knowledge-engine URL.
+- I18n wrappers `loose.prefix.prompt` + `loose.suffix.prompt` splice
+  chunks around the user question.
+- **Chunks persisted to `req_knowledge_records` keyed by request ID**
+  → multi-turn history reconstruction re-wraps the same chunks.
+- Budget guard `spark.chat.max.input.tokens` (default 8000) with
   dynamic history truncation.
 
 ### 1.5 Citation / grounding
 
-Not explicitly implemented in `core/knowledge`. Citations bubble up via
-RAGFlow's chunk metadata (doc ID, position, highlight) but there is no
-post-LLM citation verification. Knowledge-graph linking is delegated to
-RAGFlow's `use_kg` flag.
+Not explicit in `core/knowledge`. Citations bubble up via RAGFlow chunk
+metadata (doc ID, position, highlight); no post-LLM verification. KG
+linking delegated to RAGFlow's `use_kg` flag.
 
 ### 1.6 Memory module
 
@@ -110,18 +106,15 @@ It is the "Xingchen DB" service: a multi-tenant SQL-execution gateway.
 
 ### 1.7 Conversation history
 
-Lives in `core/agent` (Java/Spring Boot console + Python engine).
-`ChatHistoryServiceImpl.getSystemBotHistory` joins prior request pairs
-with `req_knowledge_records` to rebuild the historical RAG-augmented
-context. Storage = MySQL + Redis (per `docs/CONFIGURATION.md`).
-No explicit semantic-/episodic-memory layer; no summarisation pipeline
-documented.
+In `core/agent`: `ChatHistoryServiceImpl.getSystemBotHistory` joins
+prior request pairs with `req_knowledge_records` to rebuild the
+historical RAG-augmented context. Storage = MySQL + Redis. No
+semantic-/episodic-memory layer; no summarisation pipeline.
 
 ### 1.8 Embedding model
 
-Not implemented in-house — outsourced to RAGFlow (which ships its own
-embedder choice: e.g. BGE, BAAI, OpenAI). astron-agent calls `openai>=2.7.1`
-elsewhere but `core/knowledge` itself never calls `embeddings.create`.
+Outsourced to RAGFlow (BGE/BAAI/OpenAI etc.). `core/knowledge` itself
+never calls `embeddings.create`.
 
 ### Sources
 

--- a/concepts/astron-comparison/05-interfaces-console-api.md
+++ b/concepts/astron-comparison/05-interfaces-console-api.md
@@ -1,0 +1,249 @@
+# Interfaces, Console UI, APIs — astron-agent vs ihub-apps
+
+Scope: console UI (workflow builder, bot center, model mgmt, plugin store, space management), public REST/gRPC APIs, OpenAI-compatible proxy, SSE/streaming, webhooks, embedding (iframe/widget), MCP server, external integrations.
+
+---
+
+## 1. astron-agent
+
+iFlytek's astron-agent is a polyglot, microservice‑oriented enterprise platform: React/TS console on top of a Spring Boot "hub" backend and 7 FastAPI/Go "core" services, connected via Nginx + Kafka + Casdoor (OAuth2/OIDC). Confirmed from repo + DeepWiki.
+
+### 1.1 Console frontend (`console/frontend`)
+
+- Stack: React 18 + Vite + TypeScript + **Ant Design 5** + Tailwind, state managed by **Recoil (+recoil-persist)** and **Zustand**, routing via React Router DOM 6/7. (https://github.com/iflytek/astron-agent/blob/main/console/frontend/package.json)
+- Visual workflow builder: **`reactflow ^11.11.3`** plus **Monaco editor**, **ECharts**, KaTeX, Lottie. (package.json — confirmed in WebFetch)
+- Page surface under `console/frontend/src/pages`:
+  - `workflow/` — node-based flow builder with `components/{flow-container, flow-drawer, flow-header, flow-modal, node-list, btn-groups, community-qr-code, multiple-canvases-tip}` + `workflow-analysis/`.
+  - `bot-api/` — bind a "bot" to an external application; surfaces App ID, Service URL, **API Key + API Secret**, Flow ID; offers Python/Java demo downloads. (https://github.com/iflytek/astron-agent/blob/main/console/frontend/src/pages/bot-api/api.tsx)
+  - `chat-page/`, `home-page/`, `config-page/`, `callback/`.
+  - `model-management/{official-model, personal-model, model-detail}` — manage built‑in and user models.
+  - `plugin-store/{components, detail}` — browsable catalog with detail pages.
+  - `release-management/{agent-list, detail-list-page, detail-overview, released-page, trace-logs}` — agent versioning + monitoring.
+  - `resource-management/`, `space/{enterprise, personal, space-detail, team-create, hooks}`.
+  - `share-page/` — invitation acceptance/rejection (NOT public-share URLs).
+- Multi-tenant: a `useSpaceStore` (Zustand) holds `spaceId/enterpriseId/spaceType` and injects tenant headers on every Axios call.
+- Runtime config via `docker-entrypoint.sh` → `/var/www/runtime-config.js` (env-driven base URL).
+
+### 1.2 Backend (`console/backend`)
+
+Spring Boot multi-module (`commons/`, `hub/`, `toolkit/`, `config/`). Hub package: `com.iflytek.astron.console.hub` with `controller/{publish, share, bot, chat, wechat, workflow, user, space, notification, homepage, extra}`.
+
+Key controllers (verified):
+
+- **`PublishApiController`** — `POST /publish-api/create-user-app`, `GET /publish-api/app-list`, `POST /publish-api/create-bot-api`, `GET /publish-api/get-bot-api-info`. Rate-limited 30/60s.
+- **`BotPublishController`** — `GET /publish/bots`, `GET /publish/bots/{botId}`, `GET /publish/bots/{botId}/prepare` (channels: market, mcp, feishu, api, wechat), `POST /publish/bots/{botId}` (unified publish/offline via strategy pattern), `/summary`, `/timeseries`, `/versions`, `/trace`.
+- **`SparkChatController`** — `POST /api/spark/chat/stream` (`text/event-stream`).
+- **`WorkflowChatController`** — `POST /api/v1/workflow/chat/stream` (SSE), `POST /api/v1/workflow/chat/resume`, `POST /api/v1/workflow/chat/stop/{streamId}`, `GET /api/v1/workflow/chat/status`, `GET /api/v1/workflow/health`.
+- **`WechatCallbackController`** — webhook endpoint for WeChat Official Accounts.
+- `ShareController`, `S3Controller`, `HealthController`, plus bot CRUD/voice/favorites.
+
+### 1.3 Bot publishing — 5 channels (strategy pattern)
+
+| Strategy | Effect |
+|---|---|
+| `MarketPublishStrategy` | Lists bot in internal Agent Hub marketplace |
+| `ApiPublishStrategy` | Generates external REST endpoint + API Key/Secret (Bot API) |
+| `WechatPublishStrategy` | OAuth2 binding to WeChat Official Accounts |
+| `FeishuPublishStrategy` | Deploy to Feishu collaboration platform |
+| **`McpPublishStrategy`** | **Publish the bot/workflow as a Model Context Protocol server** (consumable by any MCP client incl. Claude Desktop) |
+
+### 1.4 SSE / streaming
+
+Bespoke SSE protocol (`SseEmitter` + provider-specific event chunks). **Not OpenAI-compatible**; clients use iFlytek SDKs. gRPC implied between core services only (no public surface confirmed).
+
+### 1.5 MCP
+
+- **Consumer**: `core-link` (FastAPI) registers external MCP servers (`register_mcp()`), discovers (`tool_list()`), invokes (`call_tool()`), with SSRF/blacklist guards. Naming convention `mcp@{type}{id}`.
+- **Server**: bots published via `McpPublishStrategy` are exposed as MCP servers — bidirectional support.
+- Companion repo `iflytek/ifly-workflow-mcp-server` is a separate Node/Python MCP server.
+
+### 1.6 Webhooks, embedding, OpenAPI
+
+- Webhooks: only `WechatCallbackController` is a true inbound webhook. No generic outbound webhook framework documented.
+- Embedding: `share-page` is for invitations, **not** iframe/widget. No JS chat widget located.
+- OpenAPI: Swagger/Springdoc annotations on controllers; **HTTP Tool plugins are themselves defined by OpenAPI YAML/JSON** parsed by Jackson.
+
+### 1.7 Auth/Multi-tenant
+
+External Casdoor (OAuth2/OIDC) + JWT refresh; Nginx fronts everything (SSE-aware); `spaceId/enterpriseId` headers establish tenant context throughout.
+
+---
+
+## 2. ihub-apps
+
+Single Node/Express server + React/Vite SPA + small mobile/desktop shells. No microservices. No multi-tenancy (group-permission based access only).
+
+### 2.1 Console frontend (`client/src`)
+
+- Stack: React 18 + Vite + JS (no TS) + Tailwind + custom contexts (`AuthContext`, `PlatformConfigContext`, `UIConfigContext`). No Ant Design, no Recoil/Zustand, no React Router 7. (`client/package.json`)
+- **No React Flow / X6 / G6 / antv** — confirmed via `grep` over `client/`. Workflow "editing" is a Monaco JSON textarea: `client/src/features/admin/pages/AdminWorkflowEditPage.jsx:118` (`handleJsonChange`).
+- Features (`client/src/features/`): `admin`, `apps`, `auth`, `canvas`, `chat`, `extension`, `nextcloud-embed`, `office`, `prompts`, `settings`, `setup`, `teams`, `tools`, `upload`, `voice`, `workflows`.
+- Workflows surface (`features/workflows/`): `WorkflowsPage` (tabs: Available, MyExecutions), `WorkflowExecutionPage`, `ExecutionCard`, `ExecutionProgress`, `HumanCheckpoint`, `StartWorkflowModal`, `WorkflowCard`, `WorkflowPreview`. No DAG canvas.
+- Canvas feature (`features/canvas/`): rich text editor (Quill) bound to LLM. Not a node graph.
+- Routes (`client/src/App.jsx:230-700`): apps, workflows, canvas, admin (40+ admin pages: users/groups/models/providers/prompts/tools/skills/workflows/sources/pages/ui/auth/oauth/oauth-clients/oauth-server/integrations/{jira,office365,googledrive,nextcloud}/marketplace/marketplace-registries/browser-extension/nextcloud-embed/office-integration/usage/system/logging/telemetry/features/shortlinks), unified-pages, teams tab.
+- `iframe` app type exists for embedding *external* sites into iHub (`features/apps/pages/IframeApp.jsx:9`) — not for embedding iHub elsewhere.
+
+### 2.2 Server (Express, `server/`)
+
+Route modules registered in `server/server.js:412-453`. Notable:
+
+| File | Purpose |
+|---|---|
+| `routes/openaiProxy.js:21-612` | **OpenAI-compatible proxy** at `/api/inference/v1/{models,chat/completions}` with SSE streaming + tool calls + per-user model permission filtering. |
+| `routes/swagger.js:1-273` | Swagger UI at `/api/docs` with 3 groups: chat/general, admin, openai-compat. swaggerJSDoc annotations on routes. |
+| `sse.js:1-50` | SSE client registry + heartbeat with `actionTracker` event bridge. |
+| `routes/chat/sessionRoutes.js:200` | EventSource endpoint `GET /api/apps/:appId/chat/:chatId/status` (single SSE per chat). |
+| `routes/chat/dataRoutes.js:569,904` | Send-message + cancel; uses sse.js bus. |
+| `routes/auth.js`, `oauth.js`, `oauthAuthorize.js`, `wellKnown.js` | OIDC discovery, JWKS, OAuth2 server (token/introspect/revoke/userinfo), local/LDAP/NTLM/Teams logins. |
+| `routes/admin/marketplace.js` | Registry-based marketplace for installable apps/tools/prompts/models/workflows; backed by `services/marketplace/{RegistryService,ContentInstaller}.js`. |
+| `routes/integrations/{jira,office365,googledrive,nextcloud,ifinder,officeAddin,browserExtension,nextcloudEmbed}.js` | External system integrations. |
+| `routes/workflow/workflowRoutes.js` (1892 lines) | Workflow run, list, status, executions; uses `services/workflow/{WorkflowEngine,DAGScheduler,ExecutionRegistry,StateManager}.js`. |
+| `routes/shortLinkRoutes.js` | Generate shareable short URLs to apps with pre-filled params/values. |
+| `routes/nextcloudEmbedPages.js` | Serves iHub UI as an iframe inside Nextcloud with `Content-Security-Policy: frame-ancestors` allowlist. |
+| `routes/wellKnown.js` | OIDC discovery + JWKS endpoints. |
+| `routes/setup.js`, `pwaRoutes.js`, `themeRoutes.js`, `staticRoutes.js`, `office.js`. |
+
+### 2.3 OpenAI compatibility
+
+`POST /api/inference/v1/chat/completions` and `GET /api/inference/v1/models` are full OpenAI-format endpoints (auth via `authRequired` middleware — JWT/session); supports streaming, tools, tool_choice; adapters in `server/adapters/` normalise per-provider responses.
+
+### 2.4 MCP
+
+- **Consumer only.** `server/toolLoader.js:201-218` reads `MCP_SERVER_URL` (single URL via `server/config.js:24`) and `GET /tools` from it, merging into the global tool registry.
+- **No MCP server endpoint** — iHub apps/workflows are NOT exposed as MCP. Confirmed by `grep -ri "MCP|model context protocol" server/ client/`.
+
+### 2.5 Webhooks
+
+- **No webhook framework.** `grep -ri "webhook" server/` returns 0 hits in code (only doc strings unrelated).
+- No inbound webhook receiver, no outbound webhook on lifecycle events (chat completed, workflow finished, user created…).
+
+### 2.6 Embedding / widgets
+
+- **Iframe**: only inbound (`features/apps/pages/IframeApp.jsx`) and the Nextcloud-embed iframe deployment (`routes/nextcloudEmbedPages.js`, `client/src/features/nextcloud-embed/`).
+- **No drop-in JS chat widget** (no `<script src="…widget.js">` snippet generator).
+- Public shell apps: `browser-extension/` (Manifest V3, sidepanel + background.js), `electron/` (main+preload), `teams/` (Teams tab manifest), `nextcloud-app/` (Nextcloud PHP app).
+- `shortLinkRoutes.js` enables short shareable URLs but still requires auth.
+
+### 2.7 Public REST API surface
+
+Documented in Swagger, organised into 3 specs:
+
+- Chat & General: `/api/apps`, `/api/models`, `/api/tools`, `/api/skills`, `/api/sessions`, `/api/pages`, `/api/translations`, `/api/configs/{ui,platform,mimetypes}`, `/api/styles`, magic prompts, short-links.
+- Admin: `/api/admin/...` (everything in `server/routes/admin/`).
+- OpenAI: `/api/inference/v1/...`.
+
+No public Bot/Agent CRUD API surfaced for end-users — admin only.
+
+---
+
+## 3. Gap matrix
+
+| Capability | astron-agent | ihub-apps | Gap | Notes |
+|---|---|---|---|---|
+| Visual node-based workflow builder | Yes — React Flow + 8+ node types, multi-canvas, drawer/header/modal | **No** — JSON-only editor (Monaco textarea) at `AdminWorkflowEditPage.jsx:118` | **CRITICAL** | Workflow engine exists in `server/services/workflow/`; just needs UI |
+| Bot/Agent designer (chat-style builder) | Yes — bot-create, personality, talk-agent | Partial — `AdminAppEditPage` form-based | M | iHub has app metadata UI but no chat-driven "design" flow |
+| Model management UI | Yes — official + personal sections | Yes — `AdminModelsPage`, `AdminProvidersPage` | Parity | — |
+| Plugin / tool store | Yes — `plugin-store` + tool marketplace; OpenAPI YAML tools | Partial — `AdminMarketplacePage` (registries) | S | iHub has registry-based installer; lacks user-facing browse UI |
+| Space / team management | Yes — personal/enterprise spaces, invites | **No** — groups but no spaces/tenants | L | iHub is single-tenant by design |
+| Release/version mgmt | Yes — versions, trace-logs, released-page | Partial — workflow executions list | M | No bot/app version history |
+| Conversation history UI | Yes — chat-list/history/restart | Yes — chat features | Parity | — |
+| User management UI | Yes (via space + Casdoor) | Yes — `AdminUsers/Groups/OAuthClients` | Parity | — |
+| **OpenAI-compatible REST** | **No** (bespoke iFlytek SDKs) | **Yes** — `routes/openaiProxy.js` | iHub advantage | — |
+| Public REST + SDK / OpenAPI | Yes — Swagger on hub, Python/Java demos | Yes — Swagger 3 specs; no published SDKs | M | iHub lacks generated SDKs |
+| SSE streaming | Yes — workflow/chat SSE | Yes — `sse.js`, chat status SSE | Parity | — |
+| gRPC | Internal only | None | Low | — |
+| **MCP server (expose iHub)** | **Yes** — `McpPublishStrategy` publishes bots as MCP | **No** | **CRITICAL** | iHub has tools/apps/workflows that are MCP-shaped but no protocol endpoint |
+| MCP client | Yes — `core-link` | Yes — `toolLoader.js:201` single URL | Minor | iHub limited to one MCP server |
+| Webhooks (inbound) | Wechat-only | None | M | — |
+| Webhooks (outbound, lifecycle) | None | None | M | Common enterprise ask |
+| Drop-in chat widget (JS snippet, iframe) | No | No | M | Both missing; iHub closer (iframe-friendly UI) |
+| Public share/embed link | No (invite-only) | Partial — `shortLinkRoutes.js` but auth-gated | M | iHub: no anonymous public share |
+| External shells | Console only | **Browser extension + Electron + Teams + Nextcloud app** | iHub advantage | — |
+| Wechat/Feishu channels | Yes | None | Low | Not core to iHub audience |
+| Multi-channel publishing strategy | Yes — pluggable strategies | No | M | Enabler for many gaps above |
+| Auth | Casdoor OAuth2/OIDC | Local/OIDC/LDAP/NTLM/Proxy/Teams + own OAuth2 server | Parity | iHub more flexible |
+
+---
+
+## 4. What we should reimplement (ranked)
+
+1. **Visual node-based workflow builder (UI).** Replace JSON-only editor with React Flow canvas. Backend (`services/workflow/`, `routes/workflow/workflowRoutes.js`) already supports DAG execution; missing piece is purely UI. **Scope: L–XL. Risk: M.** Dependencies: add `reactflow`, node-component library, persistence to existing workflow JSON schema. Highest user-facing value.
+2. **MCP server (expose iHub apps/workflows/tools as MCP).** Lets Claude Desktop, Cursor, etc. consume iHub agents. **Scope: M. Risk: L.** Dependencies: `@modelcontextprotocol/sdk`, mount over HTTP/SSE at `/api/mcp`, map existing tool registry. Symmetric to `McpPublishStrategy`.
+3. **Outbound webhook framework + inbound webhook receivers.** Lifecycle events (workflow.finished, chat.completed, user.created) → user-defined URLs with HMAC signing. Inbound: signed webhook endpoints to trigger workflows from external systems (e.g., Jira/GitHub/Slack). **Scope: M. Risk: L–M.**
+4. **Drop-in JS chat widget + public share links.** Snippet that mounts iHub chat into any site (`<script src="…/widget.js" data-app-id="…">`). Optional anonymous-token mode for marketing pages. **Scope: M. Risk: M** (security: anonymous quota, allowlist origins). Builds on existing iframe-embed support.
+5. **Bot/Agent public REST API publishing.** Per-app issued API keys + scoped Bot API endpoint (separate path from admin), like `PublishApiController`. Today iHub has OpenAI-proxy (model-level); missing is *app-level* keyed API. **Scope: M. Risk: L.** Mostly reusing OAuth client store + permissions.
+6. **Plugin / tool marketplace UI for end-users.** Existing admin registry → user-browse page ("Plugin Store") with detail, ratings, install. **Scope: S–M. Risk: L.** Backend exists.
+7. **Workflow versioning + trace logs UI.** Persist versions, surface `executions/trace` view. **Scope: M. Risk: M.**
+8. **Generated client SDKs (Python / TS / Java).** From existing OpenAPI specs via `openapi-generator`. **Scope: S. Risk: L.**
+9. **Spaces / multi-tenancy.** Spaces, enterprise admin, per-space resource isolation. **Scope: XL. Risk: H.** Probably skip unless commercial need.
+10. **External chat channel adapters (Slack/Teams bot/WeChat).** Slack first (Teams already exists as tab, not bot). **Scope: M per channel. Risk: M.**
+
+---
+
+## 5. Implementation outline — top 3
+
+### 5.1 Visual workflow builder (React Flow)
+
+Files to add/modify in `ihub-apps`:
+
+- `client/package.json` — add `reactflow` (or `@xyflow/react`), `dagre` for auto-layout.
+- New: `client/src/features/workflows/builder/WorkflowBuilder.jsx` — main canvas wrapper.
+- New: `client/src/features/workflows/builder/nodes/` — one component per node type the engine supports: `StartNode.jsx`, `LLMNode.jsx`, `ToolNode.jsx`, `BranchNode.jsx`, `LoopNode.jsx`, `EndNode.jsx`, `HumanCheckpointNode.jsx` (matches `server/services/workflow/executors/`).
+- New: `client/src/features/workflows/builder/edges/{ConditionalEdge.jsx,DefaultEdge.jsx}`.
+- New: `client/src/features/workflows/builder/NodePalette.jsx` (drag-and-drop sidebar) and `NodeInspector.jsx` (right-panel config form).
+- Modify: `client/src/features/admin/pages/AdminWorkflowEditPage.jsx:118` — replace `handleJsonChange` Monaco textarea with `<WorkflowBuilder/>` that emits the same JSON. Keep "Raw JSON" tab as fallback.
+- New: `client/src/features/workflows/builder/serialization.js` — map between React Flow `{nodes,edges}` and iHub's workflow JSON (preserves `inputVariables`, `config`, ports).
+- Auto-layout via `dagre`; minimap; node search; copy/paste; validation badge from existing Zod schema.
+- Test: load existing workflows under `contents/workflows/`; ensure round-trip JSON equality.
+
+Effort: ~3–4 weeks single dev. Dependencies: none server-side. Risk: aligning node port semantics with executors.
+
+### 5.2 MCP server exposing iHub apps/workflows/tools
+
+Files to add/modify:
+
+- `server/package.json` — add `@modelcontextprotocol/sdk`.
+- New: `server/routes/mcpServer.js` — register `GET/POST /api/mcp` (HTTP+SSE transport per MCP spec). Auth via existing `authRequired` (JWT in `Authorization: Bearer`) or new dedicated API keys.
+- New: `server/services/mcp/McpServerService.js`:
+  - Map iHub tools (from `toolLoader.js`) → MCP `tools/list` + `tools/call`.
+  - Map iHub apps → MCP tools whose `inputSchema` derives from app variables (reuse `appConfigSchema.js`).
+  - Map iHub workflows → MCP tools whose `inputSchema` derives from start-node `inputVariables` (reuse `buildWorkflowToolParams()` in `toolLoader.js:14`).
+- New: `server/services/mcp/transports/{httpStream.js,sse.js}` — HTTP-stream + SSE transport (using existing `server/sse.js` pattern).
+- Modify: `server/server.js:425` — register new route.
+- Modify: `contents/config/platform.json` schema — add `mcpServer: { enabled, publicMcpUrl, requireApiKey }`.
+- New admin page: `client/src/features/admin/pages/AdminMcpServerPage.jsx` — toggle, copy public URL, list exposed apps/workflows (per-resource toggle).
+- New: `docs/mcp-server.md` — connection example for Claude Desktop config.
+
+Effort: ~1–2 weeks. Risk: protocol version drift; mitigated by using official SDK.
+
+### 5.3 Webhook framework (in + out)
+
+Files to add/modify:
+
+- New: `server/services/webhooks/WebhookManager.js` — registry, retry queue (in-memory + persist to `contents/webhooks/*.json`), exponential backoff, HMAC-SHA256 signing.
+- New: `server/services/webhooks/events.js` — event bus with `actionTracker` integration. Event names: `chat.completed`, `chat.message.sent`, `workflow.execution.started/completed/failed`, `app.created`, `user.login`.
+- Hook emit points:
+  - `server/routes/chat/dataRoutes.js:904` (cancel) and end of streaming handler → fire `chat.completed`.
+  - `server/services/workflow/WorkflowEngine.js` → fire `workflow.execution.*`.
+  - `server/routes/auth.js:431` → `user.login`.
+- New: `server/routes/admin/webhooks.js` — CRUD admin endpoints `/api/admin/webhooks`; rotate secret.
+- New: `server/routes/webhooks.js` — **inbound** `POST /api/webhooks/:token` to trigger workflow runs (signed payload → workflow input mapping configurable per token).
+- New: `client/src/features/admin/pages/AdminWebhooksPage.jsx` + edit page; show delivery history, test-fire button.
+- New: `contents/config/webhooks.json` schema; new Zod validator `server/validators/webhookSchema.js`.
+- New migration: `server/migrations/Vxxx__add_webhooks_config.js` to seed defaults (per CLAUDE.md migration system).
+
+Effort: ~2 weeks. Risk: at-least-once delivery semantics; mitigation: idempotency keys in signed payload.
+
+---
+
+## 6. Open questions
+
+- Does astron's MCP server publish channel expose only the bot's chat as one MCP tool, or expand each workflow node? (DeepWiki summary says "as MCP server" but does not detail tool surface area.)
+- Is astron's gRPC actually public? "Implied" in DeepWiki; could not confirm a proto file.
+- Webhook framework in astron — is it only Wechat callback, or does the publish system emit lifecycle webhooks elsewhere (e.g., MaaS event bus on Kafka)? DeepWiki mentions Kafka but not a user-facing webhook.
+- Plugin store: does astron support user-published (third-party) plugins or only iFlytek-curated? `personal-model` exists; `personal-plugin` was not visible.
+- Has astron a JS embeddable widget? Searches surface no `<script>` snippet generator; only `share-page` (invites) was found.
+- ihub-apps marketplace registries: are they peer-to-peer (multiple iHub instances syndicate) or central? Visible code suggests static configured registries — confirm with `services/marketplace/RegistryService.js` deeper read.
+- For "Bot API" parity, do we use iHub's existing `routes/oauth.js` (Client Credentials) or introduce app-scoped API keys? Both viable; OAuth route already returns JWTs scoped via `oauthClientManager`.
+- Should the visual builder author the existing iHub workflow schema, or do we introduce a richer DAG that diverges from `workflowsLoader.js`? Recommend: keep current schema for compatibility, layer presentation metadata (`position`, `notes`) under a `viewport` field.
+- Should the MCP server require its own API tokens (separate from OAuth) similar to OpenAI key style? Likely yes for tooling clients that lack OAuth flows.

--- a/concepts/astron-comparison/06-tenant-collab-observability.md
+++ b/concepts/astron-comparison/06-tenant-collab-observability.md
@@ -1,0 +1,602 @@
+# Tenancy, Collaboration, Observability, Eval — astron-agent vs ihub-apps
+
+Research date: 2026-05-13. Focus: tenant/space/workspace management, team collaboration
+(sharing, comments, versioning), observability (tracing/metrics/audit), usage
+tracking / billing / credits / quotas, evaluation / testing harnesses.
+
+---
+
+## 1. astron-agent
+
+### 1.1 Spaces / tenants / members / roles
+
+Astron is built around a four-level identity hierarchy: **Enterprises → Spaces → Users → Resources**
+([DeepWiki tenant page](https://deepwiki.com/iflytek/astron-agent/3.2-tenant-and-multi-tenancy-management)).
+
+- **Identity provider:** Casdoor (OAuth2/OIDC). Astron does NOT implement local
+  user/credential storage — Spring Security in `console/hub` validates JWTs issued
+  by Casdoor.
+- **Core tenant service:** `core/tenant/` is a Go microservice with classic Go DDD
+  layout: `internal/{dao, service, handler, models}`. Visible files are
+  `app_dao.go`, `app_service.go`, `auth_dao.go`, `auth_service.go`, `base.go`
+  ([repo dir](https://github.com/iflytek/astron-agent/tree/main/core/tenant/internal)).
+  Despite the name "tenant", this service's _primary_ entities are **Apps**
+  (credential containers with `appKey`/`appSecret`) and **API key bundles**
+  (`SaveAuth`, `DeleteAuth`, `ListAuth`, `GetAppByAPIKey`).
+  PROJECT_MODULES describes it as: "Multi-tenant management, space isolation and
+  permission control, organization structure management, resource quota management"
+  ([docs](https://github.com/iflytek/astron-agent/blob/main/docs/PROJECT_MODULES.md)).
+- **Space data model (DB):** Persistence is split between MySQL (workflow service,
+  Alembic migrations under `core/workflow/alembic/`) and PostgreSQL (multi-tenant
+  memory DB). **Every MySQL table includes a `space_id` foreign key** for
+  row-level isolation; "all queries in the console backend include user and space
+  context for data isolation"
+  ([DeepWiki schema page](https://deepwiki.com/iflytek/astron-agent/11.4-mcp-protocol-and-tool-integration)).
+- **Two ownership models:**
+  - **Personal spaces** — keyed by requester `uid`.
+  - **Team spaces** — `uid` is resolved to the space owner, members share access
+    ([DeepWiki 7.4](https://deepwiki.com/iflytek/astron-agent/7.4-multi-tenancy-and-data-isolation)).
+- **Memory DB isolation** is two-layer: schema-based (`{env}_{uid}_{db_id}`,
+  one production + one test schema per DB) **plus** automatic row-level rewriting
+  of every `SELECT/UPDATE/DELETE/INSERT` to inject a `uid` filter and
+  system-managed `id, uid, create_time, update_time` columns.
+- **Role/member tables:** Not directly exposed in the public schema docs, but
+  console backend depends on space membership for every CRUD call (Java service
+  layer in `console/hub`). Permission decisions happen in Java aspect classes
+  (e.g. `DistributedLockAspect` for race protection on publish operations).
+
+### 1.2 Team collaboration & sharing
+
+- **Bot publishing pipeline:** Each agent (bot) goes through "Bot Lifecycle
+  Management" with explicit publish targets (Marketplace, API, WeChat, MCP).
+  Only the **space creator** can publish — enforced via Redis distributed locks
+  (`publish_api + uid`, 3000ms TTL) ([DeepWiki Bot API Publishing](https://deepwiki.com/iflytek/astron-agent/4.5-workflow-versioning-and-release-management)).
+- **Workflow versioning & release management:** Dedicated wiki section
+  "Workflow Versioning and Release Management" exists (deepwiki section 4.5).
+  Workflows have versioned releases; the `chat_bot_api` table holds bot-to-app
+  associations with channel-specific status. **Workflow execution traces are
+  stored in Elasticsearch via `WorkflowTraceEsClient`** for audit & replay-style
+  inspection.
+- **Real-time chat & SSE** for interactive collaboration with bots.
+- **Plugin store / marketplace** as a sharing channel for tools.
+- **Comments / threaded review:** Not documented as a distinct module — likely
+  absent or buried in the frontend `pages/` tree.
+
+### 1.3 Observability stack
+
+`core/common/otlp/` (Python) is a first-class subsystem:
+
+```
+core/common/otlp/
+  args/        log_trace/    metrics/    trace/    ip.py    sid.py
+```
+
+- **OpenTelemetry**: `opentelemetry-api`, `opentelemetry-sdk`, plus OTLP
+  exporters over **gRPC, HTTP, and OpenCensus** (multiple exporter packages in
+  the Python dependency set).
+- **Structured logging**: `loguru`.
+- **Kafka event bus** (optional, `KAFKA_ENABLE=0` by default):
+  - `WORKFLOW_KAFKA_TOPIC` — workflow execution events
+  - `AGENT_KAFKA_TOPIC` — agent invocations
+  - tool telemetry from `core-link`
+  - Astron explicitly calls these out as feeds for "monitoring, auditing, and
+    analytics systems"
+    ([DeepWiki Kafka page](https://deepwiki.com/iflytek/astron-agent/11.4-mcp-protocol-and-tool-integration)).
+- **Elasticsearch for trace storage**: `WorkflowTraceEsClient` retrieves agent
+  execution logs from ES.
+- **Common module advertises**: "MetrologyAuth for authentication and audit
+  system, OpenTelemetry/OTLP observability support."
+
+### 1.4 Audit log
+
+`core/common/audit_system/`:
+
+```
+audit_system/
+  base.py       enums.py    orchestrator.py    utils.py
+  audit_api/    strategy/
+```
+
+The audit system in astron is somewhat misleadingly named: it focuses on
+**content-safety auditing** of LLM input/output frames (compliance moderation),
+not user-action audit. Classes include `BaseFrameAudit`, `InputFrameAudit`,
+`OutputFrameAudit`, `FrameAuditResult`, with statuses `STOP/CONTINUE`,
+risk-detection error tracking, and a per-session `AuditContext` that holds
+`chat_id`, `uid`, content concatenation, and an async output queue. Strategies
+pluggable per provider via `strategy/`.
+
+User-/admin-action audit (e.g. "who deleted this bot") is handled implicitly
+through Kafka event streams + Casdoor's own audit log, plus Elasticsearch
+storage of workflow traces.
+
+### 1.5 Usage / billing / credits / quotas
+
+`core/common/metrology_auth/` is the metering & licensing SDK:
+
+```
+metrology_auth/
+  base.py    calc.py    conc.py    licc.py    rep.py    errors.py
+  ma-sdk-default.toml   ma-sdk.cfg.toml   ma-sdk.toml
+  ma_sdk_linux_x64.h    ma_sdk_macos_arm64.h    ma_sdk_windows.h
+  include/    ma-sdk-cfg/
+```
+
+- **Cross-platform native SDK** (C headers for Linux/macOS/Windows) — the SDK
+  appears to be a closed-source iFLYTEK-internal metering library, exposed via
+  CPython bindings.
+- `calc.py` calculates metrics; `conc.py` likely tracks concurrency; `licc.py`
+  is licensing; `rep.py` is reporting.
+- The tenant service description includes **"resource quota management"**
+  ([PROJECT_MODULES](https://github.com/iflytek/astron-agent/blob/main/docs/PROJECT_MODULES.md))
+  but no quota schema is publicly documented and no credit / billing UI is
+  documented in the wiki.
+- **No public billing UI / pricing-plan model** appears in the open-source repo
+  — likely reserved for iFLYTEK's hosted Astron Cloud offering.
+
+### 1.6 Evaluation / replay harness
+
+- **No dedicated evaluation/eval-suite/replay subsystem** found in the open
+  source repo. Wiki contents only cover Bot Lifecycle, Workflow Versioning,
+  CI/CD pipelines, tests (`make test-{go,java,python,typescript}`), and unit
+  test directories per service.
+- **Memory DB has a `test` schema** alongside `production` per database — gives
+  a per-tenant test sandbox, but that is integration-time isolation, not an
+  evaluation harness.
+- **Workflow ES trace storage** is the closest thing to replay: ES-indexed
+  traces are queryable by execution ID via `WorkflowTraceEsClient`.
+
+---
+
+## 2. ihub-apps
+
+### 2.1 Tenancy / spaces / members
+
+**There is no tenant or space concept.** The platform is single-tenant by
+design: one set of `contents/apps/*.json`, one set of `contents/models/*.json`,
+one global config. There is no `space_id` / `workspace_id` anywhere in the
+codebase — `grep -rn "spaceId\|space_id\|workspace\|tenant"` returned only:
+
+- `server/middleware/teamsAuth.js` (Microsoft Teams integration, unrelated)
+- `server/services/integrations/Office365Service.js` (Office tenant, unrelated)
+- `server/services/integrations/EntraService.js` (Azure AD tenant, unrelated)
+- `server/configCache.js`, `server/services/TokenStorageService.js` (none of
+  these are "workspaces" in the product sense)
+
+**Auth & permissions** are group-based, with hierarchical inheritance:
+
+- `server/utils/authorization.js:15` — `resolveGroupInheritance()` recursively
+  merges parent permissions, detects circular inheritance, returns flattened
+  `apps/prompts/models/workflows/skills/adminAccess` sets per group.
+- `server/utils/authorization.js:171` — `loadGroupsConfiguration()` reads
+  `contents/config/groups.json`.
+- `server/utils/authorization.js:517` — `enhanceUserWithPermissions()` resolves
+  user → groups → permissions, with OAuth-client-credential & authorization-code
+  filtering paths.
+- `server/utils/authorization.js:395` — `intersectWithClientAllowList()` for
+  OAuth client allow-list intersection.
+- `server/utils/authorization.js:465` — `hasAdminAccess()` short-circuit.
+- `server/middleware/authRequired.js:13` — `authRequired` middleware; allows
+  anonymous when `anonymousAuth.enabled`.
+- `server/middleware/authRequired.js:91` — `resourceAccessRequired(type)`
+  factory used by `appAccessRequired`, `modelAccessRequired`.
+- `server/defaults/config/groups.json` — only four built-in groups: `admins`,
+  `users`, `anonymous`, `authenticated`. No notion of group "owner" or
+  membership lists beyond external-group mappings.
+
+**Identity providers** (`server/routes/auth.js`): local, LDAP, OIDC, NTLM,
+Microsoft Teams, proxy headers — all converging on a single JWT cookie.
+Stronger than astron's pure Casdoor reliance (astron delegates everything).
+
+### 2.2 Collaboration / sharing / versioning / comments
+
+- **App/workflow sharing**: only via **short links** — `server/shortLinkManager.js`
+  stores opaque tokens in `contents/data/shortlinks.json` with expiry. There is
+  no concept of "share with user X / group Y".
+- **No comments, no review threads, no annotations** on apps, workflows, or
+  conversations.
+- **No versioning** of apps or workflows. `defaults/apps/*.json` files have **no**
+  `version` field. The marketplace installer in
+  `server/services/marketplace/ContentInstaller.js:310` has an audit-trail
+  comment about `installedBy='admin'`, but there's no version diff/history.
+- **Feedback storage** (`server/feedbackStorage.js`) writes JSONL records keyed by
+  `messageId, appId, chatId, modelId, rating, comment` to
+  `contents/data/feedback.jsonl` — a flat append-only log, not threaded.
+- **Microsoft Teams "team" feature** (`client/src/features/teams/`) is a Teams-SDK
+  embed shell (TeamsTab.jsx, TeamsAuthStart/End, TeamsWrapper) — NOT a
+  collaboration model; it's just the M365 Teams app surface for embedding iHub.
+
+### 2.3 Observability
+
+iHub already has a serious OpenTelemetry implementation:
+
+- `server/telemetry.js:77` — `initTelemetry()` bootstraps `@opentelemetry/sdk-node`
+  with configurable provider (`otlp`, `prometheus`, `console`), resource
+  attributes, optional auto-instrumentation, log record processors, periodic
+  metric reader.
+- `server/telemetry/GenAIInstrumentation.js:24` — `GenAIInstrumentation` class
+  follows OTel **GenAI semantic conventions** (`gen_ai.operation.name`,
+  `gen_ai.provider.name`, `gen_ai.request.model`, token usage attributes).
+- `server/telemetry/metrics.js:33` — strict allow-list of metric labels to avoid
+  Prometheus cardinality explosion: `gen_ai.*`, `error.type`, `app.id`,
+  `auth.provider`, `auth.event`, `ratelimit.scope`, `stream.outcome`,
+  `feedback.rating`, etc.
+- `server/telemetry/ActivityTracker.js` — rolling 5-min window for active users
+  and chats, exposed as observable gauges `ihub.active.users`, `ihub.active.chats`.
+- `server/telemetry/ProcessMetrics.js` — process-level metrics.
+- `server/telemetry/exporters.js` — OTLP/Prometheus/Console exporter factory,
+  honors `OTEL_EXPORTER_*` env vars.
+- `server/telemetry/events.js` — emit prompt/completion events on spans, gated
+  by `events.includePrompts/includeCompletions` config.
+- `server/middleware/rateLimiting.js:33` — calls `recordRateLimitHit('http', type)`
+  for telemetry on every limit hit.
+- Admin UI: `client/src/features/admin/pages/AdminTelemetryPage.jsx` and
+  `AdminUsageReports.jsx`, plus `AdminLoggingPage.jsx`.
+
+**What's missing**: no centralized **trace store / search UI** (astron uses
+Elasticsearch for `WorkflowTraceEsClient`-style retrieval). Spans go to an
+external OTLP collector but iHub doesn't ship its own trace viewer.
+
+### 2.4 Usage tracking
+
+iHub has a mature usage-tracking pipeline (more advanced than astron's
+open-source surface):
+
+- `server/usageTracker.js:230` — `recordChatRequest({userId, appId, modelId,
+  tokens, tokenSource, user})` increments aggregates in
+  `contents/data/usage.json`: messages/tokens by user/app/model, prompt vs
+  completion split, magicPrompt counters, feedback ratings, token-source quality
+  (`provider` vs `estimate`).
+- `server/usageTracker.js:312` — `recordFeedback({rating})` 1-5 star + legacy
+  good/bad.
+- `server/usageTracker.js:367` — `recordMagicPrompt({inputTokens, outputTokens})`.
+- `server/services/UsageEventLog.js:41` — `logUsageEvent()` appends every event
+  to `contents/data/usage-events.jsonl` (buffered 10 s flush).
+- `server/services/UsageAggregator.js:17` — `buildDailyRollup()` and
+  `buildMonthlyRollup()` aggregate JSONL into rollups under
+  `contents/data/usage-{daily,monthly}/`. `runRollups()` orchestrates flush →
+  daily → monthly → retention cleanup.
+- `server/services/UsageAggregator.js:278` — `startRollupScheduler()` runs
+  every hour.
+- `server/routes/admin/usage.js` — admin API: `/api/admin/usage/timeline`,
+  `/api/admin/usage/users`, with CSV export.
+- **Pseudonymisation:** `server/services/UserFingerprint.js` + `usageTracker.js:241`
+  `trackingMode` of `pseudonymous` vs `identified`.
+
+**What's missing:** there is no **quota enforcement** anywhere. `grep -rn
+"quota\|credit\|billing" /home/user/ihub-apps/server/` returned 3 hits, all in
+unrelated text content (faq.md, nda-risk-analyzer.json, telemetry/attributes.js
+metric label). Per-user rate limiting is a concept document
+(`concepts/2026-03-10 Per-User Rate Limiting Proposal.md`) but **not
+implemented** beyond IP-based limiter in `server/middleware/rateLimiting.js`.
+
+### 2.5 Audit log
+
+There is **no structured user-action audit log**. `grep -rn "audit"` returns:
+
+- A doc comment in `server/services/marketplace/ContentInstaller.js:310` about
+  `installedBy` ("Username of the installing admin for audit trail") — a single
+  metadata field, not an audit subsystem.
+- `server/routes/chat/dataRoutes.js:464` — a docstring mentioning request IDs
+  "for debugging and audit trails".
+- `server/tests/admin-endpoints-security.test.js` — security tests.
+- `server/defaults/pages/en/faq.md`, `nda-guide.md` — content files.
+
+`telemetry/attributes.js` builds OTel span attributes but spans are not a
+queryable audit log. Logging via `server/utils/logger.js` is structured JSON
+(component, action, userId) but it's an operational log, not an immutable
+chronological audit feed with retention/integrity guarantees.
+
+### 2.6 Evaluation / testing harness
+
+**Nothing.** `grep -rn "evaluation\|eval-suite\|replay\|playground"` returns
+only unrelated hits (workflow conditional-edge evaluation in
+`DAGScheduler.js:425`, OAuth code store, refresh token store). There is:
+
+- No batch eval runner.
+- No prompt regression suite.
+- No conversation replay.
+- No test-data dataset model.
+- No A/B harness for comparing models on a fixed task set.
+- No golden-output diffing.
+
+The only test surface is unit/integration tests in `server/tests/`.
+
+---
+
+## 3. Gap matrix
+
+| Capability                                  | astron-agent                                                                                | ihub-apps                                                  | Gap severity   | Notes                                                                          |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------- | ---------------------------------------------------------- | -------------- | ------------------------------------------------------------------------------ |
+| Spaces / workspaces                         | Yes — `space_id` FK on every table; personal & team spaces; isolation row-level + schema    | None — single-tenant                                       | **Critical**   | Largest single product gap                                                     |
+| Tenant service (org / quotas)               | Yes — Go `core/tenant`, advertises "resource quota management"                              | None                                                       | High           |                                                                                |
+| Members & roles per space                   | Implicit (space ownership + uid filtering); Casdoor role for global RBAC                    | Global groups only (`admins/users/anon/auth`), no per-space   | High           | iHub group inheritance is rich but global                                      |
+| Sharing apps/workflows with users           | Publish to marketplace; channel-specific bot APIs                                           | Short links only (anonymous, opaque)                       | Medium-High    | iHub short-link manager: `server/shortLinkManager.js`                          |
+| Versioning workflows/apps                   | Yes — dedicated "Workflow Versioning and Release Management" section                        | None — no `version` field on apps                          | High           |                                                                                |
+| Comments / review                           | Not visible                                                                                 | None                                                       | Low            | Neither has it                                                                 |
+| OpenTelemetry tracing                       | Yes — full OTLP stack (gRPC/HTTP/OpenCensus)                                                | Yes — `server/telemetry.js`, GenAI semantic conventions    | None / on par  | iHub may even be ahead on GenAI semconv compliance                             |
+| Centralized trace store / viewer            | Yes — Elasticsearch + `WorkflowTraceEsClient`                                               | No — relies on external OTLP collector                     | Medium         | iHub has no in-product trace UI                                                |
+| Audit log (user actions)                    | Implicit via Kafka event topics + Casdoor                                                   | None — only ad-hoc `logger.info` lines                     | High           | Compliance blocker for enterprise                                              |
+| Audit (content safety)                      | Yes — `core/common/audit_system/` (input/output frame moderation)                           | None                                                       | Medium         | Optional / domain-specific                                                     |
+| Usage tracking (tokens/messages)            | Via Kafka events + ES traces                                                                | **Mature** — `usageTracker.js`, `UsageAggregator.js`       | None / iHub ahead | iHub has daily+monthly rollups, JSONL events, pseudonymisation, admin UI       |
+| Quotas / credits enforcement                | Tenant service ("resource quota management") — closed metrology_auth SDK                    | None                                                       | High           | iHub has counters but no enforcement                                           |
+| Billing                                     | Closed (Astron Cloud commercial)                                                            | None                                                       | Low            | OSS gap on both sides                                                          |
+| Per-user rate limiting                      | Implicit per-tenant via metrology_auth                                                      | IP-based only (`server/middleware/rateLimiting.js`); per-user is a draft proposal | Medium |  |
+| Evaluation harness / replay                 | None public                                                                                 | None                                                       | High           | Both lack this; market-differentiator opportunity                              |
+| Workflow test sandbox                       | Yes — per-tenant `test` schema separate from `production`                                   | None                                                       | Medium         |                                                                                |
+| Feedback storage                            | Not surfaced                                                                                | Yes — `feedbackStorage.js`, 1-5 ratings + comments         | None           | iHub ahead                                                                     |
+
+---
+
+## 4. What we should reimplement (ranked)
+
+### Rank 1 — Spaces / workspaces with per-space membership and resource scoping
+
+- **Why:** every enterprise customer story (multiple business units, per-team
+  app catalogs, "give my agency client access to just these apps without
+  showing my internal ones") hits this wall. iHub today forces one global
+  config namespace; even the rich group inheritance in
+  `server/utils/authorization.js:15` cannot model "team A owns these 3 apps and
+  shares them with team B".
+- **Scope:** **XL**. Touches data model, every route, every loader, every admin
+  page.
+- **Risk:** very high — breaking change unless we keep a "default space" alias
+  for the legacy single-tenant mode.
+- **Dependencies:** none (foundation).
+
+### Rank 2 — Evaluation / regression harness for apps & workflows
+
+- **Why:** prompt drift, model swaps, and workflow refactors all silently
+  regress quality. Today an iHub admin cannot answer "did changing
+  `preferredModel` to gemini-2.0-pro improve or degrade this app?". Neither
+  platform offers this OSS, so building it is a differentiator.
+- **Scope:** **L**. New `contents/eval-suites/` directory, runner service,
+  results viewer, optional LLM-as-judge.
+- **Risk:** medium — execution sandboxing, cost control.
+- **Dependencies:** existing chat service (`server/services/chat/`),
+  usageTracker for cost reporting, optional structured-output mode for golden
+  comparison.
+
+### Rank 3 — Quotas, credits, and per-user rate limits
+
+- **Why:** without enforcement, every cost-leak incident requires a human
+  reading rollups. Per-user rate limiting was already proposed (`concepts/
+  2026-03-10 Per-User Rate Limiting Proposal.md`) — a credit/quota layer
+  generalises it.
+- **Scope:** **M**. Build on `UsageAggregator` infrastructure. Add a `quotas`
+  config block, enforce in chat path, return 429 with retry-after.
+- **Risk:** medium — clock skew, distributed counter consistency under
+  clustering.
+- **Dependencies:** None hard, but cleaner if scoped per-space (so Rank 1
+  should land first or in parallel).
+
+### Rank 4 — Structured user-action audit log
+
+- **Why:** "who deleted that app config", "who changed group permissions" —
+  compliance-table-stakes for enterprise. iHub's
+  `server/utils/logger.js` produces structured logs but they have no retention
+  guarantees, no immutability, no per-resource history view.
+- **Scope:** **M**. Append-only `audit-events.jsonl` similar to `UsageEventLog`,
+  schema with `actor, action, target, before, after, ts, requestId`, admin UI.
+- **Risk:** low.
+- **Dependencies:** none.
+
+### Rank 5 — App/workflow versioning + share-with-user/group
+
+- **Why:** today apps live in flat `contents/apps/*.json`. Promoting an app
+  from draft to production, or rolling back, requires git knowledge. Sharing
+  is "either everyone in your group, or use a short link".
+- **Scope:** **L**. Schema bump on `appConfigSchema`, history table, diff UI,
+  share ACL.
+- **Risk:** medium — file-based persistence vs DB tension.
+- **Dependencies:** Rank 1 (sharing scope only makes sense once spaces exist).
+
+### Rank 6 — In-product trace viewer
+
+- **Why:** OTel data already flows out; admins still need to spin up Jaeger /
+  Tempo / Grafana to debug a request. A minimal trace explorer ("show all
+  spans for this conversation ID") would massively speed up support.
+- **Scope:** **M**. Either ship a built-in Tempo/ClickHouse-backed reader or
+  pull traces from configured OTLP collector via API.
+- **Risk:** medium — storage choice.
+- **Dependencies:** none.
+
+### Rank 7 — Per-tenant test sandbox / preview environment
+
+- **Why:** astron's `test` vs `production` schema per memory DB is a neat
+  pattern. iHub doesn't have one.
+- **Scope:** **M-L**, scoped after Rank 1.
+- **Risk:** medium.
+- **Dependencies:** Rank 1.
+
+---
+
+## 5. Implementation outline (top 3)
+
+### 5.1 Spaces / workspaces (Rank 1)
+
+**Data model (new file: `contents/config/spaces.json`):**
+
+```json
+{
+  "spaces": {
+    "default": {
+      "id": "default",
+      "name": { "en": "Default workspace" },
+      "ownerId": "system",
+      "members": [
+        { "userId": "...", "role": "owner|admin|editor|viewer", "addedAt": "..." }
+      ],
+      "resources": {
+        "apps": ["*"],
+        "workflows": ["*"],
+        "models": ["*"]
+      },
+      "quotas": {
+        "monthlyTokens": null,
+        "monthlyMessages": null,
+        "maxConcurrentChats": null
+      }
+    }
+  },
+  "metadata": { "version": "1.0.0" }
+}
+```
+
+**Migration (`server/migrations/V020__add_default_space.js`):**
+
+- Create `spaces.json` with one `default` space whose `members` is empty (any
+  user falls back to default via "membership-or-default" rule).
+- Add `spaceId` field to every resource record by stamping `"default"`.
+- Add `currentSpaceId` to user session token claims.
+
+**Server changes:**
+
+- `server/configCache.js` — load and cache `spaces.json`; add
+  `getSpaceForUser(userId, providedSpaceId)`.
+- `server/utils/authorization.js` — add `enhanceUserWithSpaces()` after
+  `enhanceUserWithPermissions()` (line 517) that resolves accessible spaces and
+  exposes `req.user.spaceId` + `req.user.spaceRole`.
+- `server/middleware/authRequired.js` — extend `resourceAccessRequired()` to
+  intersect with `space.resources[type]` (line 91 currently only checks
+  `user.permissions`).
+- `server/appsLoader.js`, `workflowsLoader.js`, `promptsLoader.js` —
+  filter loaded resources by `spaceId`.
+- `server/routes/admin/spaces.js` — NEW: CRUD for spaces, members,
+  invitations.
+- `server/routes/auth.js` — `/api/auth/status` returns `availableSpaces` and
+  current `spaceId`; new endpoint `POST /api/auth/switch-space`.
+
+**Client changes:**
+
+- New space switcher in header.
+- `client/src/shared/contexts/SpaceContext.jsx` mirrors `PlatformConfigContext`.
+- All admin pages gain space scope (e.g. `AdminAppsPage` lists apps for
+  current space).
+
+**Compatibility strategy:** Single-space install (`default`) is the default.
+Spaces feature flag (`features.spaces`) gated; when off, behavior is identical
+to today.
+
+### 5.2 Evaluation harness (Rank 2)
+
+**Data model (`contents/eval-suites/<suite-id>.json`):**
+
+```json
+{
+  "id": "support-bot-regression-v1",
+  "appId": "support-bot",
+  "datasetVersion": "2026-05-13",
+  "cases": [
+    {
+      "id": "case-1",
+      "input": { "messages": [{ "role": "user", "content": "How do I reset password?" }] },
+      "expected": {
+        "contains": ["password reset", "email"],
+        "notContains": ["unable", "sorry"],
+        "minLength": 80,
+        "jsonSchema": null,
+        "judge": {
+          "model": "gpt-4o-mini",
+          "rubric": "Does the answer correctly guide the user through password reset?"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Server (new `server/services/eval/`):**
+
+- `EvalRunner.js` — runs a suite against an app (uses existing
+  `server/services/chat/ChatService.js`), captures latency, tokens, raw
+  output, judge verdict.
+- `EvalResultStore.js` — persists results to
+  `contents/data/eval-results/<suite>/<run-id>.json`.
+- `LLMJudge.js` — optional LLM-as-judge; emits structured pass/fail with
+  reasoning.
+- `server/routes/admin/evals.js` — list suites, run suite, list runs, diff two
+  runs.
+
+**Hook into existing telemetry:** every eval run emits OTel spans with
+attribute `eval.suite=...`, `eval.run=...`; admins can filter eval-vs-prod
+traffic.
+
+**Schema validator:** add `server/validators/evalSuiteSchema.js`.
+
+**Admin UI:** `client/src/features/admin/pages/AdminEvalsPage.jsx` with
+suite editor, run trigger, results matrix (case × variant), regression diff.
+
+**Migration:** none for V1 (file-only). Add `V0NN__add_eval_dir.js` to ensure
+`contents/eval-suites/` exists and add a sample suite.
+
+### 5.3 Quotas / credits / per-user rate limits (Rank 3)
+
+**Config additions in `platform.json`:**
+
+```json
+{
+  "quotas": {
+    "enabled": false,
+    "scope": "perUser|perSpace|perGroup",
+    "defaults": {
+      "monthlyTokens": 1000000,
+      "monthlyMessages": 5000,
+      "concurrentChats": 3
+    },
+    "perGroup": { "users": { "monthlyTokens": 500000 } },
+    "actionOnExceed": "block|warn|degrade"
+  }
+}
+```
+
+**Server:**
+
+- `server/services/QuotaEnforcer.js` — checks current usage from
+  `UsageAggregator` rollups (lazy-cached) + in-memory delta since last flush.
+- Hook into `server/services/chat/ChatService.js` _before_ adapter call:
+  reject with HTTP 429 + `Retry-After` header when over quota.
+- Hook into `server/middleware/rateLimiting.js` to add a per-user limiter
+  (currently IP only, line 19).
+- Add OTel metric `ihub.quota.exceeded` with `quota.scope`, `quota.kind` labels.
+- New admin route `GET /api/admin/quotas/usage` returns "X / Y used this
+  period" per user/space.
+
+**Migration:** `V0NN__add_quotas_config.js` adds `quotas.enabled=false` block
+to `platform.json` (default off, opt-in).
+
+**Schema impact:** none on app configs — quotas are platform-level + group/space
+overlays.
+
+---
+
+## 6. Open questions
+
+1. **Astron's true tenant model details** — without the source code of
+   `core/tenant/internal/models/*.go` and Java console aspects, I cannot
+   confirm whether members are stored as a join table (`space_member`) or as
+   array fields on space. DeepWiki only documents the high-level isolation
+   strategy.
+2. **Astron quota schema** — `metrology_auth` is a closed-source SDK with C
+   headers; the actual quota table layout, refresh windows, and quota types
+   are not in the public repo.
+3. **Whether iHub leadership wants per-space resource catalogs or one global
+   catalog + per-space permissions** — these are very different data models.
+   Recommend product decision before Rank 1.
+4. **Persistence direction** — iHub uses JSON files via `configCache`. At what
+   point do spaces, members, audit, eval results justify a real DB? If we
+   need this for scale, Rank 1 should land alongside a persistence-layer
+   refactor (existing concept in `concepts/persistence-layer/`).
+5. **Workflow versioning expectations** — astron uses an explicit
+   `version`/release table per workflow. iHub flat files would need either a
+   `<workflow-id>@<version>.json` filename scheme or a sidecar `versions.json`
+   per workflow.
+6. **Compliance retention requirements** — what audit log retention does the
+   target customer base need (90 days? 7 years for SOC2/GDPR? configurable)?
+7. **Whether evaluation should be runnable from CI** — i.e., a CLI entry point
+   that fails the build on regression — vs. only on-demand from admin UI.
+8. **In-product trace storage choice** — ClickHouse vs. Tempo vs. proxying
+   existing OTLP collector. Each implies a very different ops footprint.
+
+---
+
+**Word count estimate:** ~2400.


### PR DESCRIPTION
## Summary

Comprehensive comparison between [iflytek/astron-agent](https://github.com/iflytek/astron-agent) and ihub-apps. Six parallel research agents each produced a deep-dive report comparing one feature area; a seventh synthesis pass consolidates the findings into a master roadmap.

All artefacts live under [`concepts/astron-comparison/`](concepts/astron-comparison/). Read [`00-roadmap.md`](concepts/astron-comparison/00-roadmap.md) first.

### Reports

| # | File | Top-3 picks |
|---|---|---|
| 00 | [Master roadmap](concepts/astron-comparison/00-roadmap.md) | Phased sequence, decision register, risk register |
| 01 | [Workflow engine](concepts/astron-comparison/01-workflow-engine.md) | Parallel execution (M), Iteration node (L), Loop node (M) |
| 02 | [Model abstraction & MaaS](concepts/astron-comparison/02-model-abstraction.md) | Connection validation (S), Model marketplace (M), MaaS lifecycle (XL) |
| 03 | [Agent / tools / plugins / RPA](concepts/astron-comparison/03-agent-tools-plugins-rpa.md) | Real MCP client (M), OpenAPI HTTP tool runner (M), MCP server (M) |
| 04 | [Knowledge / RAG / memory](concepts/astron-comparison/04-knowledge-memory-rag.md) | Vector RAG (XL), Persistent conversations (L), Long-term user memory (L) |
| 05 | [Interfaces / console / API](concepts/astron-comparison/05-interfaces-console-api.md) | Visual workflow builder (L–XL), MCP server (M), Webhook framework (M) |
| 06 | [Tenant / collab / observability / eval](concepts/astron-comparison/06-tenant-collab-observability.md) | Spaces (XL), Eval harness (L), Quotas (M) |

### Headline findings

- **Biggest single gap:** Knowledge / RAG / memory. iHub has no embeddings, vector store, chunking, or persistent conversation memory.
- **Workflow engine is solid** (`server/services/workflow/` has WorkflowEngine, DAGScheduler, StateManager, executors) — but lacks parallel execution, Iteration / Loop / Code / Sub-workflow nodes, and a visual builder.
- **MCP is broken in both directions:** the "MCP client" at `server/toolLoader.js:203` is a one-line URL stub, and there is no MCP server endpoint.
- **Astron's "memory" module is actually a SQL gateway**, not agent memory — both platforms lack real long-term memory and an eval harness, so those are differentiator opportunities, not parity work.

### Where iHub is ahead (don't reinvent)

8 LLM adapters vs astron's 3 · cross-provider tool-calling normalization · OpenAI-compatible inference proxy · OTel GenAI semantic conventions · mature usage tracking with rollups · 5 auth modes (vs Casdoor-only) · 4 external shells (browser ext / Electron / Teams / Nextcloud) · first-class human checkpoint + ask_user tool + skills lazy-loading.

### Status

- [x] Six area reports
- [x] Master roadmap synthesis (Tier A/B/C, four-phase sequence, D1–D10 decisions, risk register)
- [ ] Promote individual Tier-B/C items into their own `concepts/` PRD docs as work starts

## Test plan

Documentation-only PR; no code changes. Reviewers should sanity-check the gap claims against the cited `path:line` references in each report.

https://claude.ai/code/session_01TvzknKvvkw4enDRLK8KKb7