### PR TITLE
feat(office): favourite apps in Outlook add-in

### DIFF
--- a/client/src/features/office/components/OfficeApp.jsx
+++ b/client/src/features/office/components/OfficeApp.jsx
@@ -6,6 +6,7 @@ import ChatHeader from './chat/ChatHeader';
 import SettingsDialog from './settings-dialog';
 import AppListPanel from '../../../shared/components/AppListPanel';
 import { officeLocale } from '../utilities/officeLocale';
+import { useOfficeFavoriteApps } from '../utilities/officeFavorites';
 import { useOfficeConfig } from '../contexts/OfficeConfigContext';
 import {
   storeTokenResponse,
@@ -53,11 +54,19 @@ function storeSelectedApp(app) {
 
 function SelectPage({ user, onLogout, onSelect }) {
   const [isSettingsOpen, setIsSettingsOpen] = React.useState(false);
+  const { favorites, toggleFavorite } = useOfficeFavoriteApps();
 
   const menuItems = [
     { key: 'settings', label: 'Settings', onClick: () => setIsSettingsOpen(true) },
     { key: 'logout', label: 'Logout', onClick: onLogout }
   ];
+
+  const handleToggleFavorite = React.useCallback(
+    (_event, appId) => {
+      toggleFavorite(appId);
+    },
+    [toggleFavorite]
+  );
 
   return (
     <div className="h-screen w-full flex flex-col p-0 bg-slate-50">
@@ -67,6 +76,8 @@ function SelectPage({ user, onLogout, onSelect }) {
             onSelect={onSelect}
             language={officeLocale}
             header={<ChatHeader title="Select App" showCheckmark={false} menuItems={menuItems} />}
+            favorites={favorites}
+            onToggleFavorite={handleToggleFavorite}
           />
         </div>
       </div>

--- a/client/src/features/office/components/apps-dialog/index.jsx
+++ b/client/src/features/office/components/apps-dialog/index.jsx
@@ -1,9 +1,15 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import AppCard from '../../../../shared/components/AppCard';
+import Icon from '../../../../shared/components/Icon';
 import { officeLocale } from '../../utilities/officeLocale';
+import { useOfficeFavoriteApps } from '../../utilities/officeFavorites';
+import { getLocalizedContent } from '../../../../utils/localizeContent';
 
 export default function ItemSelectorDialog({ items, isOpen, onSelect, onClose }) {
+  const { favorites, toggleFavorite } = useOfficeFavoriteApps();
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
+
   useEffect(() => {
     if (!isOpen) return;
     const handler = e => {
@@ -13,7 +19,30 @@ export default function ItemSelectorDialog({ items, isOpen, onSelect, onClose })
     return () => document.removeEventListener('keydown', handler);
   }, [isOpen, onClose]);
 
+  const sortedItems = useMemo(() => {
+    if (!Array.isArray(items)) return [];
+    const compareName = (a, b) => {
+      const aName = getLocalizedContent(a.name, officeLocale) || a.id || '';
+      const bName = getLocalizedContent(b.name, officeLocale) || b.id || '';
+      return aName.localeCompare(bName);
+    };
+    const list = favoritesOnly ? items.filter(item => favorites.includes(item.id)) : [...items];
+    return list.sort((a, b) => {
+      const aFav = favorites.includes(a.id);
+      const bFav = favorites.includes(b.id);
+      if (aFav && !bFav) return -1;
+      if (!aFav && bFav) return 1;
+      return compareName(a, b);
+    });
+  }, [items, favorites, favoritesOnly]);
+
   if (!isOpen) return null;
+
+  const handleToggleFavorite = (_event, appId) => {
+    toggleFavorite(appId);
+  };
+
+  const hasFavorites = favorites.length > 0;
 
   return (
     <div
@@ -25,29 +54,56 @@ export default function ItemSelectorDialog({ items, isOpen, onSelect, onClose })
       <div className="relative bg-white rounded-xl shadow-xl w-full max-w-sm mx-4 flex flex-col max-h-[80vh]">
         <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200 shrink-0">
           <h2 className="text-base font-semibold text-slate-900">Select an App</h2>
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close"
-            className="rounded-full p-1 text-slate-500 hover:text-slate-900 hover:bg-slate-100"
-          >
-            <XMarkIcon className="h-5 w-5" aria-hidden />
-          </button>
+          <div className="flex items-center gap-2">
+            {hasFavorites && (
+              <button
+                type="button"
+                onClick={() => setFavoritesOnly(prev => !prev)}
+                aria-pressed={favoritesOnly}
+                title={favoritesOnly ? 'Show all apps' : 'Show favourites only'}
+                className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium border transition-colors ${
+                  favoritesOnly
+                    ? 'bg-yellow-50 border-yellow-300 text-yellow-700'
+                    : 'bg-white border-slate-200 text-slate-600 hover:bg-slate-50'
+                }`}
+              >
+                <Icon
+                  name="star"
+                  size="xs"
+                  className={favoritesOnly ? 'text-yellow-500' : 'text-slate-400'}
+                  solid={favoritesOnly}
+                />
+                Favourites
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="rounded-full p-1 text-slate-500 hover:text-slate-900 hover:bg-slate-100"
+            >
+              <XMarkIcon className="h-5 w-5" aria-hidden />
+            </button>
+          </div>
         </div>
         <div className="overflow-y-auto p-4">
           <div className="grid gap-3 grid-cols-1">
-            {items && items.length ? (
-              items.map(item => (
+            {sortedItems.length ? (
+              sortedItems.map(item => (
                 <AppCard
                   key={item.id}
                   app={item}
                   variant="compact"
                   onClick={onSelect}
                   language={officeLocale}
+                  isFavorite={favorites.includes(item.id)}
+                  onToggleFavorite={handleToggleFavorite}
                 />
               ))
             ) : (
-              <p className="px-4 py-2 text-sm text-slate-400">No apps available</p>
+              <p className="px-4 py-2 text-sm text-slate-400">
+                {favoritesOnly ? 'No favourite apps yet' : 'No apps available'}
+              </p>
             )}
           </div>
         </div>

--- a/client/src/features/office/utilities/officeFavorites.js
+++ b/client/src/features/office/utilities/officeFavorites.js
@@ -1,0 +1,26 @@
+import { useEffect, useState, useCallback } from 'react';
+import { createFavoriteItemHelpers } from '../../../utils/favoriteItems';
+
+export const OFFICE_FAVORITE_APPS_KEY = 'office_favoriteApps';
+
+export const officeAppFavorites = createFavoriteItemHelpers(OFFICE_FAVORITE_APPS_KEY);
+
+export function useOfficeFavoriteApps() {
+  const [favorites, setFavorites] = useState(() => officeAppFavorites.getFavorites());
+
+  useEffect(() => {
+    const handleStorage = event => {
+      if (event.key && event.key !== OFFICE_FAVORITE_APPS_KEY) return;
+      setFavorites(officeAppFavorites.getFavorites());
+    };
+    window.addEventListener('storage', handleStorage);
+    return () => window.removeEventListener('storage', handleStorage);
+  }, []);
+
+  const toggle = useCallback(appId => {
+    officeAppFavorites.toggleFavorite(appId);
+    setFavorites(officeAppFavorites.getFavorites());
+  }, []);
+
+  return { favorites, toggleFavorite: toggle };
+}

--- a/client/src/shared/components/AppCard.jsx
+++ b/client/src/shared/components/AppCard.jsx
@@ -33,30 +33,58 @@ function AppCard({
 
   if (variant === 'compact') {
     return (
-      <button
-        type="button"
-        className="relative bg-white rounded-lg shadow hover:shadow-md transition-shadow duration-200 w-full flex flex-row cursor-pointer text-left"
+      <div
+        className="relative bg-white rounded-lg shadow hover:shadow-md transition-shadow duration-200 w-full"
         style={{ height: '75px', minHeight: '72px' }}
         role="listitem"
-        onClick={() => onClick?.(app)}
       >
-        <div
-          className="flex items-center justify-center w-10 h-full flex-shrink-0 rounded-l-lg"
-          style={{ backgroundColor: app.color || '#4F46E5' }}
+        {onToggleFavorite && (
+          <button
+            type="button"
+            onClick={e => {
+              e.preventDefault();
+              e.stopPropagation();
+              onToggleFavorite(e, app.id);
+            }}
+            className="absolute top-1 right-1 z-10 p-1 rounded-full hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            title={isFavorite ? t('pages.appsList.unfavorite') : t('pages.appsList.favorite')}
+            aria-label={isFavorite ? t('pages.appsList.unfavorite') : t('pages.appsList.favorite')}
+          >
+            <Icon
+              name="star"
+              size="sm"
+              className={isFavorite ? 'text-yellow-500' : 'text-gray-400'}
+              solid={isFavorite}
+            />
+          </button>
+        )}
+        <button
+          type="button"
+          className="w-full h-full flex flex-row cursor-pointer text-left rounded-lg"
+          onClick={() => onClick?.(app)}
         >
-          <div className="w-8 h-8 bg-white/30 rounded-full flex items-center justify-center">
-            <Icon name={app.icon} className="w-6 h-6 text-white" />
+          <div
+            className="flex items-center justify-center w-10 h-full flex-shrink-0 rounded-l-lg"
+            style={{ backgroundColor: app.color || '#4F46E5' }}
+          >
+            <div className="w-8 h-8 bg-white/30 rounded-full flex items-center justify-center">
+              <Icon name={app.icon} className="w-6 h-6 text-white" />
+            </div>
           </div>
-        </div>
-        <div className="px-4 py-2 flex flex-col flex-1 overflow-hidden justify-center">
-          <h4 className="font-semibold text-sm text-slate-900 truncate" title={name}>
-            {name}
-          </h4>
-          <p className="text-slate-500 text-xs truncate mt-0.5" title={description}>
-            {description}
-          </p>
-        </div>
-      </button>
+          <div
+            className={`py-2 flex flex-col flex-1 overflow-hidden justify-center ${
+              onToggleFavorite ? 'pl-4 pr-9' : 'px-4'
+            }`}
+          >
+            <h4 className="font-semibold text-sm text-slate-900 truncate" title={name}>
+              {name}
+            </h4>
+            <p className="text-slate-500 text-xs truncate mt-0.5" title={description}>
+              {description}
+            </p>
+          </div>
+        </button>
+      </div>
     );
   }
 

--- a/client/src/shared/components/AppListPanel.jsx
+++ b/client/src/shared/components/AppListPanel.jsx
@@ -69,15 +69,7 @@ function AppListPanel({
       const bName = getLocalizedContent(b.name, language) || b.id || '';
       return aName.localeCompare(bName);
     });
-  }, [
-    apps,
-    favoritesEnabled,
-    favoritesOnly,
-    favoriteIds,
-    shouldShowSearch,
-    searchQuery,
-    language
-  ]);
+  }, [apps, favoritesEnabled, favoritesOnly, favoriteIds, shouldShowSearch, searchQuery, language]);
 
   return (
     <div className="flex flex-col h-full min-h-0">

--- a/client/src/shared/components/AppListPanel.jsx
+++ b/client/src/shared/components/AppListPanel.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { fetchApps } from '../../api/api';
 import { getLocalizedContent } from '../../utils/localizeContent';
 import AppCard from './AppCard';
+import Icon from './Icon';
 
 /**
  * Compact, embeddable app list panel.
@@ -14,12 +15,22 @@ import AppCard from './AppCard';
  * @param {string} [language='en'] - Locale for app name/description
  * @param {'auto'|boolean} [showSearch='auto'] - Show search when 'auto' and > 6 apps, or always/never
  * @param {React.ReactNode} [header] - Optional header node rendered above the list
+ * @param {string[]} [favorites] - Optional list of favorited app IDs (enables favorite UI)
+ * @param {Function} [onToggleFavorite] - Called as (event, appId) when the star is clicked
  */
-function AppListPanel({ onSelect, language = 'en', showSearch = 'auto', header }) {
+function AppListPanel({
+  onSelect,
+  language = 'en',
+  showSearch = 'auto',
+  header,
+  favorites,
+  onToggleFavorite
+}) {
   const { t } = useTranslation();
   const [apps, setApps] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [searchQuery, setSearchQuery] = useState('');
+  const [favoritesOnly, setFavoritesOnly] = useState(false);
 
   useEffect(() => {
     fetchApps()
@@ -31,45 +42,98 @@ function AppListPanel({ onSelect, language = 'en', showSearch = 'auto', header }
   }, []);
 
   const shouldShowSearch = showSearch === 'auto' ? apps.length > 6 : showSearch === true;
+  const favoriteIds = favorites || [];
+  const favoritesEnabled = Boolean(onToggleFavorite);
+  const hasFavorites = favoriteIds.length > 0;
 
-  const filteredApps = useMemo(() => {
-    if (!shouldShowSearch || !searchQuery.trim()) return apps;
-    const q = searchQuery.toLowerCase();
-    return apps.filter(app => {
-      const name = getLocalizedContent(app.name, language) || '';
-      const desc = getLocalizedContent(app.description, language) || '';
-      return name.toLowerCase().includes(q) || desc.toLowerCase().includes(q);
+  const visibleApps = useMemo(() => {
+    let list = apps;
+    if (favoritesEnabled && favoritesOnly) {
+      list = list.filter(app => favoriteIds.includes(app.id));
+    }
+    if (shouldShowSearch && searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      list = list.filter(app => {
+        const name = getLocalizedContent(app.name, language) || '';
+        const desc = getLocalizedContent(app.description, language) || '';
+        return name.toLowerCase().includes(q) || desc.toLowerCase().includes(q);
+      });
+    }
+    if (!favoritesEnabled) return list;
+    return [...list].sort((a, b) => {
+      const aFav = favoriteIds.includes(a.id);
+      const bFav = favoriteIds.includes(b.id);
+      if (aFav && !bFav) return -1;
+      if (!aFav && bFav) return 1;
+      const aName = getLocalizedContent(a.name, language) || a.id || '';
+      const bName = getLocalizedContent(b.name, language) || b.id || '';
+      return aName.localeCompare(bName);
     });
-  }, [apps, shouldShowSearch, searchQuery, language]);
+  }, [
+    apps,
+    favoritesEnabled,
+    favoritesOnly,
+    favoriteIds,
+    shouldShowSearch,
+    searchQuery,
+    language
+  ]);
 
   return (
     <div className="flex flex-col h-full min-h-0">
       {header}
-      {shouldShowSearch && (
-        <div className="px-4 py-2 border-b border-slate-100">
-          <input
-            type="search"
-            value={searchQuery}
-            onChange={e => setSearchQuery(e.target.value)}
-            placeholder={t('pages.appsList.searchPlaceholder', 'Search apps...')}
-            className="w-full px-3 py-1.5 text-sm border border-slate-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-indigo-300"
-          />
+      {(shouldShowSearch || (favoritesEnabled && hasFavorites)) && (
+        <div className="px-4 py-2 border-b border-slate-100 flex items-center gap-2">
+          {shouldShowSearch && (
+            <input
+              type="search"
+              value={searchQuery}
+              onChange={e => setSearchQuery(e.target.value)}
+              placeholder={t('pages.appsList.searchPlaceholder', 'Search apps...')}
+              className="flex-1 px-3 py-1.5 text-sm border border-slate-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-indigo-300"
+            />
+          )}
+          {favoritesEnabled && hasFavorites && (
+            <button
+              type="button"
+              onClick={() => setFavoritesOnly(prev => !prev)}
+              aria-pressed={favoritesOnly}
+              title={favoritesOnly ? 'Show all apps' : 'Show favourites only'}
+              className={`flex items-center gap-1 rounded-full px-2 py-1 text-xs font-medium border transition-colors shrink-0 ${
+                favoritesOnly
+                  ? 'bg-yellow-50 border-yellow-300 text-yellow-700'
+                  : 'bg-white border-slate-200 text-slate-600 hover:bg-slate-50'
+              }`}
+            >
+              <Icon
+                name="star"
+                size="xs"
+                className={favoritesOnly ? 'text-yellow-500' : 'text-slate-400'}
+                solid={favoritesOnly}
+              />
+              {t('pages.appsList.favorites', 'Favourites')}
+            </button>
+          )}
         </div>
       )}
       <div className="relative flex-1 overflow-y-auto">
         <div className="p-4 grid gap-4 grid-cols-1">
-          {filteredApps.map(app => (
+          {visibleApps.map(app => (
             <AppCard
               key={app.id}
               app={app}
               variant="compact"
               onClick={onSelect}
               language={language}
+              isFavorite={favoritesEnabled ? favoriteIds.includes(app.id) : false}
+              onToggleFavorite={favoritesEnabled ? onToggleFavorite : undefined}
             />
           ))}
-          {!isLoading && filteredApps.length === 0 && (
+          {!isLoading && visibleApps.length === 0 && (
             <p className="text-sm text-slate-400 text-center py-8">
-              {t('pages.appsList.noApps', 'No apps available')}
+              {favoritesEnabled && favoritesOnly
+                ? t('pages.appsList.noFavorites', 'No favourite apps yet')
+                : t('pages.appsList.noApps', 'No apps available')}
             </p>
           )}
         </div>


### PR DESCRIPTION
## Summary

Adds favourite-app support to the Outlook add-in (issue #1453). Users can star apps in the compact list and the dialog; favourites are persisted in `localStorage` under a dedicated `office_favoriteApps` key so they do not collide with the main web app's favourites.

## Changes

- **`client/src/features/office/utilities/officeFavorites.js`** *(new)* — instantiates `createFavoriteItemHelpers('office_favoriteApps')` and exposes a `useOfficeFavoriteApps()` hook that keeps state in sync via the browser `storage` event (so multiple add-in instances stay aligned).
- **`client/src/shared/components/AppCard.jsx`** — compact variant now supports the same `isFavorite` / `onToggleFavorite` props as the full variant, rendering an absolutely-positioned star button matching the existing style. Refactored the outer element to a `<div>` so we can nest the star `<button>` without invalid HTML; padding shifts to leave room for the star when shown.
- **`client/src/features/office/components/apps-dialog/index.jsx`** (`ItemSelectorDialog`) — uses the hook, sorts favourites first (alphabetical), and adds an optional ⭐ Favourites-only filter toggle in the header.
- **`client/src/shared/components/AppListPanel.jsx`** — accepts optional `favorites` + `onToggleFavorite` props. When provided, sorts favourites first and shows the same filter toggle next to the search box. No change for callers that don't pass them in.
- **`client/src/features/office/components/OfficeApp.jsx`** — `SelectPage` wires the favourites hook into `AppListPanel`.

## Acceptance criteria

- [x] Clicking the star on an app card persists across reloads (localStorage).
- [x] Favourites appear at the top of the apps dialog (and the select panel).
- [x] Favourite state is local to the Outlook add-in (`office_favoriteApps` key — separate from the web's `ihub_favorite_apps`).
- [x] Visual style matches the existing `AppCard` favourite star.
- [x] No server changes required.

## Test plan

- [ ] Open the Outlook add-in, click the star on a few apps; reload the taskpane and confirm they remain starred.
- [ ] Confirm starred apps appear at the top of both the `Select an App` dialog and the `/select` panel.
- [ ] Toggle the ★ Favourites-only filter; confirm only starred apps are shown and the message reads "No favourite apps yet" when none are starred.
- [ ] In the main web app (`/apps`), confirm favourites are independent — toggling a star in Outlook does not change the web favourites and vice versa.
- [ ] Open the add-in in two windows; star/unstar an app in one and confirm the other reflects the change after a focus event (via the `storage` listener).

Closes #1453

---
_Generated by [Claude Code](https://claude.ai/code/session_012pYQFSe7MsdwsJzvPkUmMF)_