### PR TITLE
feat(outlook): promote "Add to email" to primary CTA (#1450)

### DIFF
--- a/client/office/taskpane-entry.jsx
+++ b/client/office/taskpane-entry.jsx
@@ -57,6 +57,24 @@ Office.onReady(async () => {
   const rootEl = document.getElementById('office-root');
   if (!rootEl) return;
 
+  // Detect which Office host is running this add-in so we can pick host-aware
+  // copy for the "insert into document" primary action. `Office.context.host`
+  // returns the Office.HostType enum string ("Outlook" | "Word" | "PowerPoint"
+  // | …); we fall back to the mailbox presence check that the rest of the
+  // codebase already uses, so older clients that don't populate `host` still
+  // get the Outlook label.
+  const officeHost = (() => {
+    try {
+      if (Office.context?.host) return String(Office.context.host);
+    } catch {
+      // Office.context.host can throw in some weird embed scenarios.
+    }
+    if (Office.context?.mailbox) return 'Outlook';
+    return null;
+  })();
+  const isOutlookHost = officeHost === 'Outlook';
+  const insertLabelKey = isOutlookHost ? 'office.insertIntoEmail' : 'office.insertIntoDocument';
+
   // Outlook host adapter: popup-window auth dialog + Outlook mailbox context.
   const outlookHost = {
     kind: 'office',
@@ -79,7 +97,16 @@ Office.onReady(async () => {
         defaultEnabled: true,
         controls: ['attachments']
       }
-    ]
+    ],
+    // In the Office taskpane the "insert this response into the document /
+    // email" button is the whole reason the user opened the add-in, so it
+    // gets promoted to a labelled primary button beneath each assistant
+    // message instead of the small icon used in the main web app.
+    // See issue #1450.
+    insertAction: {
+      variant: 'primary',
+      labelKey: insertLabelKey
+    }
   };
 
   const root = createRoot(rootEl);

--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -34,6 +34,8 @@ function ChatMessage({
   compact = false, // New prop to indicate compact mode (for widget or mobile)
   onOpenInCanvas,
   onInsert,
+  insertAction = null, // { variant: 'icon'|'primary', labelKey: string } — Office host promotes the per-message insert action to a labelled primary button; web app default keeps the legacy icon button on the action row.
+  isLatestAssistantMessage = false, // Keeps the primary insert button always-visible on the most recent assistant response inside small Outlook panes.
   canvasEnabled = false,
   app = null, // App configuration for custom response rendering
   models = [], // Available models for determining if model param should be included in link
@@ -913,6 +915,42 @@ function ChatMessage({
         )}
       </div>
 
+      {/*
+        Primary insert action (Office taskpane). Renders as a labelled brand-coloured
+        button beneath the bubble — the dominant CTA for "add this response to my
+        email / document" inside Outlook, where the action used to be a tiny icon
+        lost amongst the copy/feedback chrome (see issue #1450). Always visible on
+        the latest assistant message so it stays in view on small panes; older
+        assistant turns fade their button with the rest of the action row.
+      */}
+      {!isUser &&
+        !isError &&
+        !message.loading &&
+        onInsert &&
+        insertAction?.variant === 'primary' && (
+          <div
+            className={`mt-2 w-full transition-opacity duration-200 ${
+              isLatestAssistantMessage || showActions ? 'opacity-100' : 'opacity-60'
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() => onInsert(message.content)}
+              className="inline-flex w-full items-center justify-center gap-2 px-3 py-2 rounded-md text-sm font-semibold bg-indigo-600 text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 transition-colors"
+            >
+              <Icon name="arrow-right" size="sm" className="text-white" />
+              <span>
+                {t(
+                  insertAction.labelKey || 'office.insertIntoDocument',
+                  insertAction.labelKey === 'office.insertIntoEmail'
+                    ? 'Add to email'
+                    : 'Add to document'
+                )}
+              </span>
+            </button>
+          </div>
+        )}
+
       {/* Info about finish reason and retry options */}
       {!isUser && !isError && !message.loading && message.finishReason && (
         <div className="flex items-center gap-2 text-xs text-gray-600 mb-1">
@@ -1033,7 +1071,7 @@ function ChatMessage({
             </button>
           )}
 
-          {!isUser && !isError && onInsert && (
+          {!isUser && !isError && onInsert && insertAction?.variant !== 'primary' && (
             <button
               onClick={() => onInsert(message.content)}
               className="flex items-center gap-1 hover:text-blue-600 transition-colors duration-150"

--- a/client/src/features/chat/components/ChatMessageList.jsx
+++ b/client/src/features/chat/components/ChatMessageList.jsx
@@ -23,6 +23,7 @@ function ChatMessageList({
   compact = false,
   onOpenInCanvas,
   onInsert,
+  insertAction = null,
   canvasEnabled = false,
   // Integration auth props
   requiredIntegrations = [],
@@ -119,6 +120,18 @@ function ChatMessageList({
     return null;
   }
 
+  // Index of the most recent assistant message. The Office insertAction
+  // ('primary' variant) uses this to stay always-visible on the latest
+  // response while older assistant turns fold back into hover-revealed icons,
+  // so a small Outlook taskpane keeps a single dominant CTA in view.
+  let lastAssistantIndex = -1;
+  for (let i = displayedMessages.length - 1; i >= 0; i--) {
+    if (displayedMessages[i].role === 'assistant') {
+      lastAssistantIndex = i;
+      break;
+    }
+  }
+
   return (
     <div
       ref={chatContainerRef}
@@ -160,6 +173,8 @@ function ChatMessageList({
                 compact={compact}
                 onOpenInCanvas={onOpenInCanvas}
                 onInsert={onInsert}
+                insertAction={insertAction}
+                isLatestAssistantMessage={index === lastAssistantIndex}
                 canvasEnabled={canvasEnabled}
                 app={app}
                 models={models}

--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -21,6 +21,7 @@ import { getLocalizedContent } from '../../../utils/localizeContent';
 import { officeLocale } from '../utilities/officeLocale';
 import { fetchApps } from '../../../api/api';
 import { useOfficeConfig } from '../contexts/OfficeConfigContext';
+import { useEmbeddedHost } from '../contexts/EmbeddedHostContext';
 
 function buildParamsFromApp(app) {
   const params = { language: officeLocale };
@@ -38,6 +39,7 @@ function buildParamsFromApp(app) {
 function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   const navigate = useNavigate();
   const officeConfig = useOfficeConfig();
+  const embeddedHost = useEmbeddedHost();
 
   const appName = getLocalizedContent(selectedApp?.name, officeLocale);
   const greetingTitle = getLocalizedContent(selectedApp?.greeting?.title, officeLocale);
@@ -353,6 +355,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
                 editable={true}
                 compact={true}
                 onInsert={handleInsert}
+                insertAction={embeddedHost?.insertAction}
                 appId={selectedApp?.id}
                 chatId={chatIdRef.current}
                 app={selectedApp}

--- a/client/src/features/office/contexts/EmbeddedHostContext.jsx
+++ b/client/src/features/office/contexts/EmbeddedHostContext.jsx
@@ -39,8 +39,22 @@ import * as React from 'react';
  *                                    listed field is cleared from the context the
  *                                    chat hook merges into the outgoing message.
  *
+ * @typedef {Object} InsertActionConfig
+ * @property {'icon'|'primary'} variant                   How the per-message insert action is
+ *                                                        rendered. `'icon'` is the compact
+ *                                                        icon-only button used in the main
+ *                                                        web app and the browser extension.
+ *                                                        `'primary'` renders a labelled,
+ *                                                        brand-coloured button beneath each
+ *                                                        assistant message — the dominant
+ *                                                        action in the Outlook/Word taskpane.
+ * @property {string} labelKey                            i18n key resolved at render time —
+ *                                                        e.g. `'office.insertIntoEmail'` for
+ *                                                        Outlook, `'office.insertIntoDocument'`
+ *                                                        for Word/PowerPoint hosts.
+ *
  * @typedef {Object} EmbeddedHostAdapter
- * @property {string} kind                                'office' | 'extension'
+ * @property {string} kind                                'office' | 'extension' | 'nextcloud'
  * @property {string} loginSubtitle                       e.g. "iHub Apps for Outlook"
  * @property {(authorizeUrl: string, onSuccess: (callbackUrl: string) => void, onError: (err: any) => void) => void} runAuthDialog
  * @property {() => Promise<HostMailContext>} readMessageContext  Returns mail/page context appended to chat messages.
@@ -50,6 +64,15 @@ import * as React from 'react';
  *                                                        the chat input's `+` menu. Empty /
  *                                                        omitted means no toggles render and
  *                                                        all available context is always sent.
+ * @property {InsertActionConfig} [insertAction]          Optional override for how the per-message
+ *                                                        "Insert into document/email" action is
+ *                                                        rendered. When omitted the host uses the
+ *                                                        web app default (compact icon button on
+ *                                                        the action row). Outlook ships
+ *                                                        `{ variant: 'primary', labelKey: 'office.insertIntoEmail' }`
+ *                                                        so the action becomes the dominant
+ *                                                        call-to-action beneath each assistant
+ *                                                        message — see issue #1450.
  */
 
 /** @type {React.Context<EmbeddedHostAdapter|null>} */

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -581,6 +581,10 @@
       "ariaLabel": "Text in Editor diktieren"
     }
   },
+  "office": {
+    "insertIntoEmail": "In E-Mail einfügen",
+    "insertIntoDocument": "In Dokument einfügen"
+  },
   "admin": {
     "providers": {
       "title": "Anbieter-Zugangsdaten",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1766,6 +1766,10 @@
       "ariaLabel": "Dictate text to editor"
     }
   },
+  "office": {
+    "insertIntoEmail": "Add to email",
+    "insertIntoDocument": "Add to document"
+  },
   "teams": {
     "status": {
       "initializing": "Initializing...",


### PR DESCRIPTION
Fixes #1450.

## Summary

In the Outlook add-in the "Insert into document" button is the whole reason the user opened the taskpane, but it renders as a small icon (and only on hover) mixed in with copy/feedback/download chrome — easy to miss on smaller panes. This PR promotes that action to a labelled primary button beneath each assistant response and renames it to host-appropriate copy.

## What changed

- **New host-aware config on `EmbeddedHostAdapter`:** `insertAction: { variant: 'icon'|'primary', labelKey }`. The Outlook taskpane ships `{ variant: 'primary', labelKey: 'office.insertIntoEmail' }`. Word/PowerPoint hosts (when supported) fall back to `office.insertIntoDocument` via an `Office.context.host` check with a `mailbox`-presence fallback.
- **`ChatMessage`:** new `insertAction` + `isLatestAssistantMessage` props. When `variant === 'primary'`, render a full-width, brand-coloured (`bg-indigo-600`) labelled button beneath the bubble; the legacy hover-revealed icon is suppressed to avoid duplication. The primary button stays at full opacity on the most recent assistant message (sticky behaviour for small panes); older turns fade with the rest of the action row.
- **`ChatMessageList`:** forwards `insertAction` and computes `isLatestAssistantMessage` for each rendered message.
- **`OfficeChatPanel`:** reads `useEmbeddedHost().insertAction` and threads it through.
- **i18n:** adds `office.insertIntoEmail` ("Add to email" / "In E-Mail einfügen") and `office.insertIntoDocument` ("Add to document" / "In Dokument einfügen") to both `shared/i18n/en.json` and `shared/i18n/de.json`.

The web app and browser extension are intentionally unchanged — they pass no `insertAction`, so they keep the existing icon button on the hover action row.

## Acceptance criteria

- [x] In Outlook the button reads "Add to email" (EN) / "In E-Mail einfügen" (DE)
- [x] In Word/PowerPoint host (when supported) it reads "Add to document"
- [x] Button is visually distinct (labelled, brand colour) and the primary action of the assistant message
- [x] Web-app appearance unchanged (icon-only)
- [x] Translation entries added to EN and DE
- [x] Primary button stays visible on the latest assistant message even on small panes

## Test plan

- [ ] Open Outlook add-in → assistant response shows a full-width blue "Add to email" button beneath the bubble; clicking it pre-fills the reply form as before
- [ ] Switch language to German → button reads "In E-Mail einfügen"
- [ ] Scroll up through older assistant turns → their primary buttons fade until hovered, but the latest stays fully visible
- [ ] Main web app `/apps/<id>` → no primary button, original icon-only insert action still in the hover row
- [ ] Browser-extension side panel → unchanged (no `insertAction` configured)
- [x] `npx vite build` succeeds
- [x] `npx eslint` introduces no new errors/warnings
- [x] `npx prettier --check` passes
- [x] `npm run test:unit` (chat-component suite) passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABMxLdPCdPt2Fg1czr3Nwi)_