### PR TITLE
feat(office): attach multiple emails to a single Outlook chat

### DIFF
--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -12,11 +12,17 @@ import VariablesDialog, {
   missingRequiredVariableNames
 } from './variables-dialog';
 import SettingsDialog from './settings-dialog';
+import PinnedEmailsBar from './PinnedEmailsBar';
 import useOfficeChatAdapter from '../hooks/useOfficeChatAdapter';
 import useAppSettings from '../../../shared/hooks/useAppSettings';
 import useFileUploadHandler from '../../../shared/hooks/useFileUploadHandler';
 import { displayReplyFormWithAssistantResponse } from '../utilities/replyForm';
 import { buildPromptTemplate } from '../utilities/buildChatApiMessages';
+import {
+  fetchCurrentMailContext,
+  fetchSelectedItemsContext
+} from '../utilities/outlookMailContext';
+import { isMultiSelectBodySupported } from '../utilities/officeCapabilities';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import { officeLocale } from '../utilities/officeLocale';
 import { fetchApps } from '../../../api/api';
@@ -74,6 +80,17 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   const [isVariablesOpen, setIsVariablesOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [selectorItems, setSelectorItems] = useState([]);
+  // Emails the user has explicitly attached to this chat (pin/collect mode,
+  // or bulk-pulled via Mailbox 1.15+ multi-select). Survives ItemChanged so
+  // the user can navigate between emails while building up a context set;
+  // wiped on new-chat / app-switch alongside the chat history.
+  const [pinnedEmails, setPinnedEmails] = useState([]);
+  const [multiSelectLoading, setMultiSelectLoading] = useState(false);
+  // itemId of the email currently open in Outlook. Lets us hide the
+  // "Add this email" affordance once it's already in the pin list, and
+  // dedupe in the prompt builder.
+  const [currentItemId, setCurrentItemId] = useState(null);
+  const multiSelectSupported = isMultiSelectBodySupported();
 
   // Initialize variables when app changes
   useEffect(() => {
@@ -92,17 +109,109 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
     // eslint-disable-next-line @eslint-react/exhaustive-deps
   }, [selectedApp?.id]);
 
-  // Reset chat when Outlook switches emails
+  // Mirror of `pinnedEmails` for the ItemChanged listener — using a ref
+  // avoids re-binding the document listener every time the array changes.
+  const pinnedEmailsRef = useRef([]);
   useEffect(() => {
+    pinnedEmailsRef.current = pinnedEmails;
+  }, [pinnedEmails]);
+
+  // Track the currently-open email's itemId so the "Add this email" button
+  // can hide once the user has pinned it. Reading the id alone is cheap —
+  // we don't fetch the body here, that still happens lazily inside
+  // useOfficeChatAdapter.sendMessage. Refreshed on mount and whenever
+  // Outlook switches emails.
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = async () => {
+      try {
+        const ctx = await fetchCurrentMailContext();
+        if (!cancelled) setCurrentItemId(ctx?.itemId ?? null);
+      } catch {
+        if (!cancelled) setCurrentItemId(null);
+      }
+    };
+    refresh();
     const handler = () => {
-      chatIdRef.current = `office-${uuidv4()}`;
-      selectedStarterPromptRef.current = null;
-      adapter.clearMessages();
-      setInputValue('');
+      refresh();
+      // Pinned emails are the whole point of the feature, so they must
+      // survive ItemChanged. We only reset the chat history (and the
+      // staged input) when the user has nothing pinned — otherwise we'd
+      // silently throw away the context they were assembling.
+      if (pinnedEmailsRef.current.length === 0) {
+        chatIdRef.current = `office-${uuidv4()}`;
+        selectedStarterPromptRef.current = null;
+        adapter.clearMessages();
+        setInputValue('');
+      }
     };
     document.addEventListener('ihub:itemchanged', handler);
-    return () => document.removeEventListener('ihub:itemchanged', handler);
+    return () => {
+      cancelled = true;
+      document.removeEventListener('ihub:itemchanged', handler);
+    };
   }, [adapter]);
+
+  const handlePinCurrent = useCallback(async () => {
+    try {
+      const ctx = await fetchCurrentMailContext();
+      if (!ctx?.available) return;
+      if (!ctx.itemId && !ctx.subject && !ctx.bodyText) return;
+      setPinnedEmails(prev => {
+        if (ctx.itemId && prev.some(p => p.itemId === ctx.itemId)) return prev;
+        return [
+          ...prev,
+          {
+            itemId: ctx.itemId ?? null,
+            subject: ctx.subject ?? null,
+            bodyText: ctx.bodyText ?? null,
+            attachments: ctx.attachments ?? []
+          }
+        ];
+      });
+    } catch {
+      /* silently swallow — surfacing host errors here would be noisy */
+    }
+  }, []);
+
+  const handleUnpin = useCallback(itemId => {
+    setPinnedEmails(prev => {
+      if (!itemId) return prev;
+      return prev.filter(p => p.itemId !== itemId);
+    });
+  }, []);
+
+  const handleClearPinned = useCallback(() => {
+    setPinnedEmails([]);
+  }, []);
+
+  const handlePinSelected = useCallback(async () => {
+    if (!multiSelectSupported) return;
+    setMultiSelectLoading(true);
+    try {
+      const items = await fetchSelectedItemsContext();
+      if (!Array.isArray(items) || items.length === 0) return;
+      setPinnedEmails(prev => {
+        const seen = new Set(prev.map(p => p.itemId).filter(Boolean));
+        const additions = [];
+        for (const it of items) {
+          if (it.itemId && seen.has(it.itemId)) continue;
+          if (it.itemId) seen.add(it.itemId);
+          additions.push({
+            itemId: it.itemId ?? null,
+            subject: it.subject ?? null,
+            bodyText: it.bodyText ?? null,
+            attachments: []
+          });
+        }
+        return additions.length ? [...prev, ...additions] : prev;
+      });
+    } catch {
+      /* silently swallow */
+    } finally {
+      setMultiSelectLoading(false);
+    }
+  }, [multiSelectSupported]);
 
   const handleInsert = useCallback(content => {
     displayReplyFormWithAssistantResponse(content);
@@ -123,6 +232,11 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
       // contextToggles declarations) to strip body / attachments from the
       // outgoing apiMessage. Empty object in the main web app — no-op.
       params.hostContextFlags = hostContextFlags;
+      // Emails the user has explicitly attached to this chat — pin/collect
+      // mode or bulk-pulled via native multi-select. Stripped from the
+      // outgoing server payload inside useOfficeChatAdapter once their
+      // bodies have been merged into apiMessage.content.
+      params.pinnedEmails = pinnedEmails;
 
       // Resend can pass a `selectedFile` override to bypass async state updates;
       // otherwise we read whatever the user has staged in the uploader.
@@ -156,6 +270,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
       enabledTools,
       websearchEnabled,
       hostContextFlags,
+      pinnedEmails,
       fileUploadHandler
     ]
   );
@@ -243,6 +358,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
       selectedStarterPromptRef.current = null;
       adapter.clearMessages();
       setInputValue('');
+      setPinnedEmails([]);
       setSelectedApp(newApp);
       setIsSelectorOpen(false);
     },
@@ -254,6 +370,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
     selectedStarterPromptRef.current = null;
     adapter.clearMessages();
     setInputValue('');
+    setPinnedEmails([]);
   }, [adapter]);
 
   if (!authData) return null;
@@ -364,6 +481,21 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
                 showAvatars={false}
               />
             </div>
+
+            {/* Pinned emails toolbar (above input) */}
+            <PinnedEmailsBar
+              pinned={pinnedEmails}
+              onUnpin={handleUnpin}
+              onClearAll={handleClearPinned}
+              onPinCurrent={handlePinCurrent}
+              onPinSelected={handlePinSelected}
+              canPinCurrent={!!currentItemId}
+              isCurrentPinned={
+                !!currentItemId && pinnedEmails.some(p => p.itemId === currentItemId)
+              }
+              isMultiSelectSupported={multiSelectSupported}
+              multiSelectLoading={multiSelectLoading}
+            />
 
             {/* Input */}
             <div className="border-t border-gray-200 bg-white flex-shrink-0">

--- a/client/src/features/office/components/PinnedEmailsBar.jsx
+++ b/client/src/features/office/components/PinnedEmailsBar.jsx
@@ -1,0 +1,121 @@
+import { useTranslation } from 'react-i18next';
+import Icon from '../../../shared/components/Icon';
+
+function truncate(s, n) {
+  if (!s) return '';
+  const str = String(s);
+  return str.length > n ? `${str.slice(0, n - 1)}…` : str;
+}
+
+/**
+ * Toolbar that lives between the message list and the chat input in the
+ * Outlook taskpane. Lets users attach the currently-open email — and, on
+ * Mailbox 1.15+, any emails Ctrl-selected in the message list — to the
+ * outgoing prompt without losing them when they navigate between emails.
+ */
+function PinnedEmailsBar({
+  pinned,
+  onUnpin,
+  onClearAll,
+  onPinCurrent,
+  onPinSelected,
+  canPinCurrent,
+  isCurrentPinned,
+  isMultiSelectSupported,
+  multiSelectLoading
+}) {
+  const { t } = useTranslation();
+  const hasPins = Array.isArray(pinned) && pinned.length > 0;
+
+  // Nothing to do when we can't pin and don't have any pins to show.
+  if (!hasPins && !canPinCurrent && !isMultiSelectSupported) return null;
+
+  return (
+    <div className="office-pinned-bar border-t border-slate-100 bg-slate-50/70 px-3 py-2 text-xs">
+      <div className="flex flex-wrap items-center gap-1.5">
+        {canPinCurrent && (
+          <button
+            type="button"
+            onClick={onPinCurrent}
+            disabled={isCurrentPinned}
+            title={
+              isCurrentPinned
+                ? t('office.pinned.alreadyAdded', 'Already added')
+                : t('office.pinned.addCurrentTooltip', 'Attach this email to the chat')
+            }
+            className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-slate-700 hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            <Icon name="paper-clip" size="sm" />
+            <span>
+              {isCurrentPinned
+                ? t('office.pinned.alreadyAdded', 'Already added')
+                : t('office.pinned.addCurrent', 'Add this email')}
+            </span>
+          </button>
+        )}
+
+        {isMultiSelectSupported && (
+          <button
+            type="button"
+            onClick={onPinSelected}
+            disabled={multiSelectLoading}
+            title={t(
+              'office.pinned.addSelectedTooltip',
+              'Attach every email you have selected in Outlook'
+            )}
+            className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-slate-700 hover:bg-slate-100 disabled:opacity-50 transition-colors"
+          >
+            <Icon name="plus-circle" size="sm" />
+            <span>
+              {multiSelectLoading
+                ? t('common.loading', 'Loading…')
+                : t('office.pinned.addSelected', 'Add selected emails')}
+            </span>
+          </button>
+        )}
+
+        {hasPins && (
+          <button
+            type="button"
+            onClick={onClearAll}
+            title={t('office.pinned.clearAllTooltip', 'Remove every pinned email')}
+            className="ml-auto inline-flex items-center gap-1 rounded-md px-2 py-1 text-slate-500 hover:bg-slate-100 hover:text-slate-700 transition-colors"
+          >
+            <Icon name="trash" size="sm" />
+            <span>{t('office.pinned.clearAll', 'Clear')}</span>
+          </button>
+        )}
+      </div>
+
+      {hasPins && (
+        <div className="mt-1.5 flex flex-wrap gap-1.5">
+          {pinned.map((p, idx) => {
+            const key = p.itemId || `pin-${idx}`;
+            const label = truncate(p.subject || t('office.pinned.untitled', '(no subject)'), 60);
+            return (
+              <span
+                key={key}
+                className="inline-flex items-center gap-1 rounded-full bg-indigo-50 text-indigo-700 border border-indigo-100 px-2 py-0.5"
+                title={p.subject || ''}
+              >
+                <Icon name="paper-clip" size="xs" />
+                <span className="max-w-[180px] truncate">{label}</span>
+                <button
+                  type="button"
+                  onClick={() => onUnpin?.(p.itemId)}
+                  title={t('office.pinned.removeOne', 'Remove from chat')}
+                  className="ml-0.5 rounded-full p-0.5 hover:bg-indigo-100"
+                  aria-label={t('office.pinned.removeOne', 'Remove from chat')}
+                >
+                  <Icon name="x" size="xs" />
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PinnedEmailsBar;

--- a/client/src/features/office/hooks/useOfficeChatAdapter.js
+++ b/client/src/features/office/hooks/useOfficeChatAdapter.js
@@ -2,7 +2,7 @@ import { useCallback } from 'react';
 import useAppChat from '../../chat/hooks/useAppChat';
 import { useEmbeddedHost, applyHostContextFlags } from '../contexts/EmbeddedHostContext';
 import {
-  combineUserTextWithEmailBody,
+  combineUserTextWithEmailContext,
   buildImageDataFromMailAttachments,
   buildFileDataFromMailAttachments
 } from '../utilities/buildChatApiMessages';
@@ -80,7 +80,18 @@ function useOfficeChatAdapter({ appId, chatId, onMessageComplete }) {
       // No-op when the host has no toggles or the user hasn't touched any.
       ctx = applyHostContextFlags(ctx, host.contextToggles, params?.hostContextFlags);
 
-      const enrichedContent = combineUserTextWithEmailBody(apiMessage.content, ctx.bodyText);
+      // Pinned emails ride alongside the current item: either the user
+      // clicked "Pin this email" on a previously-open message, or they
+      // Ctrl-selected multiple emails and bulk-pulled them via the
+      // Mailbox 1.15+ multi-select API. Both paths feed the same shape.
+      const pinnedEmails = Array.isArray(params?.pinnedEmails) ? params.pinnedEmails : [];
+
+      const enrichedContent = combineUserTextWithEmailContext({
+        userText: apiMessage.content,
+        currentBodyText: ctx.bodyText,
+        currentItemId: ctx.itemId ?? null,
+        pinned: pinnedEmails
+      });
 
       // Combine manual uploads with attachments harvested from the host
       // (email attachments in Outlook, none today in the extension; this
@@ -91,11 +102,16 @@ function useOfficeChatAdapter({ appId, chatId, onMessageComplete }) {
       const combinedImageData = combineUploadData(apiMessage.imageData, hostImageData);
       const combinedFileData = combineUploadData(apiMessage.fileData, hostFileData);
 
-      // hostContextFlags is a client-only opt-out signal — strip it before
-      // forwarding so it doesn't show up in the outgoing chat-completion
-      // request body.
+      // hostContextFlags + pinnedEmails are client-only signals — strip
+      // them before forwarding so they don't show up in the outgoing
+      // chat-completion request body. The enriched content carries the
+      // pinned data into the prompt instead.
 
-      const { hostContextFlags: _hostContextFlags, ...paramsForServer } = params || {};
+      const {
+        hostContextFlags: _hostContextFlags,
+        pinnedEmails: _pinnedEmails,
+        ...paramsForServer
+      } = params || {};
 
       chat.sendMessage({
         displayMessage,

--- a/client/src/features/office/utilities/buildChatApiMessages.js
+++ b/client/src/features/office/utilities/buildChatApiMessages.js
@@ -76,6 +76,70 @@ export function combineUserTextWithEmailBody(userText, emailBodyText) {
   return `${u}\n\n--- Current email ---\n${e}`;
 }
 
+function formatPinnedEmail(p, idx) {
+  const subject = (p?.subject || '').trim();
+  const body = (p?.bodyText || '').trim();
+  const header = `[${idx + 1}]${subject ? ` Subject: ${subject}` : ''}`;
+  return body ? `${header}\n${body}` : header;
+}
+
+/**
+ * Stitch user text together with the current Outlook mail item and any
+ * pinned-from-other-emails context. Output shape stays identical to
+ * `combineUserTextWithEmailBody` when `pinned` is empty so the
+ * single-email flow is a strict no-op regression-wise.
+ *
+ * @param {Object}    args
+ * @param {string}    args.userText                 What the user typed.
+ * @param {string|null} args.currentBodyText        Body of Office.context.mailbox.item
+ *                                                  (already stripped by the user's
+ *                                                  context-toggle if they turned it off).
+ * @param {string|null} [args.currentItemId]        itemId of the current Outlook item —
+ *                                                  used to dedupe against pinned[].
+ * @param {Array<{subject?: string, bodyText?: string|null, itemId?: string|null}>} [args.pinned]
+ *                                                  Emails the user explicitly attached to this
+ *                                                  message (pin/collect mode, or bulk-pulled via
+ *                                                  native multi-select).
+ */
+export function combineUserTextWithEmailContext({
+  userText,
+  currentBodyText,
+  currentItemId,
+  pinned
+}) {
+  const list = Array.isArray(pinned) ? pinned : [];
+  if (list.length === 0) {
+    return combineUserTextWithEmailBody(userText, currentBodyText);
+  }
+
+  const u = (userText || '').trim();
+  const seen = new Set();
+  const dedupedPinned = [];
+  for (const p of list) {
+    const id = p?.itemId;
+    if (id && currentItemId && id === currentItemId) continue;
+    if (id && seen.has(id)) continue;
+    if (id) seen.add(id);
+    if (!(p?.subject || '').trim() && !(p?.bodyText || '').trim()) continue;
+    dedupedPinned.push(p);
+  }
+
+  const segments = [];
+  if (u) segments.push(u);
+
+  if (dedupedPinned.length > 0) {
+    const pinnedBlock = dedupedPinned.map((p, i) => formatPinnedEmail(p, i)).join('\n\n');
+    segments.push(`--- Pinned emails (${dedupedPinned.length}) ---\n${pinnedBlock}`);
+  }
+
+  const currentBody = (currentBodyText || '').trim();
+  if (currentBody) {
+    segments.push(`--- Current email ---\n${currentBody}`);
+  }
+
+  return segments.join('\n\n');
+}
+
 export function buildPromptTemplate(selectedStarterPrompt, selectedApp) {
   const fromPromptObject = p => {
     if (!p || typeof p !== 'object') return null;

--- a/client/src/features/office/utilities/officeCapabilities.js
+++ b/client/src/features/office/utilities/officeCapabilities.js
@@ -1,0 +1,42 @@
+/* global Office */
+
+function safeIsSetSupported(set, version) {
+  try {
+    if (
+      typeof Office === 'undefined' ||
+      !Office.context ||
+      !Office.context.requirements ||
+      typeof Office.context.requirements.isSetSupported !== 'function'
+    ) {
+      return false;
+    }
+    return Office.context.requirements.isSetSupported(set, version);
+  } catch {
+    return false;
+  }
+}
+
+export function isMailboxAvailable() {
+  try {
+    return typeof Office !== 'undefined' && !!Office.context && !!Office.context.mailbox;
+  } catch {
+    return false;
+  }
+}
+
+// Mailbox 1.13 introduced getSelectedItemsAsync (subject + itemId only).
+export function isMultiSelectListSupported() {
+  if (!isMailboxAvailable()) return false;
+  if (typeof Office.context.mailbox.getSelectedItemsAsync !== 'function') return false;
+  return safeIsSetSupported('Mailbox', '1.13');
+}
+
+// Mailbox 1.15 added loadItemByIdAsync (load full item, including body) for
+// items returned by getSelectedItemsAsync. Without this we'd only have
+// subjects for the bulk-select, which isn't useful for summarisation —
+// so the native multi-select button is gated on 1.15 here.
+export function isMultiSelectBodySupported() {
+  if (!isMultiSelectListSupported()) return false;
+  if (typeof Office.context.mailbox.loadItemByIdAsync !== 'function') return false;
+  return safeIsSetSupported('Mailbox', '1.15');
+}

--- a/client/src/features/office/utilities/outlookMailContext.js
+++ b/client/src/features/office/utilities/outlookMailContext.js
@@ -136,3 +136,113 @@ export async function fetchCurrentMailContext() {
     attachments
   };
 }
+
+function getSelectedItemsAsync() {
+  return new Promise((resolve, reject) => {
+    if (
+      typeof Office === 'undefined' ||
+      !Office.context ||
+      !Office.context.mailbox ||
+      typeof Office.context.mailbox.getSelectedItemsAsync !== 'function'
+    ) {
+      reject(new Error('getSelectedItemsAsync is not available (requires Mailbox 1.13+).'));
+      return;
+    }
+    Office.context.mailbox.getSelectedItemsAsync(result => {
+      if (result.status === Office.AsyncResultStatus.Failed) {
+        reject(result.error);
+        return;
+      }
+      resolve(Array.isArray(result.value) ? result.value : []);
+    });
+  });
+}
+
+function loadItemByIdAsync(itemId) {
+  return new Promise((resolve, reject) => {
+    if (
+      typeof Office === 'undefined' ||
+      !Office.context ||
+      !Office.context.mailbox ||
+      typeof Office.context.mailbox.loadItemByIdAsync !== 'function'
+    ) {
+      reject(new Error('loadItemByIdAsync is not available (requires Mailbox 1.15+).'));
+      return;
+    }
+    Office.context.mailbox.loadItemByIdAsync(itemId, result => {
+      if (result.status === Office.AsyncResultStatus.Failed) {
+        reject(result.error);
+        return;
+      }
+      resolve(result.value);
+    });
+  });
+}
+
+function getLoadedItemBodyTextAsync(loadedItem) {
+  return new Promise(resolve => {
+    if (!loadedItem || !loadedItem.body || typeof loadedItem.body.getAsync !== 'function') {
+      resolve(null);
+      return;
+    }
+    loadedItem.body.getAsync(Office.CoercionType.Text, result => {
+      resolve(result.status === Office.AsyncResultStatus.Succeeded ? (result.value ?? null) : null);
+    });
+  });
+}
+
+function unloadItemAsync(loadedItem) {
+  return new Promise(resolve => {
+    if (!loadedItem || typeof loadedItem.unloadAsync !== 'function') {
+      resolve();
+      return;
+    }
+    loadedItem.unloadAsync(() => resolve());
+  });
+}
+
+/**
+ * Read body + subject for every email the user has currently selected in
+ * Outlook (Ctrl-click multi-select). Requires Mailbox 1.15+ — callers should
+ * gate this behind `isMultiSelectBodySupported()` from officeCapabilities.js.
+ *
+ * Attachments are intentionally NOT pulled here: loadItemByIdAsync's loaded
+ * item doesn't expose getAttachmentContentAsync, and round-tripping every
+ * selected email's attachments would explode token budgets. Pinned single
+ * emails (added one-by-one via `fetchCurrentMailContext`) still carry their
+ * attachments.
+ */
+export async function fetchSelectedItemsContext() {
+  const stubs = await getSelectedItemsAsync();
+  const out = [];
+  for (const stub of stubs) {
+    if (!stub || !stub.itemId) continue;
+    let loaded = null;
+    try {
+      loaded = await loadItemByIdAsync(stub.itemId);
+      const bodyText = await getLoadedItemBodyTextAsync(loaded);
+      out.push({
+        available: true,
+        subject: stub.subject ?? null,
+        itemId: stub.itemId,
+        bodyText,
+        attachments: []
+      });
+    } catch {
+      out.push({
+        available: true,
+        subject: stub.subject ?? null,
+        itemId: stub.itemId,
+        bodyText: null,
+        attachments: []
+      });
+    } finally {
+      if (loaded) {
+        try {
+          await unloadItemAsync(loaded);
+        } catch {}
+      }
+    }
+  }
+  return out;
+}

--- a/server/routes/integrations/officeAddin.js
+++ b/server/routes/integrations/officeAddin.js
@@ -266,6 +266,7 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
                     <Action xsi:type="ShowTaskpane">
                       <SourceLocation resid="Taskpane.Url"/>
                       <SupportsPinning>true</SupportsPinning>
+                      <SupportsMultiSelect>true</SupportsMultiSelect>
                     </Action>
                   </Control>
                 </Group>

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -132,6 +132,19 @@
     "toggleLabel": "Websuche",
     "toggleDescription": "Das Web nach aktuellen Informationen durchsuchen"
   },
+  "office": {
+    "pinned": {
+      "addCurrent": "Diese E-Mail hinzufügen",
+      "addCurrentTooltip": "Diese E-Mail an den Chat anhängen",
+      "addSelected": "Ausgewählte E-Mails hinzufügen",
+      "addSelectedTooltip": "Alle in Outlook ausgewählten E-Mails anhängen",
+      "alreadyAdded": "Bereits hinzugefügt",
+      "removeOne": "Aus dem Chat entfernen",
+      "clearAll": "Leeren",
+      "clearAllTooltip": "Alle angehefteten E-Mails entfernen",
+      "untitled": "(kein Betreff)"
+    }
+  },
   "pages": {
     "home": {
       "title": "iHub Apps",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -118,6 +118,19 @@
     "toggleLabel": "Web Search",
     "toggleDescription": "Search the web for up-to-date information"
   },
+  "office": {
+    "pinned": {
+      "addCurrent": "Add this email",
+      "addCurrentTooltip": "Attach this email to the chat",
+      "addSelected": "Add selected emails",
+      "addSelectedTooltip": "Attach every email you have selected in Outlook",
+      "alreadyAdded": "Already added",
+      "removeOne": "Remove from chat",
+      "clearAll": "Clear",
+      "clearAllTooltip": "Remove every pinned email",
+      "untitled": "(no subject)"
+    }
+  },
   "pages": {
     "home": {
       "title": "iHub Apps",


### PR DESCRIPTION
## Summary

The Outlook add-in could only ever reason about the **one email currently open** — switching emails wiped the chat. This PR adds two stackable ways to feed multiple emails into a single prompt:

1. **Pin / collect** (works on every Outlook client) — a new toolbar above the chat input lets the user "Add this email" while it's open. Each pin captures `{subject, body, attachments}` and **survives `ItemChanged`**, so the user can keep navigating Outlook while assembling a context set. Pins clear on new-chat / app-switch.
2. **Native multi-select** (Mailbox API ≥ 1.15) — when supported, a second "Add selected emails" button calls `getSelectedItemsAsync` + `loadItemByIdAsync` to bulk-pull every email the user has Ctrl-selected in the message list. Falls back invisibly on older clients (Mailbox 1.13 only exposes subject/itemId, which isn't useful for summarisation, so the button is gated on 1.15).

Both paths feed the **same** `pinnedEmails` state, which `useOfficeChatAdapter` splices into the outgoing prompt via a new `combineUserTextWithEmailContext` helper. **Single-email behaviour is byte-identical to before** when no pins are present.

Manifest now declares `<SupportsMultiSelect>true</SupportsMultiSelect>` on the message-read action so Outlook activates the task pane cleanly when multiple messages are selected. `DefaultMinVersion` is unchanged — older clients keep working, they just don't see the bulk-select button.

## Prompt shape

When pins exist, the LLM receives:

```
<user text>

--- Pinned emails (N) ---
[1] Subject: Q3 numbers
<body>

[2] Subject: Re: Q3 numbers
<body>

--- Current email ---
<body of the email open in the reading pane>
```

Pinned emails are deduped by `itemId` (against each other and against the current email).

## Files

- **New** `client/src/features/office/utilities/officeCapabilities.js` — runtime capability checks
- **New** `client/src/features/office/components/PinnedEmailsBar.jsx` — toolbar + chip list
- `client/src/features/office/utilities/outlookMailContext.js` — `fetchSelectedItemsContext()` via `getSelectedItemsAsync` + `loadItemByIdAsync` + `unloadAsync`
- `client/src/features/office/utilities/buildChatApiMessages.js` — `combineUserTextWithEmailContext({ userText, currentBodyText, currentItemId, pinned })`
- `client/src/features/office/hooks/useOfficeChatAdapter.js` — reads `pinnedEmails` off `params`, strips them before sending to the server
- `client/src/features/office/components/OfficeChatPanel.jsx` — pinned state, `ItemChanged` no longer wipes chat when pins exist, renders `<PinnedEmailsBar />`
- `server/routes/integrations/officeAddin.js` — adds `<SupportsMultiSelect>true</SupportsMultiSelect>`
- `shared/i18n/{en,de}.json` — new `office.pinned.*` keys

## Test plan

- [ ] **Single-email regression** — open the add-in on one email and send a message. Outgoing prompt is byte-identical to current behaviour (no `Pinned emails` block).
- [ ] **Pin/collect happy path** — open email A → "Add this email" → chip appears. Open email B → "Add this email" → both chips visible. Ask "summarize these" → server log shows both bodies under `--- Pinned emails (2) ---` and B's body under `--- Current email ---` (deduped).
- [ ] **`ItemChanged` no longer wipes when pins exist** — pin one email, then click around in Outlook → chat history + chips persist.
- [ ] **New chat / app-switch clears pins** — pin emails, click ✚ new chat → chips empty.
- [ ] **Remove chip × button** works; "Clear" removes all chips.
- [ ] **Native multi-select** (Outlook OWA / desktop ≥ M365 build with Mailbox 1.15) — Ctrl-select 3 emails → "Add selected emails" button visible → click → 3 chips → submit → prompt contains all 3 bodies.
- [ ] **Older client fallback** — Outlook 2019 / Mailbox < 1.15 → "Add selected emails" hidden; "Add this email" still works.
- [ ] **Manifest** — `GET /api/integrations/office-addin/manifest.xml` returns `<SupportsMultiSelect>true</SupportsMultiSelect>` (verified locally).
- [ ] **Lint/format/build** — `npx eslint` clean (4 pre-existing warnings unrelated), `npx prettier` clean, `npx vite build` succeeds.

## Out of scope

- Persisting pins across page reloads (no localStorage)
- Pinning a whole conversation thread as one entity
- Token-budget warnings when many pinned bodies push over the model's context window
- Attachment dedupe / size warnings when pinning many emails

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTn59oxEGPhm2x7BFd5JsY)_