### PR TITLE
feat(outlook): extend add-in to calendar surfaces with knowledge-base apps

### DIFF
--- a/client/office/taskpane-entry.jsx
+++ b/client/office/taskpane-entry.jsx
@@ -10,7 +10,7 @@ import { EmbeddedHostProvider } from '../src/features/office/contexts/EmbeddedHo
 import OfficeApp from '../src/features/office/components/OfficeApp';
 import { installOfficeAuthInterceptor } from '../src/features/office/api/officeAuthBridge';
 import { openOfficeAuthDialog } from '../src/features/office/utilities/officeAuthDialog';
-import { fetchCurrentMailContext } from '../src/features/office/utilities/outlookMailContext';
+import { fetchCurrentOutlookItemContext } from '../src/features/office/utilities/outlookMailContext';
 
 /**
  * Derive the base path from the current URL so the config fetch works
@@ -88,7 +88,12 @@ Office.onReady(async () => {
     kind: 'office',
     loginSubtitle: 'iHub Apps for Outlook',
     runAuthDialog: openOfficeAuthDialog,
-    readMessageContext: fetchCurrentMailContext,
+    // Unified reader dispatches between mail and appointment items by
+    // inspecting `Office.context.mailbox.item.itemType`. Existing mail
+    // surfaces get the same payload as before plus `itemKind: 'message'`;
+    // calendar surfaces receive the appointment shape (subject, start,
+    // end, organizer, attendees, location, body).
+    readMessageContext: fetchCurrentOutlookItemContext,
     // In the Office taskpane the "insert this response into the document /
     // email" button is the whole reason the user opened the add-in, so it
     // gets promoted to a labelled primary button beneath each assistant

--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -21,9 +21,13 @@ import { displayReplyFormWithAssistantResponse } from '../utilities/replyForm';
 import { buildPromptTemplate } from '../utilities/buildChatApiMessages';
 import {
   fetchCurrentMailContext,
+  fetchCurrentOutlookItemContext,
   fetchSelectedItemsContext
 } from '../utilities/outlookMailContext';
-import { isMultiSelectBodySupported } from '../utilities/officeCapabilities';
+import {
+  isMultiSelectBodySupported,
+  isOutlookAppointmentMode
+} from '../utilities/officeCapabilities';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import { officeLocale } from '../utilities/officeLocale';
 import { fetchApps } from '../../../api/api';
@@ -94,6 +98,12 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   // "Add this email" affordance once it's already in the pin list, and
   // dedupe in the prompt builder.
   const [currentItemId, setCurrentItemId] = useState(null);
+  // Tracks whether the current Outlook item is a calendar appointment so
+  // we can swap the starter-prompt set (and hide the pin-email controls,
+  // which don't apply to a single meeting). Re-checked on every
+  // ihub:itemchanged event so users moving between Inbox and Calendar see
+  // the right prompts without needing to reopen the taskpane.
+  const [isAppointment, setIsAppointment] = useState(() => isOutlookAppointmentMode());
   const multiSelectSupported = isMultiSelectBodySupported();
 
   // Initialize variables when app changes
@@ -128,8 +138,18 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   useEffect(() => {
     let cancelled = false;
     const refresh = async () => {
+      // Re-detect appointment mode on every refresh so users moving
+      // between Inbox and Calendar see the right starter prompts and the
+      // pin-email toolbar stays hidden inside meeting items.
+      const apptMode = isOutlookAppointmentMode();
+      if (!cancelled) setIsAppointment(apptMode);
       try {
-        const ctx = await fetchCurrentMailContext();
+        // For appointments we only need the itemId to track changes —
+        // pulling the full mail context returns "not available". Use the
+        // unified reader so we never miss the calendar item.
+        const ctx = apptMode
+          ? await fetchCurrentOutlookItemContext()
+          : await fetchCurrentMailContext();
         if (!cancelled) setCurrentItemId(ctx?.itemId ?? null);
       } catch {
         if (!cancelled) setCurrentItemId(null);
@@ -393,8 +413,16 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   if (!authData) return null;
   if (!selectedApp) return <Navigate to="/select" replace />;
 
-  const configuredDefaults = Array.isArray(officeConfig?.starterPrompts)
-    ? officeConfig.starterPrompts
+  // Calendar items get their own starter-prompt set so users don't see
+  // mail prompts like "Summarize this email" inside a meeting. Falls back
+  // to the mail prompts when the admin hasn't configured calendar prompts
+  // yet so an upgrade with no admin action still shows _something_.
+  const configuredDefaults = Array.isArray(
+    isAppointment ? officeConfig?.calendarStarterPrompts : officeConfig?.starterPrompts
+  )
+    ? isAppointment
+      ? officeConfig.calendarStarterPrompts
+      : officeConfig.starterPrompts
     : [];
 
   const defaultPrompts = configuredDefaults.map((p, idx) => ({
@@ -519,11 +547,11 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
               onClearPinned={handleClearPinned}
               onPinCurrent={handlePinCurrent}
               onPinSelected={handlePinSelected}
-              canPinCurrent={!!currentItemId}
+              canPinCurrent={!isAppointment && !!currentItemId}
               isCurrentPinned={
                 !!currentItemId && pinnedEmails.some(p => p.itemId === currentItemId)
               }
-              isMultiSelectSupported={multiSelectSupported}
+              isMultiSelectSupported={!isAppointment && multiSelectSupported}
               multiSelectLoading={multiSelectLoading}
             />
 

--- a/client/src/features/office/components/chat/OfficeAppointmentContextBanner.jsx
+++ b/client/src/features/office/components/chat/OfficeAppointmentContextBanner.jsx
@@ -1,0 +1,201 @@
+import { useMemo } from 'react';
+import Icon from '../../../../shared/components/Icon';
+
+function shortenBody(text, max = 140) {
+  if (!text) return '';
+  const cleaned = String(text).replace(/\s+/g, ' ').trim();
+  if (cleaned.length <= max) return cleaned;
+  return `${cleaned.slice(0, max - 1).trimEnd()}…`;
+}
+
+function formatTimeRange(start, end) {
+  if (!start && !end) return '';
+  try {
+    const s = start ? new Date(start) : null;
+    const e = end ? new Date(end) : null;
+    const dateFmt = new Intl.DateTimeFormat(undefined, {
+      weekday: 'short',
+      month: 'short',
+      day: 'numeric'
+    });
+    const timeFmt = new Intl.DateTimeFormat(undefined, {
+      hour: 'numeric',
+      minute: '2-digit'
+    });
+    if (s && e) {
+      // If start and end share the same calendar day, render the date once.
+      const sameDay = s.toDateString() === e.toDateString();
+      if (sameDay) {
+        return `${dateFmt.format(s)} · ${timeFmt.format(s)} – ${timeFmt.format(e)}`;
+      }
+      return `${dateFmt.format(s)} ${timeFmt.format(s)} – ${dateFmt.format(e)} ${timeFmt.format(e)}`;
+    }
+    if (s) return `${dateFmt.format(s)} · ${timeFmt.format(s)}`;
+    if (e) return `Ends ${dateFmt.format(e)} ${timeFmt.format(e)}`;
+  } catch {
+    /* fall through to ISO */
+  }
+  return [start, end].filter(Boolean).join(' – ');
+}
+
+function formatAttendeeList(list, max = 4) {
+  if (!Array.isArray(list) || list.length === 0) return null;
+  const names = list.map(a => a?.name || a?.email).filter(Boolean);
+  if (names.length === 0) return null;
+  if (names.length <= max) return names.join(', ');
+  return `${names.slice(0, max).join(', ')} +${names.length - max} more`;
+}
+
+/**
+ * Calendar-item counterpart to OfficeMailContextBanner. Shows the meeting
+ * subject, time window, location, organizer and attendees alongside the
+ * meeting body, with an "Include body" toggle that mirrors the email
+ * banner so users can opt out of sending the full invite description.
+ *
+ * Always rendered embedded inside OfficeContextStrip — the strip owns the
+ * outer collapse chrome.
+ */
+function OfficeAppointmentContextBanner({
+  ctx,
+  loading,
+  includeBody,
+  onToggleBody,
+  embedded = false
+}) {
+  const subject = (ctx?.subject || '').trim() || 'Calendar event';
+  const hasBody = Boolean(ctx?.bodyText && ctx.bodyText.trim().length > 0);
+  const timeLine = useMemo(() => formatTimeRange(ctx?.start, ctx?.end), [ctx?.start, ctx?.end]);
+  const requiredNames = useMemo(
+    () => formatAttendeeList(ctx?.requiredAttendees),
+    [ctx?.requiredAttendees]
+  );
+  const optionalNames = useMemo(
+    () => formatAttendeeList(ctx?.optionalAttendees),
+    [ctx?.optionalAttendees]
+  );
+
+  if (loading) {
+    return (
+      <div
+        role="status"
+        aria-live="polite"
+        className="mx-3 mt-2 mb-1 flex items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-xs text-slate-600"
+      >
+        <svg className="animate-spin h-3 w-3 text-slate-400" fill="none" viewBox="0 0 24 24">
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="currentColor"
+            strokeWidth="4"
+          />
+          <path
+            className="opacity-75"
+            fill="currentColor"
+            d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+          />
+        </svg>
+        Reading current meeting…
+      </div>
+    );
+  }
+
+  // Suppress entirely when there's nothing to show.
+  const hasAnyMeta = Boolean(
+    timeLine || ctx?.location || ctx?.organizer || requiredNames || optionalNames
+  );
+  if (!hasBody && !hasAnyMeta) {
+    return null;
+  }
+
+  const bodyPreview = shortenBody(ctx?.bodyText);
+  const bodySent = includeBody !== false && hasBody;
+  const outerClassName = embedded
+    ? ''
+    : 'mx-3 mt-2 mb-1 rounded-lg border border-slate-200 bg-white shadow-sm';
+
+  return (
+    <div className={outerClassName}>
+      <div className="flex items-start gap-2 px-3 py-2">
+        <div className="flex-shrink-0 mt-0.5 text-slate-500">
+          <Icon name="calendar" size="sm" />
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <div className="text-sm font-medium text-slate-900 truncate" title={subject}>
+              {subject}
+            </div>
+            {hasBody && (
+              <label className="flex items-center gap-1.5 text-xs text-slate-600 select-none cursor-pointer flex-shrink-0">
+                <input
+                  type="checkbox"
+                  checked={bodySent}
+                  onChange={e => onToggleBody?.(e.target.checked)}
+                  className="h-3.5 w-3.5 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                />
+                Include body
+              </label>
+            )}
+          </div>
+
+          {timeLine && (
+            <div className="mt-0.5 text-[11px] text-slate-500 flex items-center gap-1">
+              <Icon name="clock" size="xs" className="flex-shrink-0 text-slate-400" />
+              <span className="truncate" title={timeLine}>
+                {timeLine}
+              </span>
+            </div>
+          )}
+          {ctx?.location && (
+            <div className="mt-0.5 text-[11px] text-slate-500 flex items-center gap-1">
+              <Icon name="globe" size="xs" className="flex-shrink-0 text-slate-400" />
+              <span className="truncate" title={ctx.location}>
+                {ctx.location}
+              </span>
+            </div>
+          )}
+          {ctx?.organizer && (
+            <div className="mt-0.5 text-[11px] text-slate-500 truncate">
+              <span className="font-medium text-slate-600">Organizer:</span>{' '}
+              {ctx.organizer.name || ctx.organizer.email}
+              {ctx?.isOrganizer && (
+                <span className="ml-1.5 inline-flex items-center rounded bg-indigo-50 px-1.5 py-0.5 text-[10px] font-medium text-indigo-700">
+                  You
+                </span>
+              )}
+            </div>
+          )}
+          {requiredNames && (
+            <div className="mt-0.5 text-[11px] text-slate-500 truncate" title={requiredNames}>
+              <span className="font-medium text-slate-600">Required:</span> {requiredNames}
+            </div>
+          )}
+          {optionalNames && (
+            <div className="mt-0.5 text-[11px] text-slate-500 truncate" title={optionalNames}>
+              <span className="font-medium text-slate-600">Optional:</span> {optionalNames}
+            </div>
+          )}
+
+          {bodyPreview && (
+            <div
+              className={`mt-1 text-xs ${
+                bodySent ? 'text-slate-500' : 'text-slate-400 italic line-through'
+              } line-clamp-2`}
+              title={bodyPreview}
+            >
+              {bodyPreview}
+            </div>
+          )}
+          {hasBody && !bodySent && (
+            <div className="mt-0.5 text-[11px] text-amber-600">
+              Meeting description will not be sent.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default OfficeAppointmentContextBanner;

--- a/client/src/features/office/components/chat/OfficeContextStrip.jsx
+++ b/client/src/features/office/components/chat/OfficeContextStrip.jsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState } from 'react';
 import Icon from '../../../../shared/components/Icon';
 import { formatFileSize } from '../../../upload/utils/cloudFileProcessing';
 import OfficeMailContextBanner from './OfficeMailContextBanner';
+import OfficeAppointmentContextBanner from './OfficeAppointmentContextBanner';
 import PinnedEmailsBar from '../PinnedEmailsBar';
 
 // Collapse by default once the strip would otherwise show this many rows
@@ -42,6 +43,7 @@ function OfficeContextStrip({
   isMultiSelectSupported,
   multiSelectLoading
 }) {
+  const isAppointment = ctx?.itemKind === 'appointment';
   const attachments = useMemo(
     () => (Array.isArray(visibleAttachments) ? visibleAttachments : []),
     [visibleAttachments]
@@ -54,8 +56,11 @@ function OfficeContextStrip({
 
   const hasBody = Boolean(ctx?.bodyText && ctx.bodyText.trim().length > 0);
   const hasAttachments = attachments.length > 0;
-  const hasPinned = pinnedList.length > 0;
-  const hasPinControls = canPinCurrent || isMultiSelectSupported;
+  // Pinned emails and pin controls are mail-only — they don't apply to a
+  // single calendar item, so we suppress them when the user is on an
+  // appointment surface to keep the strip focused on the meeting metadata.
+  const hasPinned = !isAppointment && pinnedList.length > 0;
+  const hasPinControls = !isAppointment && (canPinCurrent || isMultiSelectSupported);
 
   // Default-collapse threshold counts what the user would actually see
   // once expanded — attachments still in the queue plus pinned emails.
@@ -98,8 +103,32 @@ function OfficeContextStrip({
             d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
           />
         </svg>
-        Reading current email…
+        {isAppointment ? 'Reading current meeting…' : 'Reading current email…'}
       </div>
+    );
+  }
+
+  // For appointments we render a dedicated banner with meeting metadata —
+  // the email-style strip (collapse chevron, pinned-emails toolbar, file
+  // attachments) isn't a meaningful fit for a single calendar item.
+  if (isAppointment) {
+    const hasAnyApptMeta = Boolean(
+      ctx?.subject ||
+      ctx?.start ||
+      ctx?.end ||
+      ctx?.location ||
+      ctx?.organizer ||
+      ctx?.requiredAttendees?.length ||
+      ctx?.optionalAttendees?.length
+    );
+    if (!hasBody && !hasAnyApptMeta) return null;
+    return (
+      <OfficeAppointmentContextBanner
+        ctx={ctx}
+        loading={false}
+        includeBody={includeBody}
+        onToggleBody={onToggleBody}
+      />
     );
   }
 

--- a/client/src/features/office/contexts/EmbeddedHostContext.jsx
+++ b/client/src/features/office/contexts/EmbeddedHostContext.jsx
@@ -107,8 +107,8 @@ const DEFAULT_OFFICE_ADAPTER = {
     openOfficeAuthDialog(authorizeUrl, onSuccess, onError);
   },
   readMessageContext: async () => {
-    const { fetchCurrentMailContext } = await import('../utilities/outlookMailContext');
-    return fetchCurrentMailContext();
+    const { fetchCurrentOutlookItemContext } = await import('../utilities/outlookMailContext');
+    return fetchCurrentOutlookItemContext();
   },
   contextToggles: []
 };

--- a/client/src/features/office/hooks/useOfficeChatAdapter.js
+++ b/client/src/features/office/hooks/useOfficeChatAdapter.js
@@ -3,6 +3,7 @@ import useAppChat from '../../chat/hooks/useAppChat';
 import { useEmbeddedHost, applyHostContextFlags } from '../contexts/EmbeddedHostContext';
 import {
   combineUserTextWithEmailContext,
+  combineUserTextWithAppointmentContext,
   buildImageDataFromMailAttachments,
   buildFileDataFromMailAttachments,
   collectAttachmentsForSend
@@ -94,14 +95,27 @@ function useOfficeChatAdapter({ appId, chatId, onMessageComplete }) {
       // clicked "Pin this email" on a previously-open message, or they
       // Ctrl-selected multiple emails and bulk-pulled them via the
       // Mailbox 1.15+ multi-select API. Both paths feed the same shape.
+      // Calendar (appointment) items don't have a pin-emails flow today
+      // so this list will be empty when itemKind === 'appointment'.
       const pinnedEmails = Array.isArray(params?.pinnedEmails) ? params.pinnedEmails : [];
 
-      const enrichedContent = combineUserTextWithEmailContext({
-        userText: apiMessage.content,
-        currentBodyText: ctx.bodyText,
-        currentItemId: ctx.itemId ?? null,
-        pinned: pinnedEmails
-      });
+      // Appointment surfaces inject a structured "Current meeting" block
+      // (subject, time, organizer, attendees, location, description)
+      // instead of the email-body block. The downstream prompt for the
+      // meeting-agenda-generator / meeting-briefing apps references this
+      // section by name in its system prompt.
+      const isAppointment = ctx?.itemKind === 'appointment';
+      const enrichedContent = isAppointment
+        ? combineUserTextWithAppointmentContext({
+            userText: apiMessage.content,
+            appointmentCtx: ctx
+          })
+        : combineUserTextWithEmailContext({
+            userText: apiMessage.content,
+            currentBodyText: ctx.bodyText,
+            currentItemId: ctx.itemId ?? null,
+            pinned: pinnedEmails
+          });
 
       // Combine manual uploads with attachments harvested from the host
       // (email attachments in Outlook, none today in the extension; this
@@ -109,11 +123,9 @@ function useOfficeChatAdapter({ appId, chatId, onMessageComplete }) {
       // Pinned emails' attachments are now included too — previously they
       // were stored when the user clicked "Add this email" but never
       // forwarded to the model. See issue #1467.
-      const mergedAttachments = collectAttachmentsForSend(
-        ctx.attachments,
-        pinnedEmails,
-        ctx.itemId ?? null
-      );
+      const mergedAttachments = isAppointment
+        ? []
+        : collectAttachmentsForSend(ctx.attachments, pinnedEmails, ctx.itemId ?? null);
       const hostImageData = await buildImageDataFromMailAttachments(mergedAttachments);
       const hostFileData = await buildFileDataFromMailAttachments(mergedAttachments);
 

--- a/client/src/features/office/utilities/buildChatApiMessages.js
+++ b/client/src/features/office/utilities/buildChatApiMessages.js
@@ -234,6 +234,84 @@ export function combineUserTextWithEmailBody(userText, emailBodyText) {
   return `${u}\n\n--- Current email ---\n${e}`;
 }
 
+function formatAttendeesForPrompt(list) {
+  if (!Array.isArray(list) || list.length === 0) return '';
+  return list
+    .map(a => {
+      const name = (a?.name || '').trim();
+      const email = (a?.email || '').trim();
+      if (name && email && name !== email) return `${name} <${email}>`;
+      return name || email;
+    })
+    .filter(Boolean)
+    .join(', ');
+}
+
+function formatIsoForPrompt(iso) {
+  if (!iso) return null;
+  try {
+    return new Date(iso).toLocaleString(undefined, {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: '2-digit',
+      timeZoneName: 'short'
+    });
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * Build the calendar block stitched into the outgoing chat message when
+ * the user is on an appointment surface. Mirrors `combineUserTextWith*`
+ * for email: produces a labeled section that the system prompt can refer
+ * to without us having to update every meeting-related app's prompt
+ * template separately.
+ */
+export function combineUserTextWithAppointmentContext({ userText, appointmentCtx }) {
+  const u = (userText || '').trim();
+  if (!appointmentCtx || appointmentCtx.available === false) return u;
+
+  const lines = [];
+  if (appointmentCtx.subject) lines.push(`Subject: ${appointmentCtx.subject}`);
+  if (appointmentCtx.isOrganizer) lines.push(`Your role: Organizer`);
+  else if (appointmentCtx.organizer?.email) lines.push(`Your role: Attendee`);
+
+  const start = formatIsoForPrompt(appointmentCtx.start);
+  const end = formatIsoForPrompt(appointmentCtx.end);
+  if (start && end) lines.push(`When: ${start} – ${end}`);
+  else if (start) lines.push(`When: ${start}`);
+
+  if (appointmentCtx.location) lines.push(`Location: ${appointmentCtx.location}`);
+
+  if (appointmentCtx.organizer) {
+    const o = appointmentCtx.organizer;
+    const display =
+      o.name && o.email && o.name !== o.email ? `${o.name} <${o.email}>` : o.name || o.email;
+    if (display) lines.push(`Organizer: ${display}`);
+  }
+
+  const required = formatAttendeesForPrompt(appointmentCtx.requiredAttendees);
+  if (required) lines.push(`Required attendees: ${required}`);
+  const optional = formatAttendeesForPrompt(appointmentCtx.optionalAttendees);
+  if (optional) lines.push(`Optional attendees: ${optional}`);
+
+  const body = (appointmentCtx.bodyText || '').trim();
+  if (body) {
+    lines.push('');
+    lines.push('Description:');
+    lines.push(body);
+  }
+
+  if (lines.length === 0) return u;
+  const meetingBlock = `--- Current meeting ---\n${lines.join('\n')}`;
+  if (!u) return meetingBlock;
+  return `${u}\n\n${meetingBlock}`;
+}
+
 function formatPinnedEmail(p, idx) {
   const subject = (p?.subject || '').trim();
   const body = (p?.bodyText || '').trim();

--- a/client/src/features/office/utilities/officeCapabilities.js
+++ b/client/src/features/office/utilities/officeCapabilities.js
@@ -40,3 +40,22 @@ export function isMultiSelectBodySupported() {
   if (typeof Office.context.mailbox.loadItemByIdAsync !== 'function') return false;
   return safeIsSetSupported('Mailbox', '1.15');
 }
+
+/**
+ * True when the currently-selected Outlook item is a calendar appointment.
+ * Used by the chat panel to pick calendar-specific starter prompts and by
+ * the context strip to switch between the mail and appointment banner.
+ *
+ * Unlike the multi-select capability checks this reads from the live
+ * `Office.context.mailbox.item`, so it must be re-evaluated whenever the
+ * `ihub:itemchanged` event fires.
+ */
+export function isOutlookAppointmentMode() {
+  if (!isMailboxAvailable()) return false;
+  try {
+    const itemType = String(Office.context.mailbox.item?.itemType || '').toLowerCase();
+    return itemType === 'appointment';
+  } catch {
+    return false;
+  }
+}

--- a/client/src/features/office/utilities/outlookCalendarContext.js
+++ b/client/src/features/office/utilities/outlookCalendarContext.js
@@ -1,0 +1,260 @@
+/* global Office */
+
+/**
+ * Calendar / appointment counterpart to outlookMailContext.js.
+ *
+ * Office.context.mailbox.item exposes Appointment items via the same root
+ * but with a different property surface than Message items. The key
+ * differences this module handles:
+ *
+ *   - `subject`, `location`, `start`, `end`, `body` are direct properties
+ *     in read mode (AppointmentRead) but are async (`getAsync`) in compose
+ *     mode (AppointmentCompose) because both the user and the add-in can
+ *     mutate them concurrently.
+ *   - `organizer` (an `EmailAddressDetails`) is read-only and only exposes
+ *     a sender's name + email — there's no callback flavour needed.
+ *   - Attendees are split into `requiredAttendees` and `optionalAttendees`,
+ *     both `Array<EmailAddressDetails>` in read mode and `Recipients`
+ *     (with `getAsync`) in compose mode.
+ *
+ * We normalize all of this to a single shape:
+ *
+ *   {
+ *     available: boolean,
+ *     itemKind: 'appointment',
+ *     mode: 'read' | 'compose',
+ *     isOrganizer: boolean,
+ *     subject: string|null,
+ *     itemId: string|null,
+ *     location: string|null,
+ *     start: string|null,        // ISO timestamp
+ *     end: string|null,          // ISO timestamp
+ *     organizer: { name, email } | null,
+ *     requiredAttendees: Array<{ name, email }>,
+ *     optionalAttendees: Array<{ name, email }>,
+ *     bodyText: string|null,
+ *     attachments: Array<...>   // kept empty for now; meeting items rarely
+ *                                  carry attachments worth round-tripping.
+ *   }
+ *
+ * Shape intentionally extends the mail-context shape (bodyText + attachments)
+ * so downstream consumers — useOutlookMailContextSnapshot, the chat adapter
+ * — can treat both kinds uniformly when they don't need the calendar fields.
+ */
+
+const APPOINTMENT_ITEM_TYPE = 'appointment';
+
+export function isOutlookAppointmentItemAvailable() {
+  try {
+    if (typeof Office === 'undefined') return false;
+    const item = Office.context?.mailbox?.item;
+    if (!item) return false;
+    const itemType = String(item.itemType || '').toLowerCase();
+    return itemType === APPOINTMENT_ITEM_TYPE;
+  } catch {
+    return false;
+  }
+}
+
+function toIso(value) {
+  if (!value) return null;
+  try {
+    if (value instanceof Date) return value.toISOString();
+    if (typeof value === 'string') {
+      const d = new Date(value);
+      if (Number.isNaN(d.getTime())) return null;
+      return d.toISOString();
+    }
+    if (typeof value === 'number') {
+      const d = new Date(value);
+      return Number.isNaN(d.getTime()) ? null : d.toISOString();
+    }
+  } catch {
+    return null;
+  }
+  return null;
+}
+
+function normalizeRecipient(r) {
+  if (!r) return null;
+  const name = typeof r.displayName === 'string' ? r.displayName : null;
+  const email = typeof r.emailAddress === 'string' ? r.emailAddress : null;
+  if (!name && !email) return null;
+  return { name: name || email, email };
+}
+
+function normalizeRecipientList(list) {
+  if (!Array.isArray(list)) return [];
+  return list.map(normalizeRecipient).filter(Boolean);
+}
+
+/**
+ * In read mode (AppointmentRead) most fields are plain values. In compose
+ * mode (AppointmentCompose) the same fields are `Recipients` / async
+ * objects and need `getAsync`. We feature-detect and resolve in both.
+ */
+function getAsyncOrValue(maybeAsync) {
+  return new Promise(resolve => {
+    if (maybeAsync == null) {
+      resolve(null);
+      return;
+    }
+    if (typeof maybeAsync === 'string' || typeof maybeAsync === 'number') {
+      resolve(maybeAsync);
+      return;
+    }
+    if (maybeAsync instanceof Date) {
+      resolve(maybeAsync);
+      return;
+    }
+    if (typeof maybeAsync.getAsync === 'function') {
+      try {
+        maybeAsync.getAsync(result => {
+          if (result && result.status === Office.AsyncResultStatus.Succeeded) {
+            resolve(result.value);
+          } else {
+            resolve(null);
+          }
+        });
+      } catch {
+        resolve(null);
+      }
+      return;
+    }
+    resolve(maybeAsync);
+  });
+}
+
+function getBodyTextAsync() {
+  return new Promise(resolve => {
+    const item = Office.context.mailbox.item;
+    if (!item || !item.body || typeof item.body.getAsync !== 'function') {
+      resolve(null);
+      return;
+    }
+    try {
+      item.body.getAsync(Office.CoercionType.Text, result => {
+        resolve(
+          result?.status === Office.AsyncResultStatus.Succeeded ? (result.value ?? null) : null
+        );
+      });
+    } catch {
+      resolve(null);
+    }
+  });
+}
+
+/**
+ * Returns true when the current Outlook session belongs to the meeting
+ * organizer. We detect this two ways:
+ *   1. The item exposes `appointment.organizer` and that email matches the
+ *      user's mailbox profile.
+ *   2. We're running in AppointmentCompose mode — only the organizer can
+ *      compose a meeting (attendees see read mode).
+ */
+async function detectIsOrganizer(item, organizer) {
+  // Compose mode → user is the organizer.
+  if (item && typeof item.requiredAttendees?.setAsync === 'function') return true;
+
+  try {
+    const me = Office.context?.mailbox?.userProfile?.emailAddress;
+    if (me && organizer?.email) {
+      return String(me).toLowerCase() === String(organizer.email).toLowerCase();
+    }
+  } catch {
+    // userProfile can be unavailable in some embed scenarios.
+  }
+  return false;
+}
+
+async function readOrganizer(item) {
+  // Read mode: item.organizer is an EmailAddressDetails (plain object).
+  // There's no compose-mode flavour — the organizer is whoever is composing.
+  if (!item?.organizer) {
+    // Compose mode fallback: the current user is the organizer.
+    try {
+      const profile = Office.context?.mailbox?.userProfile;
+      if (profile?.emailAddress) {
+        return { name: profile.displayName || profile.emailAddress, email: profile.emailAddress };
+      }
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+  return normalizeRecipient(item.organizer);
+}
+
+async function readRecipients(recipients) {
+  if (!recipients) return [];
+  // Read mode: already an Array<EmailAddressDetails>.
+  if (Array.isArray(recipients)) return normalizeRecipientList(recipients);
+  // Compose mode: Recipients object with getAsync.
+  if (typeof recipients.getAsync === 'function') {
+    const val = await getAsyncOrValue(recipients);
+    return normalizeRecipientList(val);
+  }
+  return [];
+}
+
+export async function fetchCurrentAppointmentContext() {
+  if (!isOutlookAppointmentItemAvailable()) {
+    return {
+      available: false,
+      itemKind: 'appointment',
+      reason:
+        'Not running in Outlook with an appointment item (Office.js item missing or not appointment).',
+      attachments: []
+    };
+  }
+
+  const item = Office.context.mailbox.item;
+  // Compose-mode items expose setAsync on their recipient collections; read
+  // mode does not. That's the cheapest mode discriminator.
+  const isCompose = typeof item.requiredAttendees?.setAsync === 'function';
+  const mode = isCompose ? 'compose' : 'read';
+
+  const [
+    subjectVal,
+    locationVal,
+    startVal,
+    endVal,
+    bodyText,
+    organizer,
+    requiredAttendees,
+    optionalAttendees
+  ] = await Promise.all([
+    getAsyncOrValue(item.subject),
+    getAsyncOrValue(item.location),
+    getAsyncOrValue(item.start),
+    getAsyncOrValue(item.end),
+    getBodyTextAsync(),
+    readOrganizer(item),
+    readRecipients(item.requiredAttendees),
+    readRecipients(item.optionalAttendees)
+  ]);
+
+  const isOrganizer = await detectIsOrganizer(item, organizer);
+
+  return {
+    available: true,
+    itemKind: 'appointment',
+    mode,
+    isOrganizer,
+    subject: typeof subjectVal === 'string' ? subjectVal : null,
+    itemId: item.itemId ?? null,
+    location: typeof locationVal === 'string' ? locationVal : null,
+    start: toIso(startVal),
+    end: toIso(endVal),
+    organizer,
+    requiredAttendees,
+    optionalAttendees,
+    bodyText,
+    // Calendar items can technically carry attachments (e.g. agenda
+    // attached to invite). We surface descriptors only — pulling
+    // binary content for a meeting prep flow would explode token
+    // budgets and the prompts in the meeting-* apps never reference
+    // them. Future enhancement if needed.
+    attachments: []
+  };
+}

--- a/client/src/features/office/utilities/outlookMailContext.js
+++ b/client/src/features/office/utilities/outlookMailContext.js
@@ -1,5 +1,10 @@
 /* global Office */
 
+import {
+  fetchCurrentAppointmentContext,
+  isOutlookAppointmentItemAvailable
+} from './outlookCalendarContext';
+
 export function isOutlookMailItemAvailable() {
   try {
     return (
@@ -10,6 +15,21 @@ export function isOutlookMailItemAvailable() {
     );
   } catch {
     return false;
+  }
+}
+
+/**
+ * Returns the lowercased itemType of the currently selected Outlook item,
+ * or null if Office.js / mailbox.item is unavailable. Used by the host
+ * adapter to pick between the mail and appointment context readers.
+ */
+export function getCurrentOutlookItemType() {
+  try {
+    const item = Office.context?.mailbox?.item;
+    if (!item) return null;
+    return String(item.itemType || '').toLowerCase() || null;
+  } catch {
+    return null;
   }
 }
 
@@ -79,6 +99,22 @@ function getSubjectAsync() {
       resolve(null);
     }
   });
+}
+
+/**
+ * Unified entry point used by the host adapter — dispatches to either the
+ * mail-context or appointment-context reader based on the current item's
+ * `itemType`. Adds an `itemKind: 'message'|'appointment'` discriminator to
+ * the mail-context payload so downstream consumers (snapshot hook, context
+ * strip, chat adapter) can pick the right banner / prompt formatter.
+ */
+export async function fetchCurrentOutlookItemContext() {
+  const itemType = getCurrentOutlookItemType();
+  if (itemType === 'appointment' || isOutlookAppointmentItemAvailable()) {
+    return fetchCurrentAppointmentContext();
+  }
+  const ctx = await fetchCurrentMailContext();
+  return { ...ctx, itemKind: 'message' };
 }
 
 export async function fetchCurrentMailContext() {

--- a/server/defaults/apps/meeting-agenda-generator.json
+++ b/server/defaults/apps/meeting-agenda-generator.json
@@ -1,0 +1,96 @@
+{
+  "id": "meeting-agenda-generator",
+  "order": 6,
+  "category": "communication",
+  "name": {
+    "en": "Meeting Agenda Generator",
+    "de": "Meeting-Agenda-Generator"
+  },
+  "description": {
+    "en": "Draft a clear, structured agenda for an upcoming meeting using the invite metadata and the organizational knowledge base",
+    "de": "Erstellt eine klare, strukturierte Agenda für ein bevorstehendes Meeting auf Basis der Einladungs-Metadaten und der organisatorischen Wissensdatenbank"
+  },
+  "color": "#7C3AED",
+  "icon": "calendar",
+  "system": {
+    "en": "You are an executive assistant that drafts meeting agendas for the organizer. The user is preparing to host a meeting; you'll receive the invite metadata (subject, time, attendees, organizer, location, description) in a section labeled '--- Current meeting ---' inside the user message. You also have access to the organizational knowledge base below.\n\nProduce a focused, time-boxed agenda. Every agenda item must include: (1) a short title, (2) a time allocation in minutes, (3) the discussion owner if you can infer one from the attendee list, and (4) the desired outcome (decision / information / brainstorm). Cap the total at the meeting duration when known; otherwise default to 30 minutes. Close with a 'Pre-read & prep' section listing anything attendees should review beforehand and an 'Open questions' section if the invite description leaves gaps.\n\nWhen the knowledge base contains relevant context (e.g. the meeting matches a recurring cadence, a project codename, or a documented decision framework), cite the section name inline so the organizer knows where the suggestion came from. Do not invent facts that aren't in the invite or the knowledge base.\n\nKnowledge base:\n<sources>{{sources}}</sources>",
+    "de": "Du bist die Assistenz, die für die organisierende Person eine Meeting-Agenda entwirft. Die Person bereitet ein eigenes Meeting vor; du erhältst die Einladungs-Metadaten (Betreff, Zeit, Teilnehmende, Veranstalter:in, Ort, Beschreibung) in einem Abschnitt mit der Überschrift '--- Current meeting ---' innerhalb der Nutzernachricht. Außerdem hast du Zugriff auf die unten stehende organisatorische Wissensdatenbank.\n\nErstelle eine fokussierte, zeitlich getaktete Agenda. Jeder Tagesordnungspunkt muss enthalten: (1) einen knappen Titel, (2) eine Zeitangabe in Minuten, (3) die zuständige Person, sofern aus der Teilnehmendenliste ableitbar, und (4) das gewünschte Ergebnis (Entscheidung / Information / Ideenfindung). Begrenze die Gesamtdauer auf die Meeting-Länge, sofern bekannt; ansonsten standardmäßig 30 Minuten. Schließe mit einem Abschnitt 'Vorbereitung & Pre-Read' (was sollten Teilnehmende vorab durchgehen?) sowie 'Offene Fragen', falls die Beschreibung Lücken lässt.\n\nWenn die Wissensdatenbank relevanten Kontext enthält (z. B. das Meeting passt zu einer wiederkehrenden Kadenz, einem Projekt-Codenamen oder einem dokumentierten Entscheidungsmodell), verweise inline auf den Abschnittsnamen, damit nachvollziehbar bleibt, woher die Empfehlung stammt. Erfinde keine Fakten, die weder in der Einladung noch in der Wissensdatenbank stehen.\n\nWissensdatenbank:\n<sources>{{sources}}</sources>"
+  },
+  "tokenLimit": 8000,
+  "preferredOutputFormat": "markdown",
+  "preferredStyle": "professional",
+  "preferredTemperature": 0.4,
+  "sendChatHistory": true,
+  "allowEmptyContent": true,
+  "sources": ["meeting-knowledge-base"],
+  "messagePlaceholder": {
+    "en": "Optional: paste extra context, talking points, or constraints…",
+    "de": "Optional: zusätzlichen Kontext, Themenpunkte oder Vorgaben einfügen…"
+  },
+  "starterPrompts": [
+    {
+      "title": {
+        "en": "Draft an agenda for this meeting",
+        "de": "Entwirf eine Agenda für dieses Meeting"
+      },
+      "message": {
+        "en": "Draft an agenda for this meeting. Use the invite details and the knowledge base; flag anything that's missing.",
+        "de": "Entwirf eine Agenda für dieses Meeting. Nutze die Einladungsdetails und die Wissensdatenbank; markiere fehlende Punkte."
+      },
+      "autoSend": true
+    },
+    {
+      "title": {
+        "en": "Suggest discussion topics",
+        "de": "Diskussionspunkte vorschlagen"
+      },
+      "message": {
+        "en": "Suggest 5-7 discussion topics tailored to the attendees of this meeting, with desired outcomes for each.",
+        "de": "Schlage 5-7 Diskussionspunkte vor, passend zu den Teilnehmenden dieses Meetings, jeweils mit dem gewünschten Ergebnis."
+      },
+      "autoSend": true
+    },
+    {
+      "title": {
+        "en": "List required pre-reads",
+        "de": "Notwendige Vorlesematerialien auflisten"
+      },
+      "message": {
+        "en": "List the documents, dashboards, or decisions attendees should review before this meeting, based on the invite and the knowledge base.",
+        "de": "Liste die Dokumente, Dashboards oder Entscheidungen auf, die Teilnehmende vor diesem Meeting auf Basis der Einladung und der Wissensdatenbank durchgehen sollten."
+      },
+      "autoSend": true
+    }
+  ],
+  "greeting": {
+    "en": {
+      "title": "Hosting a meeting?",
+      "subtitle": "I'll turn the invite + your knowledge base into a clear agenda."
+    },
+    "de": {
+      "title": "Ein Meeting im Kalender?",
+      "subtitle": "Ich mache aus Einladung + Wissensdatenbank eine klare Agenda."
+    }
+  },
+  "enabled": true,
+  "settings": {
+    "enabled": true,
+    "model": { "enabled": true },
+    "temperature": { "enabled": true },
+    "outputFormat": { "enabled": false },
+    "chatHistory": { "enabled": true },
+    "style": { "enabled": true }
+  },
+  "inputMode": {
+    "type": "multiline",
+    "rows": 3,
+    "microphone": {
+      "enabled": true,
+      "mode": "manual",
+      "showTranscript": true
+    }
+  },
+  "upload": {
+    "enabled": false
+  }
+}

--- a/server/defaults/apps/meeting-briefing.json
+++ b/server/defaults/apps/meeting-briefing.json
@@ -1,0 +1,96 @@
+{
+  "id": "meeting-briefing",
+  "order": 7,
+  "category": "communication",
+  "name": {
+    "en": "Meeting Briefing",
+    "de": "Meeting-Briefing"
+  },
+  "description": {
+    "en": "Get a one-page prep brief for an upcoming meeting: context, attendees, expected outcomes, and the questions you should be ready to answer",
+    "de": "Erhalte ein einseitiges Vorbereitungs-Briefing für ein Meeting: Kontext, Teilnehmende, erwartete Ergebnisse und die Fragen, auf die du vorbereitet sein solltest"
+  },
+  "color": "#0EA5E9",
+  "icon": "clock",
+  "system": {
+    "en": "You are a chief-of-staff style assistant preparing the user to attend an upcoming meeting. The user will not be hosting; their goal is to walk in informed. You'll receive the invite metadata (subject, time, attendees, organizer, location, description) in a section labeled '--- Current meeting ---' inside the user message, plus access to the organizational knowledge base below.\n\nProduce a concise one-page briefing with these sections, in order:\n  1. **TL;DR** — one or two sentences on what this meeting is about and why it matters.\n  2. **Likely outcomes** — what the organizer probably wants by the end (decision, alignment, info-share, etc.). Infer from the subject + description; be explicit when you're guessing.\n  3. **Attendees worth knowing** — pick out 3–5 attendees (or fewer if the meeting is smaller) and note their probable role / interest area, using the knowledge base for context where relevant.\n  4. **Context from the knowledge base** — anything that's relevant (recurring meeting cadence, project codenames, decision frameworks). Cite section names so the reader can dig deeper.\n  5. **Questions to bring** — 3–5 questions the user should be ready to ask or answer.\n  6. **Open risks / gaps** — anything missing from the invite that the user may want to clarify with the organizer.\n\nDo not invent attendee responsibilities, project status, or commitments that aren't supported by the invite or the knowledge base. When the knowledge base is silent, say so rather than guessing.\n\nKnowledge base:\n<sources>{{sources}}</sources>",
+    "de": "Du bist eine Stabsassistenz, die die nutzende Person auf ein bevorstehendes Meeting vorbereitet. Diese Person wird nicht selbst moderieren; Ziel ist, informiert in das Meeting zu gehen. Du erhältst die Einladungs-Metadaten (Betreff, Zeit, Teilnehmende, Veranstalter:in, Ort, Beschreibung) in einem Abschnitt mit der Überschrift '--- Current meeting ---' in der Nutzernachricht, sowie Zugriff auf die unten stehende organisatorische Wissensdatenbank.\n\nErstelle ein kompaktes einseitiges Briefing in dieser Reihenfolge:\n  1. **TL;DR** — ein bis zwei Sätze, worum es geht und warum es relevant ist.\n  2. **Wahrscheinliche Ergebnisse** — was die einladende Person voraussichtlich erreichen will (Entscheidung, Abstimmung, Information o. Ä.). Aus Betreff + Beschreibung ableiten; markiere ausdrücklich, wenn du vermutest.\n  3. **Relevante Teilnehmende** — wähle 3–5 Personen aus (oder weniger bei kleinen Runden) und beschreibe ihre vermutliche Rolle bzw. ihr Interessengebiet; nutze dabei die Wissensdatenbank, falls passend.\n  4. **Kontext aus der Wissensdatenbank** — alles Relevante (wiederkehrende Kadenz, Projekt-Codenamen, Entscheidungsmodelle). Nenne dabei die Abschnittsnamen, damit die Leserin / der Leser nachschlagen kann.\n  5. **Fragen, die ich mitbringen sollte** — 3–5 Fragen, auf die die Person vorbereitet sein sollte oder die sie aktiv stellen kann.\n  6. **Offene Risiken / Lücken** — was in der Einladung fehlt und gegebenenfalls vorab geklärt werden sollte.\n\nErfinde keine Zuständigkeiten, Projektstatus oder Zusagen, die weder durch die Einladung noch durch die Wissensdatenbank gedeckt sind. Wenn die Wissensdatenbank dazu schweigt, sage das, statt zu raten.\n\nWissensdatenbank:\n<sources>{{sources}}</sources>"
+  },
+  "tokenLimit": 8000,
+  "preferredOutputFormat": "markdown",
+  "preferredStyle": "professional",
+  "preferredTemperature": 0.4,
+  "sendChatHistory": true,
+  "allowEmptyContent": true,
+  "sources": ["meeting-knowledge-base"],
+  "messagePlaceholder": {
+    "en": "Optional: tell me what you specifically want to understand or be ready for…",
+    "de": "Optional: nenne, was du gezielt verstehen oder worauf du vorbereitet sein möchtest…"
+  },
+  "starterPrompts": [
+    {
+      "title": {
+        "en": "Prepare me for this meeting",
+        "de": "Bereite mich auf dieses Meeting vor"
+      },
+      "message": {
+        "en": "Prepare me for this meeting. Give me a one-page briefing using the invite and the knowledge base.",
+        "de": "Bereite mich auf dieses Meeting vor. Erstelle ein einseitiges Briefing aus Einladung und Wissensdatenbank."
+      },
+      "autoSend": true
+    },
+    {
+      "title": {
+        "en": "Who's attending and why?",
+        "de": "Wer nimmt teil und warum?"
+      },
+      "message": {
+        "en": "Tell me about the attendees of this meeting and why each is likely on the invite, using the knowledge base where it helps.",
+        "de": "Erzähle mir etwas über die Teilnehmenden dieses Meetings und warum jede Person vermutlich eingeladen wurde — nutze die Wissensdatenbank, wo es hilft."
+      },
+      "autoSend": true
+    },
+    {
+      "title": {
+        "en": "Questions I should ask",
+        "de": "Welche Fragen sollte ich stellen?"
+      },
+      "message": {
+        "en": "Suggest 5 questions I should be ready to ask or answer in this meeting, with the rationale for each.",
+        "de": "Schlage 5 Fragen vor, auf die ich in diesem Meeting vorbereitet sein sollte (zu stellen oder zu beantworten), jeweils mit Begründung."
+      },
+      "autoSend": true
+    }
+  ],
+  "greeting": {
+    "en": {
+      "title": "Meeting coming up?",
+      "subtitle": "I'll prep you with context from the invite and the knowledge base."
+    },
+    "de": {
+      "title": "Meeting steht an?",
+      "subtitle": "Ich bereite dich mit Kontext aus Einladung und Wissensdatenbank vor."
+    }
+  },
+  "enabled": true,
+  "settings": {
+    "enabled": true,
+    "model": { "enabled": true },
+    "temperature": { "enabled": true },
+    "outputFormat": { "enabled": false },
+    "chatHistory": { "enabled": true },
+    "style": { "enabled": true }
+  },
+  "inputMode": {
+    "type": "multiline",
+    "rows": 3,
+    "microphone": {
+      "enabled": true,
+      "mode": "manual",
+      "showTranscript": true
+    }
+  },
+  "upload": {
+    "enabled": false
+  }
+}

--- a/server/defaults/config/platform.json
+++ b/server/defaults/config/platform.json
@@ -239,6 +239,38 @@
           "de": "Was sind die wichtigsten Erkenntnisse aus dieser E-Mail?"
         }
       }
+    ],
+    "calendarStarterPrompts": [
+      {
+        "title": {
+          "en": "Draft an agenda for this meeting",
+          "de": "Entwirf eine Agenda für dieses Meeting"
+        },
+        "message": {
+          "en": "Draft an agenda for this meeting. Use the invite details and the knowledge base; flag anything that is missing.",
+          "de": "Entwirf eine Agenda für dieses Meeting. Nutze die Einladungsdetails und die Wissensdatenbank; markiere fehlende Punkte."
+        }
+      },
+      {
+        "title": {
+          "en": "Prepare me for this meeting",
+          "de": "Bereite mich auf dieses Meeting vor"
+        },
+        "message": {
+          "en": "Prepare me for this meeting. Give me a one-page briefing using the invite and the knowledge base.",
+          "de": "Bereite mich auf dieses Meeting vor. Erstelle ein einseitiges Briefing aus Einladung und Wissensdatenbank."
+        }
+      },
+      {
+        "title": {
+          "en": "Who is attending and why?",
+          "de": "Wer nimmt teil und warum?"
+        },
+        "message": {
+          "en": "Tell me about the attendees of this meeting and why each is likely on the invite.",
+          "de": "Erzähle mir etwas über die Teilnehmenden dieses Meetings und warum jede Person vermutlich eingeladen wurde."
+        }
+      }
     ]
   }
 }

--- a/server/defaults/config/sources.json
+++ b/server/defaults/config/sources.json
@@ -20,6 +20,25 @@
     }
   },
   {
+    "id": "meeting-knowledge-base",
+    "name": {
+      "en": "Meeting Knowledge Base",
+      "de": "Meeting-Wissensdatenbank"
+    },
+    "description": {
+      "en": "Organizational reference material consulted by the calendar-aware apps (recurring meetings, glossary, decision frameworks). Replace with a connector to your company wiki / ifinder source for real use.",
+      "de": "Organisatorisches Referenzmaterial für die kalenderbezogenen Apps (wiederkehrende Meetings, Glossar, Entscheidungsmodelle). Für den Produktiveinsatz durch eine Verbindung zum Unternehmenswiki / iFinder ersetzen."
+    },
+    "type": "filesystem",
+    "enabled": true,
+    "exposeAs": "prompt",
+    "tags": ["meetings", "calendar"],
+    "config": {
+      "path": "sources/meeting-knowledge-base.md",
+      "encoding": "utf-8"
+    }
+  },
+  {
     "id": "intrafind-website-home",
     "name": {
       "en": "IntraFind.com"

--- a/server/defaults/sources/meeting-knowledge-base.md
+++ b/server/defaults/sources/meeting-knowledge-base.md
@@ -1,0 +1,69 @@
+# Meeting Knowledge Base
+
+This is a sample knowledge base used by the calendar-aware iHub apps
+(`meeting-agenda-generator`, `meeting-briefing`). Administrators should
+replace this content with their own organizational reference material —
+or, better, swap the source binding in `config/sources.json` to point at
+a `url`-type source backed by the company wiki, an `ifinder` source, or
+any other connector iHub supports.
+
+The content below is intentionally generic so the apps remain useful
+out-of-the-box for demos and evaluation.
+
+## Recurring Meetings
+
+### Weekly Engineering Sync
+- **Cadence:** Mondays, 10:00 – 10:30 (local time)
+- **Purpose:** Surface blockers, share progress on the current sprint,
+  align on cross-team dependencies.
+- **Typical agenda:** Status round-robin (15 min) → Open issues (10 min)
+  → Next-week priorities (5 min).
+- **Owners:** Engineering Manager hosts; tech leads contribute updates.
+
+### Monthly Product Review
+- **Cadence:** First Wednesday of the month, 14:00 – 15:30.
+- **Purpose:** Review feature launches, key metrics, customer feedback.
+- **Typical agenda:** Launch recap → Metrics deep-dive → Roadmap
+  preview → Q&A.
+
+### Quarterly Business Review (QBR)
+- **Cadence:** First week of each new quarter.
+- **Purpose:** Whole-company review of OKRs, financials, customer
+  health, and strategic priorities for the next quarter.
+
+## Team Glossary
+
+- **Platform Team:** Owns iHub infrastructure, deployments, and
+  integration adapters.
+- **Apps Team:** Owns the in-product AI applications, UX, and prompt
+  engineering.
+- **Customer Success:** Owns onboarding, training, and renewal motions.
+- **Security & Compliance:** Owns security reviews, audit responses,
+  vendor risk.
+
+## Meeting Etiquette
+
+- **Agenda first:** Every meeting longer than 30 minutes should circulate
+  an agenda at least 24 hours in advance.
+- **Decision log:** Capture decisions and owners in the meeting notes,
+  not just discussion points.
+- **Action items:** Each action item must have an assignee and a due
+  date. "We should…" without an owner doesn't count.
+- **Async first:** If a meeting can be replaced by a written update,
+  cancel it.
+
+## Common Project Codenames
+
+- **Aurora:** Outlook add-in and calendar integration (this project).
+- **Beacon:** Customer-facing analytics dashboard.
+- **Compass:** Enterprise SSO and group management.
+- **Delta:** Real-time chat infrastructure migration.
+
+## Decision-Making Frameworks
+
+- **DACI:** Driver, Approver, Contributors, Informed. Use for any
+  cross-team initiative that needs a clear owner.
+- **RFC + comment window:** Architectural decisions get a written
+  proposal with a 5-business-day comment window before sign-off.
+- **Single-threaded owner:** Long-running initiatives have one person
+  accountable end-to-end, not a committee.

--- a/server/defaults/sources/meeting-knowledge-base.md
+++ b/server/defaults/sources/meeting-knowledge-base.md
@@ -13,6 +13,7 @@ out-of-the-box for demos and evaluation.
 ## Recurring Meetings
 
 ### Weekly Engineering Sync
+
 - **Cadence:** Mondays, 10:00 – 10:30 (local time)
 - **Purpose:** Surface blockers, share progress on the current sprint,
   align on cross-team dependencies.
@@ -21,12 +22,14 @@ out-of-the-box for demos and evaluation.
 - **Owners:** Engineering Manager hosts; tech leads contribute updates.
 
 ### Monthly Product Review
+
 - **Cadence:** First Wednesday of the month, 14:00 – 15:30.
 - **Purpose:** Review feature launches, key metrics, customer feedback.
 - **Typical agenda:** Launch recap → Metrics deep-dive → Roadmap
   preview → Q&A.
 
 ### Quarterly Business Review (QBR)
+
 - **Cadence:** First week of each new quarter.
 - **Purpose:** Whole-company review of OKRs, financials, customer
   health, and strategic priorities for the next quarter.

--- a/server/migrations/V039__add_calendar_integration.js
+++ b/server/migrations/V039__add_calendar_integration.js
@@ -1,0 +1,131 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+export const version = '039';
+export const description = 'add_calendar_integration';
+
+const CALENDAR_STARTER_PROMPTS = [
+  {
+    title: {
+      en: 'Draft an agenda for this meeting',
+      de: 'Entwirf eine Agenda für dieses Meeting'
+    },
+    message: {
+      en: 'Draft an agenda for this meeting. Use the invite details and the knowledge base; flag anything that is missing.',
+      de: 'Entwirf eine Agenda für dieses Meeting. Nutze die Einladungsdetails und die Wissensdatenbank; markiere fehlende Punkte.'
+    }
+  },
+  {
+    title: {
+      en: 'Prepare me for this meeting',
+      de: 'Bereite mich auf dieses Meeting vor'
+    },
+    message: {
+      en: 'Prepare me for this meeting. Give me a one-page briefing using the invite and the knowledge base.',
+      de: 'Bereite mich auf dieses Meeting vor. Erstelle ein einseitiges Briefing aus Einladung und Wissensdatenbank.'
+    }
+  },
+  {
+    title: {
+      en: 'Who is attending and why?',
+      de: 'Wer nimmt teil und warum?'
+    },
+    message: {
+      en: 'Tell me about the attendees of this meeting and why each is likely on the invite.',
+      de: 'Erzähle mir etwas über die Teilnehmenden dieses Meetings und warum jede Person vermutlich eingeladen wurde.'
+    }
+  }
+];
+
+const MEETING_KNOWLEDGE_BASE_SOURCE = {
+  id: 'meeting-knowledge-base',
+  name: {
+    en: 'Meeting Knowledge Base',
+    de: 'Meeting-Wissensdatenbank'
+  },
+  description: {
+    en: 'Organizational reference material consulted by the calendar-aware apps. Replace with a connector to your company wiki / ifinder source for real use.',
+    de: 'Organisatorisches Referenzmaterial für die kalenderbezogenen Apps. Für den Produktiveinsatz durch eine Verbindung zum Unternehmenswiki / iFinder ersetzen.'
+  },
+  type: 'filesystem',
+  enabled: true,
+  exposeAs: 'prompt',
+  tags: ['meetings', 'calendar'],
+  config: {
+    path: 'sources/meeting-knowledge-base.md',
+    encoding: 'utf-8'
+  }
+};
+
+const APP_FILES = ['meeting-agenda-generator.json', 'meeting-briefing.json'];
+
+/**
+ * Copy a non-JSON default file into the contents/ tree. The migration ctx
+ * exposes JSON readers/writers but no raw-file copy helper, so we go
+ * through fs directly. No-op when the destination already exists so
+ * admin edits are never overwritten.
+ */
+async function copyDefaultFileIfMissing(ctx, relativePath) {
+  const dest = path.join(ctx.contentsDir, relativePath);
+  try {
+    await fs.access(dest);
+    return false; // already exists, leave admin edits alone
+  } catch {
+    // not present, continue
+  }
+  const src = path.join(ctx.defaultsDir, relativePath);
+  try {
+    const data = await fs.readFile(src);
+    await fs.mkdir(path.dirname(dest), { recursive: true });
+    await fs.writeFile(dest, data);
+    return true;
+  } catch (e) {
+    ctx.warn(`Could not copy ${relativePath}: ${e.message || e}`);
+    return false;
+  }
+}
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  // Add calendar-specific starter prompts. Mail prompts stay unchanged.
+  ctx.setDefault(platform, 'officeIntegration.calendarStarterPrompts', CALENDAR_STARTER_PROMPTS);
+
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Added officeIntegration.calendarStarterPrompts defaults');
+
+  // Register the meeting knowledge base source if the admin hasn't
+  // already claimed that id for a different source. We never overwrite —
+  // admins may have repurposed the id between the default-ship and now.
+  if (await ctx.fileExists('config/sources.json')) {
+    const sources = await ctx.readJson('config/sources.json');
+    if (Array.isArray(sources)) {
+      ctx.addIfMissing(sources, MEETING_KNOWLEDGE_BASE_SOURCE, 'id');
+      await ctx.writeJson('config/sources.json', sources);
+      ctx.log('Ensured meeting-knowledge-base source is registered');
+    } else {
+      ctx.warn('config/sources.json is not an array, skipping source registration');
+    }
+  }
+
+  // Copy the sample knowledge base markdown into contents/sources/ if
+  // the admin hasn't already created one. Without this file the
+  // filesystem source returns an empty string at runtime and the apps
+  // behave as if the knowledge base were silent.
+  if (await copyDefaultFileIfMissing(ctx, 'sources/meeting-knowledge-base.md')) {
+    ctx.log('Installed default sources/meeting-knowledge-base.md');
+  }
+
+  // Drop the two new app JSON files into contents/apps/ if not present.
+  // Existing installs that already shipped these (or were customized by
+  // the admin) are left alone.
+  for (const fileName of APP_FILES) {
+    if (await copyDefaultFileIfMissing(ctx, `apps/${fileName}`)) {
+      ctx.log(`Installed default app contents/apps/${fileName}`);
+    }
+  }
+}

--- a/server/routes/integrations/officeAddin.js
+++ b/server/routes/integrations/officeAddin.js
@@ -68,7 +68,8 @@ router.get('/config', (req, res) => {
     baseUrl,
     clientId: officeConfig.oauthClientId || '',
     redirectUri: `${baseUrl}/office/callback.html`,
-    starterPrompts: sanitizeStarterPrompts(officeConfig.starterPrompts)
+    starterPrompts: sanitizeStarterPrompts(officeConfig.starterPrompts),
+    calendarStarterPrompts: sanitizeStarterPrompts(officeConfig.calendarStarterPrompts)
   });
 });
 
@@ -126,7 +127,7 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
            xmlns:mailappor="http://schemas.microsoft.com/office/mailappversionoverrides/1.0"
            xsi:type="MailApp">
   <Id>4fe644da-8036-47f8-ac9f-e478bcbe5274</Id>
-  <Version>1.0.0.0</Version>
+  <Version>1.1.0.0</Version>
   <ProviderName>intrafind</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="${escapeXml(displayName)}"/>
@@ -142,7 +143,7 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
   </Hosts>
   <Requirements>
     <Sets>
-      <Set Name="Mailbox" MinVersion="1.1"/>
+      <Set Name="Mailbox" MinVersion="1.3"/>
     </Sets>
   </Requirements>
   <FormSettings>
@@ -162,6 +163,8 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
   <Rule xsi:type="RuleCollection" Mode="Or">
     <Rule xsi:type="ItemIs" ItemType="Message" FormType="Read"/>
     <Rule xsi:type="ItemIs" ItemType="Message" FormType="Edit"/>
+    <Rule xsi:type="ItemIs" ItemType="Appointment" FormType="Read"/>
+    <Rule xsi:type="ItemIs" ItemType="Appointment" FormType="Edit"/>
   </Rule>
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/mailappversionoverrides" xsi:type="VersionOverridesV1_0">
     <Requirements>
@@ -200,6 +203,50 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
               <Group id="msgComposeGroup">
                 <Label resid="GroupLabel"/>
                 <Control xsi:type="Button" id="msgComposeOpenPaneButton">
+                  <Label resid="TaskpaneButton.Label"/>
+                  <Supertip>
+                    <Title resid="TaskpaneButton.Label"/>
+                    <Description resid="TaskpaneButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Icon.16x16"/>
+                    <bt:Image size="32" resid="Icon.32x32"/>
+                    <bt:Image size="80" resid="Icon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="Taskpane.Url"/>
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+          <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
+            <OfficeTab id="TabDefault">
+              <Group id="apptOrganizerGroup">
+                <Label resid="GroupLabel"/>
+                <Control xsi:type="Button" id="apptOrganizerOpenPaneButton">
+                  <Label resid="TaskpaneButton.Label"/>
+                  <Supertip>
+                    <Title resid="TaskpaneButton.Label"/>
+                    <Description resid="TaskpaneButton.Tooltip"/>
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Icon.16x16"/>
+                    <bt:Image size="32" resid="Icon.32x32"/>
+                    <bt:Image size="80" resid="Icon.80x80"/>
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <SourceLocation resid="Taskpane.Url"/>
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+          <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
+            <OfficeTab id="TabDefault">
+              <Group id="apptAttendeeGroup">
+                <Label resid="GroupLabel"/>
+                <Control xsi:type="Button" id="apptAttendeeOpenPaneButton">
                   <Label resid="TaskpaneButton.Label"/>
                   <Supertip>
                     <Title resid="TaskpaneButton.Label"/>
@@ -277,6 +324,52 @@ function generateManifest({ baseUrl, origin, displayName, description }) {
                 <Group id="msgComposeGroupV1_1">
                   <Label resid="GroupLabel"/>
                   <Control xsi:type="Button" id="msgComposeOpenPaneButtonV1_1">
+                    <Label resid="TaskpaneButton.Label"/>
+                    <Supertip>
+                      <Title resid="TaskpaneButton.Label"/>
+                      <Description resid="TaskpaneButton.Tooltip"/>
+                    </Supertip>
+                    <Icon>
+                      <bt:Image size="16" resid="Icon.16x16"/>
+                      <bt:Image size="32" resid="Icon.32x32"/>
+                      <bt:Image size="80" resid="Icon.80x80"/>
+                    </Icon>
+                    <Action xsi:type="ShowTaskpane">
+                      <SourceLocation resid="Taskpane.Url"/>
+                      <SupportsPinning>true</SupportsPinning>
+                    </Action>
+                  </Control>
+                </Group>
+              </OfficeTab>
+            </ExtensionPoint>
+            <ExtensionPoint xsi:type="AppointmentOrganizerCommandSurface">
+              <OfficeTab id="TabDefault">
+                <Group id="apptOrganizerGroupV1_1">
+                  <Label resid="GroupLabel"/>
+                  <Control xsi:type="Button" id="apptOrganizerOpenPaneButtonV1_1">
+                    <Label resid="TaskpaneButton.Label"/>
+                    <Supertip>
+                      <Title resid="TaskpaneButton.Label"/>
+                      <Description resid="TaskpaneButton.Tooltip"/>
+                    </Supertip>
+                    <Icon>
+                      <bt:Image size="16" resid="Icon.16x16"/>
+                      <bt:Image size="32" resid="Icon.32x32"/>
+                      <bt:Image size="80" resid="Icon.80x80"/>
+                    </Icon>
+                    <Action xsi:type="ShowTaskpane">
+                      <SourceLocation resid="Taskpane.Url"/>
+                      <SupportsPinning>true</SupportsPinning>
+                    </Action>
+                  </Control>
+                </Group>
+              </OfficeTab>
+            </ExtensionPoint>
+            <ExtensionPoint xsi:type="AppointmentAttendeeCommandSurface">
+              <OfficeTab id="TabDefault">
+                <Group id="apptAttendeeGroupV1_1">
+                  <Label resid="GroupLabel"/>
+                  <Control xsi:type="Button" id="apptAttendeeOpenPaneButtonV1_1">
                     <Label resid="TaskpaneButton.Label"/>
                     <Supertip>
                       <Title resid="TaskpaneButton.Label"/>


### PR DESCRIPTION
## Summary

Extends the existing Outlook add-in (previously mail-only) to also launch from calendar items, with two new default apps that mix the meeting context with an organizational knowledge base.

### Manifest
- Adds `AppointmentOrganizerCommandSurface` and `AppointmentAttendeeCommandSurface` extension points in both the V1_0 and V1_1 `VersionOverrides` blocks.
- Adds `<Rule xsi:type="ItemIs" ItemType="Appointment" FormType="Read|Edit"/>` so the taskpane is activatable on calendar items.
- Bumps the manifest `Version` from `1.0.0.0` to `1.1.0.0` and raises the required mailbox set to `1.3` (needed for AppointmentOrganizer/Attendee surfaces).

### Context extraction
- New `client/src/features/office/utilities/outlookCalendarContext.js` reads the current appointment: subject, start/end, organizer, required/optional attendees, location, body, and an `isOrganizer` flag. Handles both `AppointmentRead` (plain properties) and `AppointmentCompose` (`getAsync` callback) modes.
- Unified `fetchCurrentOutlookItemContext()` dispatches between mail and appointment based on `Office.context.mailbox.item.itemType`. Existing mail payloads gain an `itemKind: 'message'` marker; appointment payloads carry `itemKind: 'appointment'` so downstream components can branch cleanly.
- New `isOutlookAppointmentMode()` capability check for synchronous decisions in the chat panel.

### UI
- New `OfficeAppointmentContextBanner` shows meeting metadata (time, location, organizer with a "You" badge when the user is the organizer, required/optional attendees) and an "Include body" toggle that mirrors the mail banner.
- `OfficeContextStrip` detects the appointment branch and renders the meeting banner instead of the mail strip — pinned-emails toolbar and file attachments are suppressed because they don't apply to a single calendar item.
- `OfficeChatPanel` swaps starter-prompt sets based on the live `isAppointment` state (re-evaluated on every `ihub:itemchanged` event so users moving between Inbox and Calendar see the right prompts).

### Prompt building
- New `combineUserTextWithAppointmentContext()` builds a labeled `--- Current meeting ---` block with subject, role (Organizer/Attendee), time window, location, organizer, attendee lists, and description. The chat adapter routes to this builder when `itemKind === 'appointment'` and bypasses the email-body / pinned-emails / attachments path entirely.

### Default apps + knowledge base
- `meeting-agenda-generator` (organizer-facing): drafts a time-boxed agenda using the invite + knowledge base, citing knowledge-base sections inline.
- `meeting-briefing` (attendee-facing): produces a one-page prep brief (TL;DR, likely outcomes, attendees worth knowing, KB context, questions to bring, open gaps).
- Both reference a new `meeting-knowledge-base` filesystem source seeded with a sample markdown file. Admins can swap the binding in `config/sources.json` to point at a real wiki / iFinder / URL source.
- Migration `V039__add_calendar_integration.js` installs the new apps, registers the source, copies the sample markdown into `contents/sources/`, and seeds `officeIntegration.calendarStarterPrompts` — all idempotent and non-destructive to existing admin edits.

### Tradeoff worth flagging

Outlook add-ins can't access Teams transcripts or recordings, so the "meeting report" use case is scoped to what's in the invite + the knowledge base. Users wanting a real recap from spoken discussion need to paste in notes or wait for a Teams/Graph integration.

## Test plan

- [ ] Sideload the new manifest in an Outlook desktop client and confirm the iHub button appears on:
  - [ ] A message in the Inbox (read)
  - [ ] A draft message (compose)
  - [ ] A meeting from the calendar viewed as attendee
  - [ ] A meeting from the calendar viewed as organizer (own meeting)
- [ ] Open the taskpane from a calendar item, confirm the meeting banner shows subject, time, organizer, attendees, and the body preview with the "Include body" toggle.
- [ ] Confirm the calendar-specific starter prompts ("Draft an agenda…", "Prepare me for this meeting", "Who is attending and why?") appear in calendar mode and the email prompts appear in mail mode.
- [ ] Switch between an email and a meeting in Outlook — the taskpane should swap prompts and banner without needing a reload.
- [ ] Run `meeting-agenda-generator` from a calendar item and verify the model receives the structured `--- Current meeting ---` block plus the knowledge base contents.
- [ ] Run `meeting-briefing` from a calendar item where you are an attendee — verify the `isOrganizer: false` path produces an attendee-style brief.
- [ ] Confirm existing mail flows are unchanged: pinned emails, attachments, the email-body banner, the email starter prompts.
- [ ] Boot the server on a fresh `contents/` and on an existing one — verify `V039` runs successfully and that admin edits to existing files aren't overwritten.

https://claude.ai/code/session_018WrvTFQHAdJKofiqdbKKhC

---
_Generated by [Claude Code](https://claude.ai/code/session_018WrvTFQHAdJKofiqdbKKhC)_