### PR TITLE
feat(workflows): node-type form panels + editor UX polish

### DIFF
--- a/client/src/features/workflows/components/WorkflowCard.jsx
+++ b/client/src/features/workflows/components/WorkflowCard.jsx
@@ -9,8 +9,9 @@ import { useTechnicalDetailsToggle } from '../hooks/useTechnicalDetailsToggle';
  * @param {Object} props - Component props
  * @param {Object} props.workflow - Workflow definition object
  * @param {Function} props.onStart - Callback when start button is clicked
+ * @param {Function} [props.onEdit] - Optional callback when edit button is clicked (shown only if provided, typically for admins)
  */
-function WorkflowCard({ workflow, onStart }) {
+function WorkflowCard({ workflow, onStart, onEdit }) {
   const { t, i18n } = useTranslation();
   const currentLanguage = i18n.language;
   const [showTechnical] = useTechnicalDetailsToggle();
@@ -36,9 +37,19 @@ function WorkflowCard({ workflow, onStart }) {
           >
             <Icon name="workflow" className="text-indigo-600 dark:text-indigo-400 w-5 h-5" />
           </div>
-          <h3 className="font-semibold text-base text-gray-900 dark:text-white leading-snug">
+          <h3 className="font-semibold text-base text-gray-900 dark:text-white leading-snug flex-1">
             {name}
           </h3>
+          {onEdit && (
+            <button
+              onClick={() => onEdit(workflow)}
+              className="flex-shrink-0 p-1.5 -m-1.5 text-gray-400 hover:text-indigo-600 dark:text-gray-500 dark:hover:text-indigo-400 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              aria-label={t('workflows.card.edit', 'Edit workflow')}
+              title={t('workflows.card.edit', 'Edit workflow')}
+            >
+              <Icon name="pencil" className="w-4 h-4" aria-hidden="true" />
+            </button>
+          )}
         </div>
 
         <p className="text-gray-600 dark:text-gray-300 text-sm mb-4 line-clamp-3 flex-1">

--- a/client/src/features/workflows/editor/WorkflowEditor.jsx
+++ b/client/src/features/workflows/editor/WorkflowEditor.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   ReactFlow,
@@ -151,13 +151,38 @@ function WorkflowEditorInner({ initialNodes, initialEdges, onSave, onPublish }) 
     [setNodes]
   );
 
+  /** Delete a node and any edges connected to it; clear selection if it was selected */
+  const handleDeleteNode = useCallback(
+    nodeId => {
+      setNodes(nds => nds.filter(n => n.id !== nodeId));
+      setEdges(eds => eds.filter(e => e.source !== nodeId && e.target !== nodeId));
+      setSelectedNode(prev => (prev?.id === nodeId ? null : prev));
+    },
+    [setNodes, setEdges]
+  );
+
+  /**
+   * Nodes enriched with `nodeId` + `onDelete` (so the WorkflowNode can render
+   * an in-canvas delete button) and a `deletable` flag (start/end nodes are
+   * never deletable).
+   */
+  const enrichedNodes = useMemo(
+    () =>
+      nodes.map(n => ({
+        ...n,
+        deletable: n.data.nodeType !== 'start' && n.data.nodeType !== 'end',
+        data: { ...n.data, nodeId: n.id, onDelete: handleDeleteNode }
+      })),
+    [nodes, handleDeleteNode]
+  );
+
   return (
     <div className="flex h-full">
       <NodePalette onAddNode={handleAddNode} />
 
       <div className="flex-1 relative">
         <ReactFlow
-          nodes={nodes}
+          nodes={enrichedNodes}
           edges={edges}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}
@@ -204,6 +229,7 @@ function WorkflowEditorInner({ initialNodes, initialEdges, onSave, onPublish }) 
         <NodeConfigPanel
           selectedNode={selectedNode}
           onUpdateNode={handleUpdateNode}
+          onDeleteNode={handleDeleteNode}
           onClose={() => setSelectedNode(null)}
         />
       )}

--- a/client/src/features/workflows/editor/nodes/WorkflowNode.jsx
+++ b/client/src/features/workflows/editor/nodes/WorkflowNode.jsx
@@ -7,8 +7,10 @@ import { NODE_TYPE_COLORS } from '../workflowEditorUtils';
  * Displays the node type as a colored header, the node name, and a config preview.
  * Start nodes have no target handle; end nodes have no source handle.
  *
+ * Non-start/end nodes show a delete button on hover.
+ *
  * @param {object} props - React Flow node props
- * @param {object} props.data - Node data containing nodeType, nodeName, and nodeConfig
+ * @param {object} props.data - Node data: nodeType, nodeName, nodeConfig, nodeId, onDelete
  * @param {boolean} props.selected - Whether the node is currently selected
  */
 export const WorkflowNode = memo(function WorkflowNode({ data, selected }) {
@@ -33,12 +35,12 @@ export const WorkflowNode = memo(function WorkflowNode({ data, selected }) {
 
   return (
     <div
-      className={`rounded-lg shadow-md border-2 bg-white dark:bg-gray-800 min-w-[180px] max-w-[220px] ${
+      className={`group relative rounded-lg shadow-md border-2 bg-white dark:bg-gray-800 min-w-[180px] max-w-[220px] ${
         selected ? 'ring-2 ring-blue-400' : ''
       }`}
       style={{ borderColor: color }}
     >
-      {!isStart && <Handle type="target" position={Position.Top} className="!bg-gray-400" />}
+      {!isStart && <Handle type="target" position={Position.Left} className="!bg-gray-400" />}
 
       <div
         className="px-3 py-1.5 text-xs font-semibold text-white rounded-t-md"
@@ -46,6 +48,20 @@ export const WorkflowNode = memo(function WorkflowNode({ data, selected }) {
       >
         {data.nodeType}
       </div>
+
+      {!isStart && !isEnd && data.onDelete && (
+        <button
+          className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 bg-red-500 hover:bg-red-600 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs transition-opacity"
+          onClick={e => {
+            e.stopPropagation();
+            data.onDelete(data.nodeId);
+          }}
+          title="Delete node"
+          aria-label="Delete node"
+        >
+          &#x2715;
+        </button>
+      )}
 
       <div className="px-3 py-2">
         <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
@@ -56,7 +72,7 @@ export const WorkflowNode = memo(function WorkflowNode({ data, selected }) {
         )}
       </div>
 
-      {!isEnd && <Handle type="source" position={Position.Bottom} className="!bg-gray-400" />}
+      {!isEnd && <Handle type="source" position={Position.Right} className="!bg-gray-400" />}
     </div>
   );
 });

--- a/client/src/features/workflows/editor/panels/NodeConfigPanel.jsx
+++ b/client/src/features/workflows/editor/panels/NodeConfigPanel.jsx
@@ -1,71 +1,141 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { nodeFormRegistry } from './forms/index';
+import { NODE_TYPE_COLORS } from '../workflowEditorUtils';
 
 /**
- * Side panel for editing the selected workflow node's name and JSON configuration.
- * Validates JSON before applying changes. Appears on the right side of the editor
- * when a node is selected.
+ * Side panel for editing the selected workflow node's configuration.
+ * Provides both a structured form view (via nodeFormRegistry) and a raw JSON editor,
+ * switchable via tabs. Includes node deletion for non-start/end nodes.
  *
  * @param {object} props
  * @param {object} props.selectedNode - The currently selected React Flow node
  * @param {function} props.onUpdateNode - Callback to update node data: (nodeId, { nodeName, nodeConfig }) => void
  * @param {function} props.onClose - Callback to close the panel
+ * @param {function} props.onDeleteNode - Callback to delete a node: (nodeId) => void
  */
-export function NodeConfigPanel({ selectedNode, onUpdateNode, onClose }) {
+export function NodeConfigPanel({ selectedNode, onUpdateNode, onClose, onDeleteNode }) {
   const { t } = useTranslation();
   const [name, setName] = useState('');
+  const [config, setConfig] = useState({});
   const [configText, setConfigText] = useState('');
+  const [activeTab, setActiveTab] = useState('form');
   const [parseError, setParseError] = useState(null);
 
   useEffect(() => {
     if (selectedNode) {
       setName(selectedNode.data.nodeName || '');
-      setConfigText(JSON.stringify(selectedNode.data.nodeConfig || {}, null, 2));
+      const nodeConfig = selectedNode.data.nodeConfig || {};
+      setConfig(nodeConfig);
+      setConfigText(JSON.stringify(nodeConfig, null, 2));
+      setActiveTab('form');
       setParseError(null);
     }
   }, [selectedNode?.id]);
 
   if (!selectedNode) return null;
 
-  /** Validates the JSON config and applies changes to the node */
+  const nodeType = selectedNode.data.nodeType;
+  const FormComponent = nodeFormRegistry[nodeType];
+
+  /**
+   * Handles switching between form and JSON tabs.
+   * Syncs data between the two representations on switch.
+   * @param {'form' | 'json'} tab - The tab to switch to
+   */
+  const handleTabSwitch = tab => {
+    if (tab === 'json') {
+      setConfigText(JSON.stringify(config, null, 2));
+    } else if (tab === 'form') {
+      try {
+        const parsed = JSON.parse(configText);
+        setConfig(parsed);
+        setParseError(null);
+      } catch (e) {
+        setParseError(e.message);
+        return;
+      }
+    }
+    setActiveTab(tab);
+  };
+
+  const handleConfigChange = newConfig => {
+    setConfig(newConfig);
+  };
+
+  /** Validates and applies changes to the node */
   const handleApply = () => {
-    try {
-      const parsed = JSON.parse(configText);
-      setParseError(null);
-      onUpdateNode(selectedNode.id, {
-        nodeName: name,
-        nodeConfig: parsed
-      });
-    } catch (e) {
-      setParseError(e.message);
+    let finalConfig = config;
+    if (activeTab === 'json') {
+      try {
+        finalConfig = JSON.parse(configText);
+        setParseError(null);
+        setConfig(finalConfig);
+      } catch (e) {
+        setParseError(e.message);
+        return;
+      }
+    }
+    onUpdateNode(selectedNode.id, {
+      nodeName: name,
+      nodeConfig: finalConfig
+    });
+  };
+
+  const handleDelete = () => {
+    if (
+      onDeleteNode &&
+      window.confirm(t('workflows.editor.confirmDeleteNode', 'Delete this node?'))
+    ) {
+      onDeleteNode(selectedNode.id);
     }
   };
 
   return (
     <div className="w-80 border-l border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-4 overflow-y-auto">
       <div className="flex items-center justify-between mb-4">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
-          {t('workflows.editor.config', 'Configuration')}
-        </h3>
-        <button
-          onClick={onClose}
-          className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-          aria-label={t('common.close', 'Close')}
-        >
-          &#x2715;
-        </button>
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block w-3 h-3 rounded-full"
+            style={{ backgroundColor: NODE_TYPE_COLORS[nodeType] || '#6B7280' }}
+            aria-hidden="true"
+          />
+          <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">{nodeType}</span>
+        </div>
+        <div className="flex items-center gap-1">
+          {nodeType !== 'start' && nodeType !== 'end' && onDeleteNode && (
+            <button
+              onClick={handleDelete}
+              className="text-red-400 hover:text-red-600 p-1"
+              aria-label={t('workflows.editor.deleteNode', 'Delete node')}
+              title={t('workflows.editor.deleteNode', 'Delete node')}
+            >
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="w-4 h-4"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          )}
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1"
+            aria-label={t('common.close', 'Close')}
+          >
+            &#x2715;
+          </button>
+        </div>
       </div>
 
       <div className="space-y-4">
-        <div>
-          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
-            {t('workflows.editor.type', 'Type')}
-          </label>
-          <div className="text-sm text-gray-900 dark:text-gray-100 font-mono bg-gray-50 dark:bg-gray-900 px-2 py-1 rounded">
-            {selectedNode.data.nodeType}
-          </div>
-        </div>
-
         <div>
           <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
             {t('workflows.editor.name', 'Name')}
@@ -79,21 +149,54 @@ export function NodeConfigPanel({ selectedNode, onUpdateNode, onClose }) {
           />
         </div>
 
-        <div>
-          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
-            {t('workflows.editor.configJson', 'Config (JSON)')}
-          </label>
-          <textarea
-            value={configText}
-            onChange={e => {
-              setConfigText(e.target.value);
-              setParseError(null);
-            }}
-            rows={12}
-            className="w-full text-xs font-mono border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
-          />
-          {parseError && <p className="text-xs text-red-500 mt-1">{parseError}</p>}
+        <div className="flex border-b border-gray-200 dark:border-gray-700">
+          <button
+            onClick={() => handleTabSwitch('form')}
+            className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors ${
+              activeTab === 'form'
+                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'
+            }`}
+          >
+            {t('workflows.editor.formTab', 'Form')}
+          </button>
+          <button
+            onClick={() => handleTabSwitch('json')}
+            className={`px-3 py-1.5 text-xs font-medium border-b-2 transition-colors ${
+              activeTab === 'json'
+                ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-400'
+            }`}
+          >
+            {t('workflows.editor.jsonTab', 'JSON')}
+          </button>
         </div>
+
+        {activeTab === 'form' ? (
+          FormComponent ? (
+            <FormComponent config={config} onChange={handleConfigChange} />
+          ) : (
+            <div className="text-xs text-gray-500 dark:text-gray-400 italic">
+              {t(
+                'workflows.editor.noFormAvailable',
+                'No form available for this node type. Use the JSON tab.'
+              )}
+            </div>
+          )
+        ) : (
+          <div>
+            <textarea
+              value={configText}
+              onChange={e => {
+                setConfigText(e.target.value);
+                setParseError(null);
+              }}
+              rows={12}
+              className="w-full text-xs font-mono border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            />
+            {parseError && <p className="text-xs text-red-500 mt-1">{parseError}</p>}
+          </div>
+        )}
 
         <button
           onClick={handleApply}

--- a/client/src/features/workflows/editor/panels/forms/ArrayField.jsx
+++ b/client/src/features/workflows/editor/panels/forms/ArrayField.jsx
@@ -1,0 +1,57 @@
+function ArrayField({ label, value = [], onChange, placeholder }) {
+  const items = Array.isArray(value) ? value : [];
+
+  const handleChange = (index, newVal) => {
+    const updated = [...items];
+    updated[index] = newVal;
+    onChange(updated);
+  };
+
+  const handleRemove = index => {
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  const handleAdd = () => {
+    onChange([...items, '']);
+  };
+
+  return (
+    <div>
+      {label && (
+        <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+          {label}
+        </label>
+      )}
+      <div className="space-y-1.5">
+        {items.map((item, index) => (
+          <div key={index} className="flex items-center gap-1.5">
+            <input
+              type="text"
+              value={item}
+              onChange={e => handleChange(index, e.target.value)}
+              placeholder={placeholder}
+              className="flex-1 text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+            />
+            <button
+              type="button"
+              onClick={() => handleRemove(index)}
+              className="text-red-500 hover:text-red-700 dark:hover:text-red-400 p-1 text-sm shrink-0"
+              aria-label="Remove item"
+            >
+              &#x2715;
+            </button>
+          </div>
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={handleAdd}
+        className="mt-1.5 text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 flex items-center gap-1"
+      >
+        <span>+</span> Add
+      </button>
+    </div>
+  );
+}
+
+export default ArrayField;

--- a/client/src/features/workflows/editor/panels/forms/CodeForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/CodeForm.jsx
@@ -1,0 +1,33 @@
+import FormField from './FormField';
+
+function CodeForm({ config, onChange }) {
+  return (
+    <div className="space-y-3">
+      <FormField
+        label="Code"
+        type="textarea"
+        rows={10}
+        value={config.code}
+        onChange={v => onChange({ ...config, code: v })}
+        placeholder="// Your code here..."
+      />
+      <FormField
+        label="Timeout"
+        type="number"
+        value={config.timeout}
+        onChange={v => onChange({ ...config, timeout: v })}
+        min={100}
+        step={1000}
+        placeholder="ms"
+      />
+      <FormField
+        label="Output Variable"
+        value={config.outputVariable}
+        onChange={v => onChange({ ...config, outputVariable: v })}
+        placeholder="e.g. codeResult"
+      />
+    </div>
+  );
+}
+
+export default CodeForm;

--- a/client/src/features/workflows/editor/panels/forms/DecisionForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/DecisionForm.jsx
@@ -1,0 +1,51 @@
+import FormField from './FormField';
+
+function DecisionForm({ config, onChange }) {
+  const type = config.type || 'expression';
+
+  return (
+    <div className="space-y-3">
+      <FormField
+        label="Type"
+        type="select"
+        value={type}
+        onChange={v => onChange({ ...config, type: v })}
+        options={[
+          { value: 'expression', label: 'Expression' },
+          { value: 'switch', label: 'Switch' }
+        ]}
+      />
+
+      {type === 'expression' ? (
+        <FormField
+          label="Expression"
+          type="textarea"
+          rows={4}
+          value={config.expression}
+          onChange={v => onChange({ ...config, expression: v })}
+          placeholder="e.g. state.score > 0.8"
+        />
+      ) : (
+        <>
+          <FormField
+            label="Variable"
+            value={config.variable}
+            onChange={v => onChange({ ...config, variable: v })}
+            placeholder="e.g. state.category"
+          />
+          <FormField
+            label="Default Branch"
+            value={config.defaultBranch}
+            onChange={v => onChange({ ...config, defaultBranch: v })}
+            placeholder="e.g. default"
+          />
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            Use JSON tab for complex switch conditions
+          </p>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default DecisionForm;

--- a/client/src/features/workflows/editor/panels/forms/EndForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/EndForm.jsx
@@ -1,0 +1,41 @@
+import FormField from './FormField';
+import ArrayField from './ArrayField';
+
+function EndForm({ config, onChange }) {
+  return (
+    <div className="space-y-3">
+      <ArrayField
+        label="Output Variables"
+        value={config.outputVariables}
+        onChange={v => onChange({ ...config, outputVariables: v })}
+        placeholder="Variable name"
+      />
+      <FormField
+        label="Output Format"
+        type="select"
+        value={config.outputFormat}
+        onChange={v => onChange({ ...config, outputFormat: v })}
+        options={[
+          { value: '', label: '— default —' },
+          { value: 'json', label: 'JSON' },
+          { value: 'text', label: 'Text' },
+          { value: 'raw', label: 'Raw' }
+        ]}
+      />
+      <FormField
+        label="Include Node Outputs"
+        type="checkbox"
+        value={config.includeNodeOutputs}
+        onChange={v => onChange({ ...config, includeNodeOutputs: v })}
+      />
+      <FormField
+        label="Include Metadata"
+        type="checkbox"
+        value={config.includeMetadata}
+        onChange={v => onChange({ ...config, includeMetadata: v })}
+      />
+    </div>
+  );
+}
+
+export default EndForm;

--- a/client/src/features/workflows/editor/panels/forms/FormField.jsx
+++ b/client/src/features/workflows/editor/panels/forms/FormField.jsx
@@ -1,0 +1,68 @@
+function FormField({
+  label,
+  type = 'text',
+  value,
+  onChange,
+  options,
+  placeholder,
+  helpText,
+  min,
+  max,
+  step,
+  rows
+}) {
+  const inputClass =
+    'w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100';
+  const labelClass = 'block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1';
+
+  if (type === 'checkbox') {
+    return (
+      <label className="flex items-center gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={!!value}
+          onChange={e => onChange(e.target.checked)}
+          className="rounded border-gray-300 dark:border-gray-600"
+        />
+        <span className="text-sm text-gray-700 dark:text-gray-300">{label}</span>
+      </label>
+    );
+  }
+
+  return (
+    <div>
+      <label className={labelClass}>{label}</label>
+      {type === 'textarea' ? (
+        <textarea
+          value={value ?? ''}
+          onChange={e => onChange(e.target.value)}
+          rows={rows || 4}
+          placeholder={placeholder}
+          className={`${inputClass} font-mono`}
+        />
+      ) : type === 'select' ? (
+        <select value={value ?? ''} onChange={e => onChange(e.target.value)} className={inputClass}>
+          {(options || []).map(opt => (
+            <option key={opt.value ?? opt} value={opt.value ?? opt}>
+              {opt.label ?? opt}
+            </option>
+          ))}
+        </select>
+      ) : (
+        <input
+          type={type}
+          value={value ?? ''}
+          onChange={e => onChange(type === 'number' ? Number(e.target.value) : e.target.value)}
+          placeholder={placeholder}
+          min={min}
+          max={max}
+          step={step}
+          className={inputClass}
+        />
+      )}
+      {helpText && <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{helpText}</p>}
+    </div>
+  );
+}
+
+export default FormField;

--- a/client/src/features/workflows/editor/panels/forms/HttpForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/HttpForm.jsx
@@ -1,0 +1,120 @@
+import FormField from './FormField';
+
+function HttpForm({ config, onChange }) {
+  const auth = config.auth || {};
+  const authType = auth.type || 'none';
+
+  const onAuth = (field, value) => {
+    onChange({ ...config, auth: { ...auth, [field]: value } });
+  };
+
+  return (
+    <div className="space-y-3">
+      <FormField
+        label="URL"
+        value={config.url}
+        onChange={v => onChange({ ...config, url: v })}
+        placeholder="https://..."
+      />
+      <FormField
+        label="Method"
+        type="select"
+        value={config.method}
+        onChange={v => onChange({ ...config, method: v })}
+        options={['GET', 'POST', 'PUT', 'DELETE', 'PATCH']}
+      />
+      <FormField
+        label="Headers"
+        type="textarea"
+        rows={4}
+        value={config.headers}
+        onChange={v => onChange({ ...config, headers: v })}
+        placeholder="JSON object"
+      />
+      <FormField
+        label="Body"
+        type="textarea"
+        rows={4}
+        value={config.body}
+        onChange={v => onChange({ ...config, body: v })}
+        placeholder="Request body..."
+      />
+
+      <h4 className="text-xs font-semibold text-gray-700 dark:text-gray-300 pt-2 border-t border-gray-200 dark:border-gray-700">
+        Authentication
+      </h4>
+      <FormField
+        label="Type"
+        type="select"
+        value={authType}
+        onChange={v => onAuth('type', v)}
+        options={[
+          { value: 'none', label: 'None' },
+          { value: 'bearer', label: 'Bearer' },
+          { value: 'basic', label: 'Basic' },
+          { value: 'apiKey', label: 'API Key' }
+        ]}
+      />
+      {authType === 'bearer' && (
+        <FormField
+          label="Token"
+          value={auth.token}
+          onChange={v => onAuth('token', v)}
+          placeholder="Bearer token"
+        />
+      )}
+      {authType === 'basic' && (
+        <>
+          <FormField label="Username" value={auth.username} onChange={v => onAuth('username', v)} />
+          <FormField label="Password" value={auth.password} onChange={v => onAuth('password', v)} />
+        </>
+      )}
+      {authType === 'apiKey' && (
+        <>
+          <FormField
+            label="Header Name"
+            value={auth.headerName}
+            onChange={v => onAuth('headerName', v)}
+            placeholder="e.g. X-API-Key"
+          />
+          <FormField label="Value" value={auth.value} onChange={v => onAuth('value', v)} />
+        </>
+      )}
+
+      <FormField
+        label="Timeout"
+        type="number"
+        value={config.timeout}
+        onChange={v => onChange({ ...config, timeout: v })}
+        min={1000}
+        step={1000}
+        placeholder="ms"
+      />
+      <FormField
+        label="Response Type"
+        type="select"
+        value={config.responseType}
+        onChange={v => onChange({ ...config, responseType: v })}
+        options={[
+          { value: 'json', label: 'JSON' },
+          { value: 'text', label: 'Text' },
+          { value: 'binary', label: 'Binary' }
+        ]}
+      />
+      <FormField
+        label="Output Variable"
+        value={config.outputVariable}
+        onChange={v => onChange({ ...config, outputVariable: v })}
+        placeholder="e.g. httpResponse"
+      />
+      <FormField
+        label="Fail on Error"
+        type="checkbox"
+        value={config.failOnError}
+        onChange={v => onChange({ ...config, failOnError: v })}
+      />
+    </div>
+  );
+}
+
+export default HttpForm;

--- a/client/src/features/workflows/editor/panels/forms/HumanForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/HumanForm.jsx
@@ -1,0 +1,113 @@
+import FormField from './FormField';
+import LocalizedField from './LocalizedField';
+
+const STYLE_OPTIONS = [
+  { value: 'primary', label: 'Primary' },
+  { value: 'secondary', label: 'Secondary' },
+  { value: 'danger', label: 'Danger' }
+];
+
+function HumanForm({ config, onChange }) {
+  const options = Array.isArray(config.options) ? config.options : [];
+
+  const updateOption = (index, field, value) => {
+    const updated = options.map((opt, i) => (i === index ? { ...opt, [field]: value } : opt));
+    onChange({ ...config, options: updated });
+  };
+
+  const addOption = () => {
+    onChange({
+      ...config,
+      options: [...options, { value: '', label: '', style: 'primary' }]
+    });
+  };
+
+  const removeOption = index => {
+    onChange({ ...config, options: options.filter((_, i) => i !== index) });
+  };
+
+  const inputClass =
+    'w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100';
+  const labelClass = 'block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1';
+
+  return (
+    <div className="space-y-3">
+      <LocalizedField
+        label="Message"
+        rows={4}
+        value={config.message}
+        onChange={v => onChange({ ...config, message: v })}
+        placeholder="What should the user be asked?"
+      />
+      <div>
+        <label className={labelClass}>Options</label>
+        <div className="space-y-2">
+          {options.map((opt, index) => (
+            <div
+              key={index}
+              className="border border-gray-200 dark:border-gray-700 rounded p-2 flex items-center gap-1.5"
+            >
+              <input
+                type="text"
+                value={opt.value || ''}
+                onChange={e => updateOption(index, 'value', e.target.value)}
+                placeholder="Value"
+                className={`flex-1 ${inputClass}`}
+              />
+              <input
+                type="text"
+                value={opt.label || ''}
+                onChange={e => updateOption(index, 'label', e.target.value)}
+                placeholder="Label"
+                className={`flex-1 ${inputClass}`}
+              />
+              <select
+                value={opt.style || 'primary'}
+                onChange={e => updateOption(index, 'style', e.target.value)}
+                className={`w-28 ${inputClass}`}
+              >
+                {STYLE_OPTIONS.map(s => (
+                  <option key={s.value} value={s.value}>
+                    {s.label}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() => removeOption(index)}
+                className="text-red-500 hover:text-red-700 dark:hover:text-red-400 p-1 text-sm shrink-0"
+                aria-label="Remove option"
+              >
+                &#x2715;
+              </button>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={addOption}
+          className="mt-1.5 text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 flex items-center gap-1"
+        >
+          <span>+</span> Add option
+        </button>
+      </div>
+      <FormField
+        label="Timeout (ms)"
+        type="number"
+        value={config.timeout}
+        onChange={v => onChange({ ...config, timeout: v })}
+        min={1000}
+        step={1000}
+        placeholder="ms"
+      />
+      <FormField
+        label="Output Variable"
+        value={config.outputVariable}
+        onChange={v => onChange({ ...config, outputVariable: v })}
+        placeholder="e.g. userResponse"
+      />
+    </div>
+  );
+}
+
+export default HumanForm;

--- a/client/src/features/workflows/editor/panels/forms/JoinForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/JoinForm.jsx
@@ -1,0 +1,34 @@
+import FormField from './FormField';
+import ArrayField from './ArrayField';
+
+function JoinForm({ config, onChange }) {
+  return (
+    <div className="space-y-3">
+      <FormField
+        label="Strategy"
+        type="select"
+        value={config.strategy}
+        onChange={v => onChange({ ...config, strategy: v })}
+        options={[
+          { value: 'all', label: 'all' },
+          { value: 'any', label: 'any' },
+          { value: 'majority', label: 'majority' }
+        ]}
+      />
+      <ArrayField
+        label="Input Variables"
+        value={config.inputVariables}
+        onChange={v => onChange({ ...config, inputVariables: v })}
+        placeholder="Variable name"
+      />
+      <FormField
+        label="Output Variable"
+        value={config.outputVariable}
+        onChange={v => onChange({ ...config, outputVariable: v })}
+        placeholder="e.g. joinedResult"
+      />
+    </div>
+  );
+}
+
+export default JoinForm;

--- a/client/src/features/workflows/editor/panels/forms/LocalizedField.jsx
+++ b/client/src/features/workflows/editor/panels/forms/LocalizedField.jsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+
+const COMMON_LANGS = ['en', 'de', 'fr', 'es', 'it', 'ja', 'zh'];
+
+function LocalizedField({ label, value, onChange, placeholder, rows = 4 }) {
+  const isObject = value !== null && typeof value === 'object' && !Array.isArray(value);
+  const langs = isObject ? Object.keys(value) : [];
+  const [activeLang, setActiveLang] = useState(langs[0] || 'en');
+
+  const inputClass =
+    'w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 font-mono';
+  const labelClass = 'block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1';
+
+  if (!isObject) {
+    return (
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <label className="text-xs font-medium text-gray-600 dark:text-gray-400">{label}</label>
+          <button
+            type="button"
+            onClick={() => onChange({ en: value || '' })}
+            className="text-xs text-blue-500 hover:text-blue-600"
+            title="Convert to multilingual"
+          >
+            + i18n
+          </button>
+        </div>
+        <textarea
+          value={value ?? ''}
+          onChange={e => onChange(e.target.value)}
+          rows={rows}
+          placeholder={placeholder}
+          className={inputClass}
+        />
+      </div>
+    );
+  }
+
+  const currentLang = langs.includes(activeLang) ? activeLang : langs[0] || 'en';
+  const availableToAdd = COMMON_LANGS.filter(l => !langs.includes(l));
+
+  const handleLangChange = newText => {
+    onChange({ ...value, [currentLang]: newText });
+  };
+
+  const addLang = lang => {
+    onChange({ ...value, [lang]: '' });
+    setActiveLang(lang);
+  };
+
+  const removeLang = lang => {
+    if (langs.length <= 1) return;
+    const next = { ...value };
+    delete next[lang];
+    onChange(next);
+    if (currentLang === lang) setActiveLang(Object.keys(next)[0]);
+  };
+
+  return (
+    <div>
+      <label className={labelClass}>{label}</label>
+      <div className="flex items-center gap-1 mb-1 flex-wrap">
+        {langs.map(lang => (
+          <button
+            key={lang}
+            type="button"
+            onClick={() => setActiveLang(lang)}
+            className={`px-2 py-0.5 text-xs rounded transition-colors ${
+              currentLang === lang
+                ? 'bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300 font-medium'
+                : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-gray-600'
+            }`}
+          >
+            {lang}
+          </button>
+        ))}
+        {availableToAdd.length > 0 && (
+          <select
+            value=""
+            onChange={e => {
+              if (e.target.value) addLang(e.target.value);
+            }}
+            className="text-xs border border-dashed border-gray-300 dark:border-gray-600 rounded px-1 py-0.5 bg-transparent text-gray-500"
+          >
+            <option value="">+</option>
+            {availableToAdd.map(l => (
+              <option key={l} value={l}>
+                {l}
+              </option>
+            ))}
+          </select>
+        )}
+        {langs.length > 1 && (
+          <button
+            type="button"
+            onClick={() => removeLang(currentLang)}
+            className="text-xs text-red-400 hover:text-red-600 ml-1"
+            title={`Remove ${currentLang}`}
+          >
+            &#x2715;
+          </button>
+        )}
+      </div>
+      <textarea
+        value={value[currentLang] ?? ''}
+        onChange={e => handleLangChange(e.target.value)}
+        rows={rows}
+        placeholder={placeholder}
+        className={inputClass}
+      />
+    </div>
+  );
+}
+
+export default LocalizedField;

--- a/client/src/features/workflows/editor/panels/forms/LoopForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/LoopForm.jsx
@@ -1,0 +1,63 @@
+import FormField from './FormField';
+
+function LoopForm({ config, onChange }) {
+  const mode = config.mode || 'for';
+
+  return (
+    <div className="space-y-3">
+      <FormField
+        label="Mode"
+        type="select"
+        value={mode}
+        onChange={v => onChange({ ...config, mode: v })}
+        options={[
+          { value: 'for', label: 'for' },
+          { value: 'forEach', label: 'forEach' },
+          { value: 'while', label: 'while' }
+        ]}
+      />
+      {mode === 'for' && (
+        <FormField
+          label="Count"
+          type="number"
+          value={config.count}
+          onChange={v => onChange({ ...config, count: v })}
+          min={1}
+        />
+      )}
+      {mode === 'forEach' && (
+        <FormField
+          label="Array"
+          value={config.array}
+          onChange={v => onChange({ ...config, array: v })}
+          placeholder="e.g. ${items}"
+        />
+      )}
+      {mode === 'while' && (
+        <FormField
+          label="Condition"
+          type="textarea"
+          rows={3}
+          value={config.condition}
+          onChange={v => onChange({ ...config, condition: v })}
+          placeholder="Loop condition..."
+        />
+      )}
+      <FormField
+        label="Max Iterations"
+        type="number"
+        value={config.maxIterations}
+        onChange={v => onChange({ ...config, maxIterations: v })}
+        min={1}
+      />
+      <FormField
+        label="Output Variable"
+        value={config.outputVariable}
+        onChange={v => onChange({ ...config, outputVariable: v })}
+        placeholder="e.g. loopResults"
+      />
+    </div>
+  );
+}
+
+export default LoopForm;

--- a/client/src/features/workflows/editor/panels/forms/MemoryForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/MemoryForm.jsx
@@ -1,0 +1,45 @@
+import FormField from './FormField';
+
+function MemoryForm({ config, onChange }) {
+  const operation = config.operation || 'get';
+
+  return (
+    <div className="space-y-3">
+      <FormField
+        label="Operation"
+        type="select"
+        value={operation}
+        onChange={v => onChange({ ...config, operation: v })}
+        options={[
+          { value: 'get', label: 'get' },
+          { value: 'set', label: 'set' },
+          { value: 'delete', label: 'delete' }
+        ]}
+      />
+      <FormField
+        label="Key"
+        value={config.key}
+        onChange={v => onChange({ ...config, key: v })}
+        placeholder="Memory key"
+      />
+      {operation === 'set' && (
+        <FormField
+          label="Value"
+          type="textarea"
+          rows={4}
+          value={config.value}
+          onChange={v => onChange({ ...config, value: v })}
+          placeholder="Value to store..."
+        />
+      )}
+      <FormField
+        label="Output Variable"
+        value={config.outputVariable}
+        onChange={v => onChange({ ...config, outputVariable: v })}
+        placeholder="e.g. memoryValue"
+      />
+    </div>
+  );
+}
+
+export default MemoryForm;

--- a/client/src/features/workflows/editor/panels/forms/ParallelForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/ParallelForm.jsx
@@ -1,0 +1,19 @@
+import FormField from './FormField';
+
+function ParallelForm({ config, onChange }) {
+  return (
+    <div className="space-y-3">
+      <FormField
+        label="Output Variable"
+        value={config.outputVariable}
+        onChange={v => onChange({ ...config, outputVariable: v })}
+        placeholder="e.g. parallelResults"
+      />
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Configure parallel branches by connecting multiple nodes from this node&apos;s output.
+      </p>
+    </div>
+  );
+}
+
+export default ParallelForm;

--- a/client/src/features/workflows/editor/panels/forms/PlannerForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/PlannerForm.jsx
@@ -1,0 +1,94 @@
+import { useCallback } from 'react';
+import FormField from './FormField';
+import LocalizedField from './LocalizedField';
+import ResourcePicker from './ResourcePicker';
+import { fetchModels } from '../../../../../api/endpoints/models';
+import { fetchTools } from '../../../../../api/endpoints/admin';
+
+function PlannerForm({ config, onChange }) {
+  const tt = config.taskTemplate || {};
+
+  const onTT = (field, value) => {
+    onChange({ ...config, taskTemplate: { ...tt, [field]: value } });
+  };
+
+  const fetchToolsFn = useCallback(() => fetchTools(), []);
+  const fetchModelsFn = useCallback(() => fetchModels(), []);
+
+  return (
+    <div className="space-y-3">
+      <LocalizedField
+        label="Goal"
+        rows={4}
+        value={config.goal}
+        onChange={v => onChange({ ...config, goal: v })}
+        placeholder="Describe the planning goal..."
+      />
+      <LocalizedField
+        label="System Prompt"
+        rows={4}
+        value={config.system}
+        onChange={v => onChange({ ...config, system: v })}
+        placeholder="System instructions for the planner..."
+      />
+      <LocalizedField
+        label="User Prompt"
+        rows={4}
+        value={config.prompt}
+        onChange={v => onChange({ ...config, prompt: v })}
+        placeholder="Prompt template with {{variables}}..."
+      />
+      <FormField
+        label="Max Tasks"
+        type="number"
+        value={config.maxTasks}
+        onChange={v => onChange({ ...config, maxTasks: v })}
+        min={1}
+        max={100}
+      />
+      <FormField
+        label="Synthesize"
+        type="checkbox"
+        value={config.synthesize}
+        onChange={v => onChange({ ...config, synthesize: v })}
+      />
+      <FormField
+        label="Max Depth"
+        type="number"
+        value={config.maxDepth}
+        onChange={v => onChange({ ...config, maxDepth: v })}
+        min={1}
+        max={10}
+      />
+
+      <h4 className="text-xs font-semibold text-gray-700 dark:text-gray-300 pt-2 border-t border-gray-200 dark:border-gray-700">
+        Task Template
+      </h4>
+      <ResourcePicker
+        label="Tools"
+        fetchFn={fetchToolsFn}
+        value={tt.tools}
+        onChange={v => onTT('tools', v)}
+        multi
+        placeholder="Search tools..."
+      />
+      <ResourcePicker
+        label="Model ID"
+        fetchFn={fetchModelsFn}
+        value={tt.modelId}
+        onChange={v => onTT('modelId', v)}
+        placeholder="Search models..."
+      />
+      <FormField
+        label="Max Iterations"
+        type="number"
+        value={tt.maxIterations}
+        onChange={v => onTT('maxIterations', v)}
+        min={1}
+        max={50}
+      />
+    </div>
+  );
+}
+
+export default PlannerForm;

--- a/client/src/features/workflows/editor/panels/forms/PromptForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/PromptForm.jsx
@@ -1,0 +1,129 @@
+import { useState, useCallback } from 'react';
+import FormField from './FormField';
+import LocalizedField from './LocalizedField';
+import ResourcePicker from './ResourcePicker';
+import { fetchModels } from '../../../../../api/endpoints/models';
+import { fetchTools } from '../../../../../api/endpoints/admin';
+import { fetchAdminSources } from '../../../../../api/adminApi';
+
+function PromptForm({ config, onChange }) {
+  const [schemaText, setSchemaText] = useState(() => {
+    try {
+      return config.outputSchema ? JSON.stringify(config.outputSchema, null, 2) : '';
+    } catch {
+      return '';
+    }
+  });
+
+  const handleSchemaChange = text => {
+    setSchemaText(text);
+    if (!text.trim()) {
+      onChange({ ...config, outputSchema: undefined });
+      return;
+    }
+    try {
+      const parsed = JSON.parse(text);
+      onChange({ ...config, outputSchema: parsed });
+    } catch {
+      // invalid JSON, keep text but don't update config
+    }
+  };
+
+  const fetchSources = useCallback(() => fetchAdminSources(), []);
+  const fetchToolsFn = useCallback(() => fetchTools(), []);
+  const fetchModelsFn = useCallback(() => fetchModels(), []);
+
+  const inputClass =
+    'w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100';
+  const labelClass = 'block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1';
+
+  return (
+    <div className="space-y-3">
+      <LocalizedField
+        label="System Prompt"
+        rows={6}
+        value={config.system}
+        onChange={v => onChange({ ...config, system: v })}
+        placeholder="System instructions for the prompt..."
+      />
+      <LocalizedField
+        label="User Prompt"
+        rows={4}
+        value={config.prompt}
+        onChange={v => onChange({ ...config, prompt: v })}
+        placeholder="Prompt template with {{variables}}..."
+      />
+      <ResourcePicker
+        label="Model ID"
+        fetchFn={fetchModelsFn}
+        value={config.modelId}
+        onChange={v => onChange({ ...config, modelId: v })}
+        placeholder="Search models..."
+      />
+      <FormField
+        label="Temperature"
+        type="number"
+        value={config.temperature}
+        onChange={v => onChange({ ...config, temperature: v })}
+        min={0}
+        max={2}
+        step={0.1}
+      />
+      <FormField
+        label="Max Tokens"
+        type="number"
+        value={config.maxTokens}
+        onChange={v => onChange({ ...config, maxTokens: v })}
+        min={1}
+      />
+      <ResourcePicker
+        label="Tools"
+        fetchFn={fetchToolsFn}
+        value={config.tools}
+        onChange={v => onChange({ ...config, tools: v })}
+        multi
+        placeholder="Search tools..."
+      />
+      <ResourcePicker
+        label="Sources"
+        fetchFn={fetchSources}
+        value={config.sources}
+        onChange={v => onChange({ ...config, sources: v })}
+        multi
+        placeholder="Search sources..."
+      />
+      <FormField
+        label="Max Iterations"
+        type="number"
+        value={config.maxIterations}
+        onChange={v => onChange({ ...config, maxIterations: v })}
+        min={1}
+        max={50}
+      />
+      <FormField
+        label="Output Variable"
+        value={config.outputVariable}
+        onChange={v => onChange({ ...config, outputVariable: v })}
+        placeholder="e.g. promptResult"
+      />
+      <div>
+        <label className={labelClass}>Output Schema (JSON)</label>
+        <textarea
+          value={schemaText}
+          onChange={e => handleSchemaChange(e.target.value)}
+          rows={4}
+          placeholder='{"type": "object", "properties": {...}}'
+          className={`${inputClass} font-mono`}
+        />
+      </div>
+      <FormField
+        label="Auto Summarize"
+        type="checkbox"
+        value={config.autoSummarize}
+        onChange={v => onChange({ ...config, autoSummarize: v })}
+      />
+    </div>
+  );
+}
+
+export default PromptForm;

--- a/client/src/features/workflows/editor/panels/forms/ResourcePicker.jsx
+++ b/client/src/features/workflows/editor/panels/forms/ResourcePicker.jsx
@@ -1,0 +1,191 @@
+import { useState, useRef, useEffect } from 'react';
+
+/**
+ * Compact searchable picker for platform resources (tools, models, sources).
+ *
+ * @param {object} props
+ * @param {string} props.label - Field label
+ * @param {Function} props.fetchFn - Async function returning array of { id, name, description? }
+ * @param {string|string[]} props.value - Selected ID (single) or IDs (multi)
+ * @param {Function} props.onChange - Callback with selected ID(s)
+ * @param {boolean} [props.multi=false] - Multi-select mode
+ * @param {string} [props.placeholder] - Search placeholder
+ * @param {Function} [props.getItemLabel] - Custom label extractor (item) => string
+ */
+function ResourcePicker({
+  label,
+  fetchFn,
+  value,
+  onChange,
+  multi = false,
+  placeholder = 'Search...',
+  getItemLabel
+}) {
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const ref = useRef(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchFn();
+        if (!cancelled) setItems(Array.isArray(data) ? data : []);
+      } catch {
+        if (!cancelled) setItems([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchFn]);
+
+  useEffect(() => {
+    const handleClick = e => {
+      if (ref.current && !ref.current.contains(e.target)) {
+        setOpen(false);
+        setSearch('');
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  const itemLabel = item => {
+    if (getItemLabel) return getItemLabel(item);
+    if (typeof item.name === 'object')
+      return item.name.en || Object.values(item.name)[0] || item.id;
+    return item.name || item.id;
+  };
+
+  const selectedIds = multi ? (Array.isArray(value) ? value : []) : [];
+  const selectedId = multi ? null : value || '';
+
+  const filtered = items.filter(item => {
+    if (multi && selectedIds.includes(item.id)) return false;
+    if (!multi && selectedId === item.id) return false;
+    if (!search) return true;
+    const text = `${itemLabel(item)} ${item.id}`.toLowerCase();
+    return text.includes(search.toLowerCase());
+  });
+
+  const handleSelect = item => {
+    if (multi) {
+      onChange([...selectedIds, item.id]);
+    } else {
+      onChange(item.id);
+    }
+    setSearch('');
+    setOpen(false);
+  };
+
+  const handleRemove = id => {
+    if (multi) {
+      onChange(selectedIds.filter(i => i !== id));
+    } else {
+      onChange('');
+    }
+  };
+
+  const inputClass =
+    'w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100';
+  const labelClass = 'block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1';
+
+  const renderTags = ids =>
+    ids.map(id => {
+      const item = items.find(i => i.id === id);
+      return (
+        <span
+          key={id}
+          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-300"
+        >
+          {item ? itemLabel(item) : id}
+          <button
+            type="button"
+            onClick={() => handleRemove(id)}
+            className="text-blue-500 hover:text-blue-700 dark:hover:text-blue-300"
+            aria-label={`Remove ${id}`}
+          >
+            &#x2715;
+          </button>
+        </span>
+      );
+    });
+
+  return (
+    <div ref={ref}>
+      <label className={labelClass}>{label}</label>
+
+      {/* Selected tags (multi) or selected value (single) */}
+      {multi && selectedIds.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-1">{renderTags(selectedIds)}</div>
+      )}
+      {!multi && selectedId && (
+        <div className="flex flex-wrap gap-1 mb-1">{renderTags([selectedId])}</div>
+      )}
+
+      {/* Search input */}
+      <div className="relative">
+        <input
+          type="text"
+          value={search}
+          onChange={e => {
+            setSearch(e.target.value);
+            setOpen(true);
+          }}
+          onFocus={() => setOpen(true)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && filtered.length > 0) {
+              handleSelect(filtered[0]);
+              e.preventDefault();
+            }
+            if (e.key === 'Escape') {
+              setOpen(false);
+              setSearch('');
+            }
+          }}
+          placeholder={placeholder}
+          className={inputClass}
+          autoComplete="off"
+        />
+
+        {/* Dropdown */}
+        {open && (
+          <div className="absolute z-20 mt-1 w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded shadow-lg max-h-48 overflow-auto">
+            {loading ? (
+              <div className="px-2 py-1.5 text-xs text-gray-500 dark:text-gray-400">Loading...</div>
+            ) : filtered.length > 0 ? (
+              filtered.map(item => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => handleSelect(item)}
+                  className="w-full text-left px-2 py-1.5 text-sm hover:bg-gray-100 dark:hover:bg-gray-700 border-b border-gray-100 dark:border-gray-700 last:border-b-0"
+                >
+                  <div className="font-medium text-gray-900 dark:text-gray-100 text-xs">
+                    {itemLabel(item)}
+                  </div>
+                  {item.id !== itemLabel(item) && (
+                    <div className="text-xs text-gray-400 dark:text-gray-500">{item.id}</div>
+                  )}
+                </button>
+              ))
+            ) : (
+              <div className="px-2 py-1.5 text-xs text-gray-500 dark:text-gray-400">
+                {search ? 'No matches' : 'No items available'}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ResourcePicker;

--- a/client/src/features/workflows/editor/panels/forms/StartForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/StartForm.jsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import LocalizedField from './LocalizedField';
+
+const TYPE_OPTIONS = [
+  { value: 'string', label: 'String' },
+  { value: 'number', label: 'Number' },
+  { value: 'boolean', label: 'Boolean' },
+  { value: 'array', label: 'Array' },
+  { value: 'object', label: 'Object' }
+];
+
+function StartForm({ config, onChange }) {
+  const vars = Array.isArray(config.inputVariables) ? config.inputVariables : [];
+
+  const updateVar = (index, field, value) => {
+    const updated = vars.map((v, i) => (i === index ? { ...v, [field]: value } : v));
+    onChange({ ...config, inputVariables: updated });
+  };
+
+  const addVar = () => {
+    onChange({
+      ...config,
+      inputVariables: [...vars, { name: '', type: 'string', required: false, description: '' }]
+    });
+  };
+
+  const removeVar = index => {
+    onChange({ ...config, inputVariables: vars.filter((_, i) => i !== index) });
+  };
+
+  const [defaultsText, setDefaultsText] = useState(() => {
+    try {
+      return config.defaults ? JSON.stringify(config.defaults, null, 2) : '';
+    } catch {
+      return '';
+    }
+  });
+
+  const handleDefaultsChange = text => {
+    setDefaultsText(text);
+    if (!text.trim()) {
+      onChange({ ...config, defaults: undefined });
+      return;
+    }
+    try {
+      const parsed = JSON.parse(text);
+      onChange({ ...config, defaults: parsed });
+    } catch {
+      // invalid JSON, keep text but don't update config
+    }
+  };
+
+  const inputClass =
+    'w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100';
+  const labelClass = 'block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1';
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className={labelClass}>Input Variables</label>
+        <div className="space-y-2">
+          {vars.map((v, index) => (
+            <div
+              key={index}
+              className="border border-gray-200 dark:border-gray-700 rounded p-2 space-y-1.5"
+            >
+              <div className="flex items-center gap-1.5">
+                <input
+                  type="text"
+                  value={v.name || ''}
+                  onChange={e => updateVar(index, 'name', e.target.value)}
+                  placeholder="Variable name"
+                  className={`flex-1 ${inputClass}`}
+                />
+                <select
+                  value={v.type || 'string'}
+                  onChange={e => updateVar(index, 'type', e.target.value)}
+                  className={`w-24 ${inputClass}`}
+                >
+                  {TYPE_OPTIONS.map(opt => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+                <label className="flex items-center gap-1 text-xs text-gray-600 dark:text-gray-400 shrink-0">
+                  <input
+                    type="checkbox"
+                    checked={!!v.required}
+                    onChange={e => updateVar(index, 'required', e.target.checked)}
+                    className="rounded border-gray-300 dark:border-gray-600"
+                  />
+                  Req
+                </label>
+                <button
+                  type="button"
+                  onClick={() => removeVar(index)}
+                  className="text-red-500 hover:text-red-700 dark:hover:text-red-400 p-1 text-sm shrink-0"
+                  aria-label="Remove variable"
+                >
+                  &#x2715;
+                </button>
+              </div>
+              <LocalizedField
+                label="Description"
+                rows={2}
+                value={v.description}
+                onChange={val => updateVar(index, 'description', val)}
+                placeholder="Variable description..."
+              />
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={addVar}
+          className="mt-1.5 text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 flex items-center gap-1"
+        >
+          <span>+</span> Add variable
+        </button>
+      </div>
+
+      <div>
+        <label className={labelClass}>Defaults (JSON)</label>
+        <textarea
+          value={defaultsText}
+          onChange={e => handleDefaultsChange(e.target.value)}
+          rows={4}
+          placeholder='{"key": "default value"}'
+          className={`${inputClass} font-mono`}
+        />
+        <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+          Default values for workflow state variables
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default StartForm;

--- a/client/src/features/workflows/editor/panels/forms/ToolForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/ToolForm.jsx
@@ -1,0 +1,36 @@
+import { useCallback } from 'react';
+import FormField from './FormField';
+import ResourcePicker from './ResourcePicker';
+import { fetchTools } from '../../../../../api/endpoints/admin';
+
+function ToolForm({ config, onChange }) {
+  const fetchToolsFn = useCallback(() => fetchTools(), []);
+
+  return (
+    <div className="space-y-3">
+      <ResourcePicker
+        label="Tool Name"
+        fetchFn={fetchToolsFn}
+        value={config.toolName}
+        onChange={v => onChange({ ...config, toolName: v })}
+        placeholder="Search tools..."
+      />
+      <FormField
+        label="Parameters"
+        type="textarea"
+        rows={6}
+        value={config.parameters}
+        onChange={v => onChange({ ...config, parameters: v })}
+        placeholder="JSON object"
+      />
+      <FormField
+        label="Output Variable"
+        value={config.outputVariable}
+        onChange={v => onChange({ ...config, outputVariable: v })}
+        placeholder="e.g. toolResult"
+      />
+    </div>
+  );
+}
+
+export default ToolForm;

--- a/client/src/features/workflows/editor/panels/forms/TransformForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/TransformForm.jsx
@@ -1,0 +1,200 @@
+const OP_TYPES = [
+  { value: 'set', label: 'Set' },
+  { value: 'copy', label: 'Copy' },
+  { value: 'push', label: 'Push' },
+  { value: 'increment', label: 'Increment' },
+  { value: 'merge', label: 'Merge' },
+  { value: 'arrayGet', label: 'Array Get' },
+  { value: 'lengthOf', label: 'Length Of' },
+  { value: 'condition', label: 'Condition' }
+];
+
+const OP_TYPE_KEYS = OP_TYPES.map(t => t.value);
+
+/**
+ * Server format uses the operation type as a key, e.g.:
+ *   { copy: "source.path", to: "target.path" }
+ *   { set: "state.result", value: "hello" }
+ * Detect which key is the operation type.
+ */
+function detectOpType(op) {
+  for (const key of OP_TYPE_KEYS) {
+    if (key in op) return key;
+  }
+  return 'set';
+}
+
+/**
+ * Field definitions for each operation type.
+ * `primaryLabel` describes the type-key's value.
+ * `fields` are the additional fields.
+ */
+const OP_FIELDS = {
+  set: {
+    primaryLabel: 'Path',
+    primaryPlaceholder: 'e.g. state.result',
+    fields: [{ key: 'value', label: 'Value', placeholder: 'Value or expression' }]
+  },
+  copy: {
+    primaryLabel: 'From',
+    primaryPlaceholder: 'e.g. state.input',
+    fields: [{ key: 'to', label: 'To', placeholder: 'e.g. state.output' }]
+  },
+  push: {
+    primaryLabel: 'Item',
+    primaryPlaceholder: 'Value to push',
+    fields: [{ key: 'to', label: 'Array Path', placeholder: 'e.g. state.items' }]
+  },
+  increment: {
+    primaryLabel: 'Path',
+    primaryPlaceholder: 'e.g. state.counter',
+    fields: [{ key: 'by', label: 'By', placeholder: '1', type: 'number' }]
+  },
+  merge: {
+    primaryLabel: 'Source',
+    primaryPlaceholder: 'e.g. state.data',
+    fields: [{ key: 'into', label: 'Into', placeholder: 'e.g. state.merged' }]
+  },
+  arrayGet: {
+    primaryLabel: 'Array Path',
+    primaryPlaceholder: 'e.g. state.items',
+    fields: [
+      { key: 'index', label: 'Index', placeholder: '0', type: 'number' },
+      { key: 'to', label: 'To', placeholder: 'e.g. state.item' }
+    ]
+  },
+  lengthOf: {
+    primaryLabel: 'Array Path',
+    primaryPlaceholder: 'e.g. state.items',
+    fields: [{ key: 'to', label: 'To', placeholder: 'e.g. state.count' }]
+  },
+  condition: {
+    primaryLabel: 'Condition',
+    primaryPlaceholder: 'Condition expression',
+    fields: [
+      { key: 'then', label: 'Then', placeholder: 'Value if true' },
+      { key: 'else', label: 'Else', placeholder: 'Value if false' },
+      { key: 'to', label: 'To', placeholder: 'e.g. state.result' }
+    ]
+  }
+};
+
+function TransformForm({ config, onChange }) {
+  const operations = Array.isArray(config.operations) ? config.operations : [];
+
+  const updateOp = (index, field, value) => {
+    const updated = operations.map((op, i) => (i === index ? { ...op, [field]: value } : op));
+    onChange({ ...config, operations: updated });
+  };
+
+  const updatePrimary = (index, opType, value) => {
+    const updated = operations.map((op, i) => (i === index ? { ...op, [opType]: value } : op));
+    onChange({ ...config, operations: updated });
+  };
+
+  const changeOpType = (index, newType) => {
+    const updated = operations.map((op, i) => {
+      if (i !== index) return op;
+      const oldType = detectOpType(op);
+      // Remove old type key, add new type key with the old primary value
+      const { [oldType]: oldValue, ...rest } = op;
+      return { [newType]: oldValue || '', ...rest };
+    });
+    onChange({ ...config, operations: updated });
+  };
+
+  const addOp = () => {
+    onChange({ ...config, operations: [...operations, { set: '' }] });
+  };
+
+  const removeOp = index => {
+    onChange({ ...config, operations: operations.filter((_, i) => i !== index) });
+  };
+
+  const inputClass =
+    'w-full text-sm border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100';
+  const labelClass = 'block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1';
+
+  return (
+    <div className="space-y-3">
+      <label className={labelClass}>Operations</label>
+      <div className="space-y-2">
+        {operations.map((op, index) => {
+          const opType = detectOpType(op);
+          const spec = OP_FIELDS[opType] || OP_FIELDS.set;
+          return (
+            <div
+              key={index}
+              className="border border-gray-200 dark:border-gray-700 rounded p-2 space-y-1.5"
+            >
+              <div className="flex items-center gap-1.5">
+                <select
+                  value={opType}
+                  onChange={e => changeOpType(index, e.target.value)}
+                  className={`flex-1 ${inputClass}`}
+                >
+                  {OP_TYPES.map(t => (
+                    <option key={t.value} value={t.value}>
+                      {t.label}
+                    </option>
+                  ))}
+                </select>
+                <button
+                  type="button"
+                  onClick={() => removeOp(index)}
+                  className="text-red-500 hover:text-red-700 dark:hover:text-red-400 p-1 text-sm shrink-0"
+                  aria-label="Remove operation"
+                >
+                  &#x2715;
+                </button>
+              </div>
+              {/* Primary field: the value of the type key */}
+              <div>
+                <label className="block text-xs text-gray-500 dark:text-gray-400 mb-0.5">
+                  {spec.primaryLabel}
+                </label>
+                <input
+                  type="text"
+                  value={op[opType] ?? ''}
+                  onChange={e => updatePrimary(index, opType, e.target.value)}
+                  placeholder={spec.primaryPlaceholder}
+                  className={inputClass}
+                />
+              </div>
+              {/* Secondary fields */}
+              {spec.fields.map(f => (
+                <div key={f.key}>
+                  <label className="block text-xs text-gray-500 dark:text-gray-400 mb-0.5">
+                    {f.label}
+                  </label>
+                  <input
+                    type={f.type || 'text'}
+                    value={op[f.key] ?? ''}
+                    onChange={e =>
+                      updateOp(
+                        index,
+                        f.key,
+                        f.type === 'number' ? Number(e.target.value) : e.target.value
+                      )
+                    }
+                    placeholder={f.placeholder}
+                    className={inputClass}
+                  />
+                </div>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={addOp}
+        className="text-xs text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 flex items-center gap-1"
+      >
+        <span>+</span> Add operation
+      </button>
+    </div>
+  );
+}
+
+export default TransformForm;

--- a/client/src/features/workflows/editor/panels/forms/VerifierForm.jsx
+++ b/client/src/features/workflows/editor/panels/forms/VerifierForm.jsx
@@ -1,0 +1,41 @@
+import FormField from './FormField';
+import LocalizedField from './LocalizedField';
+
+function VerifierForm({ config, onChange }) {
+  return (
+    <div className="space-y-3">
+      <LocalizedField
+        label="Criteria"
+        rows={4}
+        value={config.criteria}
+        onChange={v => onChange({ ...config, criteria: v })}
+        placeholder="Verification criteria..."
+      />
+      <FormField
+        label="Input Variable"
+        value={config.inputVariable}
+        onChange={v => onChange({ ...config, inputVariable: v })}
+        placeholder="e.g. promptResult"
+      />
+      <FormField
+        label="Threshold"
+        type="number"
+        value={config.threshold}
+        onChange={v => onChange({ ...config, threshold: v })}
+        min={0}
+        max={1}
+        step={0.1}
+      />
+      <FormField
+        label="Max Retries"
+        type="number"
+        value={config.maxRetries}
+        onChange={v => onChange({ ...config, maxRetries: v })}
+        min={0}
+        max={10}
+      />
+    </div>
+  );
+}
+
+export default VerifierForm;

--- a/client/src/features/workflows/editor/panels/forms/index.js
+++ b/client/src/features/workflows/editor/panels/forms/index.js
@@ -1,0 +1,33 @@
+import StartForm from './StartForm';
+import EndForm from './EndForm';
+import PromptForm from './PromptForm';
+import PlannerForm from './PlannerForm';
+import VerifierForm from './VerifierForm';
+import DecisionForm from './DecisionForm';
+import LoopForm from './LoopForm';
+import ParallelForm from './ParallelForm';
+import JoinForm from './JoinForm';
+import TransformForm from './TransformForm';
+import HttpForm from './HttpForm';
+import CodeForm from './CodeForm';
+import HumanForm from './HumanForm';
+import ToolForm from './ToolForm';
+import MemoryForm from './MemoryForm';
+
+export const nodeFormRegistry = {
+  start: StartForm,
+  end: EndForm,
+  prompt: PromptForm,
+  planner: PlannerForm,
+  verifier: VerifierForm,
+  decision: DecisionForm,
+  loop: LoopForm,
+  parallel: ParallelForm,
+  join: JoinForm,
+  transform: TransformForm,
+  http: HttpForm,
+  code: CodeForm,
+  human: HumanForm,
+  tool: ToolForm,
+  memory: MemoryForm
+};

--- a/client/src/features/workflows/editor/workflowEditorUtils.js
+++ b/client/src/features/workflows/editor/workflowEditorUtils.js
@@ -66,6 +66,14 @@ export function workflowToFlow(workflow) {
       edge.condition?.type && edge.condition.type !== 'always' ? edge.condition.type : undefined
   }));
 
+  // Auto-layout when the workflow has no saved positions (every node sits at origin).
+  // Typically happens for newly-created workflows that haven't been arranged yet.
+  const needsLayout =
+    nodes.length > 1 && nodes.every(n => n.position.x === 0 && n.position.y === 0);
+  if (needsLayout) {
+    return { nodes: applyDagreLayout(nodes, edges), edges };
+  }
+
   return { nodes, edges };
 }
 
@@ -102,7 +110,7 @@ export function flowToWorkflow(rfNodes, rfEdges, existingWorkflow) {
 }
 
 /**
- * Applies automatic Dagre-based layout to position nodes in a top-to-bottom hierarchy.
+ * Applies automatic Dagre-based layout to position nodes in a left-to-right flow.
  * Useful when importing workflows that have no position data, or to tidy up a messy graph.
  *
  * @param {object[]} nodes - React Flow node array
@@ -112,7 +120,7 @@ export function flowToWorkflow(rfNodes, rfEdges, existingWorkflow) {
 export function applyDagreLayout(nodes, edges) {
   const g = new dagre.graphlib.Graph();
   g.setDefaultEdgeLabel(() => ({}));
-  g.setGraph({ rankdir: 'TB', ranksep: 80, nodesep: 60 });
+  g.setGraph({ rankdir: 'LR', ranksep: 80, nodesep: 60 });
 
   nodes.forEach(node => {
     g.setNode(node.id, { width: 200, height: 80 });

--- a/client/src/features/workflows/pages/WorkflowListTab.jsx
+++ b/client/src/features/workflows/pages/WorkflowListTab.jsx
@@ -25,6 +25,10 @@ function WorkflowListTab() {
     setShowStartModal(true);
   };
 
+  const handleEditClick = workflow => {
+    navigate(`/admin/workflows/${workflow.id}/edit`);
+  };
+
   const handleModalClose = () => {
     setShowStartModal(false);
     setSelectedWorkflow(null);
@@ -98,7 +102,12 @@ function WorkflowListTab() {
     <>
       <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         {workflows.map(workflow => (
-          <WorkflowCard key={workflow.id} workflow={workflow} onStart={handleStartClick} />
+          <WorkflowCard
+            key={workflow.id}
+            workflow={workflow}
+            onStart={handleStartClick}
+            onEdit={isAdmin ? handleEditClick : undefined}
+          />
         ))}
       </div>
 


### PR DESCRIPTION
## Summary

Brings the missing **modular form-panel system** into the workflow editor. PR #1478 merged the broader workflows feature into `main`, but it was based on an older snapshot that didn't include the per-node-type forms refactor. This PR backfills that work on top of the latest `claude/review-workflow-ui-m0bdt` branch (which already contains the user-facing UI polish + the `agent → prompt` node-type rename).

## What this adds

### Editor (node config side-panel)
- **Form/JSON tab switcher** in `NodeConfigPanel`. The Form tab picks a structured form from a registry by `nodeType`; the JSON tab keeps the raw editor as a fallback. Switching tabs syncs data both directions.
- **Type badge** with color dot in the panel header, replacing the bare "Configuration" title.
- **Delete button** in the side panel (start/end nodes excluded), plus a **hover-reveal × button** on the node itself.
- **Left-to-right auto-layout**: \`applyDagreLayout\` switched from \`TB\` → \`LR\`; \`workflowToFlow\` auto-runs dagre when all nodes still sit at (0,0) — newly-created workflows no longer open as a stack at the origin. Handles on \`WorkflowNode\` moved to Left/Right to match.

### New \`forms/\` directory (15 form components + 4 shared field primitives)
- **Control flow**: Start, End, Decision, Loop, Parallel, Join
- **AI / agentic**: **Prompt** (renamed from \`AgentForm\` to match the server-side \`PromptNodeExecutor\` rename in \`ec8ef44e\`), Planner, Verifier, Memory
- **Integration / IO**: Http, Code, Transform, Tool, Human
- **Primitives**: \`FormField\`, \`ArrayField\`, \`LocalizedField\`, \`ResourcePicker\` (the picker hits \`fetchModels\`, \`fetchTools\`, and \`fetchAdminSources\` to populate dropdowns)

### Workflow list
- **\`WorkflowCard\`**: optional \`onEdit\` prop renders a small pencil icon-button in the card header (kept secondary so the Start CTA stays the primary action; fits the new left-border-accent design from \`12f7c053\`).
- **\`WorkflowListTab\`**: passes \`onEdit\` to \`WorkflowCard\` for admins, routing to \`/admin/workflows/:id/edit\`.

## Why a PR against \`claude/review-workflow-ui-m0bdt\`, not \`main\`

The target branch already has 4 commits in flight that this work needs to compose with (UI redesign, human-in-chat, executions list features, \`agent → prompt\` rename). Targeting it directly lets this PR land on top of the in-progress review work without forcing a rebase later.

## Notes / nuances

- **No new translation keys committed** to locale JSON. New \`t()\` calls use inline English fallbacks (\`t('workflows.editor.formTab', 'Form')\` etc.) — the keys can be backfilled into the locale files in a follow-up i18n pass.
- **\`agent → prompt\`**: \`AgentForm.jsx\` was renamed to \`PromptForm.jsx\`, the registry key changed from \`agent\` to \`prompt\`, and stale placeholder copy (\`e.g. agentResult\`) was updated to \`promptResult\` in \`VerifierForm.jsx\` too.
- **Lint**: \`npm run lint:fix && npm run format:fix\` clean (only pre-existing repo-wide warnings remain; the single error in \`client/src/services/i18nService.js\` predates this branch).

## Test plan

- [ ] \`npm run dev\` and open \`/admin/workflows/new/edit\` — confirm the canvas opens left-to-right.
- [ ] Add a \`prompt\` node → click it → confirm the **Form** tab renders \`PromptForm\` fields (System Prompt, User Prompt, Model picker, Temperature, Tools picker, etc.).
- [ ] Switch to the **JSON** tab and back — edits in either view should survive the round-trip; invalid JSON should keep you on the JSON tab with a parse error.
- [ ] Add \`decision\`, \`http\`, \`transform\`, \`human\` nodes — each should render its dedicated form.
- [ ] Hover a \`prompt\` node → confirm the × button appears → click → node + connected edges removed.
- [ ] Click \`start\` node → confirm no × button (start/end aren't deletable).
- [ ] As admin, visit \`/workflows\` → confirm cards show the pencil icon next to the workflow name → clicking it lands on \`/admin/workflows/:id/edit\`.
- [ ] As non-admin (or anonymous), the pencil should be absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)