### PR TITLE
Admin UI redesign: enterprise-ready IA proposal (draft)

### DIFF
--- a/concepts/admin-redesign-2026/2026-05-19 Admin UI Redesign Design Brief.md
+++ b/concepts/admin-redesign-2026/2026-05-19 Admin UI Redesign Design Brief.md
@@ -1,0 +1,613 @@
+# UI/UX Brief: iHub Apps Admin Redesign
+
+**Author:** Design System Custodian
+**Date:** 2026-05-19
+**Status:** Design proposal, paired with PM brief, pending engineering synthesis
+**Audience:** Engineering (implementation), Product (alignment), Junior designers (continuation)
+
+---
+
+## Executive Summary
+
+The iHub Apps admin has grown from a handful of pages to 30+, but the chrome has not evolved with it. A flat top-tab bar with three pinned items and a "More" dropdown of 20+ entries is the dominant pain: discoverability is poor, hierarchy is invisible, and the dashboard is a tile launcher with no signal. The redesign moves to a **collapsible left-rail sidebar with grouped sections, a global Cmd+K command palette, an enterprise-grade overview dashboard, and three reusable page templates** (List/CRUD, Settings, Integration Hub). It introduces consistent "needs attention" surfaces, a setup checklist for fresh instances, and an opinionated information architecture that splits LLM provider credentials from identity management. Phase 1 ships the chrome and dashboard; Phase 2 unifies page patterns; Phase 3 layers in the command palette and power-user features.
+
+This brief is opinionated by design. Where the user asked for a recommendation, you get one with rationale, not a menu.
+
+---
+
+## 1. Design Principles & Inspiration
+
+### Enterprise admin UIs worth borrowing from
+
+| Product | Specific pattern to borrow | Why it fits iHub |
+|---|---|---|
+| **Stripe Dashboard** | Left rail with collapsible section groups, persistent search at the top of the rail, "test mode" pill in the topbar | Stripe carries ~40 admin surfaces gracefully; the rail breathes by collapsing/expanding sections instead of dropdowns |
+| **Vercel Dashboard** | Project-scoped left nav, contextual sub-nav per section, top breadcrumb with project switcher | iHub has "instance-scoped" admin; the same pattern of a context selector + section nav reads well |
+| **Linear Settings** | Two-pane settings: left list of sub-sections, right detail pane with sticky save bar | This is the gold standard for sectioned forms with dirty-state UX — perfect for Authentication, OAuth, UI Customization |
+| **GitHub Org Settings** | Settings sidebar grouped by domain (Access, Code, Security, Integrations); breadcrumbs everywhere | Mirrors our IA grouping almost 1:1; their breadcrumbs anchor users in deep settings trees |
+| **Supabase Dashboard** | Compact left rail with icon+label, deep but discoverable sub-nav, "Reports" tab with stats-as-cards | Their density level is right for technical admins — info-rich, no luxury whitespace |
+| **PlanetScale** | "Insights" landing page with stat cards above fold + activity feed below | Direct template for our new Overview dashboard |
+| **Okta Admin** | Cmd+K command palette covering every admin action, including config toggles | The bar to clear for our search-first navigation |
+| **Microsoft Entra** | Status badges on nav items ("3 alerts" inline), centralized health/notification pane | Models our "needs attention" indicators well |
+| **AWS Console (2023 redesign)** | Persistent search-first UX, favorites/pinning per user, recently visited services | Their pinning pattern is the right answer to "customization for power users" |
+| **Notion Workspace Settings** | Two-column form pattern with section anchors in a right-aligned mini-TOC | Useful for very long settings pages (e.g., System) |
+
+### The 7 design principles for the new admin
+
+1. **Progressive disclosure over flat dumps.** Group 30+ pages into 6 navigable sections. Never show more than 7 to 9 sibling items at one tier without sub-grouping.
+2. **Search-first navigation.** Cmd+K is the fastest path for anyone past their first week. Every action, page, and entity is reachable by typing.
+3. **Stats and signal on landing, not just links.** The Overview shows the health of the instance, surfaces what needs attention, and offers quick actions. It is not a launcher of tiles.
+4. **One CRUD pattern to rule them all.** Apps, Models, Prompts, Users, Groups, Tools, Sources, Pages, Short Links all use the same list page anatomy. Learn it once.
+5. **Inline status, not hidden status.** Misconfigurations, expired credentials, overdue backups, and pending updates surface as badges on nav items and banners on relevant pages — not buried in detail pages.
+6. **Density by default, breathing room on request.** Enterprise admins read tables, not heroes. Default to compact density with an explicit "comfortable" toggle. Whitespace is functional, not decorative.
+7. **Consistency over cleverness.** Every list page has the same toolbar shape. Every settings page has the same save bar. Every hub page has the same status pill. Surprise is friction.
+
+---
+
+## 2. Navigation Pattern
+
+### Recommendation: confirmed — collapsible left-rail sidebar
+
+You leaned toward a collapsible left sidebar. **I agree, and I'll push the recommendation further: not "hybrid", just a clean single-rail sidebar.** Rationale:
+
+- **Top-tabs do not scale past ~6 items.** You are already at 24 surfaces and growing. Top-tabs force the "More" dropdown which is the root cause of discoverability pain.
+- **Hybrid (thin icon rail + contextual sub-nav)** looks elegant but doubles the chrome and forces a mental model of "section vs. page". For 30 pages it is more cognitive work, not less. Hybrid works for products with 6 to 8 deep verticals (Slack, Discord). iHub's admin is broad but shallow.
+- **Single collapsible rail** is the dominant enterprise pattern (Stripe, Vercel, Supabase, GitHub Settings, Linear) precisely because it scales gracefully.
+
+### Section layout
+
+```
+Overview
+AI Workspace          (expandable)
+Access & Identity     (expandable)
+Integrations          (expandable)
+Customization         (expandable)
+Observability         (expandable)
+Platform              (expandable)
+```
+
+Six top sections, plus Overview. Final IA in section 7 below.
+
+### Sub-item behavior
+
+- **Section is expandable on click**, not on hover. Hover is unreliable on touch, jittery on desktop.
+- **Active section is auto-expanded** on page load. The user's current location is always visible.
+- **Other sections collapse by default**, but their state is remembered per user (localStorage) so power users can pin two sections open.
+- **No second-level groups inside a section.** Every section is at most 9 items. If it grows past 9 we split the section, we do not nest deeper.
+- **Active page** highlighted with a left accent bar (3px wide, indigo-600) and a subtle background tint. Sibling text remains readable.
+
+### Collapse modes
+
+- **Expanded (default, ~256px wide):** icon + label.
+- **Collapsed (~64px wide):** icon only, label appears in a flyout tooltip on hover. Section group flyout opens on hover for collapsed state — this is the one place hover is acceptable because the rail is clearly an icon rail.
+- **State persisted per user.** Toggle button at the bottom of the rail.
+
+### Mobile pattern
+
+- **< 768px:** Sidebar becomes an off-canvas drawer. Topbar gains a hamburger icon (left) and a search icon (right, opens command palette).
+- **Bottom nav: no.** Enterprise admins on mobile are a tiny audience and bottom nav fits 4 to 5 sections, not 6 to 7. Off-canvas drawer is the right call.
+
+### Command palette and search
+
+- **Search input lives at the top of the left rail in expanded mode** (placeholder: "Search admin... Cmd+K"). Click or Cmd+K opens the full palette as a centered modal.
+- In collapsed mode, the search icon is the second item from the top, below the logo.
+- In the topbar, Cmd+K is also surfaced as a small pill on the right side ("Search Cmd+K") so it is discoverable for users who never expand the rail.
+
+### Breadcrumbs
+
+- **Yes, but minimal.** Show breadcrumbs only when depth > 2 (e.g., `Apps / Customer Service Bot / Variables`). On list pages (depth 1 within a section), the H1 is enough.
+- Breadcrumbs sit in the topbar, left-aligned, below the topbar's horizontal rule — they are part of page header context, not the global chrome.
+
+### ASCII wireframe — chrome
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [iHub Apps]  Admin           Breadcrumbs >                  [v3.4]  [Search Cmd+K]  [Bell 3]  [Avatar] │
+├────────────────┬─────────────────────────────────────────────────────────────┤
+│                │                                                             │
+│ [Search...   ] │  Page H1                                          [Primary] │
+│                │  Subtitle / count                                           │
+│ ⌂ Overview     │  ───────────────────────────────────────────────────────── │
+│                │                                                             │
+│ ▼ AI Workspace │  [Filters]  [Search]                          [View ⊞ ☰]   │
+│   • Apps    12 │  ───────────────────────────────────────────────────────── │
+│   • Models   8 │                                                             │
+│   • Prompts 32 │   Content area (list, form, hub grid, dashboard)            │
+│   • Tools   14 │                                                             │
+│   • Skills   2 │                                                             │
+│   • Sources 11 │                                                             │
+│   • Workflows  │                                                             │
+│   • Marketplace│                                                             │
+│                │                                                             │
+│ ▶ Access & ID  │                                                             │
+│ ▶ Integrations │                                                             │
+│ ▶ Customization│                                                             │
+│ ▶ Observability│                                                             │
+│ ▶ Platform   ⚠ │                                                             │
+│                │                                                             │
+│                │                                                             │
+│ [«Collapse]    │                                                             │
+└────────────────┴─────────────────────────────────────────────────────────────┘
+```
+
+The `⚠` on Platform is the inline status indicator pattern (described in section 6). The count next to each item ("Apps 12") is an optional density-aware metadata badge — shown when expanded, hidden when collapsed.
+
+---
+
+## 3. Dashboard / Overview Redesign
+
+The 12-tile launcher is a dead end. The new Overview is an **enterprise health dashboard**: stats first, signal second, navigation third.
+
+### ASCII wireframe — Overview (mature instance)
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Overview                                                                    │
+│  iHub Apps  •  v3.4.1  •  Up 14d 6h                                          │
+│  ────────────────────────────────────────────────────────────────────────── │
+│                                                                              │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐    │
+│  │ Apps    │ │ Users   │ │ Chats   │ │ Tokens  │ │ Errors  │ │ Latency │    │
+│  │  42     │ │ 318     │ │ 12,847  │ │ 4.2M    │ │ 0.18%   │ │ 1.2s    │    │
+│  │ ▲ 3 mo  │ │ ▲ 24 mo │ │ ▲ 18%   │ │ ▲ 22%   │ │ ▼ 0.4pp │ │ ▼ 80ms  │    │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘ └─────────┘ └─────────┘    │
+│                                                                              │
+│  ⚠ Needs your attention                                                      │
+│  ────────────────────────────────────────────────────────────────────────── │
+│  ●  Anthropic provider key invalid — last test failed 2h ago  [Fix →]       │
+│  ●  Backup overdue (last: 8 days ago, target: weekly)         [Run now →]   │
+│  ●  iHub v3.5.0 available (security patch)                    [Review →]    │
+│  ○  3 users awaiting group assignment                         [Assign →]    │
+│                                                                              │
+│  Quick actions                                                               │
+│  ┌──────────────┐ ┌──────────────┐ ┌──────────────┐ ┌──────────────┐        │
+│  │ + New app    │ │ + Invite user│ │ + Add model  │ │ View logs    │        │
+│  └──────────────┘ └──────────────┘ └──────────────┘ └──────────────┘        │
+│                                                                              │
+│  Recent activity                                          [View audit log →] │
+│  ────────────────────────────────────────────────────────────────────────── │
+│  14:32  J. Doe       updated app "Sales Assistant"                          │
+│  14:18  System       backup completed (228 MB)                              │
+│  13:51  A. Smith     created group "EU Compliance"                          │
+│  13:42  S. Patel     rotated API key for OpenAI provider                    │
+│  12:09  System       model "claude-opus-4-7" sync OK                        │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Stat card spec
+
+- 6 cards, 1 row on desktop (>= 1280px), 3x2 on tablet, 2x3 on mobile.
+- Each card: label, large value, trend delta (arrow + delta) over selected window (default: last 30 days).
+- Window selector in the page header (today / 7d / 30d / 90d).
+- Clicking a card deep-links to the relevant detail (Tokens → Usage Reports, Errors → Logging).
+
+### Needs-your-attention spec
+
+- A list, not a card grid. Severity dots: red ● critical, amber ● warning, blue ○ info.
+- Maximum 5 items shown; "See all (12) →" link if more.
+- Each row has a single primary action verb ("Fix", "Run now", "Review", "Assign"). No kebab menus here — keep it skimmable.
+- If empty: "All systems healthy." with a small green checkmark icon and a `last checked 2m ago` timestamp.
+
+### Quick actions
+
+- 4 buttons. Top-down user research will refine — sensible defaults: New app, Invite user, Add model, View logs.
+- Customizable per user in v2 (out of Phase 1).
+
+### Recent activity
+
+- 5 rows from the audit trail. If audit log does not exist yet (it does not — recommend adding it), seed from existing telemetry events.
+- "View audit log →" link sends user to Observability > Audit Log.
+
+### Fresh instance vs. mature instance
+
+**Fresh instance (Day 1):**
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Welcome to iHub Apps                                                        │
+│  Let's get your instance ready.                                              │
+│  ────────────────────────────────────────────────────────────────────────── │
+│                                                                              │
+│  Setup checklist                                                  3 / 7 done │
+│  ────────────────────────────────────────────────────────────────────────── │
+│  ✓  Install complete                                                         │
+│  ✓  Local admin account created                                              │
+│  ✓  Default groups configured                                                │
+│  ○  Configure an LLM provider                            [Add provider →]   │
+│  ○  Create your first AI app                             [Create app →]     │
+│  ○  Connect an identity provider (optional)              [Set up SSO →]     │
+│  ○  Review platform settings                             [Open settings →]  │
+│                                                                              │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │  Skip setup, I'll explore on my own                                  │   │
+│  └──────────────────────────────────────────────────────────────────────┘   │
+│                                                                              │
+│  Learn the basics                                                            │
+│  → 2-min tour    → Documentation    → Examples gallery                       │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+- Stat cards hidden until there is data (avoid showing 0 / 0 / 0 / 0).
+- Checklist collapses to a 1-line banner at top of dashboard once 100% complete: "Setup complete. [Hide]"
+- Empty states throughout the admin link back to the relevant checklist step.
+
+**Mature instance** = the full dashboard above. Threshold: count of apps > 0 AND number of users > 5 AND age > 7 days.
+
+---
+
+## 4. Page-level Patterns
+
+Three reusable page templates. Every page in the admin will be one of these three.
+
+### 4.1 List / CRUD Page
+
+Used by: Apps, Models, Prompts, Tools, Skills, Sources, Pages, Short Links, Users, Groups, Workflows.
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Apps                                                       [+ New app  ▼]   │
+│  42 apps  •  38 enabled                                                      │
+│  ────────────────────────────────────────────────────────────────────────── │
+│                                                                              │
+│  [Search...]  [Category ▾] [Status ▾] [Owner ▾]   [Sort ▾]    [☰ ⊞]  [⋯]   │
+│  ────────────────────────────────────────────────────────────────────────── │
+│                                                                              │
+│  ☐  Name              Status    Owner       Updated      Models    Actions  │
+│  ────────────────────────────────────────────────────────────────────────── │
+│  ☐  Sales Assistant   ● live    J. Doe      2h ago       3       [Edit] [⋮]│
+│  ☐  Compliance Bot    ● live    A. Smith    1d ago       1       [Edit] [⋮]│
+│  ☐  Onboarding Q&A    ○ draft   S. Patel    3d ago       —       [Edit] [⋮]│
+│  ☐  Marketing Helper  ● live    J. Doe      4d ago       2       [Edit] [⋮]│
+│                                                                              │
+│  Showing 1-25 of 42                                       ‹ 1  2  ›          │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Anatomy:**
+
+1. **Page header.** H1 title, count subtitle, primary action button (split button if multiple create paths, e.g., "+ New app ▼" with "Blank app", "From template", "Import").
+2. **Toolbar.** Search input (left), filters (next), sort, view toggle (list/grid), overflow `⋯` for less-common actions (export, import, bulk archive).
+3. **Bulk action bar.** When >= 1 row selected, the toolbar morphs into a contextual bar: `4 selected — [Disable] [Move...] [Delete] [Export] [✕ Clear]`. It slides in from above the table, replacing the filter row visually but not collapsing layout (no jump).
+4. **Table.** First column is checkbox. Last column is per-row actions: an inline primary action (`Edit`) + a kebab menu (`⋮`) with secondary actions (Duplicate, Disable, Permissions, Delete).
+5. **View toggle.** List (default for dense data: Users, Models) vs. Card grid (default for visual data: Apps, Prompts). Persisted per user per page.
+6. **Empty state.** Centered illustration (line art, not photo), one-line description, primary CTA button matching the page header CTA, and a "Learn more →" doc link.
+7. **Pagination.** Server-side, 25/50/100 per page selector. Infinite scroll explicitly not used — predictable URLs matter for an admin.
+
+**Detail / edit pattern:**
+
+- **Drawer for light edits** (rename, toggle enabled, change owner). Right-side drawer, ~480px wide, sticky footer with Cancel / Save.
+- **Full page for heavy edits** (app config with variables, system prompts, tools, etc.). Tabs within the full page for sub-areas. Full page URL is deep-linkable.
+- Rule of thumb: if the form has > 8 fields or > 1 conceptual section, it is a full page. Otherwise it is a drawer.
+
+### 4.2 Settings Page
+
+Used by: Authentication, OAuth, UI Customization, System, Features, Providers (config-level), Telemetry, Logging config.
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Authentication                                                              │
+│  Configure how users sign in to iHub Apps                                    │
+│  ────────────────────────────────────────────────────────────────────────── │
+│                                                                              │
+│  [Sections]                       │  General                                 │
+│  ─────────────────────────────────│  ────────────────────────────────────── │
+│  • General                        │                                          │
+│  • Local accounts                 │  ▼ Anonymous access                      │
+│  • OIDC                           │     [ ] Allow anonymous users            │
+│  • LDAP                           │     Default groups: [anonymous]          │
+│  • NTLM                           │                                          │
+│  • Proxy auth                     │  ▼ Session                               │
+│  • Session & tokens               │     Timeout (minutes): [60]              │
+│                                   │     Sliding renewal:   [✓]               │
+│                                   │                                          │
+│                                   │  ▼ Token policy                          │
+│                                   │     ...                                  │
+│                                   │                                          │
+│  ────────────────────────────────────────────────────────────────────────── │
+│  ● You have unsaved changes                  [Discard]  [Save changes]      │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Anatomy:**
+
+1. **Left sub-nav (sections within the settings page).** Linear-style. Scrolls to anchor or replaces right pane content depending on length. Use replacement pattern when section has > 20 form fields (System, OAuth), anchor pattern otherwise.
+2. **Right pane: sectioned form.** Each section is a card-less group with a header and short description. Form fields use a 2-column label-input layout on >=1024px, stacked on smaller widths.
+3. **Sticky save bar.** Always at the bottom. Hidden when clean. Shows: dirty indicator dot, message ("You have unsaved changes"), Discard button (secondary), Save button (primary). Save bar must be visible above any modal/drawer it might trigger.
+4. **Dirty-state warning.** Browser `beforeunload` listener when dirty. In-app navigation away triggers a confirmation modal: "Discard unsaved changes?"
+5. **Test-and-save pattern for credentials.** Any section with credentials (OIDC, LDAP, providers) shows a `Test connection` button next to Save. Save is disabled until test passes for first-time setups (existing config can save without re-testing, with a warning toast).
+
+### 4.3 Integration Hub / Landing Page
+
+Used by: Integrations (top-level), and conceptually also by OAuth Clients (list of OAuth integrations the hub exposes).
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Integrations                                                                │
+│  Connect iHub to your tools and services                                     │
+│  ────────────────────────────────────────────────────────────────────────── │
+│                                                                              │
+│  [Search...]   [Category ▾]   [Status ▾]                                    │
+│  ────────────────────────────────────────────────────────────────────────── │
+│                                                                              │
+│  Productivity                                                                │
+│  ┌────────────────┐ ┌────────────────┐ ┌────────────────┐                  │
+│  │ [icon] Office  │ │ [icon] Google  │ │ [icon] Nextcl. │                  │
+│  │ 365            │ │ Drive          │ │                │                  │
+│  │ ● Connected    │ │ ○ Not setup    │ │ ● Connected    │                  │
+│  │ Tested 14m ago │ │                │ │ Tested 2h ago  │                  │
+│  │ [Configure]    │ │ [Connect]      │ │ [Configure]    │                  │
+│  └────────────────┘ └────────────────┘ └────────────────┘                  │
+│                                                                              │
+│  Workflow                                                                    │
+│  ┌────────────────┐ ┌────────────────┐                                      │
+│  │ [icon] Jira    │ │ [icon] Outlook │                                      │
+│  │ ● Connected    │ │ ⚠ Token expired│                                      │
+│  │ Tested 1h ago  │ │ Tested 3d ago  │                                      │
+│  │ [Configure]    │ │ [Reconnect]    │                                      │
+│  └────────────────┘ └────────────────┘                                      │
+│                                                                              │
+│  Browser & Extensions                                                        │
+│  ┌────────────────┐ ┌────────────────┐                                      │
+│  │ Outlook add-in │ │ Browser ext.   │                                      │
+│  │ Available      │ │ Available      │                                      │
+│  │ [Download]     │ │ [Download]     │                                      │
+│  └────────────────┘ └────────────────┘                                      │
+│                                                                              │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+**Anatomy:**
+
+1. **Category headings.** Productivity, Workflow, Browser & Extensions, etc. Sort within category: connected first, then not-setup, then unavailable.
+2. **Integration card.** Square-ish (~240x180). Logo, name, status pill (Connected / Not setup / Token expired / Error), tested-at timestamp, single primary CTA. Click anywhere on the card opens the integration's detail/settings page.
+3. **Status pill colors.** Green (connected & healthy), neutral (not setup), amber (warning, e.g., expired token), red (error, e.g., last test failed).
+4. **Configure CTA → settings page.** The integration's detail page uses the **Settings Page** template (4.2). This is the key consolidation: the hub is just a landing, all detail is a settings page. Removes the redundancy between "Integrations" and the per-integration pages.
+
+---
+
+## 5. Command Palette (Cmd+K)
+
+Triggered by Cmd/Ctrl+K from anywhere. Modal, centered, ~640px wide, 60vh max height.
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Search admin, run commands, or jump to anything...                          │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  Recent                                                                      │
+│  ⏱  Apps                              Apps section                           │
+│  ⏱  Sales Assistant                   App                                    │
+│  ⏱  Authentication                    Settings                               │
+│                                                                              │
+│  Pages                                                                       │
+│  ⌂  Overview                          Section: Overview                      │
+│  ⊞  Apps                              Section: AI Workspace      ⌘1          │
+│  ◈  Models                            Section: AI Workspace      ⌘2          │
+│                                                                              │
+│  Actions                                                                     │
+│  +  Create new app                                                           │
+│  +  Invite user                                                              │
+│  +  Add LLM provider                                                         │
+│  ⚙  Toggle feature flag...                                                   │
+│  ↻  Run backup now                                                           │
+│  ↻  Restart server                                                           │
+│                                                                              │
+│  Entities                                                                    │
+│  👤  jane.doe@acme.com                User                                   │
+│  ⊞  Sales Assistant                   App  •  3 models                       │
+│  ◈  claude-opus-4-7                   Model  •  Anthropic                    │
+│  🗂  KB-Compliance-2026                Source                                 │
+├──────────────────────────────────────────────────────────────────────────────┤
+│  ↑↓ Navigate  ↵ Open  ⌘↵ Open in new tab  Esc Close                          │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Spec
+
+- **Sections (in order):** Recent (last 5), Pages, Actions, Entities (Apps, Users, Models, etc.). Sections hidden if empty after filter.
+- **Fuzzy match across:** page titles, page descriptions, action verbs, entity names. Use `fuse.js` style scoring.
+- **Quick actions surface verbs:** "Create new app", "Invite user", "Add LLM provider", "Toggle feature [name]", "Run backup now", "Restart server", "View logs", "Open audit log".
+- **Keyboard shortcuts.**
+  - `Cmd+K` open palette
+  - `Cmd+1..6` jump to section (Overview / AI Workspace / Access / Integrations / Customization / Observability — Platform deliberately not on a number, requires intentional nav)
+  - `Cmd+B` toggle sidebar collapse
+  - `Cmd+/` focus search field in palette
+  - `g a` then type → "go to apps" (Linear-style chord shortcuts in v2)
+- **Recently visited.** Stored in localStorage per user. Top 5 distinct entries.
+- **Entity search.** Server-side endpoint (`/api/admin/search?q=`). Returns first 5 of each entity type. Type pills next to results.
+- **Action result UX.** Some actions open a confirmation modal ("Run backup now? This will take ~2 minutes."). Destructive actions always confirm; safe actions execute immediately with a toast.
+
+---
+
+## 6. Status / Health Indicators
+
+A unified language for "this needs attention" across the chrome.
+
+### Priority levels and visual treatment
+
+| Level | Color | Icon | Use case |
+|---|---|---|---|
+| Critical | `red-600` | filled dot ● | Service broken, auth disabled, provider invalid, security risk |
+| Warning | `amber-500` | filled dot ● | Token expiring, backup overdue, deprecated config |
+| Info | `blue-500` | hollow dot ○ | Update available, pending review, optional setup step |
+| Success | `green-600` | check ✓ | (used sparingly, mainly in confirmations) |
+
+### Surfaces
+
+1. **Nav item badge.** A small colored dot to the right of a nav label when any page in that section has an issue. Hover reveals "3 alerts in this section". Bubbles up: if a sub-item has an issue, the parent section also shows the highest-severity dot.
+2. **Alert bell in topbar.** Aggregates all "Needs attention" items across the instance. Count badge. Clicking opens a panel (slide-in from the right, 400px) listing all items grouped by severity. Each item links to its source page.
+3. **Inline page banner.** At the top of any page where an issue lives. Same color system. Banner has: icon, message, single CTA, dismiss `✕` if user-dismissable.
+4. **Row-level status pill.** In tables, status column uses the same dot vocabulary. Consistency across page-level banners, table rows, integration cards.
+
+### Examples in the wild (mapped to iHub)
+
+- Provider with invalid key → red banner on `Providers` page + red dot on `Platform > Providers` nav (actually `AI Workspace > Providers` — see IA), + bell count + Overview "needs attention".
+- Backup overdue → amber dot on `Platform > Backup` nav + bell count + Overview.
+- v3.5 available → blue dot on `Platform > Updates` nav + bell count + Overview.
+
+---
+
+## 7. Information Architecture (Final)
+
+After auditing the inventory, here is the final IA. Pushback included.
+
+```
+⌂ Overview
+  └─ (single page)
+
+⊞ AI Workspace
+  ├─ Apps
+  ├─ Models
+  ├─ Prompts          (Global variables shown as a tab within Prompts, not separate)
+  ├─ Tools
+  ├─ Skills           (feature-flagged)
+  ├─ Sources
+  ├─ Workflows        (feature-flagged)
+  ├─ Marketplace      (feature-flagged)
+  └─ Providers        ⟵ LLM provider credentials live HERE, not Identity
+
+🔐 Access & Identity
+  ├─ Users
+  ├─ Groups
+  ├─ Authentication   (Local, OIDC, LDAP, NTLM, Proxy — sub-nav within the settings page)
+  └─ OAuth            (Server + Clients consolidated; "hub" view collapsed into the same page)
+
+🔌 Integrations
+  ├─ All integrations  (the hub landing — Office365, Google Drive, Nextcloud, Jira, Outlook add-in, Browser ext, etc. as cards)
+  └─ (no sub-items; each integration is a settings page reached from the hub)
+
+🎨 Customization
+  ├─ UI customization
+  ├─ Pages
+  └─ Short Links
+
+📊 Observability
+  ├─ Usage Reports
+  ├─ Audit Log         ⟵ NEW: extracted from telemetry/logs to be first-class
+  ├─ Logging
+  └─ Telemetry
+
+⚙ Platform
+  ├─ Features          (feature flags)
+  ├─ Security          (was: encryption + SSL + CORS — merged)
+  ├─ Backup & Restore  (was: buried in System)
+  ├─ Updates           (was: buried in System)
+  └─ Advanced          (was: System — now just true escape hatches)
+```
+
+### Key IA decisions and rationale
+
+1. **Providers → AI Workspace, not Access & Identity.** You flagged this correctly. Providers are LLM credentials; they are infrastructure for Apps and Models, not human identity. They sit beside Models conceptually.
+2. **OAuth consolidated.** "OAuth hub / Server / Clients" collapses into a single OAuth page with tabs (Server config, Clients). The "hub" is no longer needed because Access & Identity is itself the hub.
+3. **Integrations hub kept as a single landing.** Each integration becomes a settings page reached from the hub. The duplicated "Integrations hub" page disappears as a separate nav entry — the hub IS the section landing.
+4. **System dismantled.** It was a junk drawer. Split into Security, Backup & Restore, Updates, and Advanced (which is now small and intentional).
+5. **Audit Log added.** Currently missing. Required for enterprise. Sources data from existing telemetry + new explicit admin-action events.
+6. **Global Variables collapsed into Prompts.** They are intrinsic to prompts; a sibling page is overkill.
+7. **Marketplace, Skills, Workflows** stay feature-flagged in the same section. The rail respects flags — hidden items do not show.
+
+### Section count: 7 (including Overview)
+
+This is at the upper bound of what's comfortable. If we add an 8th, we squeeze. Section count discipline matters.
+
+---
+
+## 8. Visual Design Direction
+
+### Color usage
+
+Color is functional, not decorative. The palette is **mostly neutral grays** (Tailwind `slate` or `zinc`) with **one brand accent** (indigo-600) and a **status palette** (red-600 critical, amber-500 warning, blue-500 info, green-600 success). Brand color is used only for primary buttons, active nav, focused inputs, and the iHub logo. Buttons, cards, and surfaces are not colored. This is a Stripe-style, restrained admin palette. Light theme uses `slate-50` page background, `white` cards, `slate-200` borders. Dark theme uses `slate-950` page, `slate-900` cards, `slate-800` borders. Status colors stay vivid in both modes.
+
+### Typography
+
+System font stack (Inter where available, system fallbacks otherwise). Three sizes carry 95% of the UI: `text-sm` (14px) for body and tables, `text-base` (16px) for emphasized form fields and section subtitles, `text-xl` (20px) for H1 page titles. H2 section titles are `text-base font-semibold`. Tabular numerals (`font-variant-numeric: tabular-nums`) for all stats, counts, and tables. Line height tight (`leading-tight`) in tables, comfortable (`leading-relaxed`) in form descriptions. Avoid more than two font weights per surface — regular and semibold do the work.
+
+### Spacing and density
+
+Enterprise admins value information density. Default to **compact density**: table row height 36px, form field height 36px, button height 32px, card padding `p-4`. Provide a "Comfortable" toggle in user preferences that bumps row heights to 44px and card padding to `p-6`. Whitespace inside sections is functional — between sections (e.g., between two settings sub-cards) use `mt-8` (32px). Within a section, `mt-4` (16px) between groups. Tables hug the page edges horizontally; no double-padding.
+
+### Iconography
+
+Use **Lucide** (already widely adopted, MIT, consistent line weight, excellent coverage). Heroicons is the second choice. Tabler is broader but visually inconsistent across icons — skip. Icon sizes: 16px in tables and inline, 18px in nav rail, 20px in buttons-with-icons, 24px in section headers. Always pair icons with text labels in the nav; icon-only is reserved for icon buttons (kebab, close, sort) with `aria-label`.
+
+### Dark mode
+
+Dark mode is first-class, not an afterthought. Use the `slate` family in dark mode rather than pure black — pure black creates harsh edges on OLED and tires eyes during long admin sessions. Borders in dark mode are critical: `slate-800` for separators, `slate-700` for hovered/active edges. Charts and stat trend arrows must re-test contrast in dark mode (a green that passes AA on white often fails on dark navy). Brand indigo desaturates by one step in dark mode (`indigo-400` for active states) to avoid vibration on dark backgrounds.
+
+---
+
+## 9. Accessibility (WCAG 2.1 AA)
+
+Top 5 musts for the redesign.
+
+1. **Keyboard navigation across the entire chrome.** Tab order: skip-to-content link → topbar → sidebar (sections expandable with Enter/Space, arrow keys to traverse items within an expanded section) → page content. Cmd+K must open palette from anywhere. `Esc` closes drawers, palette, and modals. Trapped focus in modals, return focus on close.
+2. **Focus indicators always visible.** A 2px ring (`ring-2 ring-indigo-500 ring-offset-2`) on every interactive element. No `outline: none` without a replacement. Inputs get a border-color shift PLUS a ring on focus. Custom checkboxes and toggles must show focus indicators that meet 3:1 contrast against their adjacent surface.
+3. **ARIA for the nav and command palette.** Sidebar is `<nav aria-label="Admin navigation">`. Expandable sections are `<button aria-expanded="true|false" aria-controls="section-id">`. Active page link gets `aria-current="page"`. Command palette is `role="dialog" aria-modal="true" aria-label="Command palette"`. The palette input is a `combobox` with `aria-autocomplete="list"` and an `aria-activedescendant` pointing to the highlighted result. Status badges on nav items use `aria-label="3 alerts"` so they are not silent visual hints.
+4. **Color contrast.** Body text 4.5:1 minimum (AA). Status pills must pass 3:1 against their background; the dot+text combo is preferred over text-only colored badges so the signal is not color-only (color-blindness coverage). Trend arrows in stat cards include an actual `▲` or `▼` glyph plus the color, not color alone.
+5. **Form errors and live regions.** Settings pages and CRUD edit pages announce save state via `aria-live="polite"` toast region. Form field errors live in `<p id="field-error" role="alert">` and the input gets `aria-invalid="true" aria-describedby="field-error"`. The save bar's dirty indicator must include screen-reader text ("You have unsaved changes") not just the colored dot.
+
+Bonus 6th must: **respect `prefers-reduced-motion`.** Sidebar expand/collapse, drawer transitions, palette open animations all degrade to instant or 50ms fades when reduced motion is set.
+
+---
+
+## 10. Phased Rollout
+
+### Phase 1 — Chrome and Overview (Design ships)
+
+- New sidebar (collapsible, grouped, with status dots)
+- New topbar (breadcrumbs, alert bell, search pill)
+- New Overview dashboard (stat cards, needs-attention, quick actions, recent activity, setup checklist for fresh instances)
+- Visual design tokens applied: typography, spacing, colors, dark mode parity
+- Accessibility baseline: focus rings, ARIA on nav, skip link, keyboard traversal
+
+**Why ship first:** Highest impact for least architectural risk. New chrome can wrap unchanged page contents.
+
+### Phase 2 — Page pattern unification (Design ships)
+
+- List/CRUD template applied to: Apps, Models, Prompts, Tools, Users, Groups, Sources, Pages, Short Links (one PR per page, or batched in pairs)
+- Settings template applied to: Authentication, OAuth, UI Customization, Platform > Security, Platform > Advanced
+- Integration Hub template applied to: Integrations + per-integration settings pages (Office365, Jira, etc.)
+- Bulk action bars added across all list pages
+- Empty states designed and applied
+- View toggles (list vs. card) where applicable
+
+**Why second:** Largest body of work, lower per-PR risk, deliverable incrementally page by page.
+
+### Phase 3 — Command palette and power features (Design ships)
+
+- Cmd+K command palette with Pages, Actions, Entities, Recent
+- Keyboard shortcuts (Cmd+1..6, Cmd+B, Cmd+/)
+- Alert bell aggregation pane
+- Audit Log (new page in Observability)
+- "Comfortable / Compact" density toggle in user preferences
+- Pinning / favorites in the sidebar (power user customization)
+- Chord shortcuts (`g a`, `g u`, etc.)
+
+**Why third:** Highest leverage for power users but lower frequency, can layer on top of stable Phase 1 + 2 foundation.
+
+---
+
+## Implementation Notes (for the coder this brief pairs with)
+
+- **Use Tailwind tokens, not hex values, in components.** All status colors, gray scale, and spacing should reference Tailwind defaults so the design system can be tuned in one place (`tailwind.config.js`).
+- **Reusable shells.** Build three React components: `<ListPage>`, `<SettingsPage>`, `<IntegrationHubPage>`. Each accepts header, toolbar, content, and footer slots so pages cannot drift visually.
+- **Sidebar state in context.** `SidebarContext` holds: collapsed state, expanded sections, pinned items, current alert counts (subscribed to a `/api/admin/alerts/summary` poll every 60s).
+- **Command palette as a portal.** Mount once at the root, controlled by a `CommandPaletteContext`. Any page can register additional contextual commands via a hook.
+- **Status badge primitive.** `<StatusDot level="critical|warning|info|success" label="..." />` — used in nav, in tables, in cards, in banners.
+- **Save bar as a layout slot.** `<SettingsPage>` exposes a `saveBar` prop and a `useDirtyState()` hook. Browser `beforeunload` registered automatically when dirty.
+- **Do not rebuild routing.** Keep React Router. Add new top-level routes in `client/src/App.jsx` and update `client/src/utils/runtimeBasePath.js` knownRoutes for each (per CLAUDE.md).
+- **Audit Log requires a new server feature** — flag this with PM. Without it, the Recent Activity card on Overview is sourced from existing telemetry events as a temporary measure.
+
+---
+
+## Open questions to resolve with PM
+
+1. Audit Log scope and retention — is this in-scope for Phase 1 Overview, or stub it from telemetry?
+2. Customizable Quick Actions on Overview — per-user or per-instance for v1?
+3. Marketplace, Skills, Workflows feature flags — are they staying long-term or graduating soon? Affects sidebar real estate planning.
+4. Mobile audience — do we have data on how many admins use mobile? Drives investment in off-canvas vs. mobile-optimized list pages.
+5. "Test connection" pattern — does every credential-bearing settings page have a corresponding server-side test endpoint? If not, Phase 2 needs a small server roadmap.
+6. Pinning / favorites — store server-side (per user record) or localStorage? Server-side enables cross-device but adds API surface.
+
+---
+
+**End of brief.** This document, paired with the PM brief, is ready to be synthesized into a redesign draft and broken into Phase 1 tickets.

--- a/concepts/admin-redesign-2026/2026-05-19 Admin UI Redesign Draft.md
+++ b/concepts/admin-redesign-2026/2026-05-19 Admin UI Redesign Draft.md
@@ -1,0 +1,447 @@
+# Admin UI Redesign — Synthesised Draft
+
+**Document type:** Redesign proposal (synthesis of PM and Design briefs)
+**Date:** 2026-05-19
+**Status:** Draft for review
+**Audience:** Product, Design, Engineering leadership; stakeholders to align before Phase 1 build
+
+> This document is the **single deliverable** combining the product strategy brief and the UX design brief. Both source documents live in this folder and are referenced where deeper rationale is needed.
+
+---
+
+## 1. The problem in one paragraph
+
+iHub Apps has grown from a focused app builder into a full enterprise AI platform. The admin surface tracked that growth feature-by-feature but never re-architected — today there are **30+ admin pages** crammed into a flat top-tab bar with one home, three pinned tabs (Apps, Models, Prompts) and a **"More" dropdown of 20+ items**. The landing page is a **12-tile launcher** with no grouping, no status, and no signal. There is no global search, no command palette, no audit log surface, and no guided setup for new instances. The System page has become a junk drawer holding encryption, SSL, CORS, backups, and version info side-by-side. Integrations have both a hub page and legacy direct routes. OAuth has both a "hub" route and Server/Clients subpages. New admins are lost; experienced admins survive on muscle memory.
+
+The fix is not another feature. The fix is **information architecture**.
+
+---
+
+## 2. Vision: what the admin of the future looks like
+
+> An enterprise admin lands on iHub Apps and sees instantly whether the instance is healthy, what they need to do, and where to do it. Every action is reachable in two clicks or one keystroke. Every page follows the same shape. New admins are guided; power admins are out of your way.
+
+Five guiding promises:
+
+1. **Task-oriented, not data-oriented.** Sections group by what admins do, not where bytes live.
+2. **Health-first landing.** The home page answers "is everything okay?" before "where do I go?"
+3. **One CRUD shape, learn it once.** Apps, Models, Users, Groups, Sources, Tools all share a list-page anatomy.
+4. **Search-first navigation.** Cmd+K reaches anything in the system.
+5. **Enterprise table-stakes by default.** Audit log, status surfaces, dry-run, bulk operations, sub-roles.
+
+---
+
+## 3. Information architecture — the final cut
+
+### 3.1 Top-level structure
+
+Seven left-rail sections (including Overview):
+
+```
+⌂ Overview
+⊞ AI Workspace
+🔐 Access & Identity
+🔌 Integrations
+🎨 Customization
+📊 Observability
+⚙ Platform
+```
+
+### 3.2 What lives where
+
+| Section | Pages | Notes |
+|---|---|---|
+| **⌂ Overview** | Single page (dashboard) | Replaces today's tile launcher. See §4. |
+| **⊞ AI Workspace** | Apps, Models, **Providers**, Prompts (+ Global Variables as tab), Tools, Sources, Skills (FF), Workflows (FF), Marketplace (FF) | Everything users see in the app. Providers join here because they are infrastructure for Models, not human identity. |
+| **🔐 Access & Identity** | Users, Groups, Authentication (Local/OIDC/LDAP/NTLM/Proxy as sub-nav), OAuth (Server + Clients merged into tabs) | The "who can sign in, what are they grouped as" hub. |
+| **🔌 Integrations** | Single hub page with cards: Office365, Google Drive, Nextcloud, Jira, Outlook add-in, Browser extension, Nextcloud Embed | Hub IS the section landing. Each integration is a Settings page reached from the hub. **Legacy direct routes removed** with a 1-minor-version redirect window. |
+| **🎨 Customization** | UI Customization, Pages, Short Links | Everything about how iHub presents itself to users. |
+| **📊 Observability** | Usage Reports, **Audit Log (NEW)**, Logging, Telemetry | Three siblings unified. Audit log is added; sources from telemetry until a dedicated feed lands. |
+| **⚙ Platform** | Features (flags), Security (encryption + SSL + CORS — merged), Backup & Restore (promoted out of System), Updates (promoted out of System), Advanced (true escape hatches) | The System "junk drawer" is dismantled. |
+
+### 3.3 Resolved IA decisions
+
+The PM and Design briefs diverged on two points. Resolution for the draft:
+
+**Providers → AI Workspace.** Designer's recommendation accepted. Providers are LLM credential storage — infrastructure for Models, not human identity. Sit next to Models conceptually. Cross-link from Models settings. *PM brief notes this as an open question; the draft picks the designer's answer.*
+
+**Customization as its own section.** Designer's structure accepted. Folding "UI Customization", "Pages", and "Short Links" into Platform (PM's lighter structure) overloads Platform with presentation concerns that share nothing with backups/security. Keeping Customization separate is cleaner conceptually and within section-size limits.
+
+This yields 7 sections including Overview — at the upper bound of comfort, but defensible.
+
+### 3.4 What is merged, promoted, demoted
+
+**Merged:**
+- OAuth Hub + Server + Clients → single OAuth page with tabs
+- Logging + Telemetry + Usage + Audit → Observability
+- Encryption + SSL + CORS → Platform → Security
+- Integrations hub absorbs all per-integration routes (legacy direct routes removed)
+- Global Variables collapses into Prompts as a tab
+
+**Promoted (out of "More"):**
+- Backup & Restore (was buried in System)
+- Updates (was buried in System)
+- Users (now primary entry into Access & Identity)
+- Features (flags) (was buried in More)
+
+**Demoted (kept but de-emphasised):**
+- Pages, Short Links — useful but low-frequency; live under Customization
+- Skills, Workflows, Marketplace — remain feature-flagged
+
+**Removed:**
+- OAuth "hub" landing page (the section itself is the hub)
+- Integrations legacy direct routes (`/admin/office365` etc.) — replaced by hub + redirects
+
+---
+
+## 4. The new Overview page
+
+The 12-tile launcher is replaced by an **operations dashboard**. Stats first, signal second, navigation third.
+
+### 4.1 Wireframe (mature instance)
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Overview                                                                    │
+│  iHub Apps  •  v3.4.1  •  Up 14d 6h                            [30d ▾]      │
+│  ────────────────────────────────────────────────────────────────────────── │
+│                                                                              │
+│  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐    │
+│  │ Apps    │ │ Users   │ │ Chats   │ │ Tokens  │ │ Errors  │ │ Latency │    │
+│  │  42     │ │ 318     │ │ 12,847  │ │ 4.2M    │ │ 0.18%   │ │ 1.2s    │    │
+│  │ ▲ 3 mo  │ │ ▲ 24 mo │ │ ▲ 18%   │ │ ▲ 22%   │ │ ▼ 0.4pp │ │ ▼ 80ms  │    │
+│  └─────────┘ └─────────┘ └─────────┘ └─────────┘ └─────────┘ └─────────┘    │
+│                                                                              │
+│  ⚠ Needs your attention                                                      │
+│  ────────────────────────────────────────────────────────────────────────── │
+│  ●  Anthropic provider key invalid — last test failed 2h ago  [Fix →]       │
+│  ●  Backup overdue (last: 8 days ago, target: weekly)         [Run now →]   │
+│  ●  iHub v3.5.0 available (security patch)                    [Review →]    │
+│  ○  3 users awaiting group assignment                         [Assign →]    │
+│                                                                              │
+│  Quick actions                                                               │
+│  [+ New app]  [+ Invite user]  [+ Add model]  [View logs]                   │
+│                                                                              │
+│  Recent activity                                          [View audit log →] │
+│  ────────────────────────────────────────────────────────────────────────── │
+│  14:32  J. Doe       updated app "Sales Assistant"                          │
+│  14:18  System       backup completed (228 MB)                              │
+│  13:51  A. Smith     created group "EU Compliance"                          │
+│  13:42  S. Patel     rotated API key for OpenAI provider                    │
+│  12:09  System       model "claude-opus-4-7" sync OK                        │
+│                                                                              │
+│  ───── Jump to section  ▾ (collapsed launcher remains accessible) ─────     │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+### 4.2 What appears
+
+- **Stat cards** (6): Apps, Users, Chats, Tokens, Errors, Latency. Each shows current value + trend delta over the selected window (today/7d/30d/90d). Every card deep-links to a filtered Observability view.
+- **Needs your attention**: ordered list of actionable items. Severity dots (red critical, amber warning, blue info). Each row has a single primary action verb. Max 5 shown; "See all (N) →" when more. Empty state: "All systems healthy." with a freshness timestamp.
+- **Quick actions**: 4 most-common admin starters. Customizable per user in a later phase.
+- **Recent activity**: last 5 admin actions. Sourced from telemetry until a dedicated audit-log feed exists.
+- **Collapsible launcher** (footer drawer): the old tile grid lives on, but grouped by the new IA — closed by default for muscle-memory users.
+
+### 4.3 Fresh-instance variant
+
+For Day-1 installs (apps == 0, users < 5, age < 7d), the dashboard becomes a setup checklist:
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  Welcome to iHub Apps                                                        │
+│  Let's get your instance ready.                              3 / 7 done      │
+│  ────────────────────────────────────────────────────────────────────────── │
+│  ✓  Install complete                                                         │
+│  ✓  Local admin account created                                              │
+│  ✓  Default groups configured                                                │
+│  ○  Configure an LLM provider                            [Add provider →]   │
+│  ○  Create your first AI app                             [Create app →]     │
+│  ○  Connect an identity provider (optional)              [Set up SSO →]     │
+│  ○  Review platform settings                             [Open settings →]  │
+│                                                                              │
+│  [Skip setup, I'll explore on my own]                                       │
+│  → 2-min tour    → Documentation    → Examples gallery                       │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+Stat cards hidden until data exists. Checklist auto-collapses to a one-line banner when complete.
+
+---
+
+## 5. Chrome — left rail and topbar
+
+### 5.1 Wireframe
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [iHub] Admin    Apps / Sales Assistant      [v3.4]  [Search Cmd+K]  [Bell 3] [Avatar] │
+├────────────────┬─────────────────────────────────────────────────────────────┤
+│ [Search...   ] │  Page H1                                          [Primary] │
+│                │  Subtitle / count                                           │
+│ ⌂ Overview     │  ───────────────────────────────────────────────────────── │
+│                │                                                             │
+│ ▼ AI Workspace │  [Filters]  [Search]                          [View ⊞ ☰]   │
+│   • Apps    12 │  ───────────────────────────────────────────────────────── │
+│   • Models   8 │                                                             │
+│   • Providers 4│   Content area (list, settings form, hub grid, dashboard)   │
+│   • Prompts 32 │                                                             │
+│   • Tools   14 │                                                             │
+│   • Sources 11 │                                                             │
+│   • Skills   2 │                                                             │
+│   • Workflows  │                                                             │
+│   • Marketplace│                                                             │
+│ ▶ Access & ID  │                                                             │
+│ ▶ Integrations │                                                             │
+│ ▶ Customization│                                                             │
+│ ▶ Observability│                                                             │
+│ ▶ Platform   ⚠ │                                                             │
+│                │                                                             │
+│ [«Collapse]    │                                                             │
+└────────────────┴─────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Navigation behavior
+
+- **Single collapsible left rail**, not hybrid (icon rail + sub-nav). For 30 pages the cognitive cost of a hybrid is higher than the visual cost of a single rail.
+- **Active section auto-expands** on page load. Other sections collapse by default but state is remembered per user.
+- **Expanded:** ~256px, icon + label. **Collapsed:** ~64px, icon only with flyout on hover. Toggle pinned to the bottom of the rail.
+- **No second-level groups inside a section.** Max 9 items per section; if exceeded, the section splits.
+- **Status dot** appears on the parent section when any sub-page has a critical/warning issue. Dot color matches the highest severity inside.
+- **Mobile (<768px):** off-canvas drawer. Hamburger left, search-icon right.
+- **Topbar:** breadcrumbs (only when depth >2), version pill, search pill (Cmd+K), alert bell with count, avatar.
+
+### 5.3 Breadcrumbs
+
+Shown only when path depth >2 (e.g., `AI Workspace / Apps / Sales Assistant / Variables`). On list pages, the H1 is enough — no breadcrumb noise.
+
+---
+
+## 6. The three reusable page templates
+
+Every admin page is one of these three. Consistency over cleverness.
+
+### 6.1 List / CRUD page
+
+Used by: Apps, Models, Providers, Prompts, Tools, Skills, Sources, Pages, Short Links, Users, Groups, Workflows.
+
+Anatomy: page header (H1 + count + primary action with split-button options) → toolbar (search + filters + sort + view toggle + overflow) → bulk-action bar (appears on selection) → table or card grid (view-toggleable, persisted per user) → row actions (inline `Edit` + kebab) → pagination (25/50/100; no infinite scroll, URLs matter for admins).
+
+Detail/edit pattern:
+- **Drawer** for light edits (≤8 fields, single concept): right-side, ~480px, sticky save footer.
+- **Full page** for heavy edits (variables, system prompts, etc.): URL is deep-linkable; sub-tabs within the page for sub-areas.
+
+Empty state: line-art illustration, one-line description, primary CTA matching the header CTA, "Learn more →" link.
+
+### 6.2 Settings page
+
+Used by: Authentication, OAuth, UI Customization, Platform → Security, Platform → Advanced, Telemetry, Logging config.
+
+Anatomy: page header → two-pane body — left sub-nav (sections within this settings page, Linear-style) + right pane (sectioned form with `mt-8` between sections, 2-col label/input on ≥1024px) → **sticky save bar** at bottom: dirty indicator dot + "You have unsaved changes" + [Discard] + [Save].
+
+Patterns:
+- `beforeunload` listener when dirty.
+- In-app navigation triggers confirmation modal on dirty.
+- **Test-and-save** for any section with credentials: `Test connection` button; first-time setups require successful test before Save enables. Existing configs save without re-testing, with a warning toast.
+- Replacement-pane mode when a section has >20 fields (System, OAuth); anchor-scroll mode otherwise.
+
+### 6.3 Integration Hub page
+
+Used by: Integrations.
+
+Anatomy: page header → filter row (search + category + status) → category-grouped card grid. Within each category: Connected first, then Not setup, then Unavailable.
+
+Card: logo, name, status pill (Connected/Not setup/Token expired/Error), "Tested 14m ago" timestamp, single primary CTA ([Configure] / [Connect] / [Reconnect] / [Download]). Click anywhere on the card opens the integration's Settings page (template §6.2).
+
+**Key consolidation:** the hub IS the section landing; per-integration pages use the Settings template. The current redundant "Integrations hub + per-integration page + legacy direct route" mess collapses into one pattern.
+
+---
+
+## 7. Cmd+K command palette
+
+Triggered from anywhere by Cmd/Ctrl+K. Modal, centered, ~640px wide.
+
+Sections (in order, each hidden when empty after filter):
+
+1. **Recent** — last 5 distinct visits/actions per user (localStorage).
+2. **Pages** — every admin page, fuzzy-matched. Shows the section name and a keyboard shortcut hint.
+3. **Actions** — verbs: "Create new app", "Invite user", "Add LLM provider", "Toggle feature [name]", "Run backup now", "Restart server", "View logs", "Open audit log".
+4. **Entities** — server-side fuzzy search across apps, users, models, groups, prompts, sources. First 5 of each.
+
+Keyboard:
+
+- `Cmd+K` open
+- `Cmd+1..6` jump to top section (Overview / AI Workspace / Access / Integrations / Customization / Observability — Platform deliberately not on a number)
+- `Cmd+B` toggle sidebar collapse
+- `Cmd+/` focus palette search
+- `g a`, `g u`, `g m` chord shortcuts (Phase 3)
+
+Action UX: destructive actions confirm in-palette; safe actions execute with a toast.
+
+---
+
+## 8. Status and "needs attention" surfaces
+
+Unified vocabulary across the entire admin:
+
+| Level | Color | Icon | Use case |
+|---|---|---|---|
+| Critical | red-600 | ● | Auth disabled, provider invalid, security risk |
+| Warning | amber-500 | ● | Token expiring, backup overdue, deprecated config |
+| Info | blue-500 | ○ | Update available, pending review, optional step |
+| Success | green-600 | ✓ | Confirmation only, used sparingly |
+
+Surfaces:
+
+1. **Nav-item badge.** Dot to the right of a label. Bubbles up to parent section (highest severity wins).
+2. **Topbar alert bell.** Aggregates everything. Click → slide-in panel (400px right) grouped by severity, each item linking to its source page.
+3. **Inline page banner.** At the top of any page with an issue. Same color system, single CTA, optional dismiss.
+4. **Row-level status pill.** In tables, status column uses the same dot+text vocabulary so the signal is never color-only (color-blindness safe).
+
+---
+
+## 9. Visual direction (summary)
+
+- **Color:** mostly neutral (`slate` or `zinc`) + one brand accent (`indigo-600`) + the four status colors. Buttons and cards are not colored; brand color is reserved for primary buttons, active nav, focused inputs.
+- **Typography:** Inter (system fallbacks). Three sizes carry 95% of the UI: `text-sm` body/tables, `text-base` form fields, `text-xl` H1. Tabular numerals for all stats. Max two font weights per surface.
+- **Density:** compact by default (36px row/field height, 32px button height, `p-4` cards). Per-user "Comfortable" toggle bumps to 44px / `p-6`.
+- **Icons:** Lucide (consistent line weight, MIT, broad coverage).
+- **Dark mode:** first-class. Use `slate-900`/`950` family — pure black is harsh on OLED. Brand indigo desaturates one step (`indigo-400`) in dark to avoid vibration.
+
+---
+
+## 10. Accessibility (WCAG 2.1 AA)
+
+Five musts plus one bonus:
+
+1. **Keyboard navigation across the whole chrome.** Skip-to-content, tab order, Enter/Space to expand sections, arrow keys within sections, Cmd+K from anywhere, Esc to close, focus trapping in modals.
+2. **Focus indicators always visible.** 2px ring (`ring-2 ring-indigo-500 ring-offset-2`) on every interactive element. No `outline: none` without replacement.
+3. **ARIA on nav + palette.** `<nav aria-label>`, `aria-expanded`/`aria-controls` on section toggles, `aria-current="page"` on active link, palette as `role="dialog" aria-modal="true"`, `combobox` input with `aria-activedescendant`.
+4. **Color contrast.** Body ≥4.5:1, status pills ≥3:1. Dot + text combo, never color alone. Trend arrows use `▲`/`▼` glyphs plus color.
+5. **Live regions for save state & errors.** Toasts in `aria-live="polite"`. Field errors in `role="alert"` with `aria-invalid` + `aria-describedby`. Save-bar dirty indicator has screen-reader text.
+6. **Respect `prefers-reduced-motion`.** Sidebar expand, drawer transitions, palette open all degrade to instant.
+
+---
+
+## 11. Phased rollout
+
+| Phase | Scope | Target | Backend changes |
+|---|---|---|---|
+| **Phase 1 — Chrome & Overview** | Left rail with 7 sections, topbar (breadcrumbs, bell, search pill), new Overview dashboard (stats / attention / quick actions / activity / setup checklist), visual tokens, dark mode parity, a11y baseline. All existing pages migrate under new nav unchanged. Legacy routes redirect. | 4 weeks | None (existing endpoints suffice; audit log seeds from telemetry) |
+| **Phase 2 — Page templates & flows** | Apply List/CRUD template to all list pages; Settings template to Authentication/OAuth/UI/Security/Advanced; Integration Hub to Integrations. Bulk actions across list pages. Empty states. Wizards for the top 5 JTBDs (Publish App, Connect SSO, Rotate Key, Onboard Group, Bulk Edit). Command palette ships. Global search. | 8 weeks | Optional: bulk endpoints, `/api/admin/search`, "test connection" endpoints where missing |
+| **Phase 3 — Sub-roles & enterprise polish** | Sub-admin roles (read-only first, then scoped write). Dedicated Audit Log feed + retention + export. Change history per config. Generalised dry-run. Bulk import/export. Pinning/favorites. Chord shortcuts. In-product changelog. | 10 weeks | Audit-log persistence, change-history store, role-scoped permission filters |
+
+### Phase 1 success criteria
+
+- Time-to-find-setting drops from ~30s to <10s (admin survey, n≥10)
+- "Where is X?" support tickets down 50%
+- Zero increase in broken-link reports (verified via redirect logs)
+
+### Phase 3 success criteria
+
+- ≥3 customers using sub-roles within 90 days
+- Cmd+K weekly active usage ≥30% of admin sessions
+- Audit log queried in ≥40% of admin investigations
+
+---
+
+## 12. Enterprise table-stakes — what we are adding
+
+| Capability | Priority | Phase |
+|---|---|---|
+| Command palette (Cmd+K) | Must | P2 |
+| Global admin search | Must | P2 |
+| Admin audit log | Must | P3 (seed in P1) |
+| Health probes + "needs attention" widget | Must | P1 |
+| Dry-run for risky changes | Should | P2 (rotate key) + P3 (general) |
+| Change history per config | Should | P3 |
+| Bulk import/export | Should | P3 |
+| In-product "what's new" | Should | P3 |
+| Configurable email/Slack alerts | Could | P3 |
+| Two-person rule for destructive ops | Could | P3 (gated by demand) |
+
+Explicitly **not** building: custom dashboard widget layouts (single opinionated Overview), a new "Settings" mega-page (we are escaping exactly that), per-page column choosers (Phase 3+ if analytics demand).
+
+---
+
+## 13. Open decisions
+
+These need a stakeholder call **before Phase 1 build kick-off**. Draft picks a default for each.
+
+1. **Providers location.** Draft: AI Workspace. PM brief leaned Identity. Designer pushed back; draft sides with Design.
+2. **Customization as its own section.** Draft: yes. PM brief folded into Platform; Design split it out. Draft sides with Design.
+3. **Legacy integration routes.** Draft: 1-minor-version redirect, then remove. Per CLAUDE.md, breaking changes need an explicit user decision — confirm before implementation.
+4. **Sub-role timing.** Draft: defer to Phase 3. PM rationale: don't ship IA + permission-model changes simultaneously.
+5. **Audit Log scope in Phase 1.** Draft: seed from telemetry events for the Overview's Recent Activity; the dedicated Audit Log page in Observability ships in Phase 3 with retention/export.
+6. **Customizable Quick Actions on Overview.** Draft: instance-default in v1, per-user customization deferred.
+7. **Pinning/favorites storage.** Draft: localStorage in Phase 2; server-side per-user persistence in Phase 3.
+8. **Marketplace / Skills / Workflows feature flags.** Are they graduating soon? Affects rail real-estate planning. No draft default — needs PM input.
+
+---
+
+## 14. What this redesign is not
+
+- **Not a backend refactor.** Every IA change uses existing endpoints (`server/routes/admin/*`). Audit Log dedicated feed and sub-role permission filters are the only new backend asks (both Phase 3).
+- **Not a brand refresh.** Color, type, and density tighten, but the visual language is iHub's existing Tailwind palette — not a logo or identity change.
+- **Not a multi-tenant rewrite.** Soft tenancy via groups remains the model. Genuine multi-tenant separation is platform-level and out of scope.
+
+---
+
+## 15. Implementation notes (for the coder phase)
+
+- **Three React shells:** `<ListPage>`, `<SettingsPage>`, `<IntegrationHubPage>`. Slots for header, toolbar, content, footer/save-bar. Pages cannot drift visually.
+- **`SidebarContext`** holds collapsed state, expanded sections, pinned items, current alert counts (subscribed to `/api/admin/alerts/summary` polling every 60s).
+- **`CommandPaletteContext`** mounted at root; pages register contextual commands via hook.
+- **`<StatusDot level="critical|warning|info|success" label="..." />`** primitive used in nav, tables, cards, banners.
+- **`useDirtyState()`** hook for Settings pages, registers `beforeunload` automatically.
+- **Tailwind tokens, not hex values.** Tune the design system in `tailwind.config.js` only.
+- **React Router stays.** New routes added in `client/src/App.jsx` AND `client/src/utils/runtimeBasePath.js` `knownRoutes` (CLAUDE.md requirement).
+- **i18n discipline.** All new strings go through `t()` per project convention.
+
+---
+
+## 16. Next steps
+
+1. **Stakeholder review** of this draft (estimate: 60-min walk-through with PM + Eng leadership + 2-3 enterprise admins).
+2. **Decisions** on the 8 open questions in §13.
+3. **Phase 1 ticket breakdown** by engineering, scoped to the 4-week target.
+4. **Component spike** on the three page shells before opening Phase 1 implementation tickets.
+5. **Feedback loop** with 2-3 enterprise admins after a week of Phase 1 in staging — adjust IA before broader rollout.
+
+---
+
+## Appendix — current → proposed mapping
+
+| Current page | Proposed location |
+|---|---|
+| Home (12-tile dashboard) | Overview (redesigned) |
+| Apps | AI Workspace → Apps |
+| Models | AI Workspace → Models |
+| Providers | AI Workspace → Providers |
+| Prompts (+ Global Variables) | AI Workspace → Prompts (variables as tab) |
+| Tools | AI Workspace → Tools |
+| Skills (FF) | AI Workspace → Skills |
+| Sources | AI Workspace → Sources |
+| Workflows (FF) | AI Workspace → Workflows |
+| Marketplace (FF) | AI Workspace → Marketplace |
+| Users | Access & Identity → Users |
+| Groups | Access & Identity → Groups |
+| Authentication | Access & Identity → Authentication (Local/OIDC/LDAP/NTLM/Proxy as sub-nav) |
+| OAuth hub + Server + Clients | Access & Identity → OAuth (Server + Clients tabbed) |
+| Integrations hub | Integrations (the section landing) |
+| Office365, Google Drive, Nextcloud, Jira, Outlook add-in, Browser ext, Nextcloud Embed | Integrations → hub cards → Settings page each. **Legacy routes redirect 1 minor version, then removed.** |
+| UI Customization | Customization → UI Customization |
+| Pages | Customization → Pages |
+| Short Links | Customization → Short Links |
+| Usage Reports | Observability → Usage Reports |
+| Logging | Observability → Logging |
+| Telemetry | Observability → Telemetry |
+| (new) | Observability → Audit Log |
+| Features | Platform → Features |
+| System (encryption + SSL + CORS) | Platform → Security (merged) |
+| System (backup/restore) | Platform → Backup & Restore (promoted) |
+| System (version + updates) | Platform → Updates (promoted) |
+| System (remainder) | Platform → Advanced |
+
+---
+
+*Combine with the [Product Strategy & IA brief](2026-05-19%20Admin%20UI%20Redesign%20Product%20Strategy%20&%20IA.md) and the [Design Brief](2026-05-19%20Admin%20UI%20Redesign%20Design%20Brief.md) for full rationale.*

--- a/concepts/admin-redesign-2026/2026-05-19 Admin UI Redesign Draft.md
+++ b/concepts/admin-redesign-2026/2026-05-19 Admin UI Redesign Draft.md
@@ -330,6 +330,8 @@ Five musts plus one bonus:
 | **Phase 2 — Page templates & flows** | Apply List/CRUD template to all list pages; Settings template to Authentication/OAuth/UI/Security/Advanced; Integration Hub to Integrations. Bulk actions across list pages. Empty states. Wizards for the top 5 JTBDs (Publish App, Connect SSO, Rotate Key, Onboard Group, Bulk Edit). Command palette ships. Global search. | 8 weeks | Optional: bulk endpoints, `/api/admin/search`, "test connection" endpoints where missing |
 | **Phase 3 — Sub-roles & enterprise polish** | Sub-admin roles (read-only first, then scoped write). Dedicated Audit Log feed + retention + export. Change history per config. Generalised dry-run. Bulk import/export. Pinning/favorites. Chord shortcuts. In-product changelog. | 10 weeks | Audit-log persistence, change-history store, role-scoped permission filters |
 
+> **Parallel workstream throughout all three phases: documentation alignment.** See §12. Today many users edit JSON in `contents/` directly because `docs/` does not document the admin UI. Without this workstream, the redesign delivers a surface users are never taught to use.
+
 ### Phase 1 success criteria
 
 - Time-to-find-setting drops from ~30s to <10s (admin survey, n≥10)
@@ -344,7 +346,60 @@ Five musts plus one bonus:
 
 ---
 
-## 12. Enterprise table-stakes — what we are adding
+## 12. Documentation alignment (parallel workstream)
+
+The redesign has a documentation problem to solve in parallel. Today, **many users edit JSON files in `contents/` directly** — apps, models, prompts, groups, platform config — even though the admin UI already exposes everything they need. The root cause is not that the UI is missing functionality; it is that **`docs/` has almost no information about the admin UI itself**. Users follow the docs, the docs show them JSON snippets, so they edit JSON.
+
+This has knock-on effects:
+
+- Users miss validation that the UI would have caught (Zod schema errors only surface at server start)
+- Users miss the encryption-at-rest behavior for secrets (the UI encrypts on save; hand-edited JSON leaves secrets plaintext)
+- Users miss config-cache invalidation paths (the UI triggers reloads automatically)
+- Migration / inheritance / feature flags behave differently when set via UI vs. hand-edit
+- Every doc that shows "edit `apps/xyz.json`" is a missed teaching moment for the admin UI
+
+### What this means for the redesign
+
+Documentation alignment is a **required follow-up** to the IA redesign, not optional. Without it, the redesign delivers a beautiful admin that users still circumvent because the docs never tell them to use it.
+
+### Scope of documentation work
+
+**During Phase 1 (in parallel with chrome + Overview ship):**
+
+- Audit every file in `docs/` for references to direct JSON editing. Tag each as: (a) "should be done in admin UI", (b) "advanced/escape-hatch — keep JSON path", or (c) "out-of-date entirely".
+- For category (a), rewrite to show the admin UI flow as the primary path. JSON shown only as reference for what the UI produces.
+- For category (b), explicitly mark as "Advanced — most users should use Admin → [section]" with a link.
+
+**During Phase 2 (alongside page-template unification):**
+
+- For every admin page that lands on a new template, add or refresh its corresponding `docs/` chapter with screenshots and a task-oriented walkthrough ("How do I publish an app?", "How do I rotate a provider key?", "How do I connect SSO?").
+- Cross-link: every JSON schema doc gets a "Do this in the UI instead" banner at the top with a link to the relevant admin page.
+- Add a new `docs/admin-ui.md` (or section in `docs/SUMMARY.md`) that becomes the entry point for "I am an admin — where do I start?"
+
+**During Phase 3 (alongside sub-roles + audit log):**
+
+- Document sub-role boundaries with capability matrices
+- Document audit log retention and export
+- Document the command palette and keyboard shortcuts
+
+### Success criteria
+
+- Direct JSON edits by admins drop measurably (proxy metric: support tickets mentioning manual JSON edits)
+- Admin UI usage telemetry shows ≥80% of admin actions go through UI flows for the operations we have UI for
+- Every admin page in the new IA has a corresponding docs section, reachable from a single `docs/admin/` index
+- Doc PRs land in step with feature PRs (added to PR review checklist)
+
+### Risk if we skip this
+
+If we ship the redesign without documentation alignment, the most common scenario will be: an admin reads the docs, sees a JSON example, edits the file directly, hits a validation or cache error, and concludes "the admin UI is broken" — when in reality they never used it. We will have rebuilt the surface that nobody is being taught to use.
+
+### Open question
+
+Do we treat documentation alignment as a hard gate for Phase 1 ship, or as a fast-follow within 30 days of Phase 1 GA? **Draft recommendation:** fast-follow with a public README/changelog note pointing to the new admin UI as the canonical path. A 30-day window keeps Phase 1 unblocked while still landing the docs before the redesign reaches broad customer awareness.
+
+---
+
+## 13. Enterprise table-stakes — what we are adding
 
 | Capability | Priority | Phase |
 |---|---|---|
@@ -363,7 +418,7 @@ Explicitly **not** building: custom dashboard widget layouts (single opinionated
 
 ---
 
-## 13. Open decisions
+## 14. Open decisions
 
 These need a stakeholder call **before Phase 1 build kick-off**. Draft picks a default for each.
 
@@ -378,7 +433,7 @@ These need a stakeholder call **before Phase 1 build kick-off**. Draft picks a d
 
 ---
 
-## 14. What this redesign is not
+## 15. What this redesign is not
 
 - **Not a backend refactor.** Every IA change uses existing endpoints (`server/routes/admin/*`). Audit Log dedicated feed and sub-role permission filters are the only new backend asks (both Phase 3).
 - **Not a brand refresh.** Color, type, and density tighten, but the visual language is iHub's existing Tailwind palette — not a logo or identity change.
@@ -386,7 +441,7 @@ These need a stakeholder call **before Phase 1 build kick-off**. Draft picks a d
 
 ---
 
-## 15. Implementation notes (for the coder phase)
+## 16. Implementation notes (for the coder phase)
 
 - **Three React shells:** `<ListPage>`, `<SettingsPage>`, `<IntegrationHubPage>`. Slots for header, toolbar, content, footer/save-bar. Pages cannot drift visually.
 - **`SidebarContext`** holds collapsed state, expanded sections, pinned items, current alert counts (subscribed to `/api/admin/alerts/summary` polling every 60s).
@@ -399,13 +454,14 @@ These need a stakeholder call **before Phase 1 build kick-off**. Draft picks a d
 
 ---
 
-## 16. Next steps
+## 17. Next steps
 
 1. **Stakeholder review** of this draft (estimate: 60-min walk-through with PM + Eng leadership + 2-3 enterprise admins).
-2. **Decisions** on the 8 open questions in §13.
+2. **Decisions** on the 9 open questions in §14 (8 IA/feature decisions + 1 on documentation timing in §12).
 3. **Phase 1 ticket breakdown** by engineering, scoped to the 4-week target.
 4. **Component spike** on the three page shells before opening Phase 1 implementation tickets.
-5. **Feedback loop** with 2-3 enterprise admins after a week of Phase 1 in staging — adjust IA before broader rollout.
+5. **Documentation audit** kicked off in parallel — see §12. Tag every `docs/` page as UI-first, advanced/escape-hatch, or stale, and start rewriting UI-first pages in lockstep with Phase 1.
+6. **Feedback loop** with 2-3 enterprise admins after a week of Phase 1 in staging — adjust IA before broader rollout.
 
 ---
 

--- a/concepts/admin-redesign-2026/2026-05-19 Admin UI Redesign Product Strategy & IA.md
+++ b/concepts/admin-redesign-2026/2026-05-19 Admin UI Redesign Product Strategy & IA.md
@@ -1,0 +1,396 @@
+# Admin UI Redesign — Product Strategy & Information Architecture
+
+**Document type:** PRD-style strategy brief
+**Author:** Product Strategy
+**Date:** 2026-05-19
+**Status:** Draft for review (to be combined with UX wireframe proposal)
+**Audience:** Product, Design, Engineering leads on iHub Apps platform
+
+---
+
+## 0. Executive Summary
+
+iHub Apps' admin surface has organically grown to 30+ top-level pages crammed into a flat tab nav with a 20-item "More" dropdown. Admins of all experience levels — from first-time platform owners to seasoned content curators — share the same monolithic role and the same unstructured home screen. The platform has effectively outgrown its navigation.
+
+This proposal redefines the admin as a **task-oriented workspace** rather than a list of CRUD pages. We recommend:
+
+1. **Consolidating** 30+ routes into **6 top-level sections** organized by what admins are trying to accomplish, not how the data is stored.
+2. **Replacing** the launcher-style dashboard with a true **operations home** that surfaces health, alerts, recent activity, and a setup checklist for fresh instances.
+3. **Phasing** the work in three releases — nav restructure (4 weeks), flow consolidation (8 weeks), and sub-roles + enterprise table-stakes (10 weeks) — so we ship perceived value within a month.
+4. **Deferring** sub-admin roles to Phase 3, because splitting permissions before stabilizing IA risks fragmenting the user model twice.
+5. **Adding** five table-stakes capabilities expected by enterprise buyers: command palette, admin audit log, global search, dry-run for risky changes, and bulk import/export.
+
+Backend endpoints already cover every use case described here. This is a UI/IA initiative, not a platform refactor.
+
+---
+
+## 1. Admin Personas
+
+We propose five working personas. They are **role archetypes** that real users blend in different proportions — the platform should accommodate the blend without forcing the split.
+
+| # | Persona | Primary mission | Top tasks | Frequency |
+|---|---------|-----------------|-----------|-----------|
+| 1 | **Platform Owner** | Stand up and steward the instance | 1. Initial install: providers, auth, first apps<br>2. Major version upgrades & backup verification<br>3. Feature-flag rollouts<br>4. License/SSL/encryption hygiene<br>5. Capacity planning | Weekly at first, then monthly |
+| 2 | **Identity & Security Admin** | Control who can do what | 1. Onboard a business unit (users + groups)<br>2. Configure/rotate SSO (OIDC, NTLM, OAuth)<br>3. Rotate compromised API keys/secrets<br>4. Audit privileged access<br>5. Respond to access incidents | Daily/weekly |
+| 3 | **Content & AI Admin** | Curate the AI app catalog | 1. Create and publish new AI apps<br>2. Tune prompts/variables<br>3. Manage models, tools, sources<br>4. Manage prompt library + global variables<br>5. Promote/retire apps across groups | Daily |
+| 4 | **Integrations Admin** | Connect iHub to external systems | 1. Connect Office365 / GDrive / Nextcloud / Jira<br>2. Provision OAuth clients for downstream apps<br>3. Install/configure browser extension and Outlook add-in<br>4. Configure CORS for embedding | Project-based (bursty) |
+| 5 | **Observability / SRE** | Keep it running, prove its value | 1. Investigate failed chats or auth errors<br>2. Pull monthly usage reports for finance/leadership<br>3. Tune log levels during incidents<br>4. Monitor token spend by app/user<br>5. Verify telemetry pipeline | Daily during incidents, weekly otherwise |
+
+### Are these realistic separations today?
+
+**No — and that's important.** In current iHub Apps installations the same human typically wears 3–5 of these hats. The personas guide **information architecture and dashboard widgets**, not (yet) role assignments. We recommend treating personas as a **lens for grouping pages** and a **future basis for sub-roles** (Phase 3), not as a permission system to ship immediately.
+
+---
+
+## 2. Job-to-be-Done Analysis
+
+The top 10 admin JTBDs, ranked by combined frequency × business criticality. The "Click cost" column is rough today vs. target; the "Crosses pages" column is the critical signal for redesign.
+
+| # | Job to be done | Today: pages involved | Clicks today | Crosses pages | Phase 2 target |
+|---|----------------|----------------------|--------------|----------------|-----------------|
+| 1 | **Onboard a new business unit** (create group, map external IdP, set app/model permissions, invite users) | Groups → Users → Authentication (mappings) → Apps (allowedGroups) → Models | 30+ | Yes (5) | Guided "Onboard Group" wizard |
+| 2 | **Rotate a leaked API key** (rotate at provider, update in iHub, verify all dependent apps still work) | Providers → Models (per affected model) → Apps (smoke check) → Logs | 20+ | Yes (4) | "Rotate Key" flow with affected-resource preview + dry-run |
+| 3 | **Publish a new AI app to all users** (create app, attach model, attach tools/sources, set permissions, test, enable) | Apps → Models → Tools → Sources → Prompts → Groups | 25+ | Yes (6) | Single "Publish App" wizard with side-panel for tools/sources/perms |
+| 4 | **Audit who used GPT-4 this month** | Usage Reports → (manually filter) | 6–10 | No (1) but data is shallow | Saved report + drilldown to user/app |
+| 5 | **Set up enterprise SSO** (e.g., OIDC) | Authentication → OAuth Hub → OAuth Server → OAuth Clients → Groups (mappings) → Users (test) | 25+ | Yes (5+) | "Connect SSO" wizard; OAuth hub absorbs subpages |
+| 6 | **Connect a new integration** (e.g., Office365) | Integrations Hub → Office365 page (also reachable directly) → Authentication (if OAuth needed) → Sources (knowledge base) | 15+ | Yes (3–4) | One canonical integrations card-detail pattern, no legacy direct routes |
+| 7 | **Diagnose a chat failure** | Logging → (filter by app/user) → Usage Reports → Apps (config check) → Models (provider status) | 15+ | Yes (4) | Unified "Monitoring" tab with cross-linked timelines |
+| 8 | **Backup before a risky change** | System (Backup section) → execute → verify | 5–8 | No, but buried | Promote to Platform → Backups; add restore-test |
+| 9 | **Toggle a feature flag** (e.g., enable Workflows for a pilot group) | Features → Groups (assign) | 5–10 | Yes (2) | Inline flag toggle on Group detail; flags also remain in Platform → Features |
+| 10 | **Bulk update apps** (e.g., switch 12 apps to a new model) | Apps (one by one) | 24+ | No (1) but no bulk action | Bulk-select + bulk-edit in Apps |
+
+**Insight:** 7 of the top 10 JTBDs cross 3+ pages today. Three of them (onboard BU, rotate key, publish app) are good candidates for **dedicated guided flows** even if the underlying CRUD pages remain unchanged. The remaining four collapse naturally into the proposed IA.
+
+---
+
+## 3. Proposed Top-Level Information Architecture
+
+We recommend **6 top-level sections**, plus a contextual help/utility rail. Six is the upper bound of what a horizontal nav can hold without spilling; further consolidation would make labels generic ("Settings") and unhelpful.
+
+### Proposed sections
+
+| # | Section | Includes | What changes |
+|---|---------|----------|---------------|
+| 1 | **Overview** | New dashboard, setup checklist, "needs attention" feed, recent activity, quick links | Replaces today's launcher tile grid |
+| 2 | **AI Workspace** | Apps, Prompts, Models, Tools, Sources, Skills (FF), Workflows (FF), Marketplace (FF) | Merges all "what users interact with" content. Pages and Short Links demoted (see below) |
+| 3 | **Access & Identity** | Users, Groups, Authentication, OAuth (with merged sub-pages), Providers | Absorbs all auth/identity. Providers move here because they are credential management. OAuth Hub absorbs Server + Clients sub-pages as tabs within OAuth detail |
+| 4 | **Integrations** | Office365, Google Drive, Nextcloud, Nextcloud Embed, Jira, Outlook add-in, Browser extension | Single Integrations index using a card-per-provider pattern. **Legacy direct routes are removed** (breaking change — see note) |
+| 5 | **Monitoring** | Usage Reports, Logging, Telemetry, plus new "Activity feed" view | Merges three siblings into one observability surface with sub-tabs |
+| 6 | **Platform** | UI Customization, Features, Backups, Updates/Version, Security (Encryption, SSL, CORS), System Info | Replaces System "junk drawer". Security becomes its own sub-section. Backups promoted to first-class sub-nav item |
+
+### Pages to merge
+
+- **Logging + Telemetry + Usage Reports → Monitoring.** All three answer "what is the platform doing?" Splitting them creates artificial walls between cause (logs), effect (telemetry traces), and outcome (usage). One section, three tabs.
+- **Authentication + OAuth + Users + Groups → Access & Identity.** A single mental model: "who can sign in, what are they grouped as, and through which protocol?" Providers also belong here because they are credential storage, even though they're LLM-facing.
+- **OAuth Hub + Server + Clients → OAuth (single page with tabs).** The split into three routes is an artifact of incremental development, not a user need.
+- **System encryption + SSL + CORS → Platform → Security.** Keep system info (version, updates) separate from security knobs.
+
+### Pages to promote
+
+- **Backups.** Today buried inside System. Should be a top sub-nav item under Platform with last-backup timestamp visible from Overview. Backup hygiene is the #1 thing auditors check.
+- **Users.** Currently a sibling of 30 other pages. Promote into Access & Identity as the default landing tab. Most "I need to do something with a person" tasks start here.
+- **Features (flags).** Today buried in More. Flags govern feature rollout; they should sit prominently under Platform with a per-group filter view.
+
+### Pages to demote or hide
+
+- **Pages (custom embeddable pages).** Niche; keep accessible under AI Workspace → Pages, but don't pin to top-nav.
+- **Short Links.** Useful but low-frequency. Move under AI Workspace → Short Links, or fold into App detail ("share link") if usage is dominantly app-share.
+- **Skills + Workflows + Marketplace** (currently feature-flagged). Keep gated. When enabled, they appear in AI Workspace as siblings to Apps.
+
+### Why six and not five or seven?
+
+We tested mental models for collapsing further:
+
+- **5 sections** (folding Monitoring into Platform): rejected, because incident response is a distinct daily workflow for Observability personas. Burying it under "Platform" puts it behind clicks where seconds matter.
+- **7 sections** (splitting Security out of Platform): rejected, because Security would only own 3 pages and create a top-nav item where most clicks lead to one screen.
+
+### Breaking changes flag
+
+Per `CLAUDE.md` guidance: removing legacy direct integration routes (e.g., `/admin/office365` as a top-level route) is a breaking change for anyone bookmarking those URLs. **We recommend a clean break with redirects from old paths for 1 minor version, then removal.** This decision should be confirmed with the user before implementation.
+
+---
+
+## 4. Dashboard Redesign Principles
+
+### Is it a dashboard or a launcher?
+
+**It should be a dashboard with launcher affordances**, not a launcher pretending to be a home page. Enterprise admins arrive at the home page asking one of three questions:
+
+1. *Is everything okay?* (health)
+2. *Is there something I need to do?* (actions)
+3. *Where do I go to start a task?* (navigation)
+
+The current tile grid only answers #3. The new home should answer all three, top-down.
+
+### Proposed Overview layout (zones, not pixels)
+
+1. **Status banner** (top): instance health badge ("All systems operational" / "1 issue detected"). One sentence. Links to incidents/alerts.
+2. **Needs attention** (above the fold, left): an ordered list of actionable items, e.g.:
+   - "Provider OpenAI: API key returned 401 in last 5 calls"
+   - "Backup has not run for 4 days"
+   - "12 users in unmapped IdP group 'contractors'"
+   - "App 'Sales Coach' references deprecated model gpt-3.5-turbo"
+   Each item has a primary action button (e.g., "Update key", "Run backup now").
+3. **Key metrics** (above the fold, right): 4–6 KPI cards. Tap to drill into Monitoring with the same filter.
+   - Active users (last 30d)
+   - Chats this month
+   - Tokens this month (and trend vs. last month)
+   - Active apps (and total)
+   - Failed auth attempts (last 7d)
+   - Platform version + update available indicator
+4. **Setup checklist** (conditional, shown until 100% complete): for fresh installs, a 6-step checklist:
+   - [ ] Configure at least one LLM Provider
+   - [ ] Configure Authentication
+   - [ ] Create at least one Group
+   - [ ] Invite at least one user
+   - [ ] Publish at least one App
+   - [ ] Run first backup
+   Hidden once dismissed or fully completed. Re-surfaces if any item regresses (e.g., backup deleted).
+5. **Recent activity** (below the fold): last 10 admin actions — who did what, when. Doubles as a low-fidelity audit trail until the full audit log lands in Phase 3.
+6. **Quick launch grid** (below the fold or in a collapsible drawer): the existing tile grid, but **grouped** by the same 6 top-level sections, so admins can still launch a task in one click.
+
+### KPIs to surface (recommended set)
+
+- **Platform health**: provider status, auth status, backup status, version status. Roll up into a single banner.
+- **Usage**: chats this month, tokens this month (+ trend), distinct active users last 30d.
+- **Inventory**: # active apps, # active users, # groups, # integrations connected.
+- **Security**: failed auth attempts (7d), admin actions (7d), expiring secrets (next 30d).
+
+### Patterns we recommend adopting
+
+- **"Things needing attention"** — borrowed from GitHub/Stripe dashboards. Every item is actionable; nothing is decorative.
+- **Setup checklist with progress** — borrowed from Vercel/Auth0. Sets expectations for first-time admins and reduces drop-off during onboarding.
+- **Drill-everything** — every metric on the home page must link to a filtered view in Monitoring or the relevant section. Numbers without drill-down are decoration.
+
+---
+
+## 5. Sub-Permissions Recommendation
+
+### The question
+
+Should we introduce sub-admin roles (Content Admin, Identity Admin, Observability Reader) alongside the IA redesign?
+
+### Recommendation: **No, not in Phase 1 or 2. Defer to Phase 3.**
+
+### Reasoning
+
+| Factor | Now (with redesign) | Later (after redesign) |
+|--------|----------------------|------------------------|
+| User impact | High disruption: IA changes AND permission model changes hit the same admins simultaneously | Stable IA, isolated permission model change |
+| Migration risk | Existing single-admin model is well understood. Splitting it requires a migration plan and rollback story | Migration is a one-axis change; rollback is per-user |
+| Demand evidence | We have **no** concrete enterprise asks for sub-roles in current backlog | If demand materializes, Phase 3 ships on solid IA |
+| Engineering scope | Doubles Phase 1 (IA + roles) into a multi-quarter release | Each phase ships in 4–10 weeks |
+| Customer message | "We rebuilt the admin AND changed who can do what" — confusing | "We rebuilt the admin. Next, finer access control" — clear |
+
+### Pros and cons of introducing sub-roles
+
+**Pros**
+- Aligns with enterprise expectations (separation of duties)
+- Reduces blast radius of mistakes by a junior content admin
+- Enables delegation (e.g., business unit owns its own apps but cannot touch SSO)
+- Satisfies SOC2 / ISO27001 audit narratives around least privilege
+
+**Cons**
+- Adds permission matrix complexity (today: 1 axis. After: N axes)
+- Requires UI affordances for every page to render in read-only or hidden mode
+- Migration story: existing admins keep "super admin", but how do we encourage adoption of narrower roles?
+- Risk of mis-scoping (e.g., what role can rotate provider keys vs. just view them?)
+- Group inheritance already exists — adding role inheritance on top doubles the cognitive load
+
+### Recommended Phase 3 design (preview)
+
+- **Three predefined sub-roles** layered on top of the existing `admin` group: `content-admin`, `identity-admin`, `observability-admin`. Each is implemented as a real group in `groups.json` that inherits from `users` (not `admin`) and gets scoped permissions.
+- **Top-level admin (`super-admin`) remains** as a separate group for full access.
+- Reuse existing group inheritance + permission system rather than building a new ACL.
+- Read-only mode (`observability-admin`) is the simplest first slice — implement it as a feature spike before rolling out write-scoped roles.
+
+---
+
+## 6. Phasing Plan
+
+### Phase 1 — Restructure & Refresh (target: 4 weeks)
+
+**Goal:** Ship perceived progress fast. No backend changes. No page-level rewrites.
+
+**Scope:**
+- Implement the 6-section top nav with sub-nav routing
+- Migrate all 30+ existing pages under the new nav (no content changes)
+- Replace dashboard with the new Overview (status banner + needs-attention + KPIs + setup checklist + recent activity + collapsible launcher)
+- Move System → Security and System → Backups sub-sections
+- Merge OAuth Hub + Server + Clients into a single tabbed page
+- Add redirects from old routes for 1 minor version
+
+**Non-goals:** Sub-roles, wizards, bulk actions, audit log, command palette.
+
+**Success criteria:**
+- Admin survey (n≥10): "find a setting" task drops from average 30s to <10s
+- Reduction in "where is X?" support tickets by 50%
+- Zero increase in broken links (verified via redirects)
+
+### Phase 2 — Flow Consolidation & Table Stakes (target: 8 weeks)
+
+**Goal:** Collapse the highest-cost JTBDs into guided flows.
+
+**Scope:**
+- **Onboard Group wizard** (JTBD #1)
+- **Publish App wizard** with side-panels for tools/sources/perms (JTBD #3)
+- **Rotate Key flow** with affected-resource preview + dry-run mode (JTBD #2)
+- **Connect SSO wizard** (JTBD #5)
+- **Bulk actions** in Apps and Users tables (JTBD #10)
+- **Command palette (Cmd+K)** for global navigation and quick actions
+- **Global search** across apps/users/groups/prompts/etc.
+- **Monitoring unified view** with cross-linked timelines (logs ↔ usage)
+- Integrations card-detail pattern; remove legacy direct routes
+
+**Success criteria:**
+- JTBD click cost reduces by ≥50% for the 5 covered jobs
+- Cmd+K usage by week 4 ≥ 30% of weekly admin sessions
+- Bulk-edit used in ≥20% of multi-app changes
+
+### Phase 3 — Sub-Roles & Enterprise Polish (target: 10 weeks)
+
+**Goal:** Unlock enterprise selling motions and harden the admin surface.
+
+**Scope:**
+- Sub-admin roles (read-only first, then scoped write)
+- **Admin audit log** as a dedicated Monitoring sub-tab with retention and export
+- **Change history per config** (diff view, revert)
+- **Dry-run mode** generalized for risky changes
+- **Bulk import/export** (CSV/JSON) for apps, users, groups
+- **Multi-tenant scoping** if/when needed (gated by demand)
+- Onboarding for the new IA itself (in-product tour)
+
+**Success criteria:**
+- ≥3 customers using sub-roles within 90 days of release
+- Audit log queried in ≥40% of admin investigations
+- Zero unrecoverable config changes reported in pilot quarter
+
+---
+
+## 7. Enterprise Table-Stakes Gap Analysis
+
+Capabilities expected by enterprise admin buyers that we do not have today, prioritized by impact.
+
+| Capability | Priority | Why it matters | Phase |
+|------------|----------|-----------------|-------|
+| **Admin audit log** | Must | Required for SOC2/ISO/internal compliance. Today's "recent activity" on Overview is a stop-gap | P3 |
+| **Command palette (Cmd+K)** | Must | Power-user expectation. Single biggest IA mitigation — even with 30 pages, Cmd+K makes them findable | P2 |
+| **Global admin search** | Must | "I know I named a prompt 'sales coach' but can't find it" — solved in seconds | P2 |
+| **Change history per config** | Should | Reverting a bad app/prompt/model edit without a backup | P3 |
+| **Dry-run for risky changes** | Should | Rotate-key, delete-app, bulk-disable. Show preview of impact before commit | P2 (rotate key) + P3 (generalized) |
+| **Bulk import/export** | Should | Migrations, environment promotion (dev→staging→prod), DR drills | P3 |
+| **Multi-tenant separation** | Could | Genuine multi-tenant is a platform-level decision. Soft tenancy via groups already partly addresses this | P3 (gated by demand) |
+| **In-product changelog / "what's new"** | Should | Admins resent silent feature flag toggles; surface them | P3 |
+| **Health probes & uptime widget** | Must | Surface on Overview. Today admins discover problems from user reports | P1 (banner) + P2 (drilldown) |
+| **Configurable email/Slack alerts** | Could | "Notify me when provider key fails" — natural extension of needs-attention feed | P3 |
+| **Two-person rule for destructive ops** | Could | Enterprise audit ask; gated by demand | P3 |
+| **Session/admin login as user (impersonation)** | Could | Reproduce user-reported bugs without password reset. Sensitive — requires audit log | P3 |
+
+### What we **don't** recommend building
+
+- **Custom dashboard widgets / drag-and-drop layout.** Tempting, but it's a feature in search of a problem. A single, opinionated Overview serves admins better than self-service layout. Revisit only if usage data shows admins want different home views per persona.
+- **A separate "Settings" mega-page.** Today's System page is exactly this and exactly the failure mode we're escaping. Decompose, don't recompose.
+- **Per-page customization (column choosers, saved filters) in Phase 1.** Defer to Phase 3 unless usage analytics demand it earlier.
+
+---
+
+## 8. Risks & Open Questions
+
+### Risks
+
+1. **Redirects miss.** If a customer has documentation/bookmarks pointing at `/admin/office365`, breaking those without warning will generate support load. Mitigation: maintain redirects for 1 minor version + release-notes communication.
+2. **Existing admin muscle memory.** Power users will be slower for 1–2 weeks after Phase 1. Mitigation: ship an in-product "What moved where" reference accessible from the Overview.
+3. **Setup checklist false negatives.** If checklist logic is fragile, a working instance might show "incomplete". Mitigation: ship with conservative detection and a manual "mark complete" override.
+4. **KPI accuracy on Overview.** Token counts, failed auth counts, etc., must agree with Monitoring drill-down. Mitigation: pull from the same backend endpoints; no client-side aggregation.
+5. **Sub-role expectations.** If Phase 1 ships and customers immediately ask for sub-roles, deferring to Phase 3 may cost a deal. Mitigation: track this in CS calls; be ready to pull Phase 3 forward if 3+ enterprise asks land.
+
+### Open questions for stakeholders
+
+1. **Do we want a clean break on legacy integration routes,** or keep them as deprecated redirects indefinitely? (Default recommendation: 1-minor-version redirect, then remove.)
+2. **Is the Overview the default landing page for all admins,** or do power users get a setting to land directly on their last-visited section? (Recommendation: Overview default; remember-last-visited as a Phase 2 user preference.)
+3. **Should Providers live in Access & Identity** (because they are credential storage) **or in AI Workspace** (because models depend on them)? (Recommendation: Access & Identity, with a cross-link from Models.)
+4. **What is our position on customer-visible audit log retention?** (Affects Phase 3 storage decisions.)
+5. **For Phase 2 bulk actions, what is the maximum batch size** we want to commit to in UI (e.g., 100, 500, 1000)? (Determines whether bulk operations are sync or async.)
+
+---
+
+## 9. Success Metrics (Aggregate)
+
+| Metric | Baseline (today, estimate) | Phase 1 target | Phase 3 target |
+|--------|---------------------------|-----------------|------------------|
+| Time-to-find-setting (median) | ~30s | <10s | <5s |
+| Clicks to publish a new app | 25+ | 25 (unchanged) | 8–10 (wizard) |
+| Clicks to rotate a provider key | 20+ | 20 (unchanged) | 5–7 (flow) |
+| New-admin time-to-first-published-app | Unmeasured | <30 min | <15 min |
+| Admin NPS | Unmeasured | Baseline | +15 |
+| "Where is X?" support tickets | Baseline | -50% | -80% |
+| Cmd+K weekly active usage | 0% | 0% | ≥30% |
+| Overview "needs attention" items resolved within 24h | N/A | N/A | ≥70% |
+
+---
+
+## 10. Out of Scope
+
+To keep this brief focused, the following are explicitly **not** addressed here and should be handled separately:
+
+- Visual design system, color, typography (designer)
+- Mobile/tablet responsiveness specifics (designer)
+- Specific component implementation, framework choices (engineer)
+- Internationalization of new strings (translation pipeline)
+- Backend endpoint changes (none expected — confirm with engineering)
+- Accessibility audit (separate WCAG 2.1 AA pass, recommend Phase 1)
+- Pricing/packaging implications of sub-roles (separate commercial decision)
+
+---
+
+## 11. Next Steps
+
+1. **Review** this brief with engineering and design leads. Confirm no backend changes required.
+2. **Pair with UX designer's wireframe proposal** to produce a unified redesign draft.
+3. **Walk through with 2–3 enterprise admins** before Phase 1 build kick-off to validate persona blends and JTBD priorities.
+4. **Decide on open questions** in Section 8 (recommend a 30-min stakeholder review).
+5. **Commit to Phase 1 scope** with engineering sizing; lock the 4-week target.
+
+---
+
+## Appendix A — Mapping current pages to proposed IA
+
+| Current page | Proposed section | Notes |
+|---|---|---|
+| Home (dashboard) | Overview | Redesigned |
+| Apps | AI Workspace → Apps | |
+| Models | AI Workspace → Models | |
+| Prompts | AI Workspace → Prompts | |
+| Tools | AI Workspace → Tools | |
+| Skills (FF) | AI Workspace → Skills | |
+| Sources | AI Workspace → Sources | |
+| Pages | AI Workspace → Pages | Demoted within section |
+| Short Links | AI Workspace → Short Links | Demoted within section |
+| Workflows (FF) | AI Workspace → Workflows | |
+| Marketplace (FF) | AI Workspace → Marketplace | |
+| Providers | Access & Identity → Providers | Moved from "Content & Apps" mental model |
+| Authentication | Access & Identity → Authentication | |
+| OAuth Hub + Server + Clients | Access & Identity → OAuth (tabbed) | Merged |
+| Users | Access & Identity → Users | Promoted as default tab |
+| Groups | Access & Identity → Groups | |
+| Integrations Hub | Integrations | Becomes the only entry; cards link to detail |
+| Office365 | Integrations → Office365 | Direct route removed |
+| Google Drive | Integrations → Google Drive | Direct route removed |
+| Nextcloud | Integrations → Nextcloud | Direct route removed |
+| Jira | Integrations → Jira | Direct route removed |
+| Outlook add-in | Integrations → Outlook Add-in | Direct route removed |
+| Browser extension | Integrations → Browser Extension | Direct route removed |
+| Nextcloud Embed | Integrations → Nextcloud Embed | Direct route removed |
+| Logging | Monitoring → Logs | |
+| Telemetry | Monitoring → Telemetry | |
+| Usage Reports | Monitoring → Usage | |
+| (new) | Monitoring → Activity / Audit | Phase 3 |
+| UI Customization | Platform → UI | |
+| Features (flags) | Platform → Features | Promoted out of "More" |
+| System (version, updates) | Platform → System Info | |
+| System (encryption, SSL, CORS) | Platform → Security | Decomposed from System |
+| System (backup/restore) | Platform → Backups | Promoted |
+
+---
+
+*End of strategy brief. Combine with UX wireframes for the final redesign draft.*

--- a/concepts/admin-redesign-2026/README.md
+++ b/concepts/admin-redesign-2026/README.md
@@ -1,0 +1,47 @@
+# Admin UI Redesign — 2026
+
+**Status:** Draft for review
+**Date:** 2026-05-19
+**Branch:** `claude/redesign-admin-ui-AmW2j`
+**PR:** [#1484](https://github.com/intrafind/ihub-apps/pull/1484)
+
+## Why we are doing this
+
+The iHub Apps admin has grown to 30+ pages. Today they sit in a flat top-tab bar with three pinned items (Apps, Models, Prompts) and a "More" dropdown that hides the other 20+. The landing page is a 12-tile launcher with no grouping and no signal. New admins are lost; experienced admins live in muscle memory and Cmd+L.
+
+This redesign moves the admin to a **task-oriented, enterprise-grade workspace** — left-rail navigation, a real operations dashboard, three reusable page templates, a Cmd+K command palette, and consistent "needs attention" surfaces.
+
+## Documents in this folder
+
+1. **[Redesign Draft](2026-05-19%20Admin%20UI%20Redesign%20Draft.md)** — The synthesised proposal. **Start here.**
+2. **[Product Strategy & IA](2026-05-19%20Admin%20UI%20Redesign%20Product%20Strategy%20&%20IA.md)** — PRD-style brief: personas, JTBDs, IA rationale, phased rollout, enterprise gap analysis.
+3. **[Design Brief](2026-05-19%20Admin%20UI%20Redesign%20Design%20Brief.md)** — UX/UI brief: navigation pattern, dashboard wireframes, page templates, command palette, visual direction, accessibility.
+
+## Key recommendations at a glance
+
+- **7 top-level sections** (left rail): Overview, AI Workspace, Access & Identity, Integrations, Customization, Observability, Platform.
+- **Dashboard replaces the launcher**: status banner, "needs attention", KPI cards, setup checklist (fresh instances), recent activity. Tile launcher demoted to a collapsible drawer at the bottom.
+- **Three reusable page templates**: List/CRUD, Settings, Integration Hub. Every admin page becomes one of these.
+- **Command palette (Cmd+K)** for global search, navigation, and quick actions.
+- **System "junk drawer" is dismantled** into Security, Backup & Restore, Updates, Advanced.
+- **OAuth hub + Server + Clients merged** into one tabbed page.
+- **Audit Log added** as first-class observability surface.
+- **Sub-admin roles deferred to Phase 3** — ship IA changes first.
+
+## Phased rollout
+
+| Phase | Scope | Target |
+|---|---|---|
+| 1 | New chrome (sidebar, topbar) + Overview dashboard, all existing pages re-routed unchanged | 4 weeks |
+| 2 | Page-template unification, bulk actions, command palette, wizards for top 5 JTBDs | 8 weeks |
+| 3 | Sub-admin roles, audit log retention, change history, dry-run, bulk import/export | 10 weeks |
+
+## Open decisions for the user
+
+These need a call before implementation begins. The draft includes recommendations for each.
+
+1. **Providers placement** — AI Workspace (recommended) or Access & Identity?
+2. **Customization as its own section** (recommended) or folded into Platform?
+3. **Legacy integration routes** — remove with 1-minor-version redirect (recommended), or keep indefinitely?
+4. **Sub-roles timing** — Phase 3 (recommended) or sooner?
+5. **Audit Log scope** — full new feature in Phase 1 or stub from telemetry?

--- a/concepts/admin-redesign-2026/README.md
+++ b/concepts/admin-redesign-2026/README.md
@@ -27,6 +27,7 @@ This redesign moves the admin to a **task-oriented, enterprise-grade workspace**
 - **OAuth hub + Server + Clients merged** into one tabbed page.
 - **Audit Log added** as first-class observability surface.
 - **Sub-admin roles deferred to Phase 3** — ship IA changes first.
+- **Documentation alignment is a required parallel workstream.** Many users today edit JSON in `contents/` directly because `docs/` does not document the admin UI. Without rewriting docs to be UI-first, the redesign delivers a surface nobody is taught to use. See draft §12.
 
 ## Phased rollout
 
@@ -45,3 +46,4 @@ These need a call before implementation begins. The draft includes recommendatio
 3. **Legacy integration routes** — remove with 1-minor-version redirect (recommended), or keep indefinitely?
 4. **Sub-roles timing** — Phase 3 (recommended) or sooner?
 5. **Audit Log scope** — full new feature in Phase 1 or stub from telemetry?
+6. **Documentation alignment timing** — hard gate for Phase 1 ship, or 30-day fast-follow (recommended)? See draft §12.


### PR DESCRIPTION
## Summary

Proposal to redesign the iHub admin UI from a 30-page flat tab nav (with a 20-item "More" dropdown and a 12-tile launcher dashboard) into an **enterprise-grade admin workspace** with left-rail navigation, an operations dashboard, three reusable page templates, and a Cmd+K command palette.

**Docs-only PR.** No code changes. Three documents in `concepts/admin-redesign-2026/`:

1. **README.md** — entry point, key recommendations, open decisions for stakeholders
2. **Admin UI Redesign Draft.md** — the synthesised proposal (start here for review)
3. **Admin UI Redesign Product Strategy &amp; IA.md** — PRD-style brief: personas, JTBDs, IA rationale, phased rollout, enterprise gap analysis
4. **Admin UI Redesign Design Brief.md** — UX/UI brief: navigation pattern, dashboard wireframes, page templates, command palette, visual direction, accessibility

## Key moves

- **7 top-level sections** (left rail): Overview, AI Workspace, Access &amp; Identity, Integrations, Customization, Observability, Platform
- **Dashboard replaces the launcher** — status banner, "needs attention", KPI cards, setup checklist for fresh instances, recent activity. Old tile grid demoted to a collapsible footer drawer
- **Three reusable page templates** — List/CRUD, Settings, Integration Hub. Every admin page becomes one of these
- **Command palette (Cmd+K)** for global search, navigation, quick actions
- **System "junk drawer" dismantled** into Security, Backup &amp; Restore, Updates, Advanced
- **OAuth hub + Server + Clients merged** into one tabbed page
- **Audit Log added** as first-class Observability surface
- **Sub-admin roles deferred to Phase 3** — ship IA changes first

## Phasing

| Phase | Scope | Target | Backend changes |
|---|---|---|---|
| 1 | New chrome + Overview, all existing pages re-routed unchanged, legacy routes redirect | 4 weeks | None |
| 2 | Page-template unification, bulk actions, command palette, wizards for top 5 JTBDs | 8 weeks | Optional bulk + search endpoints |
| 3 | Sub-admin roles, audit log retention, change history, dry-run, bulk import/export | 10 weeks | Audit-log persistence, role-scoped permission filters |

## Open decisions before Phase 1 build

The draft picks a default for each. Listed in `README.md` and §13 of the draft:

1. Providers placement — **AI Workspace** (draft) or Access &amp; Identity?
2. Customization as its own section — **yes** (draft) or fold into Platform?
3. Legacy integration routes — **1-minor-version redirect** (draft) or keep indefinitely?
4. Sub-roles timing — **Phase 3** (draft) or sooner?
5. Audit Log Phase 1 scope — **seed from telemetry** (draft) or full feature?
6. Customizable Quick Actions — **instance-default v1** (draft), per-user later?
7. Pinning/favorites — **localStorage in P2, server-side in P3** (draft)?
8. Feature flags (Marketplace/Skills/Workflows) — graduating soon? **Needs PM input**

## Test plan

- [ ] Stakeholder review of synthesised draft (PM + Eng leads + 2–3 enterprise admins)
- [ ] Decisions on the 8 open questions
- [ ] Phase 1 ticket breakdown scoped to 4-week target
- [ ] Component spike on the three page shells before Phase 1 implementation tickets
- [ ] Feedback loop with 2–3 enterprise admins after a week of Phase 1 in staging