### PR TITLE
chore(jwt-auth): switch authenticated user log to debug level

### DIFF
--- a/server/middleware/jwtAuth.js
+++ b/server/middleware/jwtAuth.js
@@ -76,7 +76,7 @@ export default function jwtAuthMiddleware(req, res, next) {
 
     // Debug: Log JWT payload in development
     if (process.env.NODE_ENV === 'development') {
-      logger.info('JWT user authenticated', {
+      logger.debug('JWT user authenticated', {
         component: 'JwtAuth',
         userId: decoded.sub || decoded.username || decoded.id,
         name: decoded.name,


### PR DESCRIPTION
## Summary
- Switch the per-request `JWT user authenticated` log in `server/middleware/jwtAuth.js` from `logger.info` to `logger.debug` so it no longer floods info-level output in development.
- Behavior is otherwise unchanged: it is still gated by `NODE_ENV === 'development'` and logs the same fields.

## Test plan
- [ ] Start the dev server (`npm run dev`) and confirm the `JwtAuth` "JWT user authenticated" line no longer appears at the default info log level.
- [ ] Set the log level to `debug` and confirm the message reappears with the same payload shape.

https://claude.ai/code/session_01SQ8gCk1iGiB4s89QKZM5dY

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQ8gCk1iGiB4s89QKZM5dY)_