### PR TITLE
feat(apps): add Parliamentary Questions Analyzer app

### DIFF
--- a/client/src/features/apps/pages/AppChat.jsx
+++ b/client/src/features/apps/pages/AppChat.jsx
@@ -1923,6 +1923,7 @@ function AppChat({ preloadedApp = null }) {
                   canvasEnabled={app?.features?.canvas === true}
                   requiredIntegrations={requiredIntegrations}
                   onConnectIntegration={connectIntegration}
+                  app={app}
                   models={models}
                   onClarificationSubmit={handleClarificationSubmit}
                   onClarificationSkip={handleClarificationSkip}

--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -690,7 +690,13 @@ function ChatMessage({
           const parsedData =
             typeof message.content === 'string' ? JSON.parse(message.content) : message.content;
 
-          return <CustomResponseRenderer componentName={customRendererName} data={parsedData} />;
+          return (
+            <CustomResponseRenderer
+              componentName={customRendererName}
+              data={parsedData}
+              rendererConfig={app?.rendererConfig}
+            />
+          );
         } catch (error) {
           console.error('Error parsing JSON for custom renderer:', error);
           // Fall through to default JSON rendering on parse error

--- a/client/src/shared/components/CustomResponseRenderer.jsx
+++ b/client/src/shared/components/CustomResponseRenderer.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, Suspense, useMemo, useCallback, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router-dom';
 import ReactComponentRenderer from './ReactComponentRenderer';
 
 /**
@@ -14,13 +15,15 @@ import ReactComponentRenderer from './ReactComponentRenderer';
  *
  * @param {string} componentName - Name of the renderer component (e.g., 'nda-results')
  * @param {object} data - Parsed JSON data to pass to the component
+ * @param {object} rendererConfig - Optional renderer-specific config from the app JSON (passthrough)
  * @param {string} className - Optional CSS classes for the container
  */
-function CustomResponseRenderer({ componentName, data, className = '' }) {
+function CustomResponseRenderer({ componentName, data, rendererConfig, className = '' }) {
   const [rendererCode, setRendererCode] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const { t } = useTranslation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const loadRendererFromAPI = async () => {
@@ -65,6 +68,8 @@ function CustomResponseRenderer({ componentName, data, className = '' }) {
     () => ({
       data,
       t,
+      rendererConfig,
+      navigate,
       // Add React and hooks that the renderer might need
       React,
       useState,
@@ -73,7 +78,7 @@ function CustomResponseRenderer({ componentName, data, className = '' }) {
       useCallback,
       useRef
     }),
-    [data, t]
+    [data, t, rendererConfig, navigate]
   );
 
   if (loading) {

--- a/server/defaults/apps/parliamentary-questions.json
+++ b/server/defaults/apps/parliamentary-questions.json
@@ -1,0 +1,147 @@
+{
+  "id": "parliamentary-questions",
+  "order": 16,
+  "category": "government",
+  "name": {
+    "en": "Parliamentary Questions Analyzer",
+    "de": "Parlamentarische Anfragen Analysator"
+  },
+  "description": {
+    "en": "Extract individual questions from parliamentary inquiry documents (e.g. German Bundestag Kleine Anfragen) and search them in iFinder or ask iAssistant.",
+    "de": "Extrahiere einzelne Fragen aus parlamentarischen Anfragen (z. B. Kleinen Anfragen des Bundestags) und durchsuche sie in iFinder oder frage iAssistant."
+  },
+  "color": "#2563EB",
+  "icon": "document-text",
+  "system": {
+    "en": "You are an expert document analyst. Your task is to extract every distinct question from a parliamentary inquiry document (such as a Bundestag Kleine Anfrage) and return them as structured data.\n\n**Extraction rules:**\n- Identify each individual question, including sub-questions (e.g. '7', '7a', '9.8').\n- Preserve the original numbering exactly as it appears in the document, including dots and letters (e.g. '7', '9.8', '12a').\n- Return the full text of each question verbatim, without summarizing or paraphrasing.\n- For each question, provide an optional short topic label (1–3 words, in the same language as the question) that captures the subject (e.g. 'MAD-Prüfverfahren', 'Waffenzugang').\n- For each question, provide a concise search_query (5–12 keywords, no full sentences, no question marks) optimized for an enterprise document search engine. Strip filler words. Include named entities, dates, organizations, and key concepts.\n- If the document has a clear title or reference (e.g. 'Drucksache 19/30574'), include it in document_title.\n- If the user provides a topic_hint, weight your search_query toward that topic, but do NOT drop questions that fall outside the hint.\n\n**Output format:** Return strictly the JSON object defined by the schema. Do not wrap it in markdown code fences. Do not add commentary before or after the JSON.",
+    "de": "Du bist ein Experte für Dokumentenanalyse. Deine Aufgabe ist es, jede einzelne Frage aus einem parlamentarischen Anfragedokument (z. B. einer Kleinen Anfrage des Bundestags) zu extrahieren und als strukturierte Daten zurückzugeben.\n\n**Extraktionsregeln:**\n- Identifiziere jede einzelne Frage, einschließlich Unterfragen (z. B. '7', '7a', '9.8').\n- Behalte die ursprüngliche Nummerierung genau so bei, wie sie im Dokument erscheint, einschließlich Punkten und Buchstaben (z. B. '7', '9.8', '12a').\n- Gib den vollständigen Wortlaut jeder Frage wörtlich zurück, ohne zu zusammenfassen oder zu paraphrasieren.\n- Gib für jede Frage ein optionales kurzes Themen-Label an (1–3 Wörter, in der Sprache der Frage), das den Gegenstand beschreibt (z. B. 'MAD-Prüfverfahren', 'Waffenzugang').\n- Gib für jede Frage eine prägnante search_query an (5–12 Schlüsselwörter, keine vollständigen Sätze, keine Fragezeichen), die für eine Unternehmenssuchmaschine optimiert ist. Entferne Füllwörter. Füge Eigennamen, Datumsangaben, Organisationen und Schlüsselkonzepte ein.\n- Wenn das Dokument einen klaren Titel oder eine Referenz hat (z. B. 'Drucksache 19/30574'), gib sie in document_title an.\n- Wenn der Benutzer einen topic_hint angibt, gewichte deine search_query in Richtung dieses Themas, lasse aber KEINE Fragen weg, die außerhalb des Hinweises liegen.\n\n**Ausgabeformat:** Gib ausschließlich das JSON-Objekt zurück, das durch das Schema definiert ist. Verpacke es NICHT in Markdown-Codeblöcke. Füge weder vor noch nach dem JSON Kommentare hinzu."
+  },
+  "prompt": {
+    "en": "**Topic hint (optional):**\n{{topic_hint}}\n\n**Document to analyze:**\n{{content}}",
+    "de": "**Themenhinweis (optional):**\n{{topic_hint}}\n\n**Zu analysierendes Dokument:**\n{{content}}"
+  },
+  "tokenLimit": 16000,
+  "preferredOutputFormat": "json",
+  "preferredStyle": "professional",
+  "sendChatHistory": false,
+  "customResponseRenderer": "parliamentary-questions-results",
+  "rendererConfig": {
+    "iFinderUrlTemplate": "https://ifinder.example.com/?q={query}",
+    "iAssistantAppId": "ifinder-document-actions",
+    "iAssistantUrlTemplate": "https://iassistant.example.com/?q={query}"
+  },
+  "messagePlaceholder": {
+    "en": "Paste the questions here or upload a PDF...",
+    "de": "Fragen hier einfügen oder PDF hochladen..."
+  },
+  "greeting": {
+    "en": {
+      "title": "🏛️ Parliamentary Questions Analyzer",
+      "subtitle": "Upload a parliamentary inquiry PDF (e.g. Kleine Anfrage) to extract all questions into a searchable table. Each question gets one-click links to iFinder search and iAssistant."
+    },
+    "de": {
+      "title": "🏛️ Parlamentarische Anfragen Analysator",
+      "subtitle": "Laden Sie eine parlamentarische Anfrage als PDF hoch (z. B. Kleine Anfrage), um alle Fragen in eine durchsuchbare Tabelle zu extrahieren. Jede Frage erhält Ein-Klick-Links zur iFinder-Suche und zu iAssistant."
+    }
+  },
+  "outputSchema": {
+    "type": "object",
+    "properties": {
+      "document_title": {
+        "type": "string",
+        "description": "Title or reference of the document (e.g. 'Drucksache 19/30574'), empty if not present"
+      },
+      "questions": {
+        "type": "array",
+        "description": "List of every distinct question extracted from the document",
+        "items": {
+          "type": "object",
+          "properties": {
+            "number": {
+              "type": "string",
+              "description": "Original numbering as in the document (e.g. '7', '9.8', '12a')"
+            },
+            "text": {
+              "type": "string",
+              "description": "Full verbatim text of the question"
+            },
+            "topic": {
+              "type": "string",
+              "description": "Short topic label of 1-3 words, empty if not applicable"
+            },
+            "search_query": {
+              "type": "string",
+              "description": "Concise 5-12 keyword search query optimized for enterprise search"
+            }
+          },
+          "required": ["number", "text", "topic", "search_query"],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": ["document_title", "questions"],
+    "additionalProperties": false
+  },
+  "upload": {
+    "enabled": true,
+    "fileUpload": {
+      "enabled": true,
+      "maxFileSizeMB": 20,
+      "supportedFormats": ["text/plain", "text/markdown", "application/pdf"]
+    },
+    "imageUpload": {
+      "enabled": false
+    }
+  },
+  "settings": {
+    "enabled": true,
+    "model": {
+      "enabled": true
+    },
+    "temperature": {
+      "enabled": false
+    },
+    "outputFormat": {
+      "enabled": false
+    },
+    "chatHistory": {
+      "enabled": false
+    },
+    "style": {
+      "enabled": false
+    }
+  },
+  "inputMode": {
+    "type": "multiline",
+    "rows": 6,
+    "microphone": {
+      "enabled": false
+    }
+  },
+  "variables": [
+    {
+      "name": "topic_hint",
+      "label": {
+        "en": "Topic hint (optional)",
+        "de": "Themenhinweis (optional)"
+      },
+      "type": "string",
+      "defaultValue": {
+        "en": "",
+        "de": ""
+      },
+      "description": {
+        "en": "Optional topic or context to focus the extracted search queries (e.g. 'MAD, Bundeswehr').",
+        "de": "Optionales Thema oder Kontext, um die extrahierten Suchanfragen zu fokussieren (z. B. 'MAD, Bundeswehr')."
+      },
+      "placeholder": {
+        "en": "e.g. MAD, Bundeswehr, Rechtsextremismus",
+        "de": "z. B. MAD, Bundeswehr, Rechtsextremismus"
+      },
+      "required": false
+    }
+  ],
+  "allowEmptyContent": false,
+  "disallowModelSelection": false,
+  "enabled": true
+}

--- a/server/defaults/apps/parliamentary-questions.json
+++ b/server/defaults/apps/parliamentary-questions.json
@@ -1,6 +1,7 @@
 {
   "id": "parliamentary-questions",
   "order": 16,
+  "enabled": false,
   "category": "government",
   "name": {
     "en": "Parliamentary Questions Analyzer",
@@ -15,10 +16,6 @@
   "system": {
     "en": "You are an expert document analyst. Your task is to extract every distinct question from a parliamentary inquiry document (such as a Bundestag Kleine Anfrage) and return them as structured data.\n\n**Extraction rules:**\n- Identify each individual question, including sub-questions (e.g. '7', '7a', '9.8').\n- Preserve the original numbering exactly as it appears in the document, including dots and letters (e.g. '7', '9.8', '12a').\n- Return the full text of each question verbatim, without summarizing or paraphrasing.\n- For each question, provide an optional short topic label (1–3 words, in the same language as the question) that captures the subject (e.g. 'MAD-Prüfverfahren', 'Waffenzugang').\n- For each question, provide a concise search_query (5–12 keywords, no full sentences, no question marks) optimized for an enterprise document search engine. Strip filler words. Include named entities, dates, organizations, and key concepts.\n- If the document has a clear title or reference (e.g. 'Drucksache 19/30574'), include it in document_title.\n- If the user provides a topic_hint, weight your search_query toward that topic, but do NOT drop questions that fall outside the hint.\n\n**Output format:** Return strictly the JSON object defined by the schema. Do not wrap it in markdown code fences. Do not add commentary before or after the JSON.",
     "de": "Du bist ein Experte für Dokumentenanalyse. Deine Aufgabe ist es, jede einzelne Frage aus einem parlamentarischen Anfragedokument (z. B. einer Kleinen Anfrage des Bundestags) zu extrahieren und als strukturierte Daten zurückzugeben.\n\n**Extraktionsregeln:**\n- Identifiziere jede einzelne Frage, einschließlich Unterfragen (z. B. '7', '7a', '9.8').\n- Behalte die ursprüngliche Nummerierung genau so bei, wie sie im Dokument erscheint, einschließlich Punkten und Buchstaben (z. B. '7', '9.8', '12a').\n- Gib den vollständigen Wortlaut jeder Frage wörtlich zurück, ohne zu zusammenfassen oder zu paraphrasieren.\n- Gib für jede Frage ein optionales kurzes Themen-Label an (1–3 Wörter, in der Sprache der Frage), das den Gegenstand beschreibt (z. B. 'MAD-Prüfverfahren', 'Waffenzugang').\n- Gib für jede Frage eine prägnante search_query an (5–12 Schlüsselwörter, keine vollständigen Sätze, keine Fragezeichen), die für eine Unternehmenssuchmaschine optimiert ist. Entferne Füllwörter. Füge Eigennamen, Datumsangaben, Organisationen und Schlüsselkonzepte ein.\n- Wenn das Dokument einen klaren Titel oder eine Referenz hat (z. B. 'Drucksache 19/30574'), gib sie in document_title an.\n- Wenn der Benutzer einen topic_hint angibt, gewichte deine search_query in Richtung dieses Themas, lasse aber KEINE Fragen weg, die außerhalb des Hinweises liegen.\n\n**Ausgabeformat:** Gib ausschließlich das JSON-Objekt zurück, das durch das Schema definiert ist. Verpacke es NICHT in Markdown-Codeblöcke. Füge weder vor noch nach dem JSON Kommentare hinzu."
-  },
-  "prompt": {
-    "en": "**Topic hint (optional):**\n{{topic_hint}}\n\n**Document to analyze:**\n{{content}}",
-    "de": "**Themenhinweis (optional):**\n{{topic_hint}}\n\n**Zu analysierendes Dokument:**\n{{content}}"
   },
   "tokenLimit": 16000,
   "preferredOutputFormat": "json",

--- a/server/defaults/renderers/parliamentary-questions-results.jsx
+++ b/server/defaults/renderers/parliamentary-questions-results.jsx
@@ -1,0 +1,297 @@
+/**
+ * ParliamentaryQuestionsResultsRenderer
+ *
+ * Renders the structured output of the Parliamentary Questions Analyzer app
+ * as a searchable table. Each row exposes three actions:
+ *   1. Open the question's search_query in an external iFinder search.
+ *   2. Ask the full question in an in-iHub chat app (e.g. iAssistant-backed app)
+ *      with auto-send via the existing /apps/:id?prefill=...&send=true contract.
+ *   3. Open the full question in an external iAssistant UI.
+ *
+ * Configuration comes from app.rendererConfig in the app JSON:
+ *   - iFinderUrlTemplate:    full URL with {query} placeholder
+ *   - iAssistantAppId:       id of an existing iHub chat app to navigate to
+ *   - iAssistantUrlTemplate: full URL with {query} placeholder
+ *
+ * Buttons whose underlying template/id is missing render as disabled.
+ */
+const UserComponent = ({ data, t, rendererConfig, navigate, useState }) => {
+  const safeT = (key, fallback) => (t ? t(key, fallback) : fallback);
+
+  if (!data || !Array.isArray(data.questions) || data.questions.length === 0) {
+    return (
+      <div className="p-6 text-center text-gray-500 border border-dashed border-gray-300 rounded-lg">
+        {safeT(
+          'parliamentaryQuestions.noData',
+          'No questions could be extracted from the document.'
+        )}
+      </div>
+    );
+  }
+
+  const config = rendererConfig || {};
+  const iFinderUrlTemplate =
+    typeof config.iFinderUrlTemplate === 'string' ? config.iFinderUrlTemplate : '';
+  const iAssistantAppId = typeof config.iAssistantAppId === 'string' ? config.iAssistantAppId : '';
+  const iAssistantUrlTemplate =
+    typeof config.iAssistantUrlTemplate === 'string' ? config.iAssistantUrlTemplate : '';
+
+  const buildUrl = (template, query) =>
+    template ? template.replace('{query}', encodeURIComponent(query || '')) : '';
+
+  const openIFinder = question => {
+    const url = buildUrl(iFinderUrlTemplate, question.search_query || question.text);
+    if (url) window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  const openIAssistantApp = question => {
+    if (!iAssistantAppId || !navigate) return;
+    const params = new URLSearchParams({ prefill: question.text || '', send: 'true' });
+    navigate(`/apps/${iAssistantAppId}?${params.toString()}`);
+  };
+
+  const openIAssistantExternal = question => {
+    const url = buildUrl(iAssistantUrlTemplate, question.text);
+    if (url) window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
+  return (
+    <div className="space-y-6 p-4">
+      {/* Header */}
+      <div className="rounded-lg border-2 border-blue-300 bg-blue-50 border-l-8 border-l-blue-500 p-6 shadow-sm">
+        <div className="flex items-start justify-between gap-4">
+          <div className="flex-1">
+            {data.document_title ? (
+              <p className="text-xs font-semibold uppercase tracking-wide text-blue-700 mb-1">
+                {safeT('parliamentaryQuestions.documentTitle', 'Document')}
+              </p>
+            ) : null}
+            <h2 className="text-2xl font-bold text-blue-900">
+              {data.document_title ||
+                safeT('parliamentaryQuestions.headerFallback', 'Parliamentary Questions')}
+            </h2>
+            <p className="mt-2 text-sm text-blue-800">
+              {safeT('parliamentaryQuestions.questionsCount', '{count} questions detected').replace(
+                '{count}',
+                data.questions.length
+              )}
+            </p>
+          </div>
+          <div className="text-blue-500 flex-shrink-0">
+            <svg className="w-10 h-10" fill="currentColor" viewBox="0 0 20 20">
+              <path
+                fillRule="evenodd"
+                d="M4 4a2 2 0 012-2h8a2 2 0 012 2v12a2 2 0 01-2 2H6a2 2 0 01-2-2V4zm3 1a1 1 0 100 2h6a1 1 0 100-2H7zm0 4a1 1 0 100 2h6a1 1 0 100-2H7zm0 4a1 1 0 100 2h4a1 1 0 100-2H7z"
+                clipRule="evenodd"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      {/* Questions table */}
+      <div className="overflow-x-auto border border-gray-200 rounded-lg shadow-sm">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-3 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide w-20">
+                {safeT('parliamentaryQuestions.tableNumber', '#')}
+              </th>
+              <th className="px-3 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">
+                {safeT('parliamentaryQuestions.tableQuestion', 'Question')}
+              </th>
+              <th className="px-3 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide w-40">
+                {safeT('parliamentaryQuestions.tableTopic', 'Topic')}
+              </th>
+              <th className="px-3 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide w-56">
+                {safeT('parliamentaryQuestions.tableActions', 'Actions')}
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {data.questions.map((question, idx) => (
+              <QuestionRow
+                key={`${question.number || 'q'}-${idx}`}
+                question={question}
+                onOpenIFinder={openIFinder}
+                onOpenIAssistantApp={openIAssistantApp}
+                onOpenIAssistantExternal={openIAssistantExternal}
+                canIFinder={!!iFinderUrlTemplate}
+                canIAssistantApp={!!iAssistantAppId && !!navigate}
+                canIAssistantExternal={!!iAssistantUrlTemplate}
+                safeT={safeT}
+                useState={useState}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Config missing notice */}
+      {!iFinderUrlTemplate && !iAssistantAppId && !iAssistantUrlTemplate ? (
+        <div className="text-xs text-gray-500 italic">
+          {safeT(
+            'parliamentaryQuestions.configMissing',
+            'No iFinder or iAssistant targets are configured. Set rendererConfig in the app JSON to enable the action buttons.'
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+};
+
+const QuestionRow = ({
+  question,
+  onOpenIFinder,
+  onOpenIAssistantApp,
+  onOpenIAssistantExternal,
+  canIFinder,
+  canIAssistantApp,
+  canIAssistantExternal,
+  safeT,
+  useState
+}) => {
+  const [expanded, setExpanded] = useState(false);
+  const text = question.text || '';
+  const isLong = text.length > 220;
+  const displayText = expanded || !isLong ? text : `${text.slice(0, 220).trimEnd()}…`;
+
+  return (
+    <tr className="hover:bg-gray-50 transition-colors">
+      {/* Number */}
+      <td className="px-3 py-4 align-top">
+        <span className="inline-flex items-center justify-center min-w-[2rem] px-2 py-0.5 rounded-full text-sm font-semibold bg-blue-100 text-blue-800 border border-blue-200">
+          {question.number || '—'}
+        </span>
+      </td>
+
+      {/* Question text */}
+      <td className="px-3 py-4 text-sm text-gray-800 align-top">
+        <p className="leading-relaxed whitespace-pre-wrap">{displayText}</p>
+        {isLong ? (
+          <button
+            type="button"
+            onClick={() => setExpanded(!expanded)}
+            className="mt-1 text-xs font-medium text-blue-600 hover:underline focus:outline-none"
+          >
+            {expanded
+              ? safeT('parliamentaryQuestions.showLess', 'Show less')
+              : safeT('parliamentaryQuestions.showMore', 'Show more')}
+          </button>
+        ) : null}
+        {question.search_query ? (
+          <p className="mt-2 text-xs text-gray-500">
+            <span className="font-semibold uppercase tracking-wide">
+              {safeT('parliamentaryQuestions.searchQueryLabel', 'Search query')}:
+            </span>{' '}
+            <span className="font-mono">{question.search_query}</span>
+          </p>
+        ) : null}
+      </td>
+
+      {/* Topic */}
+      <td className="px-3 py-4 align-top">
+        {question.topic ? (
+          <span className="inline-block px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-700 border border-gray-200">
+            {question.topic}
+          </span>
+        ) : (
+          <span className="text-xs text-gray-400">—</span>
+        )}
+      </td>
+
+      {/* Actions */}
+      <td className="px-3 py-4 align-top">
+        <div className="flex items-center justify-end gap-2">
+          {/* iFinder */}
+          <ActionButton
+            onClick={() => onOpenIFinder(question)}
+            disabled={!canIFinder}
+            tooltip={safeT('parliamentaryQuestions.searchInIFinder', 'Search in iFinder')}
+            variant="secondary"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M21 21l-4.35-4.35M16 10a6 6 0 11-12 0 6 6 0 0112 0z"
+              />
+            </svg>
+            <span className="ml-1.5">
+              {safeT('parliamentaryQuestions.iFinderShort', 'iFinder')}
+            </span>
+          </ActionButton>
+
+          {/* iAssistant (in-app, primary) */}
+          <ActionButton
+            onClick={() => onOpenIAssistantApp(question)}
+            disabled={!canIAssistantApp}
+            tooltip={safeT('parliamentaryQuestions.askInIAssistant', 'Ask iAssistant')}
+            variant="primary"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+              />
+            </svg>
+            <span className="ml-1.5">
+              {safeT('parliamentaryQuestions.iAssistantShort', 'iAssistant')}
+            </span>
+          </ActionButton>
+
+          {/* iAssistant external (icon-only) */}
+          <ActionButton
+            onClick={() => onOpenIAssistantExternal(question)}
+            disabled={!canIAssistantExternal}
+            tooltip={safeT(
+              'parliamentaryQuestions.askInIAssistantExternal',
+              'Open in external iAssistant'
+            )}
+            variant="ghost"
+            iconOnly
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+              />
+            </svg>
+          </ActionButton>
+        </div>
+      </td>
+    </tr>
+  );
+};
+
+const ActionButton = ({ onClick, disabled, tooltip, variant, iconOnly, children }) => {
+  const base =
+    'inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1';
+  const variants = {
+    primary:
+      'bg-blue-600 text-white border-blue-600 hover:bg-blue-700 focus:ring-blue-500 disabled:bg-gray-200 disabled:text-gray-400 disabled:border-gray-200 disabled:cursor-not-allowed',
+    secondary:
+      'bg-white text-blue-700 border-blue-300 hover:bg-blue-50 focus:ring-blue-500 disabled:bg-gray-50 disabled:text-gray-400 disabled:border-gray-200 disabled:cursor-not-allowed',
+    ghost:
+      'bg-white text-gray-600 border-gray-300 hover:bg-gray-50 hover:text-gray-800 focus:ring-gray-400 disabled:text-gray-300 disabled:border-gray-200 disabled:cursor-not-allowed'
+  };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      title={tooltip}
+      aria-label={tooltip}
+      className={`${base} ${variants[variant] || variants.secondary} ${iconOnly ? 'px-2' : ''}`}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default UserComponent;

--- a/server/defaults/renderers/parliamentary-questions-results.jsx
+++ b/server/defaults/renderers/parliamentary-questions-results.jsx
@@ -103,7 +103,7 @@ const UserComponent = ({ data, t, rendererConfig, navigate, useState }) => {
               <th className="px-3 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide w-40">
                 {safeT('parliamentaryQuestions.tableTopic', 'Topic')}
               </th>
-              <th className="px-3 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide w-56">
+              <th className="px-3 py-3 text-right text-xs font-semibold text-gray-600 uppercase tracking-wide w-32">
                 {safeT('parliamentaryQuestions.tableActions', 'Actions')}
               </th>
             </tr>
@@ -202,13 +202,14 @@ const QuestionRow = ({
 
       {/* Actions */}
       <td className="px-3 py-4 align-top">
-        <div className="flex items-center justify-end gap-2">
+        <div className="flex items-center justify-end gap-1">
           {/* iFinder */}
           <ActionButton
             onClick={() => onOpenIFinder(question)}
             disabled={!canIFinder}
             tooltip={safeT('parliamentaryQuestions.searchInIFinder', 'Search in iFinder')}
             variant="secondary"
+            iconOnly
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
@@ -218,9 +219,6 @@ const QuestionRow = ({
                 d="M21 21l-4.35-4.35M16 10a6 6 0 11-12 0 6 6 0 0112 0z"
               />
             </svg>
-            <span className="ml-1.5">
-              {safeT('parliamentaryQuestions.iFinderShort', 'iFinder')}
-            </span>
           </ActionButton>
 
           {/* iAssistant (in-app, primary) */}
@@ -229,6 +227,7 @@ const QuestionRow = ({
             disabled={!canIAssistantApp}
             tooltip={safeT('parliamentaryQuestions.askInIAssistant', 'Ask iAssistant')}
             variant="primary"
+            iconOnly
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
@@ -238,9 +237,6 @@ const QuestionRow = ({
                 d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
               />
             </svg>
-            <span className="ml-1.5">
-              {safeT('parliamentaryQuestions.iAssistantShort', 'iAssistant')}
-            </span>
           </ActionButton>
 
           {/* iAssistant external (icon-only) */}
@@ -271,7 +267,8 @@ const QuestionRow = ({
 
 const ActionButton = ({ onClick, disabled, tooltip, variant, iconOnly, children }) => {
   const base =
-    'inline-flex items-center px-2.5 py-1.5 rounded-md text-xs font-medium border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1';
+    'inline-flex items-center justify-center rounded-md text-xs font-medium border transition-colors focus:outline-none focus:ring-2 focus:ring-offset-1';
+  const sizing = iconOnly ? 'p-1.5' : 'px-2.5 py-1.5';
   const variants = {
     primary:
       'bg-blue-600 text-white border-blue-600 hover:bg-blue-700 focus:ring-blue-500 disabled:bg-gray-200 disabled:text-gray-400 disabled:border-gray-200 disabled:cursor-not-allowed',
@@ -287,7 +284,7 @@ const ActionButton = ({ onClick, disabled, tooltip, variant, iconOnly, children 
       disabled={disabled}
       title={tooltip}
       aria-label={tooltip}
-      className={`${base} ${variants[variant] || variants.secondary} ${iconOnly ? 'px-2' : ''}`}
+      className={`${base} ${sizing} ${variants[variant] || variants.secondary}`}
     >
       {children}
     </button>

--- a/server/validators/appConfigSchema.js
+++ b/server/validators/appConfigSchema.js
@@ -361,6 +361,7 @@ const baseAppConfigSchema = z.object({
     .optional(),
   outputSchema: z.union([z.object({}).passthrough(), z.string()]).optional(),
   customResponseRenderer: z.string().optional(),
+  rendererConfig: z.object({}).passthrough().optional(),
   category: z.string().optional(),
   enabled: z.boolean().optional().default(true),
 

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -2159,5 +2159,24 @@
     "clearChat_de": "chat löschen",
     "sendMessage": "send message",
     "sendMessage_de": "nachricht senden"
+  },
+  "parliamentaryQuestions": {
+    "noData": "Aus dem Dokument konnten keine Fragen extrahiert werden.",
+    "headerFallback": "Parlamentarische Anfragen",
+    "documentTitle": "Dokument",
+    "questionsCount": "{count} Fragen erkannt",
+    "tableNumber": "Nr.",
+    "tableQuestion": "Frage",
+    "tableTopic": "Thema",
+    "tableActions": "Aktionen",
+    "searchQueryLabel": "Suchanfrage",
+    "searchInIFinder": "In iFinder suchen",
+    "askInIAssistant": "iAssistant fragen",
+    "askInIAssistantExternal": "In externem iAssistant öffnen",
+    "iFinderShort": "iFinder",
+    "iAssistantShort": "iAssistant",
+    "showMore": "Mehr anzeigen",
+    "showLess": "Weniger anzeigen",
+    "configMissing": "Es sind keine iFinder- oder iAssistant-Ziele konfiguriert. Setzen Sie rendererConfig in der App-JSON, um die Aktionsschaltflächen zu aktivieren."
   }
 }

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -2173,8 +2173,6 @@
     "searchInIFinder": "In iFinder suchen",
     "askInIAssistant": "iAssistant fragen",
     "askInIAssistantExternal": "In externem iAssistant öffnen",
-    "iFinderShort": "iFinder",
-    "iAssistantShort": "iAssistant",
     "showMore": "Mehr anzeigen",
     "showLess": "Weniger anzeigen",
     "configMissing": "Es sind keine iFinder- oder iAssistant-Ziele konfiguriert. Setzen Sie rendererConfig in der App-JSON, um die Aktionsschaltflächen zu aktivieren."

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -2208,8 +2208,6 @@
     "searchInIFinder": "Search in iFinder",
     "askInIAssistant": "Ask iAssistant",
     "askInIAssistantExternal": "Open in external iAssistant",
-    "iFinderShort": "iFinder",
-    "iAssistantShort": "iAssistant",
     "showMore": "Show more",
     "showLess": "Show less",
     "configMissing": "No iFinder or iAssistant targets are configured. Set rendererConfig in the app JSON to enable the action buttons."

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -2194,5 +2194,24 @@
     "clearChat_de": "chat löschen",
     "sendMessage": "send message",
     "sendMessage_de": "nachricht senden"
+  },
+  "parliamentaryQuestions": {
+    "noData": "No questions could be extracted from the document.",
+    "headerFallback": "Parliamentary Questions",
+    "documentTitle": "Document",
+    "questionsCount": "{count} questions detected",
+    "tableNumber": "#",
+    "tableQuestion": "Question",
+    "tableTopic": "Topic",
+    "tableActions": "Actions",
+    "searchQueryLabel": "Search query",
+    "searchInIFinder": "Search in iFinder",
+    "askInIAssistant": "Ask iAssistant",
+    "askInIAssistantExternal": "Open in external iAssistant",
+    "iFinderShort": "iFinder",
+    "iAssistantShort": "iAssistant",
+    "showMore": "Show more",
+    "showLess": "Show less",
+    "configMissing": "No iFinder or iAssistant targets are configured. Set rendererConfig in the app JSON to enable the action buttons."
   }
 }


### PR DESCRIPTION
## Summary

Adds a new default app **Parliamentary Questions Analyzer** that lets a user upload a PDF of a parliamentary inquiry (e.g. German Bundestag *Kleine Anfrage*) and renders the detected questions in a table with one-click actions per row:

- **iFinder** — opens an external iFinder search with a model-extracted, search-optimized query
- **iAssistant** — opens an in-iHub chat app (configurable per installation) with the full question pre-filled and auto-sent
- **External iAssistant** — opens an external iAssistant UI URL in a new tab

Architecturally this mirrors the existing **NDA Risk Analyzer** (`nda-risk-analyzer.json` + `nda-results.jsx`): PDF upload → LLM with `preferredOutputFormat: "json"` + `outputSchema` → custom `customResponseRenderer`.

## Changes

**New default app & renderer**
- `server/defaults/apps/parliamentary-questions.json` — bilingual (en/de) prompts, `outputSchema` defining `{ document_title, questions[{ number, text, topic, search_query }] }`, PDF + text upload up to 20 MB, optional `topic_hint` variable
- `server/defaults/renderers/parliamentary-questions-results.jsx` — Tailwind table with three action buttons per row, expandable long-question text, empty-state and config-missing notices

**Schema & plumbing**
- `server/validators/appConfigSchema.js` — adds a single optional `rendererConfig: z.object({}).passthrough()` field so renderers can receive per-installation config (URL templates, target app IDs) without baking it into JSX
- `client/src/shared/components/CustomResponseRenderer.jsx` — forwards `rendererConfig` and a `navigate` hook (from `react-router-dom`) to the renderer component
- `client/src/features/chat/components/ChatMessage.jsx` — passes `app.rendererConfig` to `CustomResponseRenderer`

**i18n**
- `shared/i18n/en.json` and `shared/i18n/de.json` — new `parliamentaryQuestions` namespace (table labels, action buttons, show-more/less, config-missing notice)

## Backward compatibility

- `rendererConfig` is an additive optional schema field — no migration needed
- Existing renderers (`nda-results`) ignore unknown props, so the new `rendererConfig` / `navigate` props pass through harmlessly
- The placeholder URL templates in the app JSON (`https://ifinder.example.com/?q={query}`) are deliberate — admins replace them per environment via the existing app editor

## Test plan

- [ ] Server boots without schema errors (verified locally — `Resource loaded resourceId: parliamentary-questions enabled: true`)
- [ ] Lint and Prettier clean (verified — 0 errors, only pre-existing warnings)
- [ ] Upload a sample Kleine-Anfrage PDF → table renders with extracted question numbers (e.g. "7", "9.8") preserved
- [ ] Click iFinder button → new tab opens to configured iFinder URL with `search_query` URL-encoded
- [ ] Click iAssistant button → routes to `/apps/{iAssistantAppId}?prefill=...&send=true` and the target app auto-sends
- [ ] Click external iAssistant button → new tab opens to configured iAssistant URL
- [ ] Switch UI to German → all table labels, buttons, and messages render in German
- [ ] Regression: existing NDA Risk Analyzer still renders correctly with the modified `CustomResponseRenderer`

---
_Generated by [Claude Code](https://claude.ai/code/session_01DMx3tLWrRsxkHAAUYLj1ec)_