### PR TITLE
fix(iFinder): prevent OS service account leaking into JWT sub via env var collision

### DIFF
--- a/docs/platform.md
+++ b/docs/platform.md
@@ -962,7 +962,7 @@ Accepted forms:
 - `"email"` (default) — `user.email`, falling back to `user.username`, then `user.id`.
 - `"username"` — `user.username`, falling back to `user.email`, then `user.id`.
 - `"domain\\username"` — `user.domain + "\\" + user.username`, useful for NTLM/AD setups.
-- **Custom template** — embed `${user.field}` placeholders to build the subject from user attributes. Example: `"BMG\\${user.username}"` produces `BMG\kozuch` for a user with `username = "kozuch"`. Available fields include `id`, `username`, `name`, `email`, `domain`.
+- **Custom template** — embed `${user.field}` placeholders to build the subject from user attributes. Example: `"DOMAIN\\${user.username}"` produces `DOMAIN\john.doe` for a user with `username = "john.doe"`. Available fields include `id`, `username`, `name`, `email`, `domain`.
 
 > **Security note:** Earlier versions accepted the legacy `${field}` form (no `user.` prefix). That syntax collided with the env var resolver — on Windows `process.env.username` is set to the OS user running the server, so `${username}` silently expanded to the service account name in every JWT subject, breaking per-user identity in iFinder. The configCache skip-list and migration V043 fix this; legacy `${field}` is still accepted with a deprecation warning, but **use `${user.field}` for clarity and forward-compatibility**.
 

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -951,7 +951,20 @@ Configures integration with the IntraFind iFinder enterprise search platform. Wh
 | `audience`               | String  | `"ifinder-api"`   | JWT `aud` claim value                                                                   |
 | `tokenExpirationSeconds` | Number  | `3600`            | Lifetime of generated JWT tokens in seconds                                             |
 | `defaultScope`           | String  | `"fa_index_read"` | Default OAuth scope included in generated tokens                                        |
-| `jwtSubjectField`        | String  | `"email"`         | User attribute used as the JWT `sub` claim. Options: `"email"`, `"username"`           |
+| `jwtSubjectField`        | String  | `"email"`         | User attribute used as the JWT `sub` claim. See below for supported values.            |
+
+### `jwtSubjectField` supported values
+
+The JWT `sub` claim identifies the authenticated user to iFinder. It is **always** derived from the authenticated user object — never from environment variables (configCache skips env var resolution for this field, see `ENV_VAR_RESOLUTION_SKIP_PATHS` in `server/configCache.js`).
+
+Accepted forms:
+
+- `"email"` (default) — `user.email`, falling back to `user.username`, then `user.id`.
+- `"username"` — `user.username`, falling back to `user.email`, then `user.id`.
+- `"domain\\username"` — `user.domain + "\\" + user.username`, useful for NTLM/AD setups.
+- **Custom template** — embed `${user.field}` placeholders to build the subject from user attributes. Example: `"BMG\\${user.username}"` produces `BMG\kozuch` for a user with `username = "kozuch"`. Available fields include `id`, `username`, `name`, `email`, `domain`.
+
+> **Security note:** Earlier versions accepted the legacy `${field}` form (no `user.` prefix). That syntax collided with the env var resolver — on Windows `process.env.username` is set to the OS user running the server, so `${username}` silently expanded to the service account name in every JWT subject, breaking per-user identity in iFinder. The configCache skip-list and migration V043 fix this; legacy `${field}` is still accepted with a deprecation warning, but **use `${user.field}` for clarity and forward-compatibility**.
 
 For integration details see [iFinder Integration](iFinder-Integration.md).
 

--- a/server/configCache.js
+++ b/server/configCache.js
@@ -48,24 +48,48 @@ function resolveEnvVars(value) {
 }
 
 /**
+ * Config paths whose string values must NEVER go through env var substitution.
+ *
+ * Required when a field is a *user-data* template (e.g. `${user.username}` is a
+ * placeholder for the authenticated user's username, NOT for an OS env var).
+ * Without this skip list, `${username}` would be eaten by `resolveEnvVars`
+ * because Windows sets `process.env.username` to the OS user running the
+ * process — silently leaking the service account into every templated value.
+ *
+ * Use dot-paths (e.g. "iFinder.jwtSubjectField"). Wildcards are not supported.
+ */
+const ENV_VAR_RESOLUTION_SKIP_PATHS = new Set(['iFinder.jwtSubjectField']);
+
+/**
  * Recursively resolve environment variables in an object. Exported so other
  * subsystems (e.g. server/telemetry.js) that read raw JSON before configCache
  * is up can perform the same `${VAR}` / `${VAR:-default}` substitution the
  * rest of the platform expects.
+ *
+ * Paths listed in `ENV_VAR_RESOLUTION_SKIP_PATHS` are passed through verbatim;
+ * the consumer of that value is responsible for any template substitution.
+ *
+ * @param {*} obj - Object/array/primitive to recursively resolve
+ * @param {string} [path] - Internal: current dot-path used for skip-list checks
  */
-export function resolveEnvVarsInObject(obj) {
+export function resolveEnvVarsInObject(obj, path = '') {
   if (!obj || typeof obj !== 'object') return obj;
 
   if (Array.isArray(obj)) {
-    return obj.map(item => resolveEnvVarsInObject(item));
+    return obj.map((item, idx) => resolveEnvVarsInObject(item, `${path}[${idx}]`));
   }
 
   const resolved = {};
   for (const [key, value] of Object.entries(obj)) {
+    const childPath = path ? `${path}.${key}` : key;
+    if (ENV_VAR_RESOLUTION_SKIP_PATHS.has(childPath)) {
+      resolved[key] = value;
+      continue;
+    }
     if (typeof value === 'string') {
       resolved[key] = resolveEnvVars(value);
     } else if (typeof value === 'object') {
-      resolved[key] = resolveEnvVarsInObject(value);
+      resolved[key] = resolveEnvVarsInObject(value, childPath);
     } else {
       resolved[key] = value;
     }

--- a/server/configCache.js
+++ b/server/configCache.js
@@ -48,48 +48,50 @@ function resolveEnvVars(value) {
 }
 
 /**
- * Config paths whose string values must NEVER go through env var substitution.
- *
- * Required when a field is a *user-data* template (e.g. `${user.username}` is a
- * placeholder for the authenticated user's username, NOT for an OS env var).
- * Without this skip list, `${username}` would be eaten by `resolveEnvVars`
- * because Windows sets `process.env.username` to the OS user running the
- * process — silently leaking the service account into every templated value.
- *
- * Use dot-paths (e.g. "iFinder.jwtSubjectField"). Wildcards are not supported.
- */
-const ENV_VAR_RESOLUTION_SKIP_PATHS = new Set(['iFinder.jwtSubjectField']);
-
-/**
  * Recursively resolve environment variables in an object. Exported so other
  * subsystems (e.g. server/telemetry.js) that read raw JSON before configCache
  * is up can perform the same `${VAR}` / `${VAR:-default}` substitution the
  * rest of the platform expects.
  *
- * Paths listed in `ENV_VAR_RESOLUTION_SKIP_PATHS` are passed through verbatim;
- * the consumer of that value is responsible for any template substitution.
+ * Callers can pass `skipPaths` to opt out specific dot-paths from env var
+ * substitution. This matters for fields that contain *user-data* templates
+ * (e.g. `${user.username}` is a placeholder for the authenticated user's
+ * username, NOT for `process.env.username`) — Windows automatically sets
+ * `process.env.username` to the OS user running the process, so without an
+ * opt-out the resolver would silently leak the service account into every
+ * such template. The skip decision belongs to whoever owns the config
+ * schema (e.g. `setCacheEntry` for platform.json); this function is just
+ * the mechanism.
  *
  * @param {*} obj - Object/array/primitive to recursively resolve
- * @param {string} [path] - Internal: current dot-path used for skip-list checks
+ * @param {Object} [options]
+ * @param {string[]|Set<string>} [options.skipPaths] - Dot-paths to leave verbatim
+ * @param {string} [options.path] - Internal: current dot-path used for skip-list checks
  */
-export function resolveEnvVarsInObject(obj, path = '') {
+export function resolveEnvVarsInObject(obj, options = {}) {
   if (!obj || typeof obj !== 'object') return obj;
 
+  const path = options.path || '';
+  const skipPaths =
+    options.skipPaths instanceof Set ? options.skipPaths : new Set(options.skipPaths || []);
+
   if (Array.isArray(obj)) {
-    return obj.map((item, idx) => resolveEnvVarsInObject(item, `${path}[${idx}]`));
+    return obj.map((item, idx) =>
+      resolveEnvVarsInObject(item, { skipPaths, path: `${path}[${idx}]` })
+    );
   }
 
   const resolved = {};
   for (const [key, value] of Object.entries(obj)) {
     const childPath = path ? `${path}.${key}` : key;
-    if (ENV_VAR_RESOLUTION_SKIP_PATHS.has(childPath)) {
+    if (skipPaths.has(childPath)) {
       resolved[key] = value;
       continue;
     }
     if (typeof value === 'string') {
       resolved[key] = resolveEnvVars(value);
     } else if (typeof value === 'object') {
-      resolved[key] = resolveEnvVarsInObject(value, childPath);
+      resolved[key] = resolveEnvVarsInObject(value, { skipPaths, path: childPath });
     } else {
       resolved[key] = value;
     }
@@ -222,6 +224,21 @@ function setNestedValue(obj, pathParts, value) {
 const IHUB_ENV_PREFIXES = {
   'config/platform.json': 'IHUB_PLATFORM__',
   'config/ui.json': 'IHUB_UI__'
+};
+
+/**
+ * Per-cache-key config paths that must NOT be passed through env var
+ * substitution. Used by `setCacheEntry` to opt specific fields out.
+ *
+ * Add an entry here when a config field is a *user-data* template
+ * (e.g. `${user.username}` placeholder) rather than an env var reference.
+ * Without this, `${name}` would be eaten by `resolveEnvVars` when an OS
+ * env var of the same name exists (notably Windows `process.env.username`
+ * = the OS user running the server) — silently leaking that value into
+ * the templated field.
+ */
+const ENV_VAR_SKIP_PATHS_BY_KEY = {
+  'config/platform.json': ['iFinder.jwtSubjectField']
 };
 
 /**
@@ -548,8 +565,11 @@ class ConfigCache {
       clearTimeout(this.refreshTimers.get(key));
     }
 
-    // Resolve environment variables in the data
-    const resolvedData = resolveEnvVarsInObject(data);
+    // Resolve environment variables in the data, opting specific fields out
+    // when they contain user-data templates instead of env var references.
+    const resolvedData = resolveEnvVarsInObject(data, {
+      skipPaths: ENV_VAR_SKIP_PATHS_BY_KEY[key]
+    });
 
     // Apply IHUB_* environment variable overrides
     applyIhubEnvOverrides(key, resolvedData);

--- a/server/middleware/ntlmAuth.js
+++ b/server/middleware/ntlmAuth.js
@@ -209,7 +209,7 @@ function getNtlmMiddleware(ntlmConfig) {
  * @param {Object} ntlmConfig - NTLM configuration
  * @returns {Object|null} Processed user object or null
  */
-function processNtlmUser(req, ntlmConfig) {
+export function processNtlmUser(req, ntlmConfig) {
   if (!req.ntlm) {
     logger.debug('NTLM Auth: no NTLM data in request', { component: 'NtlmAuth' });
     return null;
@@ -236,10 +236,15 @@ function processNtlmUser(req, ntlmConfig) {
     username: ntlmUser.UserName || ntlmUser.username
   });
 
-  // Extract user information
+  // Extract user information.
+  // express-ntlm exposes the authenticated identity as `UserName` and the
+  // domain as `DomainName` (capitalized). `.domain` / `.Domain` are checked
+  // first only to stay compatible with custom middleware that may set
+  // them. Without the `DomainName` fallback `user.domain` was always
+  // undefined, which made the standard `domain\\username` JWT subject
+  // template fall back to bare username.
   const userId = ntlmUser.username || ntlmUser.UserName;
-  const domain = ntlmUser.domain || ntlmUser.Domain;
-  const fullUsername = domain ? `${domain}\\${userId}` : userId;
+  const domain = ntlmUser.domain || ntlmUser.Domain || ntlmUser.DomainName;
 
   // Extract groups - check all possible field names
   let groups = [];
@@ -289,11 +294,19 @@ function processNtlmUser(req, ntlmConfig) {
 
   logger.debug('NTLM Auth: final groups for user', { component: 'NtlmAuth', mappedGroups });
 
-  // Create normalized user object
+  // Create normalized user object.
+  // `id` is the bare userId (not `domain\\userId`). Before the `DomainName`
+  // fix above, `domain` was always undefined and `id` therefore always equal
+  // to `userId`, so existing users.json entries were keyed by username
+  // alone. Keeping `id` as `userId` preserves that lookup key — switching
+  // to `domain\\userId` here would orphan every existing NTLM user record.
+  // The domain is exposed separately on `user.domain` for use by the
+  // `domain\\username` standard subject value and `${user.domain}`
+  // placeholder.
   const user = {
-    id: fullUsername,
+    id: userId,
     username: userId,
-    name: ntlmUser.DisplayName || ntlmUser.displayName || fullUsername,
+    name: ntlmUser.DisplayName || ntlmUser.displayName || userId,
     email: ntlmUser.email || ntlmUser.Email || null,
     groups: mappedGroups,
     externalGroups: groups, // Store original external groups for debugging

--- a/server/migrations/V043__fix_ifinder_jwt_subject_template.js
+++ b/server/migrations/V043__fix_ifinder_jwt_subject_template.js
@@ -1,0 +1,66 @@
+/**
+ * Migration V043 — Fix iFinder.jwtSubjectField template syntax
+ *
+ * Background: the JWT subject template in `iFinder.jwtSubjectField` used the
+ * `${field}` placeholder syntax (e.g. `"BMG\\${username}"`). configCache's
+ * env var resolver matched the same pattern and would replace `${username}`
+ * with `process.env.username` at config-load time. On Windows that env var
+ * is automatically set to the OS user running the server (typically a
+ * service account like `svc_ifinder-indexer`), which silently leaked that
+ * account into every iFinder JWT subject — every user appeared to iFinder as
+ * the service account.
+ *
+ * Fix: switch to explicit `${user.field}` syntax. The dot makes the
+ * placeholder name invalid as an env var identifier (regex
+ * `[A-Za-z_][A-Za-z0-9_]*`), so the env var resolver no longer matches it.
+ * configCache also now skips env var resolution for this path entirely
+ * (ENV_VAR_RESOLUTION_SKIP_PATHS), but the explicit `user.` prefix keeps the
+ * intent clear in the config.
+ *
+ * Standard values (`email`, `username`, `domain\\username`) are unchanged —
+ * they are looked up by `iFinderJwt.resolveJwtSubject`, not template-replaced.
+ */
+
+export const version = '043';
+export const description = 'fix_ifinder_jwt_subject_template';
+
+const STANDARD_VALUES = new Set(['email', 'username', 'domain\\username']);
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  const current = platform?.iFinder?.jwtSubjectField;
+  if (typeof current !== 'string') {
+    ctx.log('No iFinder.jwtSubjectField set; nothing to migrate');
+    return;
+  }
+
+  if (STANDARD_VALUES.has(current)) {
+    ctx.log(`iFinder.jwtSubjectField is a standard value ("${current}"); leaving unchanged`);
+    return;
+  }
+
+  // Rewrite legacy ${field} -> ${user.field}. Skip placeholders already in the
+  // new ${user.field} form.
+  const updated = current.replace(/\$\{(?!user\.)(\w+)\}/g, '${user.$1}');
+
+  if (updated === current) {
+    ctx.log(`iFinder.jwtSubjectField "${current}" already uses safe syntax; no change needed`);
+    return;
+  }
+
+  platform.iFinder.jwtSubjectField = updated;
+  await ctx.writeJson('config/platform.json', platform);
+
+  ctx.warn(
+    `Rewrote iFinder.jwtSubjectField from "${current}" to "${updated}". ` +
+      'The legacy ${field} syntax collided with env var resolution and could ' +
+      'leak the OS service account (Windows process.env.username) into every ' +
+      'iFinder JWT subject. Review your iFinder audit logs for the affected ' +
+      'time window if applicable.'
+  );
+}

--- a/server/tests/iFinderJwtSubject-securityBug.test.js
+++ b/server/tests/iFinderJwtSubject-securityBug.test.js
@@ -24,6 +24,11 @@ import { resolveEnvVarsInObject } from '../configCache.js';
 import { up as migrationUp } from '../migrations/V043__fix_ifinder_jwt_subject_template.js';
 
 describe('iFinder JWT subject — env var resolution skip', () => {
+  // configCache passes this skipPaths list when caching the platform config.
+  // Tests reproduce that contract directly so we exercise the resolver the
+  // same way `setCacheEntry` does.
+  const platformSkipPaths = ['iFinder.jwtSubjectField'];
+
   let originalUsername;
 
   before(() => {
@@ -39,17 +44,17 @@ describe('iFinder JWT subject — env var resolution skip', () => {
     }
   });
 
-  it('preserves iFinder.jwtSubjectField when process.env.username is set', () => {
+  it('preserves iFinder.jwtSubjectField when caller skips it and env var is set', () => {
     const platform = {
       iFinder: { jwtSubjectField: 'BMG\\${username}', baseUrl: 'https://x/' }
     };
-    const resolved = resolveEnvVarsInObject(platform);
+    const resolved = resolveEnvVarsInObject(platform, { skipPaths: platformSkipPaths });
     assert.equal(resolved.iFinder.jwtSubjectField, 'BMG\\${username}');
   });
 
-  it('preserves ${user.field} verbatim', () => {
+  it('preserves ${user.field} verbatim regardless of skip list', () => {
     const platform = { iFinder: { jwtSubjectField: 'BMG\\${user.username}' } };
-    const resolved = resolveEnvVarsInObject(platform);
+    const resolved = resolveEnvVarsInObject(platform, { skipPaths: platformSkipPaths });
     assert.equal(resolved.iFinder.jwtSubjectField, 'BMG\\${user.username}');
   });
 
@@ -62,7 +67,7 @@ describe('iFinder JWT subject — env var resolution skip', () => {
           baseUrl: 'https://${MY_TEST_VAR}/'
         }
       };
-      const resolved = resolveEnvVarsInObject(platform);
+      const resolved = resolveEnvVarsInObject(platform, { skipPaths: platformSkipPaths });
       assert.equal(resolved.iFinder.jwtSubjectField, 'BMG\\${username}');
       assert.equal(resolved.iFinder.baseUrl, 'https://replaced/');
     } finally {
@@ -77,11 +82,25 @@ describe('iFinder JWT subject — env var resolution skip', () => {
         iFinder: { jwtSubjectField: 'BMG\\${username}' },
         elsewhere: '${MY_TEST_VAR}'
       };
-      const resolved = resolveEnvVarsInObject(platform);
+      const resolved = resolveEnvVarsInObject(platform, { skipPaths: platformSkipPaths });
       assert.equal(resolved.elsewhere, 'replaced');
     } finally {
       delete process.env.MY_TEST_VAR;
     }
+  });
+
+  it('without skipPaths the field IS env-resolved (proves the bug returns if caller forgets)', () => {
+    const platform = { iFinder: { jwtSubjectField: 'BMG\\${username}' } };
+    const resolved = resolveEnvVarsInObject(platform);
+    assert.equal(resolved.iFinder.jwtSubjectField, 'BMG\\svc_ifinder-indexer');
+  });
+
+  it('accepts skipPaths as a Set', () => {
+    const platform = { iFinder: { jwtSubjectField: 'BMG\\${username}' } };
+    const resolved = resolveEnvVarsInObject(platform, {
+      skipPaths: new Set(['iFinder.jwtSubjectField'])
+    });
+    assert.equal(resolved.iFinder.jwtSubjectField, 'BMG\\${username}');
   });
 });
 

--- a/server/tests/iFinderJwtSubject-securityBug.test.js
+++ b/server/tests/iFinderJwtSubject-securityBug.test.js
@@ -1,0 +1,187 @@
+/**
+ * Regression tests for the iFinder JWT subject env-var leak.
+ *
+ * Bug (pre-V043 / pre-skip-list): configCache's `resolveEnvVars` matched
+ * `${field}` placeholders in `iFinder.jwtSubjectField` against process.env.
+ * On Windows `process.env.username` is set to the OS user running the
+ * server, so a template like `BMG\${username}` was rewritten to
+ * `BMG\<service-account>` at config-load time. Every iFinder JWT then
+ * carried the service account in its `sub` claim, regardless of the
+ * authenticated user.
+ *
+ * These tests pin three guarantees:
+ *   1. configCache does not env-resolve `iFinder.jwtSubjectField` even
+ *      when a same-named env var exists.
+ *   2. iFinderJwt's template regex matches both `${field}` (legacy) and
+ *      `${user.field}` (preferred) syntaxes, and the legacy detector
+ *      flags only the unprefixed form.
+ *   3. The V043 migration converts `${field}` to `${user.field}` in
+ *      existing platform.json files.
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveEnvVarsInObject } from '../configCache.js';
+import { up as migrationUp } from '../migrations/V043__fix_ifinder_jwt_subject_template.js';
+
+describe('iFinder JWT subject — env var resolution skip', () => {
+  let originalUsername;
+
+  before(() => {
+    originalUsername = process.env.username;
+    process.env.username = 'svc_ifinder-indexer';
+  });
+
+  after(() => {
+    if (originalUsername === undefined) {
+      delete process.env.username;
+    } else {
+      process.env.username = originalUsername;
+    }
+  });
+
+  it('preserves iFinder.jwtSubjectField when process.env.username is set', () => {
+    const platform = {
+      iFinder: { jwtSubjectField: 'BMG\\${username}', baseUrl: 'https://x/' }
+    };
+    const resolved = resolveEnvVarsInObject(platform);
+    assert.equal(resolved.iFinder.jwtSubjectField, 'BMG\\${username}');
+  });
+
+  it('preserves ${user.field} verbatim', () => {
+    const platform = { iFinder: { jwtSubjectField: 'BMG\\${user.username}' } };
+    const resolved = resolveEnvVarsInObject(platform);
+    assert.equal(resolved.iFinder.jwtSubjectField, 'BMG\\${user.username}');
+  });
+
+  it('still resolves env vars on sibling iFinder.* fields', () => {
+    process.env.MY_TEST_VAR = 'replaced';
+    try {
+      const platform = {
+        iFinder: {
+          jwtSubjectField: 'BMG\\${username}',
+          baseUrl: 'https://${MY_TEST_VAR}/'
+        }
+      };
+      const resolved = resolveEnvVarsInObject(platform);
+      assert.equal(resolved.iFinder.jwtSubjectField, 'BMG\\${username}');
+      assert.equal(resolved.iFinder.baseUrl, 'https://replaced/');
+    } finally {
+      delete process.env.MY_TEST_VAR;
+    }
+  });
+
+  it('still resolves env vars at unrelated config paths (no regression)', () => {
+    process.env.MY_TEST_VAR = 'replaced';
+    try {
+      const platform = {
+        iFinder: { jwtSubjectField: 'BMG\\${username}' },
+        elsewhere: '${MY_TEST_VAR}'
+      };
+      const resolved = resolveEnvVarsInObject(platform);
+      assert.equal(resolved.elsewhere, 'replaced');
+    } finally {
+      delete process.env.MY_TEST_VAR;
+    }
+  });
+});
+
+describe('iFinder JWT subject — template regex pin', () => {
+  // These regexes are intentionally duplicated from `resolveJwtSubject` in
+  // iFinderJwt.js. They are the part of the contract that callers (admins
+  // writing templates) depend on — if you change the regex, update both
+  // sites AND bump V043 (or add a new migration) to convert existing configs.
+
+  const TEMPLATE_RE = /\$\{(?:user\.)?(\w+)\}/g;
+  const LEGACY_DETECT_RE = /\$\{(?!user\.)\w+\}/;
+
+  it('captures field name from ${user.field}', () => {
+    const m = [...'BMG\\${user.username}'.matchAll(TEMPLATE_RE)];
+    assert.equal(m.length, 1);
+    assert.equal(m[0][1], 'username');
+  });
+
+  it('captures field name from ${field} (legacy)', () => {
+    const m = [...'BMG\\${username}'.matchAll(TEMPLATE_RE)];
+    assert.equal(m.length, 1);
+    assert.equal(m[0][1], 'username');
+  });
+
+  it('detects legacy placeholders but not modern ones', () => {
+    assert.equal(LEGACY_DETECT_RE.test('BMG\\${username}'), true);
+    assert.equal(LEGACY_DETECT_RE.test('BMG\\${user.username}'), false);
+    assert.equal(LEGACY_DETECT_RE.test('plain-string'), false);
+  });
+
+  it('handles multiple placeholders in one template', () => {
+    const m = [...'${domain}\\${user.username}'.matchAll(TEMPLATE_RE)];
+    assert.equal(m.length, 2);
+    assert.equal(m[0][1], 'domain');
+    assert.equal(m[1][1], 'username');
+  });
+});
+
+describe('V043 migration', () => {
+  function makeCtx(initialPlatform) {
+    let platform = JSON.parse(JSON.stringify(initialPlatform));
+    const logs = [];
+    return {
+      _platform: () => platform,
+      logs,
+      async readJson() {
+        return platform;
+      },
+      async writeJson(_path, data) {
+        platform = data;
+      },
+      async fileExists() {
+        return true;
+      },
+      log(msg) {
+        logs.push(['log', msg]);
+      },
+      warn(msg) {
+        logs.push(['warn', msg]);
+      }
+    };
+  }
+
+  it('rewrites BMG\\${username} to BMG\\${user.username}', async () => {
+    const ctx = makeCtx({ iFinder: { jwtSubjectField: 'BMG\\${username}' } });
+    await migrationUp(ctx);
+    assert.equal(ctx._platform().iFinder.jwtSubjectField, 'BMG\\${user.username}');
+    assert.ok(ctx.logs.some(([lvl]) => lvl === 'warn'));
+  });
+
+  it('rewrites all legacy placeholders in one pass', async () => {
+    const ctx = makeCtx({ iFinder: { jwtSubjectField: '${domain}\\${username}' } });
+    await migrationUp(ctx);
+    assert.equal(ctx._platform().iFinder.jwtSubjectField, '${user.domain}\\${user.username}');
+  });
+
+  it('does not touch already-safe ${user.field} templates', async () => {
+    const ctx = makeCtx({ iFinder: { jwtSubjectField: 'BMG\\${user.username}' } });
+    await migrationUp(ctx);
+    assert.equal(ctx._platform().iFinder.jwtSubjectField, 'BMG\\${user.username}');
+    assert.ok(!ctx.logs.some(([lvl]) => lvl === 'warn'));
+  });
+
+  it('leaves standard values untouched', async () => {
+    for (const std of ['email', 'username', 'domain\\username']) {
+      const ctx = makeCtx({ iFinder: { jwtSubjectField: std } });
+      await migrationUp(ctx);
+      assert.equal(ctx._platform().iFinder.jwtSubjectField, std);
+    }
+  });
+
+  it('is a no-op when iFinder.jwtSubjectField is missing', async () => {
+    const ctx = makeCtx({ iFinder: { baseUrl: 'https://x/' } });
+    await migrationUp(ctx);
+    assert.equal(ctx._platform().iFinder.jwtSubjectField, undefined);
+  });
+
+  it('is a no-op when iFinder section is missing', async () => {
+    const ctx = makeCtx({});
+    await migrationUp(ctx);
+    assert.deepEqual(ctx._platform(), {});
+  });
+});

--- a/server/tests/ntlmAuth-domain.test.js
+++ b/server/tests/ntlmAuth-domain.test.js
@@ -1,0 +1,178 @@
+/**
+ * Regression tests for NTLM user.domain extraction.
+ *
+ * Bug: express-ntlm exposes the authenticated identity as
+ *   { DomainName, UserName, Workstation, Authenticated }
+ * but `processNtlmUser` only consulted `ntlmUser.domain` / `ntlmUser.Domain`.
+ * Result: `user.domain` was always undefined, which made the standard
+ * `"domain\\username"` JWT subject template fall back to bare username
+ * (and `${user.domain}` placeholders resolve to empty).
+ */
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { processNtlmUser } from '../middleware/ntlmAuth.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const groupsConfigPath = path.join(__dirname, '../../contents/config/groups.json');
+
+// processNtlmUser calls mapExternalGroups, which loads
+// contents/config/groups.json from disk. Ensure a minimal fixture exists for
+// the test process and tear it down afterwards. If the file already exists
+// (full dev environment), leave it alone.
+let createdGroupsFixture = false;
+let createdContentsConfig = false;
+let createdContents = false;
+
+before(() => {
+  const contentsConfigDir = path.dirname(groupsConfigPath);
+  const contentsDir = path.dirname(contentsConfigDir);
+  if (!fs.existsSync(contentsDir)) {
+    fs.mkdirSync(contentsDir);
+    createdContents = true;
+  }
+  if (!fs.existsSync(contentsConfigDir)) {
+    fs.mkdirSync(contentsConfigDir);
+    createdContentsConfig = true;
+  }
+  if (!fs.existsSync(groupsConfigPath)) {
+    fs.writeFileSync(
+      groupsConfigPath,
+      JSON.stringify({
+        groups: {
+          anonymous: { id: 'anonymous', name: 'Anonymous', permissions: {} },
+          authenticated: {
+            id: 'authenticated',
+            name: 'Authenticated',
+            inherits: ['anonymous'],
+            permissions: {}
+          }
+        }
+      })
+    );
+    createdGroupsFixture = true;
+  }
+});
+
+after(() => {
+  if (createdGroupsFixture) fs.rmSync(groupsConfigPath, { force: true });
+  if (createdContentsConfig)
+    fs.rmSync(path.dirname(groupsConfigPath), { force: true, recursive: true });
+  if (createdContents)
+    fs.rmSync(path.dirname(path.dirname(groupsConfigPath)), { force: true, recursive: true });
+});
+
+function makeReq(ntlm) {
+  return { ntlm };
+}
+
+describe('processNtlmUser — domain extraction', () => {
+  it('reads domain from ntlmUser.DomainName (express-ntlm shape)', () => {
+    const user = processNtlmUser(
+      makeReq({
+        Authenticated: true,
+        UserName: 'kozuch',
+        DomainName: 'BMG',
+        Workstation: 'BN-IFINDIDX-01'
+      }),
+      { name: 'ntlm' }
+    );
+    assert.equal(user.username, 'kozuch');
+    assert.equal(user.domain, 'BMG');
+  });
+
+  it('keeps user.id stable as the bare userId (backward compat)', () => {
+    // Existing users.json rows from before the DomainName fix have
+    // `username = "kozuch"` (the old externalUser.id). user.id must keep
+    // matching that lookup key, otherwise every NTLM user re-appears as a
+    // brand new account on next login.
+    const user = processNtlmUser(
+      makeReq({ Authenticated: true, UserName: 'kozuch', DomainName: 'BMG' }),
+      { name: 'ntlm' }
+    );
+    assert.equal(user.id, 'kozuch');
+    assert.notEqual(user.id, 'BMG\\kozuch');
+  });
+
+  it('still accepts lowercase ntlmUser.domain when set by custom middleware', () => {
+    const user = processNtlmUser(
+      makeReq({ Authenticated: true, UserName: 'kozuch', domain: 'CUSTOM' }),
+      { name: 'ntlm' }
+    );
+    assert.equal(user.domain, 'CUSTOM');
+  });
+
+  it('prefers ntlmUser.domain > Domain > DomainName when multiple are set', () => {
+    // Defines a fallback order matching the source code so the
+    // precedence is pinned by a test.
+    const user = processNtlmUser(
+      makeReq({
+        Authenticated: true,
+        UserName: 'kozuch',
+        domain: 'A',
+        Domain: 'B',
+        DomainName: 'C'
+      }),
+      { name: 'ntlm' }
+    );
+    assert.equal(user.domain, 'A');
+  });
+
+  it('leaves user.domain undefined when NTLM data has no domain at all', () => {
+    const user = processNtlmUser(makeReq({ Authenticated: true, UserName: 'kozuch' }), {
+      name: 'ntlm'
+    });
+    assert.equal(user.domain, undefined);
+    assert.equal(user.id, 'kozuch');
+  });
+
+  it('falls back to userId for name when no DisplayName is provided', () => {
+    // Previously fell back to `fullUsername` (= "BMG\\kozuch"). The fix
+    // uses just `userId` so the `name` claim in the JWT stays the
+    // human-readable display (matches what admins see today).
+    const user = processNtlmUser(
+      makeReq({ Authenticated: true, UserName: 'kozuch', DomainName: 'BMG' }),
+      { name: 'ntlm' }
+    );
+    assert.equal(user.name, 'kozuch');
+  });
+
+  it('returns null when req.ntlm is missing', () => {
+    const user = processNtlmUser({}, { name: 'ntlm' });
+    assert.equal(user, null);
+  });
+
+  it('returns null when NTLM handshake did not authenticate', () => {
+    const user = processNtlmUser(
+      makeReq({ Authenticated: false, UserName: 'kozuch', DomainName: 'BMG' }),
+      { name: 'ntlm' }
+    );
+    assert.equal(user, null);
+  });
+});
+
+describe('processNtlmUser — feeds JWT subject template correctly', () => {
+  // Lightweight replica of `resolveJwtSubject` for the standard
+  // `domain\\username` value, just enough to prove the user object
+  // produced by `processNtlmUser` resolves the way an admin expects.
+  function resolveDomainBackslashUsername(user) {
+    return user.domain ? `${user.domain}\\${user.username || user.id}` : user.username || user.id;
+  }
+
+  it('domain\\username yields BMG\\kozuch when DomainName=BMG', () => {
+    const user = processNtlmUser(
+      makeReq({ Authenticated: true, UserName: 'kozuch', DomainName: 'BMG' }),
+      { name: 'ntlm' }
+    );
+    assert.equal(resolveDomainBackslashUsername(user), 'BMG\\kozuch');
+  });
+
+  it('domain\\username falls back to bare username when domain missing', () => {
+    const user = processNtlmUser(makeReq({ Authenticated: true, UserName: 'kozuch' }), {
+      name: 'ntlm'
+    });
+    assert.equal(resolveDomainBackslashUsername(user), 'kozuch');
+  });
+});

--- a/server/utils/iFinderJwt.js
+++ b/server/utils/iFinderJwt.js
@@ -141,15 +141,16 @@ function resolveJwtSubject(user, config) {
       //
       // Two accepted forms:
       //   ${user.field}  — preferred, self-documenting.
-      //   ${field}       — legacy. configCache skips env var resolution for
-      //                    `iFinder.jwtSubjectField` (see
-      //                    ENV_VAR_RESOLUTION_SKIP_PATHS), so this is now
-      //                    safe; before that skip was added it could collide
-      //                    with `process.env.field` (notably
-      //                    `process.env.username` on Windows = the OS service
-      //                    account running the server), leaking that account
-      //                    into every JWT subject. We still warn so admins
-      //                    migrate to the explicit `${user.field}` form.
+      //   ${field}       — legacy. configCache opts this path out of env var
+      //                    resolution via the `ENV_VAR_SKIP_PATHS_BY_KEY`
+      //                    entry for `config/platform.json`, so this form
+      //                    is now safe; before that skip was added it could
+      //                    collide with `process.env.field` (notably
+      //                    `process.env.username` on Windows = the OS
+      //                    service account running the server), leaking
+      //                    that account into every JWT subject. We still
+      //                    warn so admins migrate to the explicit
+      //                    `${user.field}` form.
       if (/\$\{(?!user\.)\w+\}/.test(field)) {
         logger.warn(
           'iFinder jwtSubjectField uses legacy ${field} placeholder syntax. ' +

--- a/server/utils/iFinderJwt.js
+++ b/server/utils/iFinderJwt.js
@@ -135,20 +135,42 @@ function resolveJwtSubject(user, config) {
         ? `${user.domain}\\${user.username || user.id}`
         : user.username || user.id;
       break;
-    default:
-      // Custom template: replace ${field} placeholders. Warn on missing keys so
-      // misconfigurations surface in logs instead of producing an empty `sub`.
-      resolved = field.replace(/\$\{(\w+)\}/g, (_, key) => {
+    default: {
+      // Custom template. Placeholders ALWAYS resolve from the authenticated
+      // user object (`user[field]`), never from environment variables.
+      //
+      // Two accepted forms:
+      //   ${user.field}  — preferred, self-documenting.
+      //   ${field}       — legacy. configCache skips env var resolution for
+      //                    `iFinder.jwtSubjectField` (see
+      //                    ENV_VAR_RESOLUTION_SKIP_PATHS), so this is now
+      //                    safe; before that skip was added it could collide
+      //                    with `process.env.field` (notably
+      //                    `process.env.username` on Windows = the OS service
+      //                    account running the server), leaking that account
+      //                    into every JWT subject. We still warn so admins
+      //                    migrate to the explicit `${user.field}` form.
+      if (/\$\{(?!user\.)\w+\}/.test(field)) {
+        logger.warn(
+          'iFinder jwtSubjectField uses legacy ${field} placeholder syntax. ' +
+            'Use ${user.field} instead (e.g. "BMG\\\\${user.username}") to ' +
+            'avoid collision with environment variable names.',
+          { component: 'iFinderJwt', jwtSubjectField: field }
+        );
+      }
+      resolved = field.replace(/\$\{(?:user\.)?(\w+)\}/g, (_, key) => {
         const value = user[key];
         if (value === undefined || value === null || value === '') {
           logger.warn(
-            `iFinder JWT subject template placeholder \${${key}} resolved to empty for user ${user.id || user.username || '<unknown>'}`,
+            `iFinder JWT subject template placeholder for user.${key} resolved to empty for user ${user.id || user.username || '<unknown>'}`,
             { component: 'iFinderJwt', jwtSubjectField: field }
           );
           return '';
         }
         return value;
       });
+      break;
+    }
   }
 
   if (typeof resolved !== 'string' || resolved.trim() === '') {


### PR DESCRIPTION
## Summary

Critical security/identity bug in the iFinder/iAssistant integration. When `iFinder.jwtSubjectField` used a `${field}` template (e.g. `"BMG\\${username}"`), **the configCache env var resolver replaced the placeholder with `process.env.username` at config-load time**. On Windows, `process.env.username` is set automatically to the OS user running the server — typically the service account (`svc_ifinder-indexer` in the reported case) — so:

- Every iFinder JWT's `sub` became the service account, regardless of who was actually logged in
- Per-user permission enforcement in iFinder was effectively bypassed (every user shared one identity)
- iFinder audit logs showed only the service account, hiding real user activity
- Potential privilege escalation if the service account has elevated rights in iFinder

The bug only manifests on Windows (Linux doesn't set `process.env.username` by default), which is why it slipped through.

### Reproduction (logs from the reporting deployment)

```
"sub":"BMG\\svc_ifinder-indexer","name":"kozuch","iat":...,"scope":"fa_index_read fi_iassistant"
```

The `name` claim resolves per-request from the user object (correctly "kozuch"), but `sub` is the env-var-replaced template (the service account). The chat-request log on the same line shows `"user":"kozuch"` — confirming the authenticated user is correct, only the JWT subject is wrong.

## Fix

### 1. `configCache.js` — path-based skip list

`resolveEnvVarsInObject` now tracks the current dot-path and skips any path listed in `ENV_VAR_RESOLUTION_SKIP_PATHS`. `iFinder.jwtSubjectField` is the first (and currently only) entry. The recursion threads `path` through both objects and arrays so it works at any depth.

### 2. `iFinderJwt.js` — `${user.field}` syntax

`resolveJwtSubject` now accepts the explicit `${user.field}` placeholder syntax alongside the legacy `${field}`. The `user.` prefix means env-var-style identifiers in `${user.username}` are unambiguously user-template, not env-var. Legacy `${field}` still works (configCache no longer mangles it) but emits a security warning to nudge admins toward the explicit form.

### 3. Migration `V043__fix_ifinder_jwt_subject_template.js`

Auto-rewrites `${field}` → `${user.field}` in existing `platform.json` files on next server start. Standard values (`email`, `username`, `domain\\username`) are left untouched.

### 4. Tests

`server/tests/iFinderJwtSubject-securityBug.test.js` pins:
- configCache preserves the field even when `process.env.username` is set
- The template regex matches both `${field}` and `${user.field}`
- The legacy detector flags only the unprefixed form
- Migration converts legacy templates, leaves safe templates and standard values alone

14/14 tests pass via `node --test`.

### 5. Docs

`docs/platform.md` documents the supported `jwtSubjectField` forms and the env-var-collision pitfall.

## Test plan

- [ ] Pull on Windows deployment, restart, verify `platform.json` was rewritten to `${user.username}` form
- [ ] Send a chat through the iAssistant integration, capture iFinder JWT, verify `sub` matches the authenticated user (not the service account)
- [ ] Confirm no other config values changed during migration
- [ ] Review iFinder audit logs for the affected time window to scope the identity-leak impact

---

https://claude.ai/code/session_01UppFEnL5f2bQn3oLcNUG3s

---
_Generated by [Claude Code](https://claude.ai/code/session_01UppFEnL5f2bQn3oLcNUG3s)_