### PR TITLE
fix(office365): avoid Entra ID admin consent for personal-OneDrive-only setups

### DIFF
--- a/docs/office365-integration.md
+++ b/docs/office365-integration.md
@@ -45,25 +45,42 @@ The Office 365 integration enables users to browse and upload files from OneDriv
 
 The integration requires delegated permissions (acting on behalf of the signed-in user). No application-level permissions or admin credentials are used.
 
+iHub Apps requests **only the scopes required for the sources you enable** in the provider configuration. This means you can run a personal-OneDrive-only deployment without any admin consent at all.
+
+### Scope mapping
+
+| Enabled source | Scopes requested | Admin consent required? |
+|---|---|---|
+| Personal OneDrive **only** | `User.Read`, `Files.Read`, `offline_access` | **No** — user consent only |
+| Followed SharePoint Sites | adds `Sites.Read.All`, upgrades `Files.Read` → `Files.Read.All` | **Yes** |
+| Microsoft Teams | adds `Team.ReadBasic.All`, `Channel.ReadBasic.All`, upgrades `Files.Read` → `Files.Read.All` | **Yes** |
+
+> **Tip — avoid admin consent**: If you only enable **Personal OneDrive** in the provider's `sources` configuration (see Step 5), iHub Apps will request `Files.Read` instead of `Files.Read.All`. None of the requested scopes require admin consent, so any end user can connect their account without involving an Entra ID (Azure AD) administrator.
+
+### Permissions you may need to register in Azure
+
+Register all of the permissions you might use. Azure only prompts the user for the scopes that are actually requested at sign-in time, so adding the broader scopes here is safe:
+
 1. On your app registration page, select **"API permissions"** from the left menu
 2. Click **"+ Add a permission"**
 3. Select **"Microsoft Graph"**
 4. Select **"Delegated permissions"**
-5. Search for and add the following permissions:
+5. Add the permissions matching the sources you plan to enable:
 
-   | Permission | Purpose |
-   |------------|---------|
-   | `User.Read` | Read the signed-in user's basic profile |
-   | `Files.Read.All` | Read all files the user can access (OneDrive and SharePoint) |
-   | `Sites.Read.All` | Read items in all SharePoint site collections the user can access |
-   | `Team.ReadBasic.All` | Read basic information about Teams the user is a member of |
-   | `Channel.ReadBasic.All` | Read basic information about Teams channels |
-   | `offline_access` | Maintain access when the user is not actively using the app (required for refresh tokens) |
+   | Permission | Required for | Admin consent? |
+   |------------|--------------|----------------|
+   | `User.Read` | All deployments | No |
+   | `offline_access` | All deployments (refresh tokens) | No |
+   | `Files.Read` | Personal-OneDrive-only deployments | **No** |
+   | `Files.Read.All` | SharePoint or Teams sources | Yes |
+   | `Sites.Read.All` | Followed SharePoint sites | Yes |
+   | `Team.ReadBasic.All` | Microsoft Teams source | Yes |
+   | `Channel.ReadBasic.All` | Microsoft Teams source | Yes |
 
 6. Click **"Add permissions"**
-7. Click **"Grant admin consent for [your organization]"** and confirm
+7. **Only if** you are using SharePoint or Teams sources: click **"Grant admin consent for [your organization]"** and confirm. For personal-OneDrive-only setups you can skip this step — Azure will prompt the user for consent on first sign-in.
 
-   > **Note**: The `Files.Read.All` and `Sites.Read.All` permissions require admin consent. Without admin consent being granted, users will be blocked from authorizing the application. Coordinate with your Azure AD administrator if you do not have the required permissions.
+   > **Note**: If you grant admin consent for the broader `.All` scopes but only enable Personal OneDrive in the provider config, iHub Apps will still only request the narrower scopes — admin consent doesn't force broader access than the app asks for.
 
 ---
 
@@ -241,9 +258,9 @@ Each source is controlled by the `sources` configuration object in the provider 
 
 ### Admin consent not granted — "AADSTS65001" error
 
-- This error means admin consent has not been granted for the required permissions
-- An Azure AD administrator must visit the app registration in Azure Portal and click **"Grant admin consent"**
-- Alternatively, the administrator can grant consent by navigating to: `https://login.microsoftonline.com/{tenantId}/adminconsent?client_id={clientId}`
+- This error means admin consent has not been granted for one of the `.All` scopes the integration is requesting
+- **If you don't have an Entra ID administrator**: disable **Followed SharePoint Sites** and **Microsoft Teams** in the provider's `sources` configuration and keep only **Personal OneDrive** enabled. iHub Apps will then request only `User.Read`, `Files.Read`, and `offline_access`, none of which require admin consent.
+- **If you do have an administrator**: have them visit the app registration in Azure Portal and click **"Grant admin consent"**, or have them grant consent by navigating to: `https://login.microsoftonline.com/{tenantId}/adminconsent?client_id={clientId}`
 
 ### No files showing for SharePoint or Teams
 
@@ -273,7 +290,8 @@ Each source is controlled by the `sources` configuration object in the provider 
 
 ## Security Considerations
 
-- **Read-only access**: The integration requests only read permissions (`Files.Read.All`, `Sites.Read.All`) — it cannot create, modify, or delete files
+- **Read-only access**: The integration requests only read permissions (`Files.Read` or `Files.Read.All`, plus `Sites.Read.All` if SharePoint is enabled) — it cannot create, modify, or delete files
+- **Least-privilege scopes**: Scopes are derived from the enabled `sources` (personal/SharePoint/Teams). A personal-OneDrive-only deployment uses `Files.Read` and avoids admin-consent scopes entirely.
 - **Per-user tokens**: Each user connects their own Microsoft account; no shared service account is used
 - **Encrypted storage**: Tokens are encrypted at rest using AES-256-GCM via `TokenStorageService`
 - **PKCE**: OAuth flow uses Proof Key for Code Exchange (S256 method) to prevent authorization code interception attacks

--- a/server/services/integrations/Office365Service.js
+++ b/server/services/integrations/Office365Service.js
@@ -79,6 +79,56 @@ class Office365Service {
   }
 
   /**
+   * Build the minimal set of Microsoft Graph scopes required for the
+   * provider's enabled sources.
+   *
+   * Microsoft Entra ID classifies many Graph scopes as "admin consent
+   * required" (Files.Read.All, Sites.Read.All, Team.ReadBasic.All,
+   * Channel.ReadBasic.All). Requesting them forces every user through a
+   * tenant admin even when they only need their own OneDrive. We only
+   * ask for those when the corresponding source toggle is enabled.
+   *
+   * @param {Object} provider - Office 365 provider configuration
+   * @returns {string} Space-separated scope string
+   */
+  _buildScopes(provider) {
+    const sources = provider.sources || {
+      personalDrive: true,
+      followedSites: true,
+      teams: true
+    };
+
+    const personalDrive = sources.personalDrive !== false;
+    const followedSites = sources.followedSites !== false;
+    const teams = sources.teams !== false;
+
+    // User.Read and offline_access are delegated user-consent scopes
+    // and do not require admin consent.
+    const scopes = ['User.Read', 'offline_access'];
+
+    if (followedSites) {
+      scopes.push('Sites.Read.All');
+    }
+
+    if (teams) {
+      scopes.push('Team.ReadBasic.All', 'Channel.ReadBasic.All');
+    }
+
+    // For file content access:
+    // - If SharePoint or Teams is enabled we need Files.Read.All to read
+    //   drive items across all the sources the user can reach.
+    // - If only personal OneDrive is enabled, Files.Read is sufficient
+    //   AND avoids admin consent entirely.
+    if (followedSites || teams) {
+      scopes.push('Files.Read.All');
+    } else if (personalDrive) {
+      scopes.push('Files.Read');
+    }
+
+    return scopes.join(' ');
+  }
+
+  /**
    * Generate OAuth 2.0 authorization URL with PKCE
    * @param {string} providerId - The provider ID
    * @param {string} state - CSRF protection state
@@ -113,15 +163,14 @@ class Office365Service {
 
     const authUrl = `${this.authBaseUrl}/${provider.tenantId}/oauth2/v2.0/authorize`;
 
-    // Microsoft Graph API scopes for file access
-    const scopes = [
-      'User.Read', // Basic user info
-      'Files.Read.All', // Read files in all site collections
-      'Sites.Read.All', // Read items in all site collections
-      'Team.ReadBasic.All', // Read Teams information
-      'Channel.ReadBasic.All', // Read Teams channel information
-      'offline_access' // Refresh token
-    ].join(' ');
+    const scopes = this._buildScopes(provider);
+
+    logger.info('Office 365 OAuth scopes selected from enabled sources', {
+      component: 'Office365Service',
+      providerId,
+      scopes,
+      sources: provider.sources
+    });
 
     const params = new URLSearchParams({
       client_id: provider.clientId,
@@ -241,8 +290,7 @@ class Office365Service {
         client_secret: provider.clientSecret,
         refresh_token: refreshToken,
         grant_type: 'refresh_token',
-        scope:
-          'User.Read Files.Read.All Sites.Read.All Team.ReadBasic.All Channel.ReadBasic.All offline_access'
+        scope: this._buildScopes(provider)
       });
 
       const response = await httpFetch(tokenUrl, {

--- a/server/tests/office365-scope-build.test.js
+++ b/server/tests/office365-scope-build.test.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+
+/**
+ * Unit test for Office 365 conditional scope building.
+ *
+ * Verifies _buildScopes() picks the minimum Microsoft Graph scopes needed
+ * for the provider's enabled sources, so personal-OneDrive-only setups
+ * avoid admin-consent scopes (Files.Read.All, Sites.Read.All, etc.).
+ */
+
+import office365Service from '../services/integrations/Office365Service.js';
+
+const ADMIN_CONSENT_SCOPES = [
+  'Files.Read.All',
+  'Sites.Read.All',
+  'Team.ReadBasic.All',
+  'Channel.ReadBasic.All'
+];
+
+let failures = 0;
+
+function assert(condition, message) {
+  if (condition) {
+    console.log(`  ✅ ${message}`);
+  } else {
+    console.log(`  ❌ ${message}`);
+    failures += 1;
+  }
+}
+
+function scopeList(provider) {
+  return office365Service._buildScopes(provider).split(' ');
+}
+
+function hasAdminConsentScope(scopes) {
+  return scopes.some(s => ADMIN_CONSENT_SCOPES.includes(s));
+}
+
+console.log('\nTest 1: personalDrive only — no admin consent scopes');
+{
+  const scopes = scopeList({
+    sources: { personalDrive: true, followedSites: false, teams: false }
+  });
+  assert(scopes.includes('User.Read'), 'includes User.Read');
+  assert(scopes.includes('offline_access'), 'includes offline_access');
+  assert(scopes.includes('Files.Read'), 'includes Files.Read (user-consent)');
+  assert(!scopes.includes('Files.Read.All'), 'does NOT include Files.Read.All');
+  assert(!hasAdminConsentScope(scopes), 'does NOT include any admin-consent scope');
+}
+
+console.log('\nTest 2: personalDrive + followedSites — Sites.Read.All required');
+{
+  const scopes = scopeList({
+    sources: { personalDrive: true, followedSites: true, teams: false }
+  });
+  assert(scopes.includes('Sites.Read.All'), 'includes Sites.Read.All');
+  assert(scopes.includes('Files.Read.All'), 'upgrades to Files.Read.All');
+  assert(!scopes.includes('Files.Read'), 'does not also include Files.Read');
+  assert(!scopes.includes('Team.ReadBasic.All'), 'does not include Team scope');
+}
+
+console.log('\nTest 3: teams enabled — Team and Channel scopes added');
+{
+  const scopes = scopeList({
+    sources: { personalDrive: true, followedSites: false, teams: true }
+  });
+  assert(scopes.includes('Team.ReadBasic.All'), 'includes Team.ReadBasic.All');
+  assert(scopes.includes('Channel.ReadBasic.All'), 'includes Channel.ReadBasic.All');
+  assert(scopes.includes('Files.Read.All'), 'upgrades to Files.Read.All');
+  assert(!scopes.includes('Sites.Read.All'), 'does not include Sites.Read.All');
+}
+
+console.log('\nTest 4: all sources enabled — full scope set');
+{
+  const scopes = scopeList({
+    sources: { personalDrive: true, followedSites: true, teams: true }
+  });
+  assert(scopes.includes('Files.Read.All'), 'includes Files.Read.All');
+  assert(scopes.includes('Sites.Read.All'), 'includes Sites.Read.All');
+  assert(scopes.includes('Team.ReadBasic.All'), 'includes Team.ReadBasic.All');
+  assert(scopes.includes('Channel.ReadBasic.All'), 'includes Channel.ReadBasic.All');
+}
+
+console.log('\nTest 5: sources undefined — backward compatible default (all enabled)');
+{
+  const scopes = scopeList({});
+  assert(scopes.includes('Files.Read.All'), 'includes Files.Read.All by default');
+  assert(scopes.includes('Sites.Read.All'), 'includes Sites.Read.All by default');
+  assert(scopes.includes('Team.ReadBasic.All'), 'includes Team scope by default');
+}
+
+console.log('\nTest 6: all sources disabled — minimal scopes only');
+{
+  const scopes = scopeList({
+    sources: { personalDrive: false, followedSites: false, teams: false }
+  });
+  assert(scopes.includes('User.Read'), 'still includes User.Read');
+  assert(scopes.includes('offline_access'), 'still includes offline_access');
+  assert(!scopes.includes('Files.Read'), 'does not include Files.Read');
+  assert(!hasAdminConsentScope(scopes), 'does NOT include any admin-consent scope');
+}
+
+console.log(`\n${failures === 0 ? '✨ All tests passed!' : `❌ ${failures} assertion(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Problem

Connecting an Office 365 provider always required a Microsoft Entra ID (Azure AD) **administrator** to grant tenant-wide admin consent, even for users who only wanted to upload files from their own OneDrive.

The OAuth scopes in `Office365Service.js` were hardcoded to:

```
User.Read Files.Read.All Sites.Read.All Team.ReadBasic.All Channel.ReadBasic.All offline_access
```

Four of those (`Files.Read.All`, `Sites.Read.All`, `Team.ReadBasic.All`, `Channel.ReadBasic.All`) are classified by Microsoft as **admin-consent required** scopes. Without an administrator, end users hit `AADSTS65001` and were blocked from connecting at all.

## Fix

Derive scopes from the provider's existing `sources` configuration (`personalDrive`, `followedSites`, `teams`) instead of hardcoding them:

| Enabled source                 | Scopes added                                                 | Admin consent? |
| ------------------------------ | ------------------------------------------------------------ | -------------- |
| Personal OneDrive **only**     | `User.Read`, `Files.Read`, `offline_access`                  | **No**         |
| + Followed SharePoint sites    | adds `Sites.Read.All`, upgrades to `Files.Read.All`          | Yes            |
| + Microsoft Teams              | adds `Team.ReadBasic.All`, `Channel.ReadBasic.All`           | Yes            |

A personal-OneDrive-only deployment now uses only user-consent scopes — no administrator needed.

The new logic lives in a single private helper `Office365Service._buildScopes(provider)` and is used by both `generateAuthUrl()` and `refreshAccessToken()`.

## Changes

- `server/services/integrations/Office365Service.js` — added `_buildScopes()`; replaced hardcoded scope strings in `generateAuthUrl` and `refreshAccessToken`; added an info log when scopes are selected.
- `server/tests/office365-scope-build.test.js` — new unit test (23 assertions, all passing) covering personal-only, SharePoint, Teams, all-enabled, default (undefined sources), and all-disabled cases.
- `docs/office365-integration.md` — rewrote the API-permissions section with the new scope mapping, added an "avoid admin consent" tip, and updated the `AADSTS65001` troubleshooting entry to point at the personal-only workaround.

## Backward compatibility

- Existing tokens with broader scopes continue to work — the old-token-migration logic for legacy `Group.Read.All` / `ChannelSettings.Read.All` is unchanged.
- Provider configs without an explicit `sources` block still default to all three sources enabled (matches the schema default), so existing deployments behave exactly as before.
- The change is purely a reduction in scopes requested when admins narrow `sources` — never a broadening.

## Test plan

- [x] `node server/tests/office365-scope-build.test.js` — all 23 assertions pass
- [x] Server starts cleanly (`timeout 8s node server/server.js`)
- [x] ESLint clean on changed files (two pre-existing warnings in untouched code remain)
- [ ] Manual: configure an Office 365 provider with `sources.personalDrive: true` and the other two false; confirm Microsoft's consent screen shows only `Sign you in and read your profile`, `Read your files`, and `Maintain access to data you have given it access to` — no admin-consent badges.
- [ ] Manual: enable SharePoint + Teams; confirm consent screen lists the `.All` scopes and admin consent flow still works.

https://claude.ai/code/session_01WT8JvhBAMj27oedq1v6AVQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01WT8JvhBAMj27oedq1v6AVQ)_