### PR TITLE
fix(outlook): consolidate email pin controls into one "Add email(s)" button (#1553)

### DIFF
--- a/client/office/taskpane-entry.jsx
+++ b/client/office/taskpane-entry.jsx
@@ -47,11 +47,26 @@ Office.onReady(async () => {
   // can call refreshTokenOrExpireSession() without threading config everywhere.
   installOfficeAuthInterceptor(config);
 
-  // Register the ItemChanged event to reset chat when user switches emails
+  // Register the ItemChanged event to reset chat when user switches emails.
+  // Also listen for SelectedItemsChanged so the taskpane reacts when the user
+  // Ctrl-selects multiple messages in the list (ItemChanged does NOT fire for
+  // multi-select transitions). Both dispatch the same internal event so the
+  // chat panel can refresh its current-item state and the "Add email(s)"
+  // control stays in sync with the live Outlook selection. Issue #1553.
   if (Office.context?.mailbox?.addHandlerAsync) {
-    Office.context.mailbox.addHandlerAsync(Office.EventType.ItemChanged, () => {
-      document.dispatchEvent(new CustomEvent('ihub:itemchanged'));
-    });
+    const dispatchItemChanged = () => document.dispatchEvent(new CustomEvent('ihub:itemchanged'));
+    Office.context.mailbox.addHandlerAsync(Office.EventType.ItemChanged, dispatchItemChanged);
+    if (Office.EventType?.SelectedItemsChanged) {
+      try {
+        Office.context.mailbox.addHandlerAsync(
+          Office.EventType.SelectedItemsChanged,
+          dispatchItemChanged
+        );
+      } catch {
+        // SelectedItemsChanged requires Mailbox 1.13+; older hosts simply
+        // keep the ItemChanged-only behavior.
+      }
+    }
   }
 
   const rootEl = document.getElementById('office-root');

--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -93,7 +93,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   // the user can navigate between emails while building up a context set;
   // wiped on new-chat / app-switch alongside the chat history.
   const [pinnedEmails, setPinnedEmails] = useState([]);
-  const [multiSelectLoading, setMultiSelectLoading] = useState(false);
+  const [addEmailsLoading, setAddEmailsLoading] = useState(false);
   // itemId of the email currently open in Outlook. Lets us hide the
   // "Add this email" affordance once it's already in the pin list, and
   // dedupe in the prompt builder.
@@ -176,28 +176,6 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
     };
   }, [adapter]);
 
-  const handlePinCurrent = useCallback(async () => {
-    try {
-      const ctx = await fetchCurrentMailContext();
-      if (!ctx?.available) return;
-      if (!ctx.itemId && !ctx.subject && !ctx.bodyText) return;
-      setPinnedEmails(prev => {
-        if (ctx.itemId && prev.some(p => p.itemId === ctx.itemId)) return prev;
-        return [
-          ...prev,
-          {
-            itemId: ctx.itemId ?? null,
-            subject: ctx.subject ?? null,
-            bodyText: ctx.bodyText ?? null,
-            attachments: ctx.attachments ?? []
-          }
-        ];
-      });
-    } catch {
-      /* silently swallow — surfacing host errors here would be noisy */
-    }
-  }, []);
-
   const handleUnpin = useCallback(itemId => {
     setPinnedEmails(prev => {
       if (!itemId) return prev;
@@ -209,31 +187,82 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
     setPinnedEmails([]);
   }, []);
 
-  const handlePinSelected = useCallback(async () => {
-    if (!multiSelectSupported) return;
-    setMultiSelectLoading(true);
+  // Single "Add email(s)" entry point (issue #1553). Attaches every email
+  // the user has Ctrl-selected in Outlook (Mailbox 1.15+) AND/OR the email
+  // currently open in the reading pane. Replaces the old split
+  // "Add this email" / "Add selected emails" buttons which (a) confused
+  // users by always showing both and (b) silently no-op'd when the
+  // multi-select reader returned nothing.
+  const handleAddEmails = useCallback(async () => {
+    setAddEmailsLoading(true);
     try {
-      const items = await fetchSelectedItemsContext();
-      if (!Array.isArray(items) || items.length === 0) return;
+      const collected = [];
+      const seenIds = new Set();
+      const pushEntry = entry => {
+        if (entry.itemId && seenIds.has(entry.itemId)) return;
+        if (entry.itemId) seenIds.add(entry.itemId);
+        collected.push(entry);
+      };
+
+      // 1. Pull every email the user has multi-selected in Outlook. On a
+      //    single selection this returns just the open email; on no
+      //    selection it returns nothing — both handled by the fallback
+      //    below. Errors are logged, not swallowed, so a failing host API
+      //    no longer leaves the user staring at an unresponsive button.
+      if (multiSelectSupported) {
+        try {
+          const items = await fetchSelectedItemsContext();
+          if (Array.isArray(items)) {
+            for (const it of items) {
+              pushEntry({
+                itemId: it.itemId ?? null,
+                subject: it.subject ?? null,
+                bodyText: it.bodyText ?? null,
+                attachments: []
+              });
+            }
+          }
+        } catch (err) {
+          console.warn('[office] reading selected emails failed', err);
+        }
+      }
+
+      // 2. When the user has a single email open — either because
+      //    multi-select isn't supported, or only one message is selected —
+      //    pull the full current-mail context. This guarantees the open
+      //    email is always added (the core fix for "nothing happened") and
+      //    captures its attachments, which the lightweight multi-select
+      //    reader deliberately skips.
+      if (collected.length <= 1) {
+        try {
+          const ctx = await fetchCurrentMailContext();
+          if (ctx?.available && (ctx.itemId || ctx.subject || ctx.bodyText)) {
+            const entry = {
+              itemId: ctx.itemId ?? null,
+              subject: ctx.subject ?? null,
+              bodyText: ctx.bodyText ?? null,
+              attachments: ctx.attachments ?? []
+            };
+            // Upgrade the matching multi-select stub with attachments rather
+            // than adding a duplicate of the same email.
+            const idx = ctx.itemId ? collected.findIndex(c => c.itemId === ctx.itemId) : -1;
+            if (idx >= 0) collected[idx] = entry;
+            else pushEntry(entry);
+          }
+        } catch (err) {
+          console.warn('[office] reading current email failed', err);
+        }
+      }
+
+      if (collected.length === 0) return;
+
       setPinnedEmails(prev => {
         const seen = new Set(prev.map(p => p.itemId).filter(Boolean));
-        const additions = [];
-        for (const it of items) {
-          if (it.itemId && seen.has(it.itemId)) continue;
-          if (it.itemId) seen.add(it.itemId);
-          additions.push({
-            itemId: it.itemId ?? null,
-            subject: it.subject ?? null,
-            bodyText: it.bodyText ?? null,
-            attachments: []
-          });
-        }
+        const additions = collected.filter(c => !(c.itemId && seen.has(c.itemId)));
         return additions.length ? [...prev, ...additions] : prev;
       });
-    } catch {
-      /* silently swallow */
     } finally {
-      setMultiSelectLoading(false);
+      setAddEmailsLoading(false);
     }
   }, [multiSelectSupported]);
 
@@ -545,14 +574,19 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
               pinned={pinnedEmails}
               onUnpin={handleUnpin}
               onClearPinned={handleClearPinned}
-              onPinCurrent={handlePinCurrent}
-              onPinSelected={handlePinSelected}
-              canPinCurrent={!isAppointment && !!currentItemId}
-              isCurrentPinned={
-                !!currentItemId && pinnedEmails.some(p => p.itemId === currentItemId)
+              onAddEmails={handleAddEmails}
+              canAddEmails={!isAppointment && (!!currentItemId || multiSelectSupported)}
+              addEmailsLoading={addEmailsLoading}
+              // When multi-select isn't available we can reliably tell the
+              // single open email is already attached, so we disable the
+              // button and show "Already added". With multi-select the user
+              // may still want to pull other selected emails, so it stays
+              // enabled and the prompt builder dedupes by itemId.
+              addEmailsDisabled={
+                !multiSelectSupported &&
+                !!currentItemId &&
+                pinnedEmails.some(p => p.itemId === currentItemId)
               }
-              isMultiSelectSupported={!isAppointment && multiSelectSupported}
-              multiSelectLoading={multiSelectLoading}
             />
 
             {/* Input */}

--- a/client/src/features/office/components/PinnedEmailsBar.jsx
+++ b/client/src/features/office/components/PinnedEmailsBar.jsx
@@ -9,88 +9,74 @@ function truncate(s, n) {
 
 /**
  * Toolbar that lives between the message list and the chat input in the
- * Outlook taskpane. Lets users attach the currently-open email — and, on
- * Mailbox 1.15+, any emails Ctrl-selected in the message list — to the
- * outgoing prompt without losing them when they navigate between emails.
+ * Outlook taskpane. A single "Add email(s)" button attaches the currently
+ * open email — and, on Mailbox 1.15+, every email Ctrl-selected in the
+ * message list — to the outgoing prompt without losing them when the user
+ * navigates between emails. Issue #1553 consolidated the previous pair of
+ * "Add this email" / "Add selected emails" buttons into one control.
  *
  * When `embedded` is true (the OfficeContextStrip usage) the surrounding
  * collapsible strip owns the page-level margins / borders, so this bar
  * just renders its contents flush. Issue #1467.
  *
- * When `collapsedMode` is true, only the action buttons ("Add this email",
- * "Add selected emails") are shown without the pinned items list or clear
- * button, enabling always-visible pin controls in the collapsed strip header.
+ * When `collapsedMode` is true, only the action button is shown without the
+ * pinned items list or clear button, enabling an always-visible pin control
+ * in the collapsed strip header.
  */
 function PinnedEmailsBar({
   pinned,
   onUnpin,
   onClearAll,
-  onPinCurrent,
-  onPinSelected,
-  canPinCurrent,
-  isCurrentPinned,
-  isMultiSelectSupported,
-  multiSelectLoading,
+  onAddEmails,
+  canAddEmails,
+  addEmailsLoading,
+  addEmailsDisabled,
   embedded = false,
   collapsedMode = false
 }) {
   const { t } = useTranslation();
   const hasPins = Array.isArray(pinned) && pinned.length > 0;
 
-  // In collapsed mode, we only show the action buttons, never the pinned list
+  const compact = collapsedMode;
+  const buttonClass = compact
+    ? 'inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-slate-700 hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-xs'
+    : 'inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-slate-700 hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors';
+
+  const addButton = canAddEmails ? (
+    <button
+      type="button"
+      onClick={onAddEmails}
+      disabled={addEmailsLoading || addEmailsDisabled}
+      title={
+        addEmailsDisabled
+          ? t('office.pinned.alreadyAdded', 'Already added')
+          : t(
+              'office.pinned.addEmailsTooltip',
+              "Attach the open email — or every email you've selected in Outlook — to the chat"
+            )
+      }
+      className={buttonClass}
+    >
+      <Icon name="paper-clip" size="sm" />
+      <span>
+        {addEmailsLoading
+          ? t('common.loading', 'Loading…')
+          : addEmailsDisabled
+            ? t('office.pinned.alreadyAdded', 'Already added')
+            : t('office.pinned.addEmails', 'Add email(s)')}
+      </span>
+    </button>
+  ) : null;
+
+  // In collapsed mode, we only show the action button, never the pinned list.
   if (collapsedMode) {
-    // Show nothing if there are no pin controls available
-    if (!canPinCurrent && !isMultiSelectSupported) return null;
-
-    return (
-      <div className="flex flex-wrap items-center gap-1.5">
-        {canPinCurrent && (
-          <button
-            type="button"
-            onClick={onPinCurrent}
-            disabled={isCurrentPinned}
-            title={
-              isCurrentPinned
-                ? t('office.pinned.alreadyAdded', 'Already added')
-                : t('office.pinned.addCurrentTooltip', 'Attach this email to the chat')
-            }
-            className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-slate-700 hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-xs"
-          >
-            <Icon name="paper-clip" size="sm" />
-            <span>
-              {isCurrentPinned
-                ? t('office.pinned.alreadyAdded', 'Already added')
-                : t('office.pinned.addCurrent', 'Add this email')}
-            </span>
-          </button>
-        )}
-
-        {isMultiSelectSupported && (
-          <button
-            type="button"
-            onClick={onPinSelected}
-            disabled={multiSelectLoading}
-            title={t(
-              'office.pinned.addSelectedTooltip',
-              'Attach every email you have selected in Outlook'
-            )}
-            className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-slate-700 hover:bg-slate-100 disabled:opacity-50 transition-colors text-xs"
-          >
-            <Icon name="plus-circle" size="sm" />
-            <span>
-              {multiSelectLoading
-                ? t('common.loading', 'Loading…')
-                : t('office.pinned.addSelected', 'Add selected emails')}
-            </span>
-          </button>
-        )}
-      </div>
-    );
+    if (!canAddEmails) return null;
+    return <div className="flex flex-wrap items-center gap-1.5">{addButton}</div>;
   }
 
-  // Normal (expanded) mode below
-  // Nothing to do when we can't pin and don't have any pins to show.
-  if (!hasPins && !canPinCurrent && !isMultiSelectSupported) return null;
+  // Normal (expanded) mode below.
+  // Nothing to do when we can't add emails and don't have any pins to show.
+  if (!hasPins && !canAddEmails) return null;
 
   const outerClassName = embedded
     ? 'office-pinned-bar bg-slate-50/70 px-3 py-2 text-xs'
@@ -99,46 +85,7 @@ function PinnedEmailsBar({
   return (
     <div className={outerClassName}>
       <div className="flex flex-wrap items-center gap-1.5">
-        {canPinCurrent && (
-          <button
-            type="button"
-            onClick={onPinCurrent}
-            disabled={isCurrentPinned}
-            title={
-              isCurrentPinned
-                ? t('office.pinned.alreadyAdded', 'Already added')
-                : t('office.pinned.addCurrentTooltip', 'Attach this email to the chat')
-            }
-            className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-slate-700 hover:bg-slate-100 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            <Icon name="paper-clip" size="sm" />
-            <span>
-              {isCurrentPinned
-                ? t('office.pinned.alreadyAdded', 'Already added')
-                : t('office.pinned.addCurrent', 'Add this email')}
-            </span>
-          </button>
-        )}
-
-        {isMultiSelectSupported && (
-          <button
-            type="button"
-            onClick={onPinSelected}
-            disabled={multiSelectLoading}
-            title={t(
-              'office.pinned.addSelectedTooltip',
-              'Attach every email you have selected in Outlook'
-            )}
-            className="inline-flex items-center gap-1 rounded-md border border-slate-200 bg-white px-2 py-1 text-slate-700 hover:bg-slate-100 disabled:opacity-50 transition-colors"
-          >
-            <Icon name="plus-circle" size="sm" />
-            <span>
-              {multiSelectLoading
-                ? t('common.loading', 'Loading…')
-                : t('office.pinned.addSelected', 'Add selected emails')}
-            </span>
-          </button>
-        )}
+        {addButton}
 
         {hasPins && (
           <button

--- a/client/src/features/office/components/chat/OfficeContextStrip.jsx
+++ b/client/src/features/office/components/chat/OfficeContextStrip.jsx
@@ -36,12 +36,10 @@ function OfficeContextStrip({
   pinned,
   onUnpin,
   onClearPinned,
-  onPinCurrent,
-  onPinSelected,
-  canPinCurrent,
-  isCurrentPinned,
-  isMultiSelectSupported,
-  multiSelectLoading
+  onAddEmails,
+  canAddEmails,
+  addEmailsLoading,
+  addEmailsDisabled
 }) {
   const isAppointment = ctx?.itemKind === 'appointment';
   const attachments = useMemo(
@@ -60,7 +58,7 @@ function OfficeContextStrip({
   // single calendar item, so we suppress them when the user is on an
   // appointment surface to keep the strip focused on the meeting metadata.
   const hasPinned = !isAppointment && pinnedList.length > 0;
-  const hasPinControls = !isAppointment && (canPinCurrent || isMultiSelectSupported);
+  const hasPinControls = !isAppointment && !!canAddEmails;
 
   // Default-collapse threshold counts what the user would actually see
   // once expanded — attachments still in the queue plus pinned emails.
@@ -204,12 +202,10 @@ function OfficeContextStrip({
             pinned={[]}
             onUnpin={() => {}}
             onClearAll={() => {}}
-            onPinCurrent={onPinCurrent}
-            onPinSelected={onPinSelected}
-            canPinCurrent={canPinCurrent}
-            isCurrentPinned={isCurrentPinned}
-            isMultiSelectSupported={isMultiSelectSupported}
-            multiSelectLoading={multiSelectLoading}
+            onAddEmails={onAddEmails}
+            canAddEmails={canAddEmails}
+            addEmailsLoading={addEmailsLoading}
+            addEmailsDisabled={addEmailsDisabled}
             embedded
             collapsedMode
           />
@@ -237,12 +233,10 @@ function OfficeContextStrip({
               pinned={pinnedList}
               onUnpin={onUnpin}
               onClearAll={onClearPinned}
-              onPinCurrent={onPinCurrent}
-              onPinSelected={onPinSelected}
-              canPinCurrent={canPinCurrent}
-              isCurrentPinned={isCurrentPinned}
-              isMultiSelectSupported={isMultiSelectSupported}
-              multiSelectLoading={multiSelectLoading}
+              onAddEmails={onAddEmails}
+              canAddEmails={canAddEmails}
+              addEmailsLoading={addEmailsLoading}
+              addEmailsDisabled={addEmailsDisabled}
               embedded
             />
           )}

--- a/server/routes/integrations/officeAddin.js
+++ b/server/routes/integrations/officeAddin.js
@@ -117,7 +117,8 @@ router.get('/manifest.xml', (req, res) => {
   // Get localized values for all supported languages
   const displayNameEn = getLocalizedContent(officeConfig.displayName, 'en') || 'iHub Apps';
   const displayNameDe = getLocalizedContent(officeConfig.displayName, 'de') || displayNameEn;
-  const descriptionEn = getLocalizedContent(officeConfig.description, 'en') || 'AI-powered assistant for Outlook';
+  const descriptionEn =
+    getLocalizedContent(officeConfig.description, 'en') || 'AI-powered assistant for Outlook';
   const descriptionDe = getLocalizedContent(officeConfig.description, 'de') || descriptionEn;
   const showTaskPaneLabelEn = translations.en?.office?.showTaskPane || 'Show Task Pane';
   const showTaskPaneLabelDe = translations.de?.office?.showTaskPane || showTaskPaneLabelEn;
@@ -147,7 +148,16 @@ router.get('/manifest.xml', (req, res) => {
   res.send(manifest);
 });
 
-function generateManifest({ baseUrl, origin, displayNameEn, displayNameDe, descriptionEn, descriptionDe, showTaskPaneLabelEn, showTaskPaneLabelDe }) {
+function generateManifest({
+  baseUrl,
+  origin,
+  displayNameEn,
+  displayNameDe,
+  descriptionEn,
+  descriptionDe,
+  showTaskPaneLabelEn,
+  showTaskPaneLabelDe
+}) {
   return `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <OfficeApp xmlns="http://schemas.microsoft.com/office/appforoffice/1.1"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -137,10 +137,8 @@
     "insertIntoEmail": "In E-Mail einfügen",
     "insertIntoDocument": "In Dokument einfügen",
     "pinned": {
-      "addCurrent": "Diese E-Mail hinzufügen",
-      "addCurrentTooltip": "Diese E-Mail an den Chat anhängen",
-      "addSelected": "Ausgewählte E-Mails hinzufügen",
-      "addSelectedTooltip": "Alle in Outlook ausgewählten E-Mails anhängen",
+      "addEmails": "E-Mail(s) hinzufügen",
+      "addEmailsTooltip": "Die geöffnete E-Mail – oder alle in Outlook ausgewählten E-Mails – an den Chat anhängen",
       "alreadyAdded": "Bereits hinzugefügt",
       "removeOne": "Aus dem Chat entfernen",
       "clearAll": "Leeren",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -123,10 +123,8 @@
     "insertIntoEmail": "Add to email",
     "insertIntoDocument": "Add to document",
     "pinned": {
-      "addCurrent": "Add this email",
-      "addCurrentTooltip": "Attach this email to the chat",
-      "addSelected": "Add selected emails",
-      "addSelectedTooltip": "Attach every email you have selected in Outlook",
+      "addEmails": "Add email(s)",
+      "addEmailsTooltip": "Attach the open email — or every email you've selected in Outlook — to the chat",
       "alreadyAdded": "Already added",
       "removeOne": "Remove from chat",
       "clearAll": "Clear",


### PR DESCRIPTION
Fixes #1553

## Problem

A customer using Outlook with multi-select reported two issues with the email-attachment controls in the task pane:

1. **Two buttons always shown** — both "Add this email" and "Add selected emails" rendered whenever a single message was open on a Mailbox 1.15+ client. They expected a single "Add email(s)" button that attaches whatever is selected.
2. **"Add selected emails" did nothing** — selecting multiple messages and clicking the button produced no visible result.

### Root cause

- `handlePinSelected` ran only `fetchSelectedItemsContext()` and wrapped everything in a `catch {}` that **silently swallowed all errors**. If `getSelectedItemsAsync` returned empty or threw (e.g. the pane wasn't activated in a multi-select context, or a host API quirk), nothing was added and the user got zero feedback.
- The task pane registered only `ItemChanged`, which does **not** fire on multi-select transitions (that's `SelectedItemsChanged`), so the pane's current-item state could drift out of sync with the live selection.

## Changes

- **One button.** `PinnedEmailsBar` now renders a single **"Add email(s)"** control (collapsed + expanded modes) instead of the `Add this email` / `Add selected emails` pair.
- **Robust unified handler.** `handleAddEmails`:
  - pulls every Ctrl-selected email via the Mailbox 1.15+ reader, **and**
  - falls back to the currently open email (with attachments) on single/no selection, so a click always attaches something;
  - dedupes across both sources by `itemId` and upgrades a multi-select stub with the open email's attachments rather than duplicating it;
  - **logs** host errors instead of swallowing them.
- **Event coverage.** Registers `SelectedItemsChanged` alongside `ItemChanged` (guarded for older hosts) so the pane reacts to multi-select changes.
- **i18n.** Replaced `office.pinned.addCurrent` / `addSelected` with `addEmails` / `addEmailsTooltip` in `en.json` and `de.json`.

## Notes / behavior

- When multi-select isn't supported and the open email is already pinned, the button is disabled and shows **"Already added"**. With multi-select supported it stays enabled (the user may still want other selected emails); the prompt builder dedupes by `itemId`.
- Appointment surfaces are unaffected — pin controls remain hidden for calendar items.

## Testing

- `npx eslint` on all touched files: **0 errors** (the 4 remaining warnings are pre-existing in the app-init effect).
- `npx prettier --write` applied; i18n JSON validated.
- ⚠️ Behavior in a live Outlook host (desktop/web/mobile) with real multi-select has **not** been verified in this environment and should be smoke-tested before merge.

https://claude.ai/code/session_01D3A2FFjmkaC6pjS155HzHd

---
_Generated by [Claude Code](https://claude.ai/code/session_01D3A2FFjmkaC6pjS155HzHd)_