### PR TITLE
fix: data table kebab menu hidden behind row action icons

### DIFF
--- a/client/src/features/admin/components/data-table/DataTableKebabMenu.jsx
+++ b/client/src/features/admin/components/data-table/DataTableKebabMenu.jsx
@@ -1,15 +1,25 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import Icon from '../../../../shared/components/Icon';
+
+const MENU_WIDTH = 192; // matches w-48
 
 /**
  * Vertical-dots popover for row overflow actions.
+ *
+ * The menu is rendered in a portal with fixed positioning so it escapes the
+ * table's stacking contexts (each sticky action cell creates its own) and the
+ * container's overflow clipping. Without this it would render behind the action
+ * icons of subsequent rows.
  *
  * Keyboard support: Enter/Space toggles, Esc closes and returns focus to the
  * trigger, ArrowDown/Up cycle through menu items, Tab exits the menu.
  */
 function DataTableKebabMenu({ items, label = 'More actions', row }) {
   const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
   const ref = useRef(null);
+  const menuRef = useRef(null);
   const triggerRef = useRef(null);
   const itemRefs = useRef([]);
 
@@ -18,11 +28,38 @@ function DataTableKebabMenu({ items, label = 'More actions', row }) {
     if (returnFocus) triggerRef.current?.focus();
   }, []);
 
+  // Position the fixed-position menu relative to the trigger, right-aligned and
+  // clamped to the viewport.
+  const updatePosition = useCallback(() => {
+    const trigger = triggerRef.current;
+    if (!trigger) return;
+    const rect = trigger.getBoundingClientRect();
+    const left = Math.max(8, Math.min(rect.right - MENU_WIDTH, window.innerWidth - MENU_WIDTH - 8));
+    setPosition({ top: rect.bottom + 4, left });
+  }, []);
+
+  useLayoutEffect(() => {
+    if (open) updatePosition();
+  }, [open, updatePosition]);
+
+  // Reposition while scrolling/resizing so the menu tracks its trigger.
+  useEffect(() => {
+    if (!open) return undefined;
+    const handler = () => updatePosition();
+    window.addEventListener('scroll', handler, true);
+    window.addEventListener('resize', handler);
+    return () => {
+      window.removeEventListener('scroll', handler, true);
+      window.removeEventListener('resize', handler);
+    };
+  }, [open, updatePosition]);
+
   // Click-outside close (mousedown matches ArtifactDownloadMenu convention).
   useEffect(() => {
     if (!open) return undefined;
     const handler = e => {
-      if (ref.current && !ref.current.contains(e.target)) close({ returnFocus: false });
+      if (ref.current?.contains(e.target) || menuRef.current?.contains(e.target)) return;
+      close({ returnFocus: false });
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
@@ -80,40 +117,45 @@ function DataTableKebabMenu({ items, label = 'More actions', row }) {
       >
         <Icon name="ellipsis-vertical" size="sm" />
       </button>
-      {open && (
-        <div
-          role="menu"
-          aria-label={label}
-          onKeyDown={handleMenuKeyDown}
-          className="absolute right-0 top-full mt-1 w-48 rounded-md bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-lg z-30 py-1"
-        >
-          {items.map((item, idx) => {
-            const disabled = item.disabled ? item.disabled(row) : false;
-            const onSelect = () => {
-              if (disabled) return;
-              close();
-              if (item.onClick) item.onClick(row);
-            };
-            const colorClass = item.destructive
-              ? 'text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/30 focus:bg-red-50 dark:focus:bg-red-900/30'
-              : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700 focus:bg-gray-100 dark:focus:bg-gray-700';
-            return (
-              <button
-                key={item.id}
-                ref={el => (itemRefs.current[idx] = el)}
-                type="button"
-                role="menuitem"
-                disabled={disabled}
-                onClick={onSelect}
-                className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed ${colorClass}`}
-              >
-                {item.icon && <Icon name={item.icon} size="sm" />}
-                <span>{item.label}</span>
-              </button>
-            );
-          })}
-        </div>
-      )}
+      {open &&
+        createPortal(
+          <div
+            ref={menuRef}
+            role="menu"
+            aria-label={label}
+            onKeyDown={handleMenuKeyDown}
+            onClick={e => e.stopPropagation()}
+            style={{ position: 'fixed', top: position.top, left: position.left, width: MENU_WIDTH }}
+            className="rounded-md bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 shadow-lg z-50 py-1"
+          >
+            {items.map((item, idx) => {
+              const disabled = item.disabled ? item.disabled(row) : false;
+              const onSelect = () => {
+                if (disabled) return;
+                close();
+                if (item.onClick) item.onClick(row);
+              };
+              const colorClass = item.destructive
+                ? 'text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/30 focus:bg-red-50 dark:focus:bg-red-900/30'
+                : 'text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-700 focus:bg-gray-100 dark:focus:bg-gray-700';
+              return (
+                <button
+                  key={item.id}
+                  ref={el => (itemRefs.current[idx] = el)}
+                  type="button"
+                  role="menuitem"
+                  disabled={disabled}
+                  onClick={onSelect}
+                  className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed ${colorClass}`}
+                >
+                  {item.icon && <Icon name={item.icon} size="sm" />}
+                  <span>{item.label}</span>
+                </button>
+              );
+            })}
+          </div>,
+          document.body
+        )}
     </div>
   );
 }


### PR DESCRIPTION
## Problem

In admin data tables, the overflow ("...") kebab menu opened from a row's action column rendered **behind** the action icons (edit / view / delete) of other rows.

## Root cause

`DataTableKebabMenu` used `absolute` positioning inside the sticky action `<td>`, which has `z-10`. A `position: sticky` element with a `z-index` creates its own **stacking context**, so the menu's `z-30` only applied *within that row's cell*. Later rows' action cells (also `z-10`, later in DOM order) painted on top of the open menu, and the table container's `overflow-hidden` / `overflow-x-auto` could clip it.

## Fix

Render the menu in a **portal to `document.body`** with `position: fixed`:

- Right-aligned to the trigger button and clamped to the viewport.
- Repositions on `scroll` (capture) and `resize` so it tracks the trigger.
- Click-outside, Esc, and arrow-key navigation behaviour preserved (the portaled menu is now included in the click-outside check).

This escapes the table's stacking contexts and overflow clipping entirely, so the menu always renders above other rows.

## Testing

- Verified formatting with Prettier.
- Manual: open a kebab menu in an admin table with multiple rows and confirm it overlays the rows below.

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLbxg3jivQXJogDi6EYxE9)_