### PR TITLE
Fix spurious "unsaved changes" prompt after clicking Save

### DIFF
--- a/client/src/features/admin/hooks/useUnsavedChanges.js
+++ b/client/src/features/admin/hooks/useUnsavedChanges.js
@@ -33,34 +33,46 @@ export function useUnsavedChanges(initialData, currentData) {
 
   const isDirty = !savedRef.current && initialData !== null && !deepEqual(initialData, currentData);
 
+  // Live ref so the navigation interceptor reads the current dirty state at
+  // call-time. markSaved() typically runs synchronously right before navigate()
+  // (e.g. in a save handler), before React re-renders. Reading a ref avoids
+  // blocking that programmatic navigation with a stale, closure-captured value.
+  const isDirtyRef = useRef(isDirty);
+  isDirtyRef.current = isDirty;
+
   const markSaved = useCallback(() => {
     savedRef.current = true;
+    isDirtyRef.current = false;
   }, []);
 
-  // Intercept React Router's navigator.push / navigator.replace when dirty.
+  // Intercept React Router's navigator.push / navigator.replace.
   // This is the recommended BrowserRouter workaround since useBlocker requires
-  // a data router. We patch and restore on cleanup to avoid stacking interceptors.
+  // a data router. The interceptor stays installed and checks the live dirty
+  // ref so a save-then-navigate sequence is never blocked. We restore on
+  // cleanup to avoid stacking interceptors.
   useEffect(() => {
-    if (!isDirty) return undefined;
-
     const origPush = navigator.push.bind(navigator);
     const origReplace = navigator.replace.bind(navigator);
 
     navigator.push = (...args) => {
+      if (!isDirtyRef.current) return origPush(...args);
       pendingNavRef.current = { fn: origPush, args };
       setBlockerState('blocked');
+      return undefined;
     };
 
     navigator.replace = (...args) => {
+      if (!isDirtyRef.current) return origReplace(...args);
       pendingNavRef.current = { fn: origReplace, args };
       setBlockerState('blocked');
+      return undefined;
     };
 
     return () => {
       navigator.push = origPush;
       navigator.replace = origReplace;
     };
-  }, [isDirty, navigator]);
+  }, [navigator]);
 
   // Browser close / reload
   useEffect(() => {

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -163,3 +163,10 @@ The platform now targets **WCAG 2.2 Level AA** (up from 2.1), strengthening alig
 - **Automated runtime scans**: the axe-core suite now scans against WCAG 2.2 AA rule tags and runs on every pull request via a dedicated Accessibility GitHub Actions workflow.
 - **Remediations**: the Export dialog is now a proper focus-trapped modal (`role="dialog"`, Escape to close, focus restored on close); image remove/download buttons expose screen-reader labels; and footer links are grouped in a labeled navigation landmark.
 - See **docs/accessibility.md** for the full compliance statement, keyboard reference, and manual testing checklist.
+
+## Fix — Spurious "Unsaved Changes" Prompt After Saving
+
+Clicking **Save** on any admin edit page (apps, models, prompts, sources, users, groups, and others) no longer triggers the "You have unsaved changes" confirmation dialog. Saving now navigates back to the list immediately.
+
+- The unsaved-changes guard previously used a stale dirty-state value captured before the save completed, so the navigation triggered by Save itself was treated as an unsaved-changes navigation.
+- The guard now reads the live dirty state at navigation time, so genuine back/cancel navigation with unsaved edits is still protected.


### PR DESCRIPTION
## Problem

When editing an app (or any admin resource) and clicking **Save**, the user was prompted with a "You have unsaved changes" confirmation dialog — even though they just saved. Confirming was required to actually leave the page.

## Root cause

The shared `useUnsavedChanges` hook (`client/src/features/admin/hooks/useUnsavedChanges.js`) installed its React Router `navigator.push`/`replace` interceptor conditionally on the `isDirty` value captured during render.

Save handlers do:

```js
markSaved();           // flips a ref — does NOT trigger a re-render
navigate('/admin/apps'); // runs synchronously in the same tick
```

Because `markSaved()` only mutates a ref, no re-render occurs before `navigate()` runs. The interceptor installed during the previous (dirty) render is therefore still active, so the post-save navigation gets blocked and shows the confirmation dialog.

## Fix

- Install the navigation interceptor once and have it read a **live** `isDirtyRef` at call time.
- `markSaved()` clears that ref synchronously, so the navigation it triggers passes through unblocked.
- Genuine cancel/back navigation with unsaved edits is still guarded.

## Scope

The hook is shared by all 15 admin edit pages (apps, models, prompts, sources, users, groups, tools, agents, etc.), so the fix applies everywhere.

## Testing

- `npx eslint` on the changed file: 0 errors (one pre-existing unrelated `useContext` warning).

https://claude.ai/code/session_01CwzvybS32n76iWqao3eG5o

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwzvybS32n76iWqao3eG5o)_