### PR TITLE
Improve MCP implementation: dialog fixes, in-dialog testing, app-editor MCP tools

### DIFF
--- a/client/src/api/endpoints/admin.js
+++ b/client/src/api/endpoints/admin.js
@@ -83,6 +83,18 @@ export const fetchTools = async (options = {}) => {
   );
 };
 
+/**
+ * Fetch the per-server MCP tool catalog for the app editor's MCP picker.
+ * Returns an array of { id, name, enabled, tools: [{ name, description }], error }.
+ * Not cached — tool discovery reflects live connection state.
+ *
+ * @returns {Promise<Array>} Array of MCP server entries with their tools
+ */
+export const fetchMcpToolCatalog = async () => {
+  const data = await handleApiResponse(() => apiClient.get('/admin/mcp/tools'), null, null, false);
+  return data?.servers || [];
+};
+
 // ---------------------------------------------------------------------------
 // Admin skill endpoints
 // ---------------------------------------------------------------------------

--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import DynamicLanguageEditor from '../../../shared/components/DynamicLanguageEditor';
 import ToolsSelector from '../../../shared/components/ToolsSelector';
+import McpToolsSelector from './McpToolsSelector';
 import SkillsSelector from '../../../shared/components/SkillsSelector';
 import WorkflowsSelector from '../../../shared/components/WorkflowsSelector';
 import SourcePicker from './SourcePicker';
@@ -43,6 +44,9 @@ function AppFormEditor({
   const { t, i18n } = useTranslation();
   const currentLanguage = i18n.language;
   const [validationErrors, setValidationErrors] = useState({});
+  // Tool ids sourced from MCP servers. Managed in a dedicated section and
+  // excluded from the generic tools picker so they don't appear twice.
+  const [mcpToolIds, setMcpToolIds] = useState([]);
   const featureFlags = useFeatureFlags();
 
   // Check if sources feature is enabled
@@ -1267,8 +1271,33 @@ function AppFormEditor({
                       'tavilySearch',
                       'googleSearch',
                       'webSearch',
-                      'webContentExtractor'
+                      'webContentExtractor',
+                      ...mcpToolIds
                     ]}
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* MCP Server Tools */}
+            <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+              <div className="md:grid md:grid-cols-3 md:gap-6">
+                <div className="md:col-span-1">
+                  <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+                    {t('admin.apps.edit.mcpTools.title', 'MCP server tools')}
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    {t(
+                      'admin.apps.edit.mcpTools.desc',
+                      'Enable tools provided by connected MCP servers for this app.'
+                    )}
+                  </p>
+                </div>
+                <div className="mt-5 md:mt-0 md:col-span-2">
+                  <McpToolsSelector
+                    selectedTools={app.tools || []}
+                    onToolsChange={tools => handleInputChange('tools', tools)}
+                    onMcpToolIdsChange={setMcpToolIds}
                   />
                 </div>
               </div>

--- a/client/src/features/admin/components/McpToolsSelector.jsx
+++ b/client/src/features/admin/components/McpToolsSelector.jsx
@@ -1,0 +1,199 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import Icon from '../../../shared/components/Icon';
+import LoadingSpinner from '../../../shared/components/LoadingSpinner';
+import { fetchMcpToolCatalog } from '../../../api/api';
+import { getLocalizedContent } from '../../../utils/localizeContent';
+
+/**
+ * Dedicated picker for tools exposed by configured MCP servers. Unlike the
+ * generic ToolsSelector (which lists statically configured tools), this groups
+ * tools by their originating MCP server. Selected MCP tool ids are stored in
+ * the same `app.tools` array — the runtime tool loader already resolves MCP
+ * ids back to their server — but the UI keeps them in a separate section so
+ * admins manage them per server rather than hunting through a flat list.
+ *
+ * @param {string[]} selectedTools - The full app.tools array
+ * @param {(tools:string[])=>void} onToolsChange - Receives the updated full array
+ * @param {(ids:string[])=>void} [onMcpToolIdsChange] - Reports all known MCP tool
+ *   ids so the parent can exclude them from the generic tools picker
+ */
+function McpToolsSelector({ selectedTools = [], onToolsChange, onMcpToolIdsChange }) {
+  const { t, i18n } = useTranslation();
+  const lang = i18n.language;
+  const [servers, setServers] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    let active = true;
+    (async () => {
+      try {
+        setLoading(true);
+        const data = await fetchMcpToolCatalog();
+        if (!active) return;
+        setServers(data);
+        const ids = data.flatMap(s => (s.tools || []).map(tool => tool.name));
+        onMcpToolIdsChange?.(ids);
+      } catch (err) {
+        if (active) setError(err.message);
+      } finally {
+        if (active) setLoading(false);
+      }
+    })();
+    return () => {
+      active = false;
+    };
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+  }, []);
+
+  const toolNamesFor = server => (server.tools || []).map(tool => tool.name);
+
+  const toggleTool = name => {
+    if (selectedTools.includes(name)) {
+      onToolsChange(selectedTools.filter(id => id !== name));
+    } else {
+      onToolsChange([...selectedTools, name]);
+    }
+  };
+
+  const allSelected = server => {
+    const names = toolNamesFor(server);
+    return names.length > 0 && names.every(n => selectedTools.includes(n));
+  };
+
+  const toggleServer = server => {
+    const names = toolNamesFor(server);
+    if (allSelected(server)) {
+      onToolsChange(selectedTools.filter(id => !names.includes(id)));
+    } else {
+      const set = new Set(selectedTools);
+      names.forEach(n => set.add(n));
+      onToolsChange(Array.from(set));
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center text-sm text-gray-500 dark:text-gray-400">
+        <LoadingSpinner size="sm" />
+        <span className="ml-2">{t('admin.apps.edit.mcpTools.loading', 'Loading MCP tools…')}</span>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="text-sm text-red-700 dark:text-red-400">
+        {t('admin.apps.edit.mcpTools.error', 'Failed to load MCP tools: {{error}}', { error })}
+      </div>
+    );
+  }
+
+  if (servers.length === 0) {
+    return (
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {t(
+          'admin.apps.edit.mcpTools.empty',
+          'No MCP servers are configured. Add one under Integrations → MCP servers to expose its tools here.'
+        )}
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {servers.map(server => {
+        const names = toolNamesFor(server);
+        const selectedCount = names.filter(n => selectedTools.includes(n)).length;
+        const serverName = getLocalizedContent(server.name, lang) || server.id;
+        return (
+          <div
+            key={server.id}
+            className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden"
+          >
+            <div className="flex items-center justify-between bg-gray-50 dark:bg-gray-900/40 px-3 py-2">
+              <div className="flex items-center space-x-2 min-w-0">
+                <span className="font-medium text-sm text-gray-900 dark:text-gray-100 truncate">
+                  {serverName}
+                </span>
+                <span className="font-mono text-xs text-gray-400 dark:text-gray-500">
+                  {server.id}
+                </span>
+                {!server.enabled && (
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-yellow-100 dark:bg-yellow-900/50 text-yellow-800 dark:text-yellow-300">
+                    {t('admin.apps.edit.mcpTools.disabled', 'disabled')}
+                  </span>
+                )}
+                {selectedCount > 0 && (
+                  <span className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-300">
+                    {t('admin.apps.edit.mcpTools.selectedCount', '{{count}} selected', {
+                      count: selectedCount
+                    })}
+                  </span>
+                )}
+              </div>
+              {names.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => toggleServer(server)}
+                  className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 whitespace-nowrap ml-2"
+                >
+                  {allSelected(server)
+                    ? t('admin.apps.edit.mcpTools.deselectAll', 'Deselect all')
+                    : t('admin.apps.edit.mcpTools.selectAll', 'Select all')}
+                </button>
+              )}
+            </div>
+
+            {server.error ? (
+              <div className="px-3 py-2 text-sm text-red-700 dark:text-red-400 flex items-center">
+                <Icon name="x-circle" size="sm" className="mr-1.5 flex-shrink-0" />
+                {t('admin.apps.edit.mcpTools.serverError', 'Could not list tools: {{error}}', {
+                  error: server.error
+                })}
+              </div>
+            ) : names.length === 0 ? (
+              <p className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
+                {t('admin.apps.edit.mcpTools.noServerTools', 'This server exposes no tools.')}
+              </p>
+            ) : (
+              <ul className="divide-y divide-gray-100 dark:divide-gray-700">
+                {server.tools.map(tool => (
+                  <li key={tool.name}>
+                    <label className="flex items-start gap-2 px-3 py-2 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                      <input
+                        type="checkbox"
+                        className="mt-0.5 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-indigo-500"
+                        checked={selectedTools.includes(tool.name)}
+                        onChange={() => toggleTool(tool.name)}
+                      />
+                      <span className="min-w-0">
+                        <span className="block font-mono text-xs text-gray-900 dark:text-gray-100">
+                          {tool.name}
+                        </span>
+                        {tool.description && (
+                          <span className="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                            {tool.description}
+                          </span>
+                        )}
+                      </span>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        );
+      })}
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {t(
+          'admin.apps.edit.mcpTools.helper',
+          'Tools provided by connected MCP servers. Selections are saved with the app and resolved at runtime.'
+        )}
+      </p>
+    </div>
+  );
+}
+
+export default McpToolsSelector;

--- a/client/src/features/admin/pages/AdminMcpServersPage.jsx
+++ b/client/src/features/admin/pages/AdminMcpServersPage.jsx
@@ -16,6 +16,15 @@ const BLANK_FORM = {
   timeoutMs: 30000
 };
 
+// Shared input styling. The project does not use @tailwindcss/forms, so a bare
+// `border-gray-300` sets only the colour and leaves the element with no border
+// width — invisible against the white modal background. These classes set an
+// explicit border, padding, text colour, and focus ring so inputs are legible
+// in both light and dark mode.
+const INPUT_CLASS =
+  'w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm px-3 py-2 text-sm focus:border-blue-500 focus:ring-blue-500';
+const MONO_INPUT_CLASS = `${INPUT_CLASS} font-mono`;
+
 function transportFields(transport, onChange, t) {
   if (
     transport.type === 'streamableHttp' ||
@@ -32,7 +41,7 @@ function transportFields(transport, onChange, t) {
           required
           value={transport.url || ''}
           onChange={e => onChange({ ...transport, url: e.target.value })}
-          className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+          className={INPUT_CLASS}
           placeholder="https://mcp.example.com/sse"
         />
       </div>
@@ -50,7 +59,7 @@ function transportFields(transport, onChange, t) {
             required
             value={transport.command || ''}
             onChange={e => onChange({ ...transport, command: e.target.value })}
-            className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+            className={INPUT_CLASS}
             placeholder="/usr/local/bin/my-mcp-server"
           />
         </div>
@@ -70,7 +79,7 @@ function transportFields(transport, onChange, t) {
                   .filter(Boolean)
               })
             }
-            className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 font-mono text-sm"
+            className={MONO_INPUT_CLASS}
           />
         </div>
       </div>
@@ -96,7 +105,7 @@ function authFields(auth, onChange, t) {
             if (v === 'oauth')
               return onChange({ type: 'oauth', tokenUrl: '', clientId: '', clientSecret: '' });
           }}
-          className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+          className={INPUT_CLASS}
         >
           <option value="none">{t('admin.mcp.servers.form.authNone', 'None')}</option>
           <option value="bearer">{t('admin.mcp.servers.form.authBearer', 'Bearer token')}</option>
@@ -115,7 +124,7 @@ function authFields(auth, onChange, t) {
             type="password"
             value={auth.token || ''}
             onChange={e => onChange({ ...auth, token: e.target.value })}
-            className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 font-mono text-sm"
+            className={MONO_INPUT_CLASS}
             placeholder="ghp_..."
           />
           <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
@@ -136,7 +145,7 @@ function authFields(auth, onChange, t) {
               type="text"
               value={auth.username || ''}
               onChange={e => onChange({ ...auth, username: e.target.value })}
-              className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+              className={INPUT_CLASS}
             />
           </div>
           <div>
@@ -147,7 +156,7 @@ function authFields(auth, onChange, t) {
               type="password"
               value={auth.password || ''}
               onChange={e => onChange({ ...auth, password: e.target.value })}
-              className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+              className={INPUT_CLASS}
             />
           </div>
         </>
@@ -194,6 +203,8 @@ function AdminMcpServersPage() {
   const [message, setMessage] = useState(null);
   const [editing, setEditing] = useState(null); // null | server | 'new'
   const [form, setForm] = useState(BLANK_FORM);
+  const [draftTesting, setDraftTesting] = useState(false);
+  const [draftTest, setDraftTest] = useState(null); // null | { ok, status, tools } | { ok:false, error }
 
   const load = async () => {
     setLoading(true);
@@ -219,6 +230,7 @@ function AdminMcpServersPage() {
 
   const startCreate = () => {
     setForm(BLANK_FORM);
+    setDraftTest(null);
     setEditing('new');
   };
 
@@ -230,23 +242,55 @@ function AdminMcpServersPage() {
       description:
         typeof server.description === 'string' ? server.description : server.description?.en || ''
     });
+    setDraftTest(null);
     setEditing(server.id);
+  };
+
+  const closeDialog = () => {
+    setEditing(null);
+    setDraftTest(null);
+  };
+
+  // Build the request body shared by save() and the in-dialog test probe.
+  const buildBody = () => ({
+    ...form,
+    name: form.name ? { en: form.name } : undefined,
+    description: form.description ? { en: form.description } : undefined,
+    allowedTools:
+      typeof form.allowedTools === 'string'
+        ? form.allowedTools
+            .split(',')
+            .map(s => s.trim())
+            .filter(Boolean)
+        : form.allowedTools || ['*']
+  });
+
+  // Probe the connection for the config currently in the dialog, without
+  // persisting it. Lets the admin validate credentials and preview the tool
+  // catalog before saving.
+  const testDraft = async () => {
+    setDraftTesting(true);
+    setDraftTest(null);
+    try {
+      const { data } = await makeAdminApiCall('/admin/mcp/test', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(buildBody())
+      });
+      setDraftTest({ ok: true, status: data.status, tools: data.tools || [] });
+    } catch (err) {
+      setDraftTest({
+        ok: false,
+        error: err.response?.data?.error || err.message
+      });
+    } finally {
+      setDraftTesting(false);
+    }
   };
 
   const save = async () => {
     try {
-      const body = {
-        ...form,
-        name: form.name ? { en: form.name } : undefined,
-        description: form.description ? { en: form.description } : undefined,
-        allowedTools:
-          typeof form.allowedTools === 'string'
-            ? form.allowedTools
-                .split(',')
-                .map(s => s.trim())
-                .filter(Boolean)
-            : form.allowedTools || ['*']
-      };
+      const body = buildBody();
       const path =
         editing === 'new'
           ? '/admin/mcp/servers'
@@ -258,7 +302,7 @@ function AdminMcpServersPage() {
         body: JSON.stringify(body)
       });
       setMessage({ type: 'success', text: t('admin.mcp.common.saved', 'Saved') });
-      setEditing(null);
+      closeDialog();
       await load();
     } catch (err) {
       setMessage({
@@ -444,7 +488,7 @@ function AdminMcpServersPage() {
                     required
                     value={form.id}
                     onChange={e => setForm({ ...form, id: e.target.value })}
-                    className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                    className={INPUT_CLASS}
                     placeholder="github-mcp"
                   />
                 </div>
@@ -457,7 +501,7 @@ function AdminMcpServersPage() {
                   type="text"
                   value={form.name || ''}
                   onChange={e => setForm({ ...form, name: e.target.value })}
-                  className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                  className={INPUT_CLASS}
                 />
               </div>
               <div>
@@ -468,7 +512,7 @@ function AdminMcpServersPage() {
                   rows={2}
                   value={form.description || ''}
                   onChange={e => setForm({ ...form, description: e.target.value })}
-                  className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                  className={INPUT_CLASS}
                 />
               </div>
               <div className="flex items-center space-x-2">
@@ -496,7 +540,7 @@ function AdminMcpServersPage() {
                         type === 'stdio' ? { type, command: '', args: [] } : { type, url: '' };
                       setForm({ ...form, transport: next });
                     }}
-                    className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                    className={INPUT_CLASS}
                   >
                     <option value="streamableHttp">
                       {t(
@@ -539,7 +583,7 @@ function AdminMcpServersPage() {
                     value={form.toolPrefix || ''}
                     onChange={e => setForm({ ...form, toolPrefix: e.target.value })}
                     placeholder={`${form.id || 'server'}__`}
-                    className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 font-mono text-sm"
+                    className={MONO_INPUT_CLASS}
                   />
                 </div>
                 <div>
@@ -552,7 +596,7 @@ function AdminMcpServersPage() {
                     max="600000"
                     value={form.timeoutMs}
                     onChange={e => setForm({ ...form, timeoutMs: Number(e.target.value) })}
-                    className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700"
+                    className={INPUT_CLASS}
                   />
                 </div>
               </div>
@@ -572,23 +616,89 @@ function AdminMcpServersPage() {
                       : form.allowedTools || '*'
                   }
                   onChange={e => setForm({ ...form, allowedTools: e.target.value })}
-                  className="w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 font-mono text-sm"
+                  className={MONO_INPUT_CLASS}
                 />
               </div>
 
-              <div className="flex justify-end space-x-2 pt-2">
+              {(draftTesting || draftTest) && (
+                <div className="rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/40 p-3">
+                  {draftTesting ? (
+                    <div className="flex items-center text-sm text-gray-600 dark:text-gray-300">
+                      <LoadingSpinner size="sm" />
+                      <span className="ml-2">
+                        {t('admin.mcp.servers.test.running', 'Testing connection…')}
+                      </span>
+                    </div>
+                  ) : draftTest?.ok ? (
+                    <div>
+                      <div className="flex items-center text-sm font-medium text-green-700 dark:text-green-400">
+                        <Icon name="check" size="sm" className="mr-1.5" />
+                        {t(
+                          'admin.mcp.servers.test.success',
+                          'Connected — {{count}} tools discovered',
+                          { count: draftTest.tools.length }
+                        )}
+                      </div>
+                      {draftTest.tools.length > 0 ? (
+                        <ul className="mt-3 max-h-56 overflow-y-auto divide-y divide-gray-200 dark:divide-gray-700 rounded border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800">
+                          {draftTest.tools.map(tool => (
+                            <li key={tool.name} className="px-3 py-2">
+                              <div className="font-mono text-xs text-gray-900 dark:text-gray-100">
+                                {tool.name}
+                              </div>
+                              {tool.description && (
+                                <div className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
+                                  {tool.description}
+                                </div>
+                              )}
+                            </li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+                          {t(
+                            'admin.mcp.servers.test.noTools',
+                            'The server connected but exposed no tools (or all were filtered by the allowlist).'
+                          )}
+                        </p>
+                      )}
+                    </div>
+                  ) : (
+                    <div className="flex items-start text-sm text-red-700 dark:text-red-400">
+                      <Icon name="x-circle" size="sm" className="mr-1.5 mt-0.5 flex-shrink-0" />
+                      <span>
+                        {t('admin.mcp.servers.test.failed', 'Connection failed: {{error}}', {
+                          error: draftTest?.error || 'unknown error'
+                        })}
+                      </span>
+                    </div>
+                  )}
+                </div>
+              )}
+
+              <div className="flex justify-between items-center pt-2">
                 <button
-                  onClick={() => setEditing(null)}
-                  className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700"
+                  onClick={testDraft}
+                  disabled={draftTesting}
+                  className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50"
                 >
-                  {t('common.cancel', 'Cancel')}
+                  <Icon name="play" size="sm" className="mr-1.5" />
+                  {t('admin.mcp.servers.test.button', 'Test connection')}
                 </button>
-                <button
-                  onClick={save}
-                  className="px-4 py-2 rounded text-white bg-blue-600 hover:bg-blue-700"
-                >
-                  {t('common.save', 'Save')}
-                </button>
+                <div className="flex space-x-2">
+                  <button
+                    onClick={closeDialog}
+                    className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700"
+                  >
+                    {t('common.cancel', 'Cancel')}
+                  </button>
+                  <button
+                    onClick={save}
+                    className="px-4 py-2 rounded text-white bg-blue-600 hover:bg-blue-700"
+                  >
+                    {t('common.save', 'Save')}
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/client/src/shared/components/ToolsSelector.jsx
+++ b/client/src/shared/components/ToolsSelector.jsx
@@ -92,30 +92,32 @@ function ToolsSelector({ selectedTools = [], onToolsChange, excludeToolIds = [] 
 
   return (
     <div className="space-y-3">
-      {/* Selected Tools */}
-      {selectedTools.length > 0 && (
+      {/* Selected Tools (excluded ids are managed elsewhere, e.g. MCP picker) */}
+      {selectedTools.filter(id => !excludeToolIds.includes(id)).length > 0 && (
         <div className="flex flex-wrap gap-2">
-          {selectedTools.map(toolId => {
-            const toolInfo = availableTools.find(t => t.id === toolId);
-            const displayName = toolInfo
-              ? getLocalizedContent(toolInfo.name, currentLanguage)
-              : toolId;
-            return (
-              <span
-                key={toolId}
-                className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-300"
-              >
-                {displayName}
-                <button
-                  onClick={() => handleRemoveTool(toolId)}
-                  className="ml-1 flex-shrink-0 text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300"
-                  aria-label={`Remove ${displayName}`}
+          {selectedTools
+            .filter(id => !excludeToolIds.includes(id))
+            .map(toolId => {
+              const toolInfo = availableTools.find(t => t.id === toolId);
+              const displayName = toolInfo
+                ? getLocalizedContent(toolInfo.name, currentLanguage)
+                : toolId;
+              return (
+                <span
+                  key={toolId}
+                  className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-300"
                 >
-                  <Icon name="x" className="w-3 h-3" />
-                </button>
-              </span>
-            );
-          })}
+                  {displayName}
+                  <button
+                    onClick={() => handleRemoveTool(toolId)}
+                    className="ml-1 flex-shrink-0 text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300"
+                    aria-label={`Remove ${displayName}`}
+                  >
+                    <Icon name="x" className="w-3 h-3" />
+                  </button>
+                </span>
+              );
+            })}
         </div>
       )}
 

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -163,3 +163,12 @@ The platform now targets **WCAG 2.2 Level AA** (up from 2.1), strengthening alig
 - **Automated runtime scans**: the axe-core suite now scans against WCAG 2.2 AA rule tags and runs on every pull request via a dedicated Accessibility GitHub Actions workflow.
 - **Remediations**: the Export dialog is now a proper focus-trapped modal (`role="dialog"`, Escape to close, focus restored on close); image remove/download buttons expose screen-reader labels; and footer links are grouped in a labeled navigation landmark.
 - See **docs/accessibility.md** for the full compliance statement, keyboard reference, and manual testing checklist.
+
+## MCP Servers — Easier Setup, Connection Testing, and Per-App Tool Selection
+
+Configuring and using external MCP (Model Context Protocol) servers is now far smoother.
+
+- **Readable "Add MCP server" dialog**: form fields are no longer invisible (white-on-white) — inputs now have proper borders and focus styling in both light and dark mode.
+- **Test before you save**: a **Test connection** button inside the create/edit dialog probes the server (even with unsaved changes) and lists the tools it exposes, so you can verify credentials and discover tool names without saving first.
+- **Dedicated MCP tools section in the app editor**: each app now has an **MCP server tools** section that groups available tools by server with per-tool and "select all" toggles, instead of requiring you to know and type MCP tool ids in the generic tools list.
+- **Stronger gateway authorization**: the inbound MCP gateway now re-checks the caller's scope (and, for apps and workflows, their permissions) at call time — not just when listing — so revoked access takes effect immediately within a session.

--- a/server/jest.config.js
+++ b/server/jest.config.js
@@ -2,19 +2,13 @@ export default {
   // Use Node.js environment for testing
   testEnvironment: 'node',
 
-  // Support ES modules
-  preset: '@babel/preset-env',
-  extensionsToTreatAsEsm: ['.js'],
-
-  // Transform files with Babel
-  transform: {
-    '^.+\\.js$': [
-      'babel-jest',
-      {
-        presets: [['@babel/preset-env', { targets: { node: 'current' } }]]
-      }
-    ]
-  },
+  // The package is "type": "module" and source files use native ESM features
+  // such as `import.meta.url`, so tests run as real ES modules under Jest's
+  // experimental VM modules (the `test` script sets --experimental-vm-modules).
+  // .js is treated as ESM automatically because package.json is type:module, and
+  // an empty transform lets Node execute the ESM directly — a CommonJS
+  // down-level transpile would break `import.meta`.
+  transform: {},
 
   // Test file patterns
   testMatch: ['**/tests/**/*.test.js', '**/__tests__/**/*.js'],
@@ -41,8 +35,9 @@ export default {
     }
   },
 
-  // Module name mapping for mocks
-  moduleNameMapping: {
+  // Strip explicit .js extensions from relative imports so they resolve under
+  // Jest's transpiled-CommonJS module system.
+  moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
 

--- a/server/package.json
+++ b/server/package.json
@@ -7,11 +7,11 @@
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "jest",
-    "test:auth": "jest tests/authentication-security.test.js",
+    "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
+    "test:auth": "node --experimental-vm-modules node_modules/jest/bin/jest.js tests/authentication-security.test.js",
     "test:security": "node tests/run-security-tests.js",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
+    "test:watch": "node --experimental-vm-modules node_modules/jest/bin/jest.js --watch",
+    "test:coverage": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage"
   },
   "dependencies": {
     "@hyzyla/pdfium": "^2.1.12",

--- a/server/routes/admin/mcpServers.js
+++ b/server/routes/admin/mcpServers.js
@@ -178,13 +178,13 @@ export default function registerAdminMcpServersRoutes(app) {
     }
   });
 
-  // Probe connection and refresh tool catalog.
+  // Probe a saved server connection and refresh its tool catalog.
   app.post(buildServerPath('/api/admin/mcp/servers/:id/test'), adminAuth, async (req, res) => {
     try {
       const { id } = req.params;
       if (!validateIdForPath(id, 'mcpServer', res)) return;
-      const status = await mcpClientManager.testConnection(id);
-      res.json({ success: true, status });
+      const { status, tools } = await mcpClientManager.testConnection(id);
+      res.json({ success: true, status, tools });
     } catch (error) {
       logger.warn('[MCP Admin] Test connection failed', {
         component: 'AdminMcp',
@@ -194,9 +194,50 @@ export default function registerAdminMcpServersRoutes(app) {
     }
   });
 
+  // Probe an arbitrary (possibly unsaved) server config. Used by the create /
+  // edit dialog so the admin can validate a connection and preview the tools
+  // before persisting. Redacted secrets submitted for an existing server are
+  // restored from the stored (encrypted) config so editing without retyping a
+  // token still tests correctly.
+  app.post(buildServerPath('/api/admin/mcp/test'), adminAuth, async (req, res) => {
+    try {
+      const incoming = { ...req.body };
+      const cfg = await readConfig();
+      const existing = (cfg.servers || []).find(s => s.id === incoming.id);
+      if (incoming.auth && existing?.auth) {
+        incoming.auth = { ...incoming.auth };
+        for (const f of ['token', 'password', 'clientSecret']) {
+          if (incoming.auth[f] === '***REDACTED***' && existing.auth[f]) {
+            incoming.auth[f] = existing.auth[f];
+          }
+        }
+      }
+      const { status, tools } = await mcpClientManager.testConfig(incoming);
+      res.json({ success: true, status, tools });
+    } catch (error) {
+      logger.warn('[MCP Admin] Test config failed', {
+        component: 'AdminMcp',
+        error: error.message
+      });
+      res.status(400).json({ success: false, error: error.message, details: error.details });
+    }
+  });
+
   // Aggregate health snapshot.
   app.get(buildServerPath('/api/admin/mcp/status'), adminAuth, (req, res) => {
     res.json({ success: true, servers: mcpClientManager.status() });
+  });
+
+  // Per-server tool catalog for the app editor's MCP picker. Best-effort: each
+  // server reports its discovered tools, or an `error` if discovery failed.
+  app.get(buildServerPath('/api/admin/mcp/tools'), adminAuth, async (req, res) => {
+    try {
+      const servers = await mcpClientManager.listToolsByServer();
+      res.json({ success: true, servers });
+    } catch (error) {
+      logger.error('[MCP Admin] Tool catalog error', { component: 'AdminMcp', error });
+      res.status(500).json({ success: false, error: 'Failed to list MCP tools' });
+    }
   });
 
   // ---- Inbound gateway settings ----

--- a/server/services/mcp/McpClientManager.js
+++ b/server/services/mcp/McpClientManager.js
@@ -1,6 +1,22 @@
 import { McpServerConnection } from './McpServerConnection.js';
-import { mcpServersFileSchema } from '../../validators/mcpServerConfigSchema.js';
+import {
+  mcpServersFileSchema,
+  mcpServerConfigSchema
+} from '../../validators/mcpServerConfigSchema.js';
 import logger from '../../utils/logger.js';
+
+/**
+ * Slim down the internal tool representation for transport to the admin UI.
+ * Drops the `_mcp` dispatch markers and keeps the human-facing fields.
+ */
+function summarizeTools(tools) {
+  return (tools || []).map(t => ({
+    name: t.name,
+    originalName: t._mcp?.originalName ?? t.name,
+    description: t.description || '',
+    parameters: t.parameters || { type: 'object', properties: {} }
+  }));
+}
 
 /**
  * Singleton that owns one McpServerConnection per configured MCP server.
@@ -179,8 +195,41 @@ class McpClientManager {
   }
 
   /**
-   * Force-trigger a connection attempt and return its status. Used by the
-   * admin "Test connection" button.
+   * Per-server tool catalog used by the app editor's MCP picker. Unlike
+   * `listAllTools` (which flattens + dedupes across servers) this preserves the
+   * server grouping so the UI can present "tools from server X". Best-effort:
+   * a server that fails tool discovery is returned with an `error` and an empty
+   * tool list rather than poisoning the whole response.
+   */
+  async listToolsByServer() {
+    if (!this.initialized) return [];
+    const out = [];
+    await Promise.all(
+      Array.from(this.connections.values()).map(async conn => {
+        const entry = {
+          id: conn.config.id,
+          name: conn.config.name || conn.config.id,
+          enabled: conn.config.enabled !== false,
+          tools: [],
+          error: null
+        };
+        if (entry.enabled) {
+          try {
+            entry.tools = summarizeTools(await conn.listTools());
+          } catch (err) {
+            entry.error = err.message;
+          }
+        }
+        out.push(entry);
+      })
+    );
+    return out;
+  }
+
+  /**
+   * Force-trigger a connection attempt on an already-configured server and
+   * return its status plus the discovered tool catalog. Used by the admin
+   * "Test connection" button on saved servers.
    */
   async testConnection(serverId) {
     const conn = this.connections.get(serverId);
@@ -189,8 +238,34 @@ class McpClientManager {
     conn.consecutiveFailures = 0;
     conn.unhealthy = false;
     await conn.connect();
-    await conn.listTools(); // also exercise tools/list
-    return conn.status();
+    const tools = await conn.listTools(); // also exercise tools/list
+    return { status: conn.status(), tools: summarizeTools(tools) };
+  }
+
+  /**
+   * Probe an arbitrary (possibly unsaved) server config without registering
+   * it. Used by the admin dialog so an operator can validate a connection and
+   * preview the available tools before persisting the server. The ephemeral
+   * connection is always torn down, even on failure, so no socket or child
+   * process leaks.
+   */
+  async testConfig(rawServerConfig) {
+    const parsed = mcpServerConfigSchema.safeParse(rawServerConfig);
+    if (!parsed.success) {
+      const err = new Error('Invalid server config');
+      err.details = parsed.error.errors;
+      throw err;
+    }
+    // Force-enable for the probe: the admin explicitly asked to test it, even
+    // if they intend to leave the server disabled after saving.
+    const conn = new McpServerConnection({ ...parsed.data, enabled: true }, this.security);
+    try {
+      await conn.connect();
+      const tools = await conn.listTools();
+      return { status: conn.status(), tools: summarizeTools(tools) };
+    } finally {
+      await conn.disconnect().catch(() => {});
+    }
   }
 }
 

--- a/server/services/mcp/McpServerService.js
+++ b/server/services/mcp/McpServerService.js
@@ -188,6 +188,15 @@ export async function buildMcpServer({ user, platform }) {
           ...jsonSchemaToInputSchema(buildAppInputSchema(app))
         },
         async args => {
+          // Re-check scope + permission at call time so a token that loses the
+          // scope, or a user removed from the app's groups, between list and
+          // call can't still invoke it (mirrors the tools handler above).
+          if (!tokenScopes.includes(MCP_SCOPES.APPS_INVOKE)) {
+            return toolErrorResult('insufficient_scope: mcp:apps:invoke required');
+          }
+          if (!isAppAllowed(app, user, expose)) {
+            return toolErrorResult('access_denied: app not permitted for this caller');
+          }
           try {
             const text = await invokeAppNonStreaming({
               appId: app.id,
@@ -226,6 +235,15 @@ export async function buildMcpServer({ user, platform }) {
           ...jsonSchemaToInputSchema(paramsSchema)
         },
         async args => {
+          // Re-check scope + permission at call time so a token that loses the
+          // scope, or a user removed from the workflow's groups, between list
+          // and call can't still run it (mirrors the tools handler above).
+          if (!tokenScopes.includes(MCP_SCOPES.WORKFLOWS_RUN)) {
+            return toolErrorResult('insufficient_scope: mcp:workflows:run required');
+          }
+          if (!isWorkflowAllowed(wf, user, expose)) {
+            return toolErrorResult('access_denied: workflow not permitted for this caller');
+          }
           try {
             const result = await runTool(`workflow_${wf.id}`, args || {});
             return toolSuccessResult(result);
@@ -254,6 +272,12 @@ export async function buildMcpServer({ user, platform }) {
         r.uri,
         { description: r.description, mimeType: r.mimeType },
         async uriObj => {
+          // Re-check scope at call time for consistency with the tool/app/
+          // workflow handlers. resourceAdapter additionally re-validates the
+          // caller's visibility of the underlying source/skill at read time.
+          if (!tokenScopes.includes(MCP_SCOPES.RESOURCES_READ)) {
+            throw new Error('insufficient_scope: mcp:resources:read required');
+          }
           try {
             return await readMcpResource(uriObj.href || String(uriObj), {
               user,

--- a/server/tests/mcp/resourceAdapter.test.js
+++ b/server/tests/mcp/resourceAdapter.test.js
@@ -2,12 +2,12 @@ import { describe, it, expect } from '@jest/globals';
 import { listMcpResources, readMcpResource } from '../../services/mcp/resourceAdapter.js';
 
 describe('MCP resource adapter — URI parsing', () => {
-  it('listMcpResources returns [] when expose.resources is false', () => {
-    expect(listMcpResources({ user: {}, expose: { resources: false } })).toEqual([]);
+  it('listMcpResources returns [] when expose.resources is false', async () => {
+    await expect(listMcpResources({ user: {}, expose: { resources: false } })).resolves.toEqual([]);
   });
 
-  it('listMcpResources returns an array when expose.resources is true', () => {
-    const r = listMcpResources({ user: { permissions: {} }, expose: { resources: true } });
+  it('listMcpResources returns an array when expose.resources is true', async () => {
+    const r = await listMcpResources({ user: { permissions: {} }, expose: { resources: true } });
     expect(Array.isArray(r)).toBe(true);
   });
 
@@ -34,14 +34,16 @@ describe('MCP resource adapter — URI parsing', () => {
   });
 
   it('rejects URL-encoded path-traversal in source ids', async () => {
+    // The path.basename sanitiser rejects the decoded `../config` before any
+    // source lookup, so the failure surfaces as "Invalid resource id".
     await expect(readMcpResource('ihub://source/..%2Fconfig', { user: {} })).rejects.toThrow(
-      /Source not found/
+      /Invalid resource id/
     );
   });
 
   it('rejects URL-encoded path-traversal in skill names', async () => {
     await expect(readMcpResource('ihub://skill/..%2Fetc%2Fpasswd', { user: {} })).rejects.toThrow(
-      /Skill not found/
+      /Invalid resource id/
     );
   });
 

--- a/server/tests/setup.js
+++ b/server/tests/setup.js
@@ -1,3 +1,4 @@
+import { jest } from '@jest/globals';
 import logger from '../utils/logger.js';
 /**
  * Jest setup file for authentication security tests

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1455,6 +1455,13 @@
         "actions": {
           "test": "Verbindung testen"
         },
+        "test": {
+          "button": "Verbindung testen",
+          "running": "Verbindung wird getestet …",
+          "success": "Verbunden — {{count}} Tools gefunden",
+          "failed": "Verbindung fehlgeschlagen: {{error}}",
+          "noTools": "Der Server ist verbunden, stellt aber keine Tools bereit (oder alle wurden durch die Allowlist gefiltert)."
+        },
         "status": {
           "unknown": "unbekannt",
           "unhealthy": "fehlerhaft",
@@ -1654,6 +1661,20 @@
       "edit": {
         "autoStart": "Konversation automatisch starten",
         "autoStartHelp": "Wenn aktiviert, startet die App automatisch die Konversation, wenn der Chat geöffnet oder zurückgesetzt wird",
+        "mcpTools": {
+          "title": "MCP-Server-Tools",
+          "desc": "Aktivieren Sie Tools, die von verbundenen MCP-Servern bereitgestellt werden, für diese App.",
+          "loading": "MCP-Tools werden geladen …",
+          "error": "MCP-Tools konnten nicht geladen werden: {{error}}",
+          "empty": "Es sind keine MCP-Server konfiguriert. Fügen Sie unter Integrationen → MCP-Server einen hinzu, um dessen Tools hier anzuzeigen.",
+          "disabled": "deaktiviert",
+          "selectedCount": "{{count}} ausgewählt",
+          "selectAll": "Alle auswählen",
+          "deselectAll": "Alle abwählen",
+          "serverError": "Tools konnten nicht aufgelistet werden: {{error}}",
+          "noServerTools": "Dieser Server stellt keine Tools bereit.",
+          "helper": "Von verbundenen MCP-Servern bereitgestellte Tools. Die Auswahl wird mit der App gespeichert und zur Laufzeit aufgelöst."
+        },
         "websearch": "Websuche",
         "websearchDesc": "Websuch-Funktionen für diese App konfigurieren",
         "websearchEnabled": "Websuche aktivieren",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1209,6 +1209,13 @@
         "actions": {
           "test": "Test connection"
         },
+        "test": {
+          "button": "Test connection",
+          "running": "Testing connection…",
+          "success": "Connected — {{count}} tools discovered",
+          "failed": "Connection failed: {{error}}",
+          "noTools": "The server connected but exposed no tools (or all were filtered by the allowlist)."
+        },
         "status": {
           "unknown": "unknown",
           "unhealthy": "unhealthy",
@@ -1408,6 +1415,20 @@
       "edit": {
         "autoStart": "Auto-start conversation",
         "autoStartHelp": "When enabled, the app will automatically start the conversation when the chat is opened or reset",
+        "mcpTools": {
+          "title": "MCP server tools",
+          "desc": "Enable tools provided by connected MCP servers for this app.",
+          "loading": "Loading MCP tools…",
+          "error": "Failed to load MCP tools: {{error}}",
+          "empty": "No MCP servers are configured. Add one under Integrations → MCP servers to expose its tools here.",
+          "disabled": "disabled",
+          "selectedCount": "{{count}} selected",
+          "selectAll": "Select all",
+          "deselectAll": "Deselect all",
+          "serverError": "Could not list tools: {{error}}",
+          "noServerTools": "This server exposes no tools.",
+          "helper": "Tools provided by connected MCP servers. Selections are saved with the app and resolved at runtime."
+        },
         "websearch": "Web Search",
         "websearchDesc": "Configure web search capabilities for this app",
         "websearchEnabled": "Enable Web Search",


### PR DESCRIPTION
## Summary

Improves the MCP (Model Context Protocol) implementation across four areas, plus a jest-config fix.

### 1. Fix white-on-white "Add MCP server" dialog
The project doesn't use `@tailwindcss/forms`, so the inputs' bare `border-gray-300` set only a colour and rendered **no** border — invisible against the white modal. All dialog inputs now use shared `INPUT_CLASS`/`MONO_INPUT_CLASS` constants with an explicit border, padding, text colour, and focus ring (light + dark mode).

### 2. Test a connection from inside the dialog + preview tools
- New **Test connection** button inside the create/edit dialog probes the *(possibly unsaved)* config without persisting it and renders the discovered tool list (name + description), or a clear error.
- Backend: `McpClientManager.testConfig()` builds an ephemeral connection (always torn down). Redacted secrets for an existing server are restored from the stored encrypted config so editing without retyping a token still works.
- The saved-server test endpoint and `testConnection()` now also return the tool list.

### 3. Dedicated "MCP server tools" section in the app editor
Previously MCP tools couldn't be selected when editing an app (the `/admin/tools` catalog doesn't include them). Added:
- `GET /api/admin/mcp/tools` — per-server tool catalog (best-effort discovery).
- `McpToolsSelector` — a dedicated section grouping tools by MCP server with per-tool and per-server (select all) toggles.
- MCP tool ids are excluded from the generic `ToolsSelector` to avoid duplication. Selections are stored in `app.tools` (the runtime tool loader already resolves MCP ids back to their server).

### 4. Inbound MCP gateway audit + hardening
Audited the four exposable families. All are wired to working handlers and gated at registration + token level. **Found and fixed a gap**: apps, workflows, and resources only checked their scope at `tools/list` time, not at call/read time (the tools handler already re-checked). A token that lost a scope — or a user removed from an app/workflow's groups — mid-session could still invoke them.
- Apps: re-check `mcp:apps:invoke` + `isAppAllowed` at call time
- Workflows: re-check `mcp:workflows:run` + `isWorkflowAllowed` at call time
- Resources: re-check `mcp:resources:read` at read time (visibility was already re-validated in `resourceAdapter`)

A2A remains a working stub (synchronous `agent/info`, `agent/skills`, `tasks/send`; stateful task methods return method-not-found per spec).

### 5. Fix broken server jest config
`server/jest.config.js` had two bugs that made jest fail before running any test: `preset: '@babel/preset-env'` (Babel preset misused as a Jest preset) and `moduleNameMapping` (typo for `moduleNameMapper`). Switched to running tests as native ESM under `--experimental-vm-modules` (the package is `type:module` and uses `import.meta.url`, which a CJS babel transpile breaks), added the missing `import { jest }` to `tests/setup.js`, and aligned the `resourceAdapter` tests with the adapter's actual behaviour. **MCP suite now passes 55/55** (jest previously couldn't run at all). Other long-standing failures in the broader server suite (standalone node scripts caught by `testMatch`, circular imports) predate this and are out of scope.

## Verification
- `npm run lint:fix` / `format:fix`: 0 errors.
- `cd server && npm test -- tests/mcp`: 8 suites / 55 tests pass.
- Server boots cleanly; smoke-tested the new admin endpoints with the local admin account: `GET /api/admin/mcp/tools`, `GET /api/admin/mcp/servers`, and `POST /api/admin/mcp/test` (validation error + graceful connection-failure paths).

## Notes
- New en/de translations added; changelog entry added under `docs/releases/5.4.0/`.
- No config schema changes; no migration required.

https://claude.ai/code/session_013p8JnyvyJRg9FvugZBS4LH