### PR TITLE
Fix chat PDF/HTML export to render markdown properly

### DIFF
--- a/client/src/api/endpoints/apps.js
+++ b/client/src/api/endpoints/apps.js
@@ -1,5 +1,24 @@
+import { Marked } from 'marked';
+import DOMPurify from 'dompurify';
 import { apiClient, streamingApiClient } from '../client';
 import { handleApiResponse } from '../utils/requestHandler';
+
+// Isolated marked instance for static exports (PDF/HTML). It intentionally does
+// NOT use the global configureMarked() renderer, which injects interactive
+// toolbars/buttons and mermaid placeholders that don't work in a downloaded
+// document. GFM is enabled so tables, lists, and code blocks render correctly.
+const exportMarked = new Marked({
+  gfm: true,
+  breaks: true,
+  pedantic: false
+});
+
+// Convert message markdown to sanitized HTML for export documents.
+const renderMarkdownForExport = content => {
+  if (!content) return '';
+  const html = exportMarked.parse(String(content));
+  return DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+};
 
 // Apps
 export const fetchApps = async (options = {}) => {
@@ -147,73 +166,7 @@ const generatePDFHTML = (messages, settings, template, watermark, appName) => {
     }
   };
 
-  const formatContent = content => {
-    if (!content) return '';
-
-    // Split content into lines to process block-level elements
-    const lines = content.split('\n');
-    const processedLines = [];
-
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      const trimmedLine = line.trim();
-
-      // Handle horizontal rules: ***, ---, ___ (three or more)
-      if (/^(\*{3,}|-{3,}|_{3,})$/.test(trimmedLine)) {
-        processedLines.push('<hr>');
-        continue;
-      }
-
-      // Handle headings (# through ######)
-      const headingMatch = trimmedLine.match(/^(#{1,6})\s+(.+)$/);
-      if (headingMatch) {
-        const level = headingMatch[1].length;
-        const text = headingMatch[2];
-        processedLines.push(`<h${level}>${processInlineMarkdown(text)}</h${level}>`);
-        continue;
-      }
-
-      // Handle unordered lists (* - +) - must check AFTER horizontal rule
-      const unorderedListMatch = trimmedLine.match(/^[\*\-\+]\s+(.+)$/);
-      if (unorderedListMatch) {
-        processedLines.push(`<li>${processInlineMarkdown(unorderedListMatch[1])}</li>`);
-        continue;
-      }
-
-      // Handle ordered lists (1. 2. etc.)
-      const orderedListMatch = trimmedLine.match(/^(\d+)\.\s+(.+)$/);
-      if (orderedListMatch) {
-        processedLines.push(
-          `<li class="ordered">${processInlineMarkdown(orderedListMatch[2])}</li>`
-        );
-        continue;
-      }
-
-      // Empty line creates paragraph break
-      if (trimmedLine === '') {
-        if (processedLines.length > 0 && processedLines[processedLines.length - 1] !== '<br>') {
-          processedLines.push('<br>');
-        }
-        continue;
-      }
-
-      // Regular paragraph text
-      processedLines.push(processInlineMarkdown(line));
-      processedLines.push('<br>');
-    }
-
-    // Join with line breaks and wrap in paragraph tags
-    return processedLines.join('');
-  };
-
-  // Helper function to process inline markdown (bold, italic, code)
-  const processInlineMarkdown = text => {
-    return text
-      .replace(/\*\*\*([\s\S]*?)\*\*\*/g, '<strong><em>$1</em></strong>') // ***bold italic***
-      .replace(/\*\*([\s\S]*?)\*\*/g, '<strong>$1</strong>') // **bold**
-      .replace(/\*([^\*\n]+?)\*/g, '<em>$1</em>') // *italic*
-      .replace(/`([^`]+?)`/g, '<code>$1</code>'); // `code`
-  };
+  const formatContent = renderMarkdownForExport;
 
   const messagesHTML = messages
     .filter(msg => !msg.isGreeting) // Exclude greeting messages
@@ -228,7 +181,7 @@ const generatePDFHTML = (messages, settings, template, watermark, appName) => {
             <span class="timestamp">${formatTimestamp(message.timestamp || Date.now())}</span>
           </div>
           <div class="message-content">
-            <p>${formatContent(message.content)}</p>
+            ${formatContent(message.content)}
           </div>
         </div>
       `;
@@ -453,16 +406,83 @@ const getTemplateStyles = template => {
       margin: 15px 0;
     }
     
-    .message-content li {
-      margin-left: 20px;
-      margin-bottom: 5px;
+    .message-content ul,
+    .message-content ol {
+      margin: 10px 0;
+      padding-left: 24px;
+    }
+
+    .message-content ul {
       list-style-type: disc;
     }
-    
-    .message-content li.ordered {
+
+    .message-content ol {
       list-style-type: decimal;
     }
-    
+
+    .message-content li {
+      margin-bottom: 5px;
+    }
+
+    .message-content pre {
+      background-color: #1a202c;
+      color: #f7fafc;
+      padding: 12px 16px;
+      border-radius: 6px;
+      overflow-x: auto;
+      margin: 12px 0;
+      font-size: 13px;
+      line-height: 1.5;
+    }
+
+    .message-content pre code {
+      background-color: transparent;
+      padding: 0;
+      color: inherit;
+      font-size: inherit;
+    }
+
+    .message-content blockquote {
+      border-left: 4px solid #cbd5e0;
+      padding-left: 12px;
+      margin: 12px 0;
+      color: #4a5568;
+    }
+
+    .message-content table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 12px 0;
+      font-size: 14px;
+    }
+
+    .message-content th,
+    .message-content td {
+      border: 1px solid #e2e8f0;
+      padding: 8px 12px;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .message-content th {
+      background-color: #f7fafc;
+      font-weight: 600;
+    }
+
+    .message-content tr:nth-child(even) td {
+      background-color: #fafbfc;
+    }
+
+    .message-content a {
+      color: #3182ce;
+      text-decoration: underline;
+    }
+
+    .message-content img {
+      max-width: 100%;
+      height: auto;
+    }
+
     @media print {
       .container {
         max-width: none;

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -155,6 +155,14 @@ The audit log now supports a configurable retention policy.
 
 The admin Overview now shows a **Recent activity** card listing the eight most recent audit log entries (action pill, summary, admin, resource, relative time). Clicking "View all" jumps to the filtered Audit Log page.
 
+## Chat Export — Proper Markdown Rendering in PDF and HTML
+
+PDF and HTML chat exports now render the full assistant markdown instead of showing raw markup. The export previously used a limited hand-rolled parser that left GFM tables as raw `| ... |` text, emitted list items without proper `<ul>`/`<ol>` wrappers, and wrapped all block content in a single invalid `<p>` tag.
+
+- Exports now use the same `marked` + DOMPurify pipeline the chat UI uses, so **tables, headings, ordered/unordered lists, code blocks, blockquotes, links, and horizontal rules** all render correctly.
+- An isolated `marked` instance is used for exports so the downloaded document contains clean semantic HTML — no interactive copy/download toolbars or mermaid placeholders that wouldn't work outside the app.
+- Added print-friendly styling for tables, code blocks, blockquotes, and links in the export template.
+
 ## Accessibility — WCAG 2.2 AA Tooling and Remediation
 
 The platform now targets **WCAG 2.2 Level AA** (up from 2.1), strengthening alignment with EN 301 549 and BITV 2.0 for public-sector procurement.


### PR DESCRIPTION
## Problem

HTML (and PDF) chat exports did not render markdown — content appeared as raw markup. For example, GFM tables showed up as raw `| Nr | Paragraph | ... |` text rather than rendered tables.

## Root cause

`generatePDFHTML` in `client/src/api/endpoints/apps.js` (used by both PDF and HTML export) relied on a limited hand-rolled regex parser (`formatContent` / `processInlineMarkdown`) that:

- **Did not handle GFM tables** at all → rendered as raw pipe text
- Emitted bare `<li>` items **without `<ul>`/`<ol>` wrappers**
- Wrapped **all block content in a single `<p>` tag** — invalid HTML for headings/tables/lists
- Only supported a subset of inline markdown (bold/italic/code)

## Fix

Replace the hand-rolled parser with the same **`marked` + DOMPurify** pipeline the chat UI already uses throughout the client:

- Uses an **isolated `marked` instance** for exports (not the global `configureMarked()` renderer) so the downloaded document gets clean semantic HTML — no interactive copy/download toolbars or mermaid placeholders that wouldn't work in a static file.
- Output is sanitized with DOMPurify before being embedded.
- Removed the invalid `<p>` wrapper around message content.
- Added print-friendly CSS for tables, code blocks (`<pre>`), blockquotes, links, and images; replaced the `<li>` hack with proper `<ul>`/`<ol>` styling.

Now tables, headings, ordered/unordered lists, code blocks, blockquotes, links, and horizontal rules all render correctly in exported PDF/HTML.

## Testing

- Verified `marked` GFM rendering of the exact reported content (table + headings + lists + `---`) produces correct semantic HTML, sanitized through DOMPurify.
- `npx eslint client/src/api/endpoints/apps.js` → 0 errors (remaining warnings are pre-existing in untouched functions).

https://claude.ai/code/session_01SWCcDC9L5gz5B7YQrvFDy3

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWCcDC9L5gz5B7YQrvFDy3)_