### PR TITLE
Show which file triggers the document size warning on upload

### DIFF
--- a/client/src/features/apps/pages/AppChat.jsx
+++ b/client/src/features/apps/pages/AppChat.jsx
@@ -302,23 +302,29 @@ function AppChat({ preloadedApp = null }) {
       return;
     }
 
-    // Estimate token count using chars/4 approximation (standard heuristic for English text;
-    // token-to-character ratios vary for other languages and scripts)
-    const totalEstimatedTokens = documentFiles.reduce(
-      (sum, f) => sum + Math.ceil((f.content?.length || 0) / 4),
-      0
-    );
+    // Estimate token count per file using chars/4 approximation (standard heuristic for English
+    // text; token-to-character ratios vary for other languages and scripts)
+    const perFile = documentFiles.map((f, index) => ({
+      fileName:
+        f.fileName ||
+        f.name ||
+        t('common.untitledFile', 'Document {{index}}', { index: index + 1 }),
+      estimatedTokens: Math.ceil((f.content?.length || 0) / 4)
+    }));
+    const totalEstimatedTokens = perFile.reduce((sum, f) => sum + f.estimatedTokens, 0);
 
-    // Warn when document content alone would exceed 80% of the model's context window
+    // Warn when document content alone would exceed 80% of the model's context window.
+    // The estimate is the combined total across ALL attached documents, not per file.
     if (totalEstimatedTokens > currentModel.tokenLimit * 0.8) {
       setFileTokenWarning({
         estimatedTokens: totalEstimatedTokens,
-        tokenLimit: currentModel.tokenLimit
+        tokenLimit: currentModel.tokenLimit,
+        files: perFile
       });
     } else {
       setFileTokenWarning(null);
     }
-  }, [fileUploadHandler.selectedFile, selectedModel, models]);
+  }, [fileUploadHandler.selectedFile, selectedModel, models, t]);
 
   // Integration authentication detection
   const {

--- a/client/src/features/chat/components/ChatInput.jsx
+++ b/client/src/features/chat/components/ChatInput.jsx
@@ -375,12 +375,33 @@ function ChatInput({
       {fileTokenWarning && (
         <div className="mx-2 mb-2 flex items-start gap-2 rounded-lg border border-amber-300 bg-amber-50 p-2 text-sm text-amber-800 dark:border-amber-700 dark:bg-amber-900/20 dark:text-amber-200">
           <span className="mt-0.5 flex-shrink-0">⚠️</span>
-          <span>
-            {t('errors.documentTooLarge', {
-              estimatedTokens: fileTokenWarning.estimatedTokens.toLocaleString(i18n.language),
-              tokenLimit: fileTokenWarning.tokenLimit.toLocaleString(i18n.language)
-            })}
-          </span>
+          <div className="flex flex-col gap-1">
+            <span>
+              {(fileTokenWarning.files?.length || 0) > 1
+                ? t('errors.documentTooLargeCombined', {
+                    fileCount: fileTokenWarning.files.length,
+                    estimatedTokens: fileTokenWarning.estimatedTokens.toLocaleString(i18n.language),
+                    tokenLimit: fileTokenWarning.tokenLimit.toLocaleString(i18n.language)
+                  })
+                : t('errors.documentTooLarge', {
+                    fileName: fileTokenWarning.files?.[0]?.fileName || '',
+                    estimatedTokens: fileTokenWarning.estimatedTokens.toLocaleString(i18n.language),
+                    tokenLimit: fileTokenWarning.tokenLimit.toLocaleString(i18n.language)
+                  })}
+            </span>
+            {(fileTokenWarning.files?.length || 0) > 1 && (
+              <ul className="ml-1 list-inside list-disc">
+                {fileTokenWarning.files.map((f, idx) => (
+                  <li key={idx}>
+                    {t('errors.documentTooLargeFileItem', {
+                      fileName: f.fileName,
+                      estimatedTokens: f.estimatedTokens.toLocaleString(i18n.language)
+                    })}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
         </div>
       )}
 

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -178,3 +178,10 @@ Clicking **Save** on any admin edit page (apps, models, prompts, sources, users,
 
 - The unsaved-changes guard previously used a stale dirty-state value captured before the save completed, so the navigation triggered by Save itself was treated as an unsaved-changes navigation.
 - The guard now reads the live dirty state at navigation time, so genuine back/cancel navigation with unsaved edits is still protected.
+
+## Clearer Document Size Warning on File Upload
+
+The warning shown when an attached document may exceed the model's context window now names the file responsible, so users can tell which upload is too large.
+
+- For a single document, the warning includes the file name (e.g. `"report.pdf" is large (~270,509 estimated tokens)…`).
+- When multiple documents are attached, the warning makes clear the estimate is the **combined** total across all of them and lists each file with its individual token estimate, so it's obvious which files contribute most.

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -485,7 +485,9 @@
     "tiffProcessingError": "Fehler beim Verarbeiten der TIFF-Datei. Die Datei ist möglicherweise beschädigt oder in einem nicht unterstützten TIFF-Format.",
     "readError": "Fehler beim Lesen der Datei",
     "fileProcessingError": "Fehler beim Verarbeiten der Datei. Bitte versuchen Sie es erneut.",
-    "documentTooLarge": "Das Dokument ist groß (~{{estimatedTokens}} geschätzte Token) und überschreitet möglicherweise das Kontextfenster des Modells von {{tokenLimit}} Token. Die Anfrage könnte fehlschlagen. Erwägen Sie ein kürzeres Dokument oder wählen Sie ein Modell mit größerem Kontextfenster."
+    "documentTooLarge": "„{{fileName}}“ ist groß (~{{estimatedTokens}} geschätzte Token) und überschreitet möglicherweise das Kontextfenster des Modells von {{tokenLimit}} Token. Die Anfrage könnte fehlschlagen. Erwägen Sie ein kürzeres Dokument oder wählen Sie ein Modell mit größerem Kontextfenster.",
+    "documentTooLargeCombined": "Die {{fileCount}} angehängten Dokumente sind zusammen groß (~{{estimatedTokens}} geschätzte Token insgesamt) und überschreiten möglicherweise das Kontextfenster des Modells von {{tokenLimit}} Token. Die Anfrage könnte fehlschlagen. Entfernen Sie einige Dokumente oder wählen Sie ein Modell mit größerem Kontextfenster.",
+    "documentTooLargeFileItem": "{{fileName}}: ~{{estimatedTokens}} Token"
   },
   "serverErrors": {
     "appNotFound": "Anwendung nicht gefunden",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1596,7 +1596,9 @@
     "tiffProcessingError": "Error processing TIFF file. The file may be corrupted or in an unsupported TIFF format.",
     "readError": "Error reading file",
     "fileProcessingError": "Error processing file. Please try again.",
-    "documentTooLarge": "The document is large (~{{estimatedTokens}} estimated tokens) and may exceed the model's context window of {{tokenLimit}} tokens. The request may fail. Consider using a shorter document or selecting a model with a larger context window."
+    "documentTooLarge": "\"{{fileName}}\" is large (~{{estimatedTokens}} estimated tokens) and may exceed the model's context window of {{tokenLimit}} tokens. The request may fail. Consider using a shorter document or selecting a model with a larger context window.",
+    "documentTooLargeCombined": "The {{fileCount}} attached documents together are large (~{{estimatedTokens}} estimated tokens combined) and may exceed the model's context window of {{tokenLimit}} tokens. The request may fail. Consider removing some documents or selecting a model with a larger context window.",
+    "documentTooLargeFileItem": "{{fileName}}: ~{{estimatedTokens}} tokens"
   },
   "toolbar": {
     "bold": "Bold",


### PR DESCRIPTION
## Problem

When uploading a document, users could see a warning like:

> Das Dokument ist groß (~270.509 geschätzte Token) und überschreitet möglicherweise das Kontextfenster des Modells von 128.000 Token…

But the warning gave **no indication of which file** was responsible, and it was unclear whether the estimate was per file or combined.

## Answer to the question

The estimate is the **combined total across all attached documents**, not per file. The warning logic in `AppChat.jsx` sums `chars/4` over every attached document and compares the total against 80% of the model's `tokenLimit`.

## Changes

- **`AppChat.jsx`** — the `fileTokenWarning` object now carries a per-file breakdown (`files: [{ fileName, estimatedTokens }]`) alongside the combined total. Added a comment clarifying the estimate is combined across all documents.
- **`ChatInput.jsx`** — the warning now:
  - Names the file for a single document.
  - For multiple documents, states the estimate is **combined** and lists each file with its individual token estimate.
- **Locales** — added `errors.documentTooLargeCombined` and `errors.documentTooLargeFileItem`, and added the file name to the existing `errors.documentTooLarge` (en + de).
- **Changelog** — added an entry under `docs/releases/5.4.0/features.md`.

## Notes

- Only `en.json` and `de.json` contain these `errors.*` keys; other languages fall back to these.
- ESLint could not be run in this environment (`globals` package not installed); Prettier was applied to the changed JS files.

https://claude.ai/code/session_01C1nkUNRgomj1XbTZEejner

---
_Generated by [Claude Code](https://claude.ai/code/session_01C1nkUNRgomj1XbTZEejner)_