### PR TITLE
Fix MCP/JSON Schema tools failing on Google Gemini (400 INVALID_REQUEST)

### DIFF
--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -203,3 +203,11 @@ Attaching many files to a chat message no longer pushes the message box and send
 - When expanded, the list is **height-capped and scrolls internally** — about 6 rows on desktop and 4 rows in the narrow Outlook task pane — so the chat input always remains reachable.
 - **1–3 files** display exactly as before, with no extra controls.
 - **Remove All** stays one click away in both the collapsed and expanded states, and loading files are reflected in the summary.
+
+## MCP and JSON Schema Tools Now Work with Google Gemini
+
+Tools whose parameter schemas include standard JSON Schema metadata — most notably tools exposed through MCP servers — now work with Google Gemini models. Previously these calls failed with a `400 INVALID_REQUEST` error from Google.
+
+- Gemini's tool format rejects JSON Schema keywords such as `$schema` and `additionalProperties`, which MCP tools routinely emit. These keywords are now stripped from tool parameter schemas before the request is sent to Google.
+- A parameter literally named `additionalProperties` is preserved, so legitimate tool inputs are unaffected.
+- Other providers (OpenAI, Anthropic, Bedrock, Mistral) are unchanged.

--- a/server/adapters/toolCalling/GenericToolCalling.js
+++ b/server/adapters/toolCalling/GenericToolCalling.js
@@ -274,6 +274,14 @@ export function sanitizeSchemaForProvider(schema, provider) {
         delete obj.format; // Google has limited format support
         delete obj.minLength; // Use 'minimum' instead for strings
         delete obj.maxLength; // Use 'maximum' instead for strings
+        // JSON Schema meta keywords that Google's restricted OpenAPI subset
+        // rejects with HTTP 400 ("Unknown name ..."). MCP tools routinely emit
+        // these ($schema + additionalProperties: false from their JSON Schema
+        // draft), so strip them or every MCP tool call to Gemini fails.
+        delete obj.$schema;
+        delete obj.$id;
+        delete obj.additionalProperties;
+        delete obj.patternProperties;
       }
 
       if (provider === 'anthropic') {

--- a/server/tests/googleAdapter.test.js
+++ b/server/tests/googleAdapter.test.js
@@ -18,3 +18,44 @@ const req = GoogleAdapter.createCompletionRequest(model, messages, 'key', {
 assert.strictEqual(req.body.generationConfig.responseMimeType, 'application/json');
 assert.deepStrictEqual(req.body.generationConfig.response_schema, schema);
 logger.info('Google adapter structured output test passed');
+
+// Regression: MCP tool schemas include JSON Schema meta keywords ($schema,
+// additionalProperties) that Google's restricted OpenAPI subset rejects with
+// HTTP 400 ("Unknown name ..."). The adapter must strip them before sending.
+const mcpTool = {
+  id: 'echo',
+  name: 'echo',
+  description: 'Echoes back the input',
+  parameters: {
+    $schema: 'http://json-schema.org/draft-07/schema#',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      message: { type: 'string', description: 'text to echo' },
+      // A property literally named additionalProperties must be preserved.
+      additionalProperties: { type: 'string', description: 'edge case property name' }
+    },
+    required: ['message']
+  }
+};
+
+const toolReq = GoogleAdapter.createCompletionRequest(model, messages, 'key', {
+  tools: [mcpTool]
+});
+
+const declaredParams = toolReq.body.tools[0].functionDeclarations[0].parameters;
+const serialized = JSON.stringify(toolReq.body.tools);
+
+assert.ok(!serialized.includes('$schema'), '$schema must be stripped from tool parameters');
+assert.strictEqual(
+  declaredParams.additionalProperties,
+  undefined,
+  'additionalProperties keyword must be stripped'
+);
+assert.ok(
+  declaredParams.properties.additionalProperties,
+  'a property literally named additionalProperties must be preserved'
+);
+assert.ok(declaredParams.properties.message, 'message property must be preserved');
+assert.deepStrictEqual(declaredParams.required, ['message'], 'required must be preserved');
+logger.info('Google adapter MCP tool schema sanitization test passed');


### PR DESCRIPTION
## Problem

Calling an MCP tool (e.g. an `echo` tool) on a Google Gemini model fails with:

```
400 INVALID_ARGUMENT — Invalid JSON payload received.
Unknown name "additionalProperties" at 'tools[0].function_declarations[0].parameters': Cannot find field.
Unknown name "$schema" at 'tools[0].function_declarations[0].parameters': Cannot find field.
```

MCP servers expose tools whose parameter schemas are full JSON Schema documents, which include meta keywords like `$schema` and `additionalProperties: false`. Google Gemini's tool format uses a **restricted OpenAPI schema subset** that does not recognize these keywords and rejects the whole request.

## Fix

`sanitizeSchemaForProvider()` in `server/adapters/toolCalling/GenericToolCalling.js` — the function used by the real Google request path (`createCompletionRequest` → `convertToolsFromGeneric` → `GoogleConverter`) — now strips the unsupported JSON Schema meta keywords for the `google` provider:

- `$schema`, `$id`, `additionalProperties`, `patternProperties`

The existing properties-container guard means a tool input **literally named** `additionalProperties` is still preserved — only the schema keyword form is removed.

Other providers (OpenAI, Anthropic, Bedrock, Mistral) are untouched.

## Testing

- Extended `server/tests/googleAdapter.test.js` with a regression test that runs an MCP-style schema through `createCompletionRequest` and asserts `$schema`/`additionalProperties` are gone, while a property named `additionalProperties`, the `message` property, and `required` are preserved.
- `npm run test:google`, `npm run test:bedrock`, `npm run test:anthropic` pass.
- `npm run test:openai` / `npm run test:tool-calling` fail on a **pre-existing** circular-import error in `server/adapters/index.js` (confirmed on the clean tree, unrelated to this change).
- Lint clean on changed files.

## Note on the Amazon Nova "empty answer"

The reported empty response from Amazon Nova with the same MCP tool is a **separate symptom** — Bedrock returned no error, so this schema fix does not explain it. I did not change the Bedrock path. If you can share the server logs for the Nova run (it routes through `BedrockConverter`), I can dig into that separately.

https://claude.ai/code/session_01Vnrw9ifGxZW9S4XmGtZ866

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vnrw9ifGxZW9S4XmGtZ866)_