### PR TITLE
fix(export): make export dialog robust in Outlook and responsive mode

### DIFF
--- a/client/src/api/endpoints/apps.js
+++ b/client/src/api/endpoints/apps.js
@@ -125,6 +125,67 @@ export const checkAppChatStatus = async (appId, chatId) => {
   );
 };
 
+// Print an HTML document via a hidden, same-origin iframe.
+//
+// We deliberately avoid `window.open()` here: inside sandboxed/embedded hosts
+// such as the Outlook taskpane and the browser-extension side panel, popups
+// are blocked and `window.open()` returns `null`. The previous implementation
+// then accessed `printWindow.document`, which crashed the whole export with
+// "null is not an object (evaluating '...document')". An offscreen iframe
+// prints the document in-place and works across those hosts.
+const printHtmlDocument = htmlContent =>
+  new Promise((resolve, reject) => {
+    const iframe = document.createElement('iframe');
+    iframe.setAttribute('aria-hidden', 'true');
+    iframe.style.position = 'fixed';
+    iframe.style.left = '-9999px';
+    iframe.style.width = '0';
+    iframe.style.height = '0';
+    iframe.style.border = '0';
+
+    let settled = false;
+    const removeFrame = () => setTimeout(() => iframe.remove(), 1000);
+
+    const triggerPrint = () => {
+      if (settled) return;
+      try {
+        const frameWindow = iframe.contentWindow;
+        if (!frameWindow) throw new Error('Print frame is unavailable');
+        settled = true;
+        frameWindow.focus();
+        frameWindow.print();
+        removeFrame();
+        resolve();
+      } catch (err) {
+        settled = true;
+        removeFrame();
+        reject(err);
+      }
+    };
+
+    iframe.onload = triggerPrint;
+    // Safety net in case `onload` never fires for the generated document.
+    setTimeout(triggerPrint, 1500);
+
+    document.body.appendChild(iframe);
+
+    // Prefer `srcdoc`; fall back to document.write for engines that ignore it.
+    try {
+      iframe.srcdoc = htmlContent;
+    } catch {
+      const doc = iframe.contentWindow?.document;
+      if (!doc) {
+        settled = true;
+        iframe.remove();
+        reject(new Error('Unable to initialise print frame'));
+        return;
+      }
+      doc.open();
+      doc.write(htmlContent);
+      doc.close();
+    }
+  });
+
 // Client-side PDF generation using browser print functionality
 export const exportChatToPDF = async (
   messages,
@@ -150,26 +211,6 @@ export const exportChatToPDF = async (
     isSingleMessage
   );
 
-  // Create a new window for printing
-  const printWindow = window.open('', '_blank');
-  printWindow.document.write(htmlContent);
-  printWindow.document.close();
-
-  // Wait for content to load
-  await new Promise(resolve => {
-    printWindow.onload = resolve;
-    setTimeout(resolve, 1000); // Fallback timeout
-  });
-
-  // Focus and print
-  printWindow.focus();
-  printWindow.print();
-
-  // Close after a delay
-  setTimeout(() => {
-    printWindow.close();
-  }, 1000);
-
   const filename = buildChatExportFilename({
     format: 'pdf',
     appName,
@@ -178,7 +219,24 @@ export const exportChatToPDF = async (
     isSingleMessage
   });
 
-  return { success: true, filename };
+  try {
+    await printHtmlDocument(htmlContent);
+    return { success: true, filename };
+  } catch (err) {
+    // Printing is unavailable in this host (e.g. a locked-down embedded
+    // sandbox). Fall back to downloading the rendered HTML so the user can
+    // still open and print it themselves, instead of hitting a hard crash.
+    console.warn('PDF print unavailable, falling back to HTML download:', err);
+    const htmlFilename = buildChatExportFilename({
+      format: 'html',
+      appName,
+      appId,
+      messages,
+      isSingleMessage
+    });
+    downloadFile(htmlContent, htmlFilename, 'text/html');
+    return { success: true, filename: htmlFilename, fallback: 'html' };
+  }
 };
 
 // Generate HTML content for PDF

--- a/client/src/features/chat/components/ExportDialog.jsx
+++ b/client/src/features/chat/components/ExportDialog.jsx
@@ -14,6 +14,11 @@ import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import useFeatureFlags from '../../../shared/hooks/useFeatureFlags';
 
+// Formats whose content can be copied to the clipboard as plain text. Binary
+// formats (pdf, docx, xlsx, pptx) and the styled HTML document can only be
+// downloaded, so the Copy button is disabled when one of those is selected.
+const COPYABLE_FORMATS = ['txt', 'markdown', 'json', 'jsonl'];
+
 function ExportDialog({
   isOpen,
   onClose,
@@ -63,6 +68,8 @@ function ExportDialog({
   });
 
   if (!isOpen) return null;
+
+  const canCopySelectedFormat = COPYABLE_FORMATS.includes(selectedFormat);
 
   const buildMeta = () => ({
     model: settings.model,
@@ -133,6 +140,18 @@ function ExportDialog({
     setCopied(false);
     setExportError(null);
 
+    // The Copy button is disabled for non-copyable formats; this guard keeps
+    // the handler safe if it is ever invoked programmatically.
+    if (!canCopySelectedFormat) {
+      setExportError(
+        t(
+          'pages.appChat.export.copyNotSupported',
+          'Copy not supported for this format. Please use download instead.'
+        )
+      );
+      return;
+    }
+
     try {
       const filteredMessages = messages.filter(m => !m.isGreeting);
       const exportSettings = buildMeta();
@@ -152,28 +171,6 @@ function ExportDialog({
         case 'jsonl':
           content = generateJSONLContent(filteredMessages, exportSettings);
           break;
-        case 'html':
-          // For HTML, we need to generate it via the API since it's complex
-          setExportError(
-            t(
-              'pages.appChat.export.copyNotSupported',
-              'Copy not supported for this format. Please use download instead.'
-            )
-          );
-          return;
-        case 'pdf':
-        case 'docx':
-        case 'xlsx':
-        case 'csv':
-        case 'pptx':
-          // Binary formats can't be copied to clipboard
-          setExportError(
-            t(
-              'pages.appChat.export.copyNotSupported',
-              'Copy not supported for this format. Please use download instead.'
-            )
-          );
-          return;
         default:
           throw new Error(`Unsupported format: ${selectedFormat}`);
       }
@@ -360,7 +357,7 @@ function ExportDialog({
 
   return (
     <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-2 sm:p-4"
       onClick={e => {
         if (e.target === e.currentTarget) onClose?.();
       }}
@@ -370,10 +367,10 @@ function ExportDialog({
         role="dialog"
         aria-modal="true"
         aria-labelledby="export-dialog-title"
-        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[90vh] overflow-hidden flex flex-col"
+        className="bg-white dark:bg-gray-800 rounded-lg shadow-xl w-full max-w-2xl max-h-[95vh] sm:max-h-[90vh] overflow-hidden flex flex-col"
       >
         {/* Header */}
-        <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+        <div className="px-4 sm:px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
           <h2
             id="export-dialog-title"
             className="text-xl font-semibold text-gray-900 dark:text-gray-100"
@@ -393,19 +390,19 @@ function ExportDialog({
         </div>
 
         {/* Content */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <div className="flex-1 overflow-y-auto p-4 sm:p-6">
           {/* Format Selection */}
           <div className="mb-6">
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
               {t('pages.appChat.export.selectFormat', 'Select export format')}
             </label>
-            <div className="grid grid-cols-2 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
               {exportFormats.map(format => (
                 <button
                   key={format.id}
                   onClick={() => setSelectedFormat(format.id)}
                   disabled={isExporting}
-                  className={`p-4 rounded-lg border-2 text-left transition-all ${
+                  className={`p-3 sm:p-4 rounded-lg border-2 text-left transition-all ${
                     selectedFormat === format.id
                       ? 'border-blue-500 bg-blue-50 dark:bg-blue-900/20'
                       : 'border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600'
@@ -559,18 +556,26 @@ function ExportDialog({
         </div>
 
         {/* Footer */}
-        <div className="px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex items-center justify-end gap-3">
+        <div className="px-4 sm:px-6 py-4 border-t border-gray-200 dark:border-gray-700 flex flex-col-reverse sm:flex-row sm:items-center sm:justify-end gap-3">
           <button
             onClick={onClose}
             disabled={isExporting}
-            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="w-full sm:w-auto px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 disabled:opacity-50 disabled:cursor-not-allowed"
           >
             {t('common.cancel', 'Cancel')}
           </button>
           <button
             onClick={handleCopy}
-            disabled={isExporting || !selectedFormat}
-            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
+            disabled={isExporting || !selectedFormat || !canCopySelectedFormat}
+            title={
+              !canCopySelectedFormat
+                ? t(
+                    'pages.appChat.export.copyNotSupported',
+                    'Copy not supported for this format. Please use download instead.'
+                  )
+                : undefined
+            }
+            className="w-full sm:w-auto px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-600 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >
             {copied ? (
               <>
@@ -587,7 +592,7 @@ function ExportDialog({
           <button
             onClick={handleExport}
             disabled={isExporting || !selectedFormat}
-            className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center gap-2"
+            className="w-full sm:w-auto px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:bg-gray-400 disabled:cursor-not-allowed flex items-center justify-center gap-2"
           >
             {isExporting ? (
               <>

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -227,3 +227,12 @@ Tools whose parameter schemas include standard JSON Schema metadata — most not
 - Gemini's tool format rejects JSON Schema keywords such as `$schema` and `additionalProperties`, which MCP tools routinely emit. These keywords are now stripped from tool parameter schemas before the request is sent to Google.
 - A parameter literally named `additionalProperties` is preserved, so legitimate tool inputs are unaffected.
 - Other providers (OpenAI, Anthropic, Bedrock, Mistral) are unchanged.
+
+## Export Dialog — Reliable in Outlook and on Small Screens
+
+The chat export dialog now works inside the Outlook task pane and the browser-extension side panel, and adapts cleanly to narrow widths.
+
+- **PDF export no longer crashes in embedded hosts.** Printing previously relied on opening a new browser window, which is blocked in the Outlook task pane and produced a "null is not an object" error. Export now prints through an in-place hidden frame and, where printing is unavailable, downloads the formatted document as HTML instead.
+- **Responsive layout:** the format picker switches to a single column on narrow screens and the action buttons stack full-width, so the dialog stays usable in the Outlook task pane and on phones.
+- **Copy button reflects the selected format:** it is now enabled only for formats that can be copied as text (Text, Markdown, JSON, JSON Lines) and disabled with an explanatory tooltip for PDF, Word, Excel, PowerPoint, CSV, and HTML.
+- The dialog can be dismissed with the **✕ button** or the **Esc** key.


### PR DESCRIPTION
## Summary

Fixes several issues with the chat export dialog, with a focus on the Outlook integration and small-screen usability.

### Outlook crash on export (`null is not an object (evaluating 'i.document')`)
PDF export printed via `window.open('', '_blank')`. In the sandboxed Outlook task pane (and the extension side panel) popups are blocked, so `window.open` returns `null` and the subsequent `printWindow.document.write(...)` threw — the minified `i.document` error reported when clicking **Export**.

- Printing now goes through a hidden, same-origin iframe (`printHtmlDocument`), which works inside embedded hosts.
- When printing is genuinely unavailable, it falls back to **downloading the rendered HTML** so the user still gets their content instead of a hard crash.

### Copy button enablement
The **Copy** button is now enabled only for formats that can be copied as text — Text, Markdown, JSON, JSON Lines. For PDF, Word, Excel, PowerPoint, CSV and HTML it's disabled with an explanatory tooltip (previously it was always enabled and surfaced an error only after clicking).

### Responsive / Outlook layout
- Format picker: `grid-cols-1` on narrow widths, `sm:grid-cols-2` above.
- Footer actions stack full-width on small screens (`flex-col-reverse` → row).
- Tighter padding and taller max-height on small viewports.

### Already present
The **✕** close button and the **Esc**-to-close listener were already in the committed code, so no change was needed there.

## Files
- `client/src/api/endpoints/apps.js` — iframe-based printing + HTML fallback.
- `client/src/features/chat/components/ExportDialog.jsx` — copy enablement + responsive layout.
- `docs/releases/5.4.0/features.md` — changelog entry.

## Testing
- `npx eslint` on both changed files: no new warnings/errors (only pre-existing warnings remain).
- `npx prettier --check`: clean.

Manual verification of the Outlook task-pane print path would be a good follow-up before marking ready.

https://claude.ai/code/session_017TXAKhLHhjiBJPdyhj33sz

---
_Generated by [Claude Code](https://claude.ai/code/session_017TXAKhLHhjiBJPdyhj33sz)_