### PR TITLE
fix(outlook): make Office task pane resolution-aware on small/high-DPI laptops

### DIFF
--- a/client/office/office.css
+++ b/client/office/office.css
@@ -2,6 +2,31 @@
 @tailwind components;
 @tailwind utilities;
 
+/*
+ * Resolution-aware base scale for the Office task pane.
+ *
+ * Outlook desktop renders the add-in inside WebView2 at the OS display-scale
+ * factor — a small 13" Windows laptop is typically 125–150%. Crucially, the
+ * <meta name="viewport"> tag in taskpane.html is a no-op in desktop WebView2,
+ * so nothing in the add-in otherwise compensates for that scaling and the whole
+ * UI (tiles, chat input, attachments, dialogs) renders oversized — forcing the
+ * user to manually zoom out to fit the pane.
+ *
+ * Both "scaled small screen" and "narrow pane" surface as a small CSS-pixel
+ * viewport width (CSS px = device px / devicePixelRatio), so we key a fluid
+ * root font-size off the pane width. Because the entire add-in is built with
+ * rem-based Tailwind sizing (text, spacing, widths, icon sizes), shrinking the
+ * root font-size scales everything down together instead of patching each
+ * component. The pane viewport == the add-in's viewport, so `vw` is the pane
+ * width here.
+ *
+ * ~13px floor at/under a ~300px pane, ramping to the 16px default once the pane
+ * is comfortably wide (≥ ~470px).
+ */
+html {
+  font-size: clamp(13px, 1.7vw + 8px, 16px);
+}
+
 html,
 body {
   box-sizing: border-box;

--- a/client/src/features/chat/components/ChatInput.jsx
+++ b/client/src/features/chat/components/ChatInput.jsx
@@ -245,9 +245,12 @@ function ChatInput({
         // Reset height to auto to get the correct scrollHeight
         textarea.style.height = 'auto';
 
-        // Calculate the new height based on content
+        // Calculate the new height based on content. Use the live root font-size
+        // rather than a hardcoded 16px so the min/max line heights follow the
+        // Office task pane's responsive scaling on small / high-DPI panes.
         const scrollHeight = textarea.scrollHeight;
-        const minHeight = inputRows * 1.5 * 16; // Convert em to px (assuming 16px base font size)
+        const rootFontSize = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+        const minHeight = inputRows * 1.5 * rootFontSize; // line-height (1.5) × rows × base font
         // Default cap: 5 lines (single-line mode) / 12 lines (multiline mode).
         // `maxRows` lets the embedding host (Outlook taskpane) clamp lower.
         const defaultMaxLines = multilineMode ? 12 : 5;
@@ -255,7 +258,8 @@ function ChatInput({
           typeof maxRows === 'number' && maxRows > 0
             ? Math.max(maxRows, inputRows)
             : defaultMaxLines;
-        const maxHeight = effectiveMaxLines * 1.5 * 16 + (multilineMode ? 24 : 0);
+        const maxHeight =
+          effectiveMaxLines * 1.5 * rootFontSize + (multilineMode ? 1.5 * rootFontSize : 0);
 
         // Set the height to fit content, but respect min/max limits
         const newHeight = Math.min(Math.max(scrollHeight, minHeight), maxHeight);

--- a/client/src/shared/components/AppCard.jsx
+++ b/client/src/shared/components/AppCard.jsx
@@ -35,7 +35,10 @@ function AppCard({
     return (
       <div
         className="relative bg-white rounded-lg shadow hover:shadow-md transition-shadow duration-200 w-full"
-        style={{ height: '75px', minHeight: '72px' }}
+        // rem (not px) so the row scales with the Office task pane's responsive
+        // root font-size on small / high-DPI panes. 4.6875rem = 75px, 4.5rem = 72px
+        // at the default 16px base — identical sizing in the main web app.
+        style={{ height: '4.6875rem', minHeight: '4.5rem' }}
         role="listitem"
       >
         {onToggleFavorite && (

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -220,6 +220,14 @@ Attaching many files to a chat message no longer pushes the message box and send
 - **1–3 files** display exactly as before, with no extra controls.
 - **Remove All** stays one click away in both the collapsed and expanded states, and loading files are reflected in the summary.
 
+## Outlook Add-in — Scales Correctly on Small / High-DPI Laptops
+
+The iHub add-in in Outlook now sizes itself to the available task pane instead of rendering everything oversized on small, high-resolution laptops (e.g. a 13" Windows device at 125–150% display scaling). Previously users had to manually zoom the add-in out to fit the app tiles, chat input, and attachments on screen.
+
+- The add-in now uses a fluid base scale keyed to the task pane width, so the whole interface — app tiles, chat input, attachment chips, and dialogs — shrinks together on narrow or high-DPI panes and returns to full size on wider panes.
+- The app-selection tiles, which previously stayed at a fixed desktop size, now scale with the rest of the add-in.
+- No configuration required; the behavior applies automatically in the Outlook (and other Office) task pane.
+
 ## MCP and JSON Schema Tools Now Work with Google Gemini
 
 Tools whose parameter schemas include standard JSON Schema metadata — most notably tools exposed through MCP servers — now work with Google Gemini models. Previously these calls failed with a `400 INVALID_REQUEST` error from Google.


### PR DESCRIPTION
## Problem

In Outlook on a small 13" Windows laptop, the add-in renders **everything** (app tiles, chat input, attachments, dialogs) oversized — users have to manually zoom out to fit it on screen.

### Root cause

The Outlook desktop add-in runs in **WebView2**, which renders at the OS display-scale factor (a 13" laptop is typically **125–150%**). The only viewport hint is `<meta name="viewport" content="width=device-width, initial-scale=1">` in `taskpane.html`, which is **a no-op in desktop WebView2** — so nothing in the add-in compensates for the scaling.

Earlier responsive work (#1467) added CSS container queries to a few chat elements (greeting, header, message bubbles), but the rest of the add-in — the app-selection tiles, the chat input, attachment chips — stayed at **fixed desktop sizes**. The add-in simply never took the resolution into account globally.

## Fix

A global, resolution-aware base scale plus fixing the two `px` holdouts that wouldn't follow it:

- **`client/office/office.css`** — add a fluid root `font-size` keyed to the pane width (`clamp(13px, 1.7vw + 8px, 16px)`). The add-in is built almost entirely with **rem-based Tailwind** sizing (text, spacing, widths, icon sizes), so shrinking the root font-size scales the whole UI down together on narrow / high-DPI panes and back to full size on wider panes. Because CSS px = device px / devicePixelRatio, a *scaled small screen* surfaces as a small CSS-px viewport width — so keying off pane width naturally captures the DPI scaling. `office.css` is imported only by the taskpane entry, so this is scoped to the Office task pane.
- **`AppCard.jsx` (compact variant)** — convert the inline `height: 75px / minHeight: 72px` to rem so the app-selection tiles scale with everything else (identical sizing at the 16px base in the main web app).
- **`ChatInput.jsx`** — the textarea auto-grow computed its min/max heights from a hardcoded `16` px-per-rem assumption; now reads the live root font-size so the input follows the pane scale.

## Notes / scope

- Container queries in `OfficeChatPanel.css` are left in place — they compose cleanly with the root scale (they use rem, which now also scales).
- A handful of arbitrary `text-[11px]` accents are intentionally left as-is; the dominant sizing is all rem and now scales.
- No config changes; behavior applies automatically in the Outlook (and other Office) task pane.

## Testing

- `eslint --fix` on changed files: 0 errors.
- Recommended manual check: open the add-in in Outlook desktop on a 125–150% scaled display and confirm the tiles / chat input / attachments fit without manual zoom; verify the main web app is unchanged (root font-size there is the default 16px).

https://claude.ai/code/session_01GmkXYtKwjJP6998qfdk5ud

---
_Generated by [Claude Code](https://claude.ai/code/session_01GmkXYtKwjJP6998qfdk5ud)_