### PR TITLE
Fix SSRF bypass in workflow HTTP node via IPv4-mapped IPv6 (GHSA-fp9c-pq7w-vr34)

### DIFF
--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -397,3 +397,13 @@ When the brief enumerates multiple distinct angles for the same subject (e.g. "f
 The canonical planner system prompt now carries an explicit **DECOMPOSITION TEST**: read each task's title and description back — if it contains "and" joining research subjects, or a comma-separated list of distinct angles, it must be split. Three worked examples (Rowan Curran's 4 angles, two people, three products) are included so the model has anchors.
 
 Migration **V054** clears stale `planner.system` overrides on agent profiles that were verbatim snapshots of the old default. Operator-customized prompts (longer than the snapshot or with a different opening sentence) are left untouched. Cleared profiles fall back to the canonical default at runtime, so the new decomposition rules take effect immediately on next server restart.
+
+## Security: Workflow HTTP Node SSRF Bypass Fixed
+
+The SSRF guard that protects workflow HTTP-request nodes from reaching internal hosts and cloud metadata endpoints could be bypassed with an IPv4-mapped IPv6 address written in hex form (e.g. `http://[::ffff:a9fe:a9fe]/`, which is `169.254.169.254` — the AWS instance-metadata address). The address-classifier now parses every IPv6 literal to its canonical bytes and blocks it by network range regardless of how it is written, so the mapped-hex, dotted, and NAT64 (`64:ff9b::`) forms of an internal address are all caught.
+
+- Closes the IPv4-mapped-IPv6 hex bypass (GHSA-fp9c-pq7w-vr34).
+- Adds the shared-address / CGNAT range `100.64.0.0/10` to the blocklist.
+- Pins each request to the exact IP addresses validated by the guard, closing a DNS-rebinding window where a hostname could resolve to a public IP during the check and an internal IP at connect time. Pinning applies to direct connections; when an outbound HTTP proxy is configured the proxy remains the egress boundary.
+
+No configuration change is required. This affects any deployment whose workflows feed request-controlled input into an HTTP node's URL (including the public webhook trigger and chat `@mention` / MCP run triggers).

--- a/server/services/workflow/executors/HttpNodeExecutor.js
+++ b/server/services/workflow/executors/HttpNodeExecutor.js
@@ -11,11 +11,10 @@
  * @module services/workflow/executors/HttpNodeExecutor
  */
 
-import dns from 'node:dns/promises';
-import net from 'node:net';
 import { BaseNodeExecutor } from './BaseNodeExecutor.js';
 import { throttledFetch } from '../../../requestThrottler.js';
 import logger from '../../../utils/logger.js';
+import { assertPublicTarget, createPinnedLookup } from './ssrfGuard.js';
 
 /**
  * HTTP node configuration
@@ -41,107 +40,6 @@ import logger from '../../../utils/logger.js';
  * @property {string} [key] - API key value (for type 'apikey')
  * @property {string} [headerName='X-API-Key'] - Header name for API key
  */
-
-/**
- * Check whether a single IP address (v4 or v6 in normalized form) belongs
- * to a private or otherwise sensitive network range.
- *
- * Blocks:
- * - IPv4 loopback (127/8) and unspecified (0/8)
- * - RFC 1918 private ranges (10/8, 172.16/12, 192.168/16)
- * - Link-local (169.254/16) -- includes AWS IMDS
- * - IPv4 multicast/reserved (224/4, 240/4)
- * - IPv4-mapped IPv6 (::ffff:0:0/96), checked via inner IPv4
- * - IPv6 loopback (::1), link-local (fe80::/10), ULA (fc00::/7), unspecified (::)
- *
- * @param {string} ip - The IP address to check
- * @returns {boolean} True if the IP is in a blocked range
- */
-function isPrivateIP(ip) {
-  if (!ip) return true; // be safe: unknown is blocked
-  const family = net.isIP(ip);
-
-  if (family === 4) {
-    const parts = ip.split('.').map(Number);
-    const [a, b] = parts;
-    if (a === 10) return true;
-    if (a === 127) return true;
-    if (a === 0) return true;
-    if (a === 169 && b === 254) return true;
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    if (a === 192 && b === 168) return true;
-    if (a >= 224) return true; // multicast + reserved
-    return false;
-  }
-
-  if (family === 6) {
-    const lower = ip.toLowerCase();
-    if (lower === '::1' || lower === '::') return true;
-    if (lower.startsWith('fe80:') || lower.startsWith('fe80::')) return true;
-    // ULA: fc00::/7 -> first byte 0xfc or 0xfd
-    if (lower.startsWith('fc') || lower.startsWith('fd')) return true;
-    // IPv4-mapped IPv6 (::ffff:a.b.c.d) -> check inner IPv4
-    const mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
-    if (mapped) return isPrivateIP(mapped[1]);
-    // IPv4-compatible IPv6 (::a.b.c.d) is deprecated but check anyway
-    const compat = lower.match(/^::(\d+\.\d+\.\d+\.\d+)$/);
-    if (compat) return isPrivateIP(compat[1]);
-    return false;
-  }
-
-  // Not a valid IP -- callers should resolve DNS first
-  return false;
-}
-
-/**
- * SSRF guard: resolve the URL's hostname to one or more IP addresses and
- * verify every resolved IP is in a public range. Catches DNS-based
- * bypasses where an external hostname resolves to a private IP.
- *
- * @param {URL} parsedUrl - The parsed request URL
- * @returns {Promise<{ok: boolean, reason?: string}>}
- */
-async function assertPublicTarget(parsedUrl) {
-  // Strip IPv6 brackets that URL parsing leaves on the hostname.
-  let host = parsedUrl.hostname;
-  if (host.startsWith('[') && host.endsWith(']')) {
-    host = host.slice(1, -1);
-  }
-
-  // Block obvious magic hostnames before DNS even runs.
-  const lowerHost = host.toLowerCase();
-  if (lowerHost === 'localhost' || lowerHost.endsWith('.localhost')) {
-    return { ok: false, reason: 'localhost is blocked' };
-  }
-
-  // If the hostname is already an IP, check it directly.
-  if (net.isIP(host)) {
-    return isPrivateIP(host) ? { ok: false, reason: `IP ${host} is private` } : { ok: true };
-  }
-
-  // Resolve A and AAAA. If both fail we'll reject; if either resolves to a
-  // private IP we reject. Any unresolved family is ignored (not all hosts
-  // have both records).
-  let addrs = [];
-  try {
-    const [v4, v6] = await Promise.allSettled([dns.resolve4(host), dns.resolve6(host)]);
-    if (v4.status === 'fulfilled') addrs.push(...v4.value);
-    if (v6.status === 'fulfilled') addrs.push(...v6.value);
-  } catch (err) {
-    return { ok: false, reason: `DNS resolution failed: ${err.message}` };
-  }
-
-  if (addrs.length === 0) {
-    return { ok: false, reason: 'host did not resolve to any IP' };
-  }
-
-  for (const addr of addrs) {
-    if (isPrivateIP(addr)) {
-      return { ok: false, reason: `host resolves to private IP ${addr}` };
-    }
-  }
-  return { ok: true };
-}
 
 /**
  * Interpolate {{variable}} placeholders in a template string using workflow state data.
@@ -294,6 +192,11 @@ export class HttpNodeExecutor extends BaseNodeExecutor {
         );
       }
 
+      // Pin the connection to the addresses we just validated so the fetch
+      // cannot re-resolve to a private IP (DNS rebinding). Applied for direct
+      // connections only; under a proxy the proxy is the egress boundary.
+      const pinnedLookup = createPinnedLookup(ssrfCheck.addresses);
+
       // Safe logging - only hostname and path, no query params that might contain secrets
       logger.info({
         component: 'HttpNodeExecutor',
@@ -338,7 +241,8 @@ export class HttpNodeExecutor extends BaseNodeExecutor {
           headers: fetchHeaders,
           body,
           signal: controller.signal,
-          redirect: 'manual'
+          redirect: 'manual',
+          lookup: pinnedLookup
         });
 
         clearTimeout(timeoutId);

--- a/server/services/workflow/executors/ssrfGuard.js
+++ b/server/services/workflow/executors/ssrfGuard.js
@@ -1,0 +1,271 @@
+/**
+ * SSRF protection helpers for outbound workflow HTTP requests.
+ *
+ * Classifies IP addresses by network range on their canonical numeric form and
+ * provides a DNS-pinning lookup so a validated request cannot be re-pointed at
+ * an internal host between the check and the connection (DNS rebinding).
+ *
+ * Kept dependency-free (only node:net / node:dns) so it can be unit tested in
+ * isolation and reused by any outbound-request code path.
+ *
+ * @module services/workflow/executors/ssrfGuard
+ */
+
+import dns from 'node:dns/promises';
+import net from 'node:net';
+
+/**
+ * Classify a 4-octet IPv4 address (as bytes) as private/sensitive.
+ *
+ * Blocks:
+ * - Unspecified (0/8) and loopback (127/8)
+ * - RFC 1918 private ranges (10/8, 172.16/12, 192.168/16)
+ * - Link-local (169.254/16) -- includes AWS/GCP/Azure IMDS (169.254.169.254)
+ * - Shared address space / CGNAT (100.64.0.0/10, RFC 6598)
+ * - Multicast and reserved (224/4, 240/4)
+ *
+ * @param {number[]} bytes - Four octets [a, b, c, d]
+ * @returns {boolean} True if the address is in a blocked range
+ */
+export function isPrivateIPv4Bytes([a, b]) {
+  if (a === 0) return true; // "this" network
+  if (a === 10) return true; // RFC 1918
+  if (a === 127) return true; // loopback
+  if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 shared/CGNAT
+  if (a === 169 && b === 254) return true; // link-local (IMDS)
+  if (a === 172 && b >= 16 && b <= 31) return true; // RFC 1918
+  if (a === 192 && b === 168) return true; // RFC 1918
+  if (a >= 224) return true; // multicast (224/4) + reserved (240/4)
+  return false;
+}
+
+/**
+ * Parse an IPv6 address literal into its 16 octets.
+ *
+ * Handles `::` zero-compression, an embedded dotted-quad IPv4 tail
+ * (e.g. `::ffff:1.2.3.4` or `64:ff9b::1.2.3.4`), and zone identifiers
+ * (`fe80::1%eth0`). The input is expected to already be a syntactically
+ * valid IPv6 literal (net.isIP(ip) === 6); anything that fails to parse
+ * returns null so callers can treat it as blocked.
+ *
+ * @param {string} ip - IPv6 address literal
+ * @returns {number[]|null} 16 octets, or null if unparseable
+ */
+export function ipv6ToBytes(ip) {
+  // Drop any zone identifier (e.g. fe80::1%eth0).
+  let addr = ip.toLowerCase().split('%')[0];
+
+  // Fold an embedded dotted-quad IPv4 tail into two hextets so the address
+  // becomes pure hex. This is what lets the mapped-hex form and the
+  // dotted form normalize to the same 16 octets.
+  const lastColon = addr.lastIndexOf(':');
+  if (lastColon !== -1 && addr.slice(lastColon + 1).includes('.')) {
+    const v4 = addr.slice(lastColon + 1);
+    if (net.isIP(v4) !== 4) return null;
+    const [a, b, c, d] = v4.split('.').map(Number);
+    addr =
+      addr.slice(0, lastColon + 1) +
+      (((a << 8) | b) >>> 0).toString(16) +
+      ':' +
+      (((c << 8) | d) >>> 0).toString(16);
+  }
+
+  const halves = addr.split('::');
+  if (halves.length > 2) return null; // more than one '::' is illegal
+
+  const head = halves[0] ? halves[0].split(':') : [];
+  let hextets;
+  if (halves.length === 2) {
+    const tail = halves[1] ? halves[1].split(':') : [];
+    const missing = 8 - head.length - tail.length;
+    if (missing < 0) return null;
+    hextets = [...head, ...Array(missing).fill('0'), ...tail];
+  } else {
+    hextets = head;
+  }
+  if (hextets.length !== 8) return null;
+
+  const bytes = [];
+  for (const h of hextets) {
+    if (!/^[0-9a-f]{1,4}$/.test(h)) return null;
+    const val = parseInt(h, 16);
+    bytes.push((val >> 8) & 0xff, val & 0xff);
+  }
+  return bytes;
+}
+
+/**
+ * Classify a 16-octet IPv6 address (as bytes) as private/sensitive.
+ *
+ * Decodes IPv4-in-IPv6 transition wrappers to the embedded IPv4 and
+ * classifies that instead, so e.g. `::ffff:a9fe:a9fe`, `::ffff:169.254.169.254`,
+ * and `64:ff9b::169.254.169.254` all resolve to 169.254.169.254 and are blocked.
+ *
+ * Blocks: unspecified (::), loopback (::1), multicast (ff00::/8),
+ * link-local (fe80::/10), unique-local (fc00::/7), and any wrapper whose
+ * embedded IPv4 is private.
+ *
+ * @param {number[]} b - 16 octets
+ * @returns {boolean} True if the address is in a blocked range
+ */
+export function isPrivateIPv6Bytes(b) {
+  const zeroRange = (start, end) => b.slice(start, end).every(x => x === 0);
+
+  if (zeroRange(0, 16)) return true; // :: unspecified
+  if (zeroRange(0, 15) && b[15] === 1) return true; // ::1 loopback
+  if (b[0] === 0xff) return true; // ff00::/8 multicast
+  if (b[0] === 0xfe && (b[1] & 0xc0) === 0x80) return true; // fe80::/10 link-local
+  if ((b[0] & 0xfe) === 0xfc) return true; // fc00::/7 unique-local (fc/fd)
+
+  // IPv4-mapped ::ffff:0:0/96 -> classify embedded IPv4
+  if (zeroRange(0, 10) && b[10] === 0xff && b[11] === 0xff) {
+    return isPrivateIPv4Bytes(b.slice(12));
+  }
+  // IPv4-compatible ::/96 (deprecated) -> classify embedded IPv4
+  if (zeroRange(0, 12)) {
+    return isPrivateIPv4Bytes(b.slice(12));
+  }
+  // NAT64 64:ff9b::/96 -> classify embedded IPv4
+  if (b[0] === 0x00 && b[1] === 0x64 && b[2] === 0xff && b[3] === 0x9b && zeroRange(4, 12)) {
+    return isPrivateIPv4Bytes(b.slice(12));
+  }
+  return false;
+}
+
+/**
+ * Check whether a single IP address literal (v4 or v6, in any serialization)
+ * belongs to a private or otherwise sensitive network range.
+ *
+ * IPv6 is parsed to its canonical 16 octets and classified by range, rather
+ * than matched textually. This closes serialization-based SSRF bypasses such
+ * as the IPv4-mapped hex form `::ffff:a9fe:a9fe` (== 169.254.169.254), which a
+ * dotted-decimal regex would miss.
+ *
+ * @param {string} ip - The IP address to check
+ * @returns {boolean} True if the IP is in a blocked range
+ */
+export function isPrivateIP(ip) {
+  if (!ip) return true; // be safe: unknown is blocked
+  const family = net.isIP(ip);
+
+  if (family === 4) {
+    return isPrivateIPv4Bytes(ip.split('.').map(Number));
+  }
+
+  if (family === 6) {
+    const bytes = ipv6ToBytes(ip);
+    if (!bytes) return true; // unparseable IPv6 literal -> block to be safe
+    return isPrivateIPv6Bytes(bytes);
+  }
+
+  // Not a valid IP literal -- callers should resolve DNS first.
+  return false;
+}
+
+/**
+ * SSRF guard: resolve the URL's hostname to one or more IP addresses and
+ * verify every resolved IP is in a public range. Catches DNS-based
+ * bypasses where an external hostname resolves to a private IP.
+ *
+ * On success returns the set of validated public addresses so the caller can
+ * pin the connection to them (see {@link createPinnedLookup}) and avoid a
+ * DNS-rebinding window between this check and the actual fetch.
+ *
+ * @param {URL} parsedUrl - The parsed request URL
+ * @returns {Promise<{ok: boolean, reason?: string, addresses?: string[]}>}
+ */
+export async function assertPublicTarget(parsedUrl) {
+  // Strip IPv6 brackets that URL parsing leaves on the hostname.
+  let host = parsedUrl.hostname;
+  if (host.startsWith('[') && host.endsWith(']')) {
+    host = host.slice(1, -1);
+  }
+
+  // Block obvious magic hostnames before DNS even runs.
+  const lowerHost = host.toLowerCase();
+  if (lowerHost === 'localhost' || lowerHost.endsWith('.localhost')) {
+    return { ok: false, reason: 'localhost is blocked' };
+  }
+
+  // If the hostname is already an IP literal, check it directly. No DNS is
+  // performed for literals, so there is nothing to pin/rebind.
+  if (net.isIP(host)) {
+    return isPrivateIP(host)
+      ? { ok: false, reason: `IP ${host} is private` }
+      : { ok: true, addresses: [host] };
+  }
+
+  // Resolve A and AAAA. If both fail we'll reject; if either resolves to a
+  // private IP we reject. Any unresolved family is ignored (not all hosts
+  // have both records).
+  let addrs = [];
+  try {
+    const [v4, v6] = await Promise.allSettled([dns.resolve4(host), dns.resolve6(host)]);
+    if (v4.status === 'fulfilled') addrs.push(...v4.value);
+    if (v6.status === 'fulfilled') addrs.push(...v6.value);
+  } catch (err) {
+    return { ok: false, reason: `DNS resolution failed: ${err.message}` };
+  }
+
+  if (addrs.length === 0) {
+    return { ok: false, reason: 'host did not resolve to any IP' };
+  }
+
+  for (const addr of addrs) {
+    if (isPrivateIP(addr)) {
+      return { ok: false, reason: `host resolves to private IP ${addr}` };
+    }
+  }
+  return { ok: true, addresses: addrs };
+}
+
+/**
+ * Build a `dns.lookup`-compatible function that pins resolution to a fixed set
+ * of pre-validated public addresses.
+ *
+ * Passing this as the connection's `lookup` closes the DNS-rebinding window:
+ * without it, {@link assertPublicTarget} validates the records returned by one
+ * resolution but the fetch re-resolves at connect time, so an attacker who
+ * controls the authoritative DNS can answer "public" during the check and
+ * "private" at connect. Here the connection can only ever reach an address
+ * that already passed the guard, and each address is re-checked for good
+ * measure before it is handed back.
+ *
+ * Note: this only takes effect for direct connections. When an HTTP proxy is
+ * configured the proxy performs egress DNS itself and is treated as the trust
+ * boundary, so the lookup is not applied there.
+ *
+ * @param {string[]} addresses - Validated public IP addresses
+ * @returns {Function} A `(hostname, options, callback)` lookup function
+ */
+export function createPinnedLookup(addresses) {
+  const allowed = [...new Set(addresses || [])];
+  return function pinnedLookup(hostname, options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = {};
+    } else if (typeof options === 'number') {
+      options = { family: options };
+    }
+    options = options || {};
+
+    const wantFamily = options.family || 0;
+    const entries = [];
+    for (const addr of allowed) {
+      const fam = net.isIP(addr);
+      if (fam === 0) continue;
+      if (wantFamily && wantFamily !== fam) continue;
+      if (isPrivateIP(addr)) continue; // defense-in-depth re-check
+      entries.push({ address: addr, family: fam });
+    }
+
+    if (entries.length === 0) {
+      const err = new Error(`pinned lookup: no validated public address for ${hostname}`);
+      err.code = 'ENOTFOUND';
+      return callback(err);
+    }
+
+    if (options.all) return callback(null, entries);
+    return callback(null, entries[0].address, entries[0].family);
+  };
+}

--- a/server/utils/httpConfig.js
+++ b/server/utils/httpConfig.js
@@ -315,7 +315,12 @@ export function matchesProxyPattern(url, patterns) {
  */
 function createDirectAgent(isHttps, shouldIgnoreSSL, lookup = null) {
   const options = {};
-  if (shouldIgnoreSSL) options.rejectUnauthorized = false;
+  // Admin opt-in only: reached solely when shouldIgnoreSSL is true, which
+  // requires ssl.ignoreInvalidCertificates=true AND an explicit per-domain
+  // whitelist match (see shouldIgnoreSSLForURL / isDomainWhitelisted). This is
+  // pre-existing, intentional behavior consolidated here from three prior call
+  // sites; it is not introduced by this change.
+  if (shouldIgnoreSSL) options.rejectUnauthorized = false; // codeql[js/disabling-certificate-validation]
   if (typeof lookup === 'function') options.lookup = lookup;
 
   if (Object.keys(options).length === 0 && !isHttps) {

--- a/server/utils/httpConfig.js
+++ b/server/utils/httpConfig.js
@@ -3,6 +3,7 @@
  * Provides centralized configuration for HTTP clients including SSL and proxy settings.
  * All outbound HTTP calls should use httpFetch() to ensure proxy/SSL configuration is applied.
  */
+import http from 'http';
 import https from 'https';
 import nodeFetch from 'node-fetch';
 import { HttpProxyAgent } from 'http-proxy-agent';
@@ -299,12 +300,42 @@ export function matchesProxyPattern(url, patterns) {
 }
 
 /**
+ * Build an agent for a direct (non-proxied) connection.
+ *
+ * Returns `undefined` (letting the fetch library use its default agent) when
+ * no SSL bypass and no pinned DNS lookup are required, preserving prior
+ * behavior. When a `lookup` is supplied it is attached to a concrete agent so
+ * the connection resolves only to the caller-validated addresses (SSRF DNS
+ * pinning); the lookup is intentionally never attached to proxy agents.
+ *
+ * @param {boolean} isHttps - Whether the request is HTTPS
+ * @param {boolean} shouldIgnoreSSL - Whether to disable certificate validation
+ * @param {Function|null} lookup - Optional dns.lookup-compatible function to pin DNS
+ * @returns {http.Agent|https.Agent|undefined}
+ */
+function createDirectAgent(isHttps, shouldIgnoreSSL, lookup = null) {
+  const options = {};
+  if (shouldIgnoreSSL) options.rejectUnauthorized = false;
+  if (typeof lookup === 'function') options.lookup = lookup;
+
+  if (Object.keys(options).length === 0 && !isHttps) {
+    return undefined; // nothing to customize for plain HTTP -> default agent
+  }
+  if (Object.keys(options).length === 0) {
+    return undefined; // plain HTTPS with default settings -> default agent
+  }
+  return isHttps ? new https.Agent(options) : new http.Agent(options);
+}
+
+/**
  * Create HTTP/HTTPS agent with global SSL and proxy configuration
  * @param {string} url - Request URL (used to determine protocol and proxy bypass)
  * @param {boolean} [forceIgnoreSSL] - Force ignore SSL (overrides global setting)
+ * @param {Function} [lookup] - Optional dns.lookup-compatible function to pin DNS resolution
+ *   for direct connections (used by the SSRF guard). Ignored for proxied requests.
  * @returns {http.Agent|https.Agent|HttpProxyAgent|HttpsProxyAgent|undefined} Agent with appropriate configuration
  */
-export function createAgent(url = '', forceIgnoreSSL = null) {
+export function createAgent(url = '', forceIgnoreSSL = null, lookup = null) {
   // Always call getSSLConfig() to ensure configuration is loaded
   const sslConfig = getSSLConfig();
   const proxyConfig = getProxyConfig();
@@ -323,11 +354,8 @@ export function createAgent(url = '', forceIgnoreSSL = null) {
   // Check if proxy should be bypassed for this URL
   if (proxyConfig.enabled && proxyConfig.noProxy && shouldBypassProxy(url, proxyConfig.noProxy)) {
     logger.info('Bypassing proxy for URL', { component: 'HttpConfig', url });
-    // Return standard agent with SSL configuration if needed
-    if (isHttps && shouldIgnoreSSL) {
-      return new https.Agent({ rejectUnauthorized: false });
-    }
-    return undefined;
+    // Direct connection: apply SSL bypass and/or DNS pinning as needed.
+    return createDirectAgent(isHttps, shouldIgnoreSSL, lookup);
   }
 
   // Check if URL matches selective proxy patterns
@@ -338,11 +366,8 @@ export function createAgent(url = '', forceIgnoreSSL = null) {
     !matchesProxyPattern(url, proxyConfig.urlPatterns)
   ) {
     logger.info('URL does not match proxy patterns', { component: 'HttpConfig', url });
-    // Return standard agent with SSL configuration if needed
-    if (isHttps && shouldIgnoreSSL) {
-      return new https.Agent({ rejectUnauthorized: false });
-    }
-    return undefined;
+    // Direct connection: apply SSL bypass and/or DNS pinning as needed.
+    return createDirectAgent(isHttps, shouldIgnoreSSL, lookup);
   }
 
   // Apply proxy configuration
@@ -370,25 +395,22 @@ export function createAgent(url = '', forceIgnoreSSL = null) {
     }
   }
 
-  // No proxy path: optionally bypass SSL via plain https.Agent.
+  // No proxy path: optionally bypass SSL and/or pin DNS via a direct agent.
   if (isHttps && shouldIgnoreSSL) {
     logger.info('SSL certificate verification disabled for direct HTTPS request', {
       component: 'HttpConfig',
       url
     });
-    return new https.Agent({ rejectUnauthorized: false });
-  }
-
-  // No agent applied. If the request later fails with a TLS error, the operator can
-  // look at the preceding shouldIgnoreSSLForURL log to see why bypass was skipped.
-  if (isHttps) {
+  } else if (isHttps && typeof lookup !== 'function') {
+    // No agent applied. If the request later fails with a TLS error, the operator can
+    // look at the preceding shouldIgnoreSSLForURL log to see why bypass was skipped.
     logger.debug('No SSL bypass agent applied for HTTPS request', {
       component: 'HttpConfig',
       url,
       proxyConfigured: Boolean(proxyConfig.https)
     });
   }
-  return undefined;
+  return createDirectAgent(isHttps, shouldIgnoreSSL, lookup);
 }
 
 /**
@@ -396,14 +418,15 @@ export function createAgent(url = '', forceIgnoreSSL = null) {
  * @param {Object} options - Existing fetch options
  * @param {string} url - Request URL
  * @param {boolean} [forceIgnoreSSL] - Force ignore SSL (overrides global setting)
+ * @param {Function} [lookup] - Optional dns.lookup-compatible function to pin DNS resolution
  * @returns {Object} Enhanced fetch options
  */
-export function enhanceFetchOptions(options = {}, url = '', forceIgnoreSSL = null) {
+export function enhanceFetchOptions(options = {}, url = '', forceIgnoreSSL = null, lookup = null) {
   const enhancedOptions = { ...options };
 
   // Only add agent if not already specified
   if (!enhancedOptions.agent) {
-    const agent = createAgent(url, forceIgnoreSSL);
+    const agent = createAgent(url, forceIgnoreSSL, lookup);
     if (agent) {
       enhancedOptions.agent = agent;
     }
@@ -420,7 +443,9 @@ export function enhanceFetchOptions(options = {}, url = '', forceIgnoreSSL = nul
  * All outbound HTTP calls in the server should use this function.
  *
  * @param {string} url - The URL to fetch
- * @param {Object} [options] - Standard fetch options (method, headers, body, signal, etc.)
+ * @param {Object} [options] - Standard fetch options (method, headers, body, signal, etc.).
+ *   A `lookup` property (dns.lookup-compatible) is extracted to pin DNS resolution for
+ *   direct connections and is not forwarded to the underlying fetch.
  * @param {boolean} [forceIgnoreSSL] - Force ignore SSL (overrides global setting)
  * @returns {Promise<Response>} node-fetch Response
  */
@@ -432,6 +457,9 @@ export async function httpFetch(url, options = {}, forceIgnoreSSL = null) {
       throw new Error(`Unsupported URL scheme: ${scheme}`);
     }
   }
-  const enhanced = enhanceFetchOptions(options, url, forceIgnoreSSL);
+  // `lookup` is not a node-fetch option; pull it out and apply it to the agent
+  // (used by the workflow SSRF guard to pin connections to validated IPs).
+  const { lookup = null, ...fetchOptions } = options;
+  const enhanced = enhanceFetchOptions(fetchOptions, url, forceIgnoreSSL, lookup);
   return nodeFetch(url, enhanced);
 }

--- a/tests/unit/server/httpNodeExecutorSsrf.test.js
+++ b/tests/unit/server/httpNodeExecutorSsrf.test.js
@@ -1,0 +1,149 @@
+/**
+ * SSRF guard regression tests for the workflow HTTP node executor.
+ *
+ * Pins the fix for the IPv4-mapped-IPv6 hex bypass (GHSA-fp9c-pq7w-vr34):
+ * `http://[::ffff:a9fe:a9fe]/` decodes to 169.254.169.254 (AWS IMDS) and must
+ * be classified as private regardless of serialization. Also covers the
+ * additional classification gaps (NAT64, 100.64.0.0/10) and the DNS-pinning
+ * lookup that closes the rebinding window.
+ */
+import { describe, expect, test } from '@jest/globals';
+import {
+  isPrivateIP,
+  ipv6ToBytes,
+  assertPublicTarget,
+  createPinnedLookup
+} from '../../../server/services/workflow/executors/ssrfGuard.js';
+
+describe('isPrivateIP — IPv4-mapped IPv6 hex bypass (GHSA-fp9c-pq7w-vr34)', () => {
+  test('blocks the canonical mapped-hex form of AWS IMDS', () => {
+    // ::ffff:a9fe:a9fe == 169.254.169.254
+    expect(isPrivateIP('::ffff:a9fe:a9fe')).toBe(true);
+  });
+
+  test('blocks the mapped-hex form of loopback', () => {
+    // ::ffff:7f00:1 == 127.0.0.1
+    expect(isPrivateIP('::ffff:7f00:1')).toBe(true);
+  });
+
+  test('blocks the dotted mapped form of IMDS (already covered, stays covered)', () => {
+    expect(isPrivateIP('::ffff:169.254.169.254')).toBe(true);
+  });
+
+  test('both serializations decode to the same octets', () => {
+    expect(ipv6ToBytes('::ffff:a9fe:a9fe')).toEqual(ipv6ToBytes('::ffff:169.254.169.254'));
+  });
+
+  test('does NOT over-block a mapped public address', () => {
+    expect(isPrivateIP('::ffff:8.8.8.8')).toBe(false);
+    expect(isPrivateIP('::ffff:0808:0808')).toBe(false);
+  });
+});
+
+describe('isPrivateIP — IPv4 ranges', () => {
+  test.each([
+    ['10.0.0.1', true],
+    ['127.0.0.1', true],
+    ['169.254.169.254', true],
+    ['172.16.0.1', true],
+    ['172.31.255.255', true],
+    ['192.168.1.1', true],
+    ['0.0.0.0', true],
+    ['100.64.0.1', true], // CGNAT / shared address space (RFC 6598)
+    ['100.127.255.255', true],
+    ['224.0.0.1', true], // multicast
+    ['8.8.8.8', false],
+    ['1.1.1.1', false],
+    ['100.63.255.255', false], // just below 100.64/10
+    ['100.128.0.0', false] // just above 100.64/10
+  ])('%s -> %s', (ip, expected) => {
+    expect(isPrivateIP(ip)).toBe(expected);
+  });
+});
+
+describe('isPrivateIP — IPv6 ranges', () => {
+  test.each([
+    ['::1', true], // loopback
+    ['::', true], // unspecified
+    ['fe80::1', true], // link-local
+    ['fc00::1', true], // ULA
+    ['fd12:3456::1', true], // ULA
+    ['ff02::1', true], // multicast
+    ['64:ff9b::169.254.169.254', true], // NAT64 wrapping IMDS
+    ['64:ff9b::a9fe:a9fe', true], // NAT64 wrapping IMDS (hex)
+    ['2606:4700:4700::1111', false], // public (Cloudflare)
+    ['2001:4860:4860::8888', false] // public (Google)
+  ])('%s -> %s', (ip, expected) => {
+    expect(isPrivateIP(ip)).toBe(expected);
+  });
+
+  test('unparseable / empty inputs are blocked (fail closed)', () => {
+    expect(isPrivateIP('')).toBe(true);
+    expect(isPrivateIP(null)).toBe(true);
+  });
+});
+
+describe('assertPublicTarget — IP literal targets', () => {
+  test('rejects the mapped-hex IMDS literal', async () => {
+    const res = await assertPublicTarget(new URL('http://[::ffff:a9fe:a9fe]/latest/meta-data/'));
+    expect(res.ok).toBe(false);
+  });
+
+  test('rejects localhost before any DNS', async () => {
+    const res = await assertPublicTarget(new URL('http://localhost:8080/'));
+    expect(res.ok).toBe(false);
+  });
+
+  test('accepts a public IP literal and returns it for pinning', async () => {
+    const res = await assertPublicTarget(new URL('http://8.8.8.8/'));
+    expect(res.ok).toBe(true);
+    expect(res.addresses).toEqual(['8.8.8.8']);
+  });
+});
+
+describe('createPinnedLookup — DNS rebinding protection', () => {
+  const call = (lookup, hostname, options) =>
+    new Promise(resolve => {
+      lookup(hostname, options, (err, address, family) => resolve({ err, address, family }));
+    });
+
+  test('returns only the pre-validated address', async () => {
+    const lookup = createPinnedLookup(['93.184.216.34']);
+    const { err, address, family } = await call(lookup, 'example.com', {});
+    expect(err).toBeFalsy();
+    expect(address).toBe('93.184.216.34');
+    expect(family).toBe(4);
+  });
+
+  test('supports the all:true (Happy Eyeballs) form', async () => {
+    const lookup = createPinnedLookup(['93.184.216.34', '2606:2800:220:1::1']);
+    const { err, address: entries } = await call(lookup, 'example.com', { all: true });
+    expect(err).toBeFalsy();
+    expect(entries).toEqual([
+      { address: '93.184.216.34', family: 4 },
+      { address: '2606:2800:220:1::1', family: 6 }
+    ]);
+  });
+
+  test('filters by requested family', async () => {
+    const lookup = createPinnedLookup(['93.184.216.34', '2606:2800:220:1::1']);
+    const v6 = await call(lookup, 'example.com', { family: 6 });
+    expect(v6.address).toBe('2606:2800:220:1::1');
+    const v4 = await call(lookup, 'example.com', { family: 4 });
+    expect(v4.address).toBe('93.184.216.34');
+  });
+
+  test('re-checks addresses and refuses a private one (defense in depth)', async () => {
+    const lookup = createPinnedLookup(['169.254.169.254']);
+    const { err } = await call(lookup, 'evil.example', {});
+    expect(err).toBeTruthy();
+    expect(err.code).toBe('ENOTFOUND');
+  });
+
+  test('errors when no address matches the requested family', async () => {
+    const lookup = createPinnedLookup(['93.184.216.34']);
+    const { err } = await call(lookup, 'example.com', { family: 6 });
+    expect(err).toBeTruthy();
+    expect(err.code).toBe('ENOTFOUND');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes **GHSA-fp9c-pq7w-vr34**: the SSRF guard for workflow HTTP-request nodes (`HttpNodeExecutor`) could be bypassed with an IPv4-mapped IPv6 address in hex form, e.g. `http://[::ffff:a9fe:a9fe]/` — which is `169.254.169.254`, the cloud instance-metadata address the guard is meant to block.

### Root cause
`isPrivateIP()` only recognized IPv4-mapped IPv6 through a dotted-decimal regex (`/^::ffff:(\d+\.\d+\.\d+\.\d+)$/`). The canonical hex serialization `::ffff:a9fe:a9fe` (which Node's WHATWG `URL` preserves) didn't match, so the function fell through to `return false` and the address was treated as public. Node then connects the mapped literal to the embedded IPv4, reaching internal hosts / cloud metadata.

## Changes

- **Classify IPv6 by range, not by text.** Extracted the guard into `server/services/workflow/executors/ssrfGuard.js`. IPv6 literals are now parsed to their canonical 16 octets and classified by network range. Every IPv4-in-IPv6 transition wrapper — `::ffff:` (mapped), `::` (compatible), and `64:ff9b::` (NAT64) — is decoded to the embedded IPv4 before checking, so the mapped-hex, dotted, and NAT64 forms of an internal address are all blocked. Unparseable IPv6 now **fails closed**.
- **Added `100.64.0.0/10`** (RFC 6598 shared / CGNAT) to the IPv4 blocklist.
- **DNS-rebinding pin.** `assertPublicTarget()` returns the validated addresses, and the request is pinned to them via a custom `dns.lookup` (`createPinnedLookup`) that re-checks each address. This closes the window where a hostname could resolve to a public IP during the check and an internal IP at connect time. Threaded through `httpFetch`/`createAgent` for **direct connections**; intentionally skipped under an HTTP proxy, where the proxy is the egress boundary.

## Behavioral notes
- No configuration change required.
- `createAgent`/`enhanceFetchOptions`/`httpFetch` gain an optional `lookup` parameter; default behavior for all existing callers is unchanged (still returns `undefined` → fetch default agent when no SSL bypass / pin is needed).

## Testing
- New unit suite `tests/unit/server/httpNodeExecutorSsrf.test.js` (38 cases): the mapped-hex bypass, IPv4/IPv6 range tables, NAT64, `100.64.0.0/10`, fail-closed inputs, IP-literal `assertPublicTarget` rejection, and the pinned-lookup (family filtering, `all:true` Happy-Eyeballs form, defense-in-depth re-check). All pass.
- Verified end-to-end that node-fetch honors the agent-level `lookup`, so the pin actually reaches the connection.
- `eslint` + `prettier` clean on all touched files.

> Note: a few `tests/integration/workflows` cases fail in CI-fresh checkouts because `contents/` isn't provisioned (ENOENT on workflow JSON) — pre-existing and unrelated to this change.

https://claude.ai/code/session_01Rzn76oavbyU3AjpDjEJKZD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rzn76oavbyU3AjpDjEJKZD)_