### PR TITLE
feat(audit): expand audit logging to auth, OAuth, and user events

### DIFF
--- a/client/src/features/admin/pages/AdminAuditLogPage.jsx
+++ b/client/src/features/admin/pages/AdminAuditLogPage.jsx
@@ -25,10 +25,33 @@ const RESOURCE_TYPES = [
   'backup',
   'source',
   'feature',
-  'provider'
+  'provider',
+  'auth',
+  'user',
+  'oauthClient',
+  'oauthToken'
 ];
 
-const ACTION_TYPES = ['all', 'create', 'update', 'delete', 'toggle', 'import', 'export'];
+const ACTION_TYPES = [
+  'all',
+  'create',
+  'update',
+  'delete',
+  'toggle',
+  'import',
+  'export',
+  'login',
+  'logout'
+];
+
+const RESULT_TYPES = ['all', 'success', 'failure'];
+
+const SOURCE_TYPES = ['all', 'web', 'admin', 'api', 'mcp'];
+
+const RESULT_PILL_COLORS = {
+  success: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  failure: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
+};
 
 const DEFAULT_PAGE_SIZE = 50;
 
@@ -54,6 +77,18 @@ function ActionPill({ action }) {
       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colorClass}`}
     >
       {action}
+    </span>
+  );
+}
+
+function ResultPill({ result }) {
+  const value = result || 'success';
+  const colorClass = RESULT_PILL_COLORS[value] || DEFAULT_PILL_COLOR;
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colorClass}`}
+    >
+      {value}
     </span>
   );
 }
@@ -183,9 +218,11 @@ function AdminAuditLogPage() {
 
   const [fromDate, setFromDate] = useFilterState('from', getDefaultFromDate());
   const [toDate, setToDate] = useFilterState('to', getDefaultToDate());
-  const [adminFilter, setAdminFilter] = useFilterState('admin', 'all');
+  const [actorFilter, setActorFilter] = useFilterState('actor', 'all');
   const [resourceFilter, setResourceFilter] = useFilterState('resource', 'all');
   const [actionFilter, setActionFilter] = useFilterState('action', 'all');
+  const [resultFilter, setResultFilter] = useFilterState('result', 'all');
+  const [sourceFilter, setSourceFilter] = useFilterState('source', 'all');
   const [pageParam, setPageParam] = useFilterState('page', '1');
   const [pageSizeParam, setPageSizeParam] = useFilterState('pageSize', String(DEFAULT_PAGE_SIZE));
 
@@ -194,7 +231,47 @@ function AdminAuditLogPage() {
   const offset = (page - 1) * pageSize;
 
   const [expandedRows, setExpandedRows] = useState(new Set());
-  const [adminList, setAdminList] = useState([]);
+  const [actorList, setActorList] = useState([]);
+  const [exporting, setExporting] = useState(false);
+
+  const buildFilterParams = useCallback(() => {
+    const params = new URLSearchParams();
+    if (fromDate) params.set('from', fromDate);
+    if (toDate) params.set('to', toDate);
+    if (actorFilter && actorFilter !== 'all') params.set('actor', actorFilter);
+    if (resourceFilter && resourceFilter !== 'all') params.set('resource', resourceFilter);
+    if (actionFilter && actionFilter !== 'all') params.set('action', actionFilter);
+    if (resultFilter && resultFilter !== 'all') params.set('result', resultFilter);
+    if (sourceFilter && sourceFilter !== 'all') params.set('source', sourceFilter);
+    return params;
+  }, [fromDate, toDate, actorFilter, resourceFilter, actionFilter, resultFilter, sourceFilter]);
+
+  const handleExport = useCallback(async () => {
+    setExporting(true);
+    try {
+      const params = buildFilterParams();
+      const response = await makeAdminApiCall(`/admin/audit-log/export?${params.toString()}`, {
+        responseType: 'blob'
+      });
+      const blob = new Blob([response.data], { type: 'text/csv' });
+      const url = window.URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = `audit-log-${getDefaultToDate()}.csv`;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+    } catch (err) {
+      setError(
+        err.response?.data?.error ||
+          err.message ||
+          t('admin.auditLog.exportError', 'Failed to export audit log')
+      );
+    } finally {
+      setExporting(false);
+    }
+  }, [buildFilterParams, t]);
 
   const toggleRow = id => {
     setExpandedRows(prev => {
@@ -209,12 +286,7 @@ function AdminAuditLogPage() {
     setLoading(true);
     setError(null);
     try {
-      const params = new URLSearchParams();
-      if (fromDate) params.set('from', fromDate);
-      if (toDate) params.set('to', toDate);
-      if (adminFilter && adminFilter !== 'all') params.set('admin', adminFilter);
-      if (resourceFilter && resourceFilter !== 'all') params.set('resource', resourceFilter);
-      if (actionFilter && actionFilter !== 'all') params.set('action', actionFilter);
+      const params = buildFilterParams();
       params.set('limit', String(pageSize));
       params.set('offset', String(offset));
 
@@ -225,10 +297,11 @@ function AdminAuditLogPage() {
       setTotal(data.total || 0);
 
       if (data.entries && data.entries.length > 0) {
-        setAdminList(prev => {
+        setActorList(prev => {
           const existing = new Set(prev);
           for (const entry of data.entries) {
-            if (entry.admin) existing.add(entry.admin);
+            const name = entry.actor?.username ?? entry.admin;
+            if (name) existing.add(name);
           }
           const sorted = Array.from(existing).sort();
           if (sorted.length !== prev.length || sorted.some((v, i) => v !== prev[i])) {
@@ -246,7 +319,7 @@ function AdminAuditLogPage() {
     } finally {
       setLoading(false);
     }
-  }, [fromDate, toDate, adminFilter, resourceFilter, actionFilter, offset, pageSize, t]);
+  }, [buildFilterParams, offset, pageSize, t]);
 
   useEffect(() => {
     fetchEntries();
@@ -266,12 +339,12 @@ function AdminAuditLogPage() {
       )
     },
     {
-      key: 'admin',
-      header: t('admin.auditLog.adminColumn', 'Admin'),
+      key: 'actor',
+      header: t('admin.auditLog.actorColumn', 'Actor'),
       hideBelow: 'md',
       render: e => (
         <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-          {e.admin || '-'}
+          {e.actor?.username ?? e.admin ?? '-'}
         </span>
       )
     },
@@ -281,11 +354,24 @@ function AdminAuditLogPage() {
       render: e => <ActionPill action={e.action} />
     },
     {
+      key: 'result',
+      header: t('admin.auditLog.resultColumn', 'Result'),
+      render: e => <ResultPill result={e.result} />
+    },
+    {
       key: 'resource',
       header: t('admin.auditLog.resourceColumn', 'Resource'),
       hideBelow: 'md',
       render: e => (
         <span className="text-sm text-gray-600 dark:text-gray-300">{e.resource || '-'}</span>
+      )
+    },
+    {
+      key: 'source',
+      header: t('admin.auditLog.sourceColumn', 'Source'),
+      hideBelow: 'lg',
+      render: e => (
+        <span className="text-sm text-gray-600 dark:text-gray-300">{e.source || '-'}</span>
       )
     },
     {
@@ -311,11 +397,30 @@ function AdminAuditLogPage() {
         <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
           {t('admin.auditLog.title', 'Audit Log')}
         </h1>
-        <AuditLogRetentionBadge t={t} />
+        <div className="flex items-center gap-4">
+          <AuditLogRetentionBadge t={t} />
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={exporting}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-md bg-indigo-600 text-white hover:bg-indigo-700 disabled:opacity-50"
+          >
+            <svg className="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+              <path
+                fillRule="evenodd"
+                d="M10 3a.75.75 0 01.75.75v6.69l1.72-1.72a.75.75 0 111.06 1.06l-3 3a.75.75 0 01-1.06 0l-3-3a.75.75 0 111.06-1.06l1.72 1.72V3.75A.75.75 0 0110 3zM3.75 13a.75.75 0 01.75.75v1.5c0 .414.336.75.75.75h9.5a.75.75 0 00.75-.75v-1.5a.75.75 0 011.5 0v1.5A2.25 2.25 0 0115.25 17.5h-9.5A2.25 2.25 0 013.5 15.25v-1.5A.75.75 0 013.75 13z"
+                clipRule="evenodd"
+              />
+            </svg>
+            {exporting
+              ? t('admin.auditLog.exporting', 'Exporting…')
+              : t('admin.auditLog.exportCsv', 'Export CSV')}
+          </button>
+        </div>
       </div>
 
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 mb-6">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-7 gap-4">
           <div>
             <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               {t('admin.auditLog.from', 'From')}
@@ -339,12 +444,12 @@ function AdminAuditLogPage() {
             />
           </div>
           <FilterSelect
-            label={t('admin.auditLog.admin', 'Admin')}
-            value={adminFilter}
-            onChange={handleFilterChange(setAdminFilter)}
+            label={t('admin.auditLog.actor', 'Actor')}
+            value={actorFilter}
+            onChange={handleFilterChange(setActorFilter)}
             options={[
-              { value: 'all', label: t('admin.auditLog.allAdmins', 'All Admins') },
-              ...adminList.map(a => ({ value: a, label: a }))
+              { value: 'all', label: t('admin.auditLog.allActors', 'All Actors') },
+              ...actorList.map(a => ({ value: a, label: a }))
             ]}
           />
           <FilterSelect
@@ -372,6 +477,30 @@ function AdminAuditLogPage() {
                 type === 'all'
                   ? t('admin.auditLog.allActions', 'All Actions')
                   : t(`admin.auditLog.action.${type}`, type.charAt(0).toUpperCase() + type.slice(1))
+            }))}
+          />
+          <FilterSelect
+            label={t('admin.auditLog.result', 'Result')}
+            value={resultFilter}
+            onChange={handleFilterChange(setResultFilter)}
+            options={RESULT_TYPES.map(type => ({
+              value: type,
+              label:
+                type === 'all'
+                  ? t('admin.auditLog.allResults', 'All Results')
+                  : t(`admin.auditLog.result.${type}`, type.charAt(0).toUpperCase() + type.slice(1))
+            }))}
+          />
+          <FilterSelect
+            label={t('admin.auditLog.source', 'Source')}
+            value={sourceFilter}
+            onChange={handleFilterChange(setSourceFilter)}
+            options={SOURCE_TYPES.map(type => ({
+              value: type,
+              label:
+                type === 'all'
+                  ? t('admin.auditLog.allSources', 'All Sources')
+                  : t(`admin.auditLog.source.${type}`, type.charAt(0).toUpperCase() + type.slice(1))
             }))}
           />
         </div>

--- a/client/src/features/admin/pages/AdminAuditLogPage.jsx
+++ b/client/src/features/admin/pages/AdminAuditLogPage.jsx
@@ -146,7 +146,7 @@ function AuditLogRetentionBadge({ t }) {
         className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 border border-gray-200 dark:border-gray-700"
         title={t(
           'admin.auditLog.retentionHint',
-          'Configured in platform.json → auditLog. Edit under Platform → Advanced.'
+          'Configured in platform.json → audit. Edit under Platform → Advanced.'
         )}
       >
         <svg className="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/client/src/features/admin/pages/AdminOverview.jsx
+++ b/client/src/features/admin/pages/AdminOverview.jsx
@@ -439,7 +439,7 @@ function RecentActivityCard({ entries }) {
                 <div className="min-w-0 flex-1">
                   <p className="text-sm text-gray-900 dark:text-gray-100 truncate">{e.summary}</p>
                   <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
-                    <span className="font-medium">{e.admin}</span>
+                    <span className="font-medium">{e.actor?.username ?? e.admin}</span>
                     <span className="mx-1.5">·</span>
                     {e.resource}
                     <span className="mx-1.5">·</span>

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -53,21 +53,33 @@ export default defineConfig({
         'nextcloud-full-embed': resolve(__dirname, 'nextcloud/full-embed.html')
       },
       output: {
-        manualChunks: {
-          // Vendor chunks
-          'vendor-react': ['react', 'react-dom', 'react-router-dom'],
-          'vendor-ui': ['@heroicons/react', 'react-icons', 'tailwindcss'],
-          'vendor-forms': ['react-quill', 'ajv', 'ajv-formats'],
-          'vendor-utils': ['axios', 'uuid', 'file-saver', 'fuse.js', 'marked', 'turndown'],
+        // Function form (object form is rejected by the rolldown-based Vite 8).
+        // Maps a module id to its vendor chunk by package name; anything not
+        // listed falls through to the default chunking.
+        manualChunks(id) {
+          if (!id.includes('node_modules')) return undefined;
+          const chunkMap = {
+            // Vendor chunks
+            'vendor-react': ['react', 'react-dom', 'react-router-dom'],
+            'vendor-ui': ['@heroicons/react', 'react-icons', 'tailwindcss'],
+            'vendor-forms': ['react-quill', 'ajv', 'ajv-formats'],
+            'vendor-utils': ['axios', 'uuid', 'file-saver', 'fuse.js', 'marked', 'turndown'],
 
-          // Heavy dependencies that should be separate
-          mermaid: ['mermaid'],
-          monaco: ['@monaco-editor/react'],
-          teams: ['@microsoft/teams-js', 'microsoft-cognitiveservices-speech-sdk'],
-          pdf: ['pdfjs-dist'],
-          babel: ['@babel/standalone'],
-          office: ['react-markdown'],
-          xlsx: ['xlsx']
+            // Heavy dependencies that should be separate
+            mermaid: ['mermaid'],
+            monaco: ['@monaco-editor/react'],
+            teams: ['@microsoft/teams-js', 'microsoft-cognitiveservices-speech-sdk'],
+            pdf: ['pdfjs-dist'],
+            babel: ['@babel/standalone'],
+            office: ['react-markdown'],
+            xlsx: ['xlsx']
+          };
+          for (const [chunk, pkgs] of Object.entries(chunkMap)) {
+            if (pkgs.some(pkg => id.includes(`node_modules/${pkg}/`))) {
+              return chunk;
+            }
+          }
+          return undefined;
         }
       }
     },

--- a/docs/releases/5.4.0/breaking-changes.md
+++ b/docs/releases/5.4.0/breaking-changes.md
@@ -15,3 +15,9 @@ Apps no longer configure a token limit. The context window and output cap now co
 - Model configs: `tokenLimit` is renamed to `contextWindow`; a new `maxOutputTokens` field controls the response cap.
 
 **Before upgrading:** No manual action required. A configuration migration runs automatically on startup — it renames `model.tokenLimit` to `contextWindow`, seeds a sensible per-provider `maxOutputTokens` default, and strips `tokenLimit` from all app configs. Review the seeded `maxOutputTokens` values afterward if you need larger responses for a specific model.
+
+## Audit config consolidated under a single `audit` block
+
+Audit retention settings moved from the top-level `auditLog` block into the unified `audit` block, alongside the new behavior/privacy options. `platform.auditLog.retentionDays` / `cleanupEnabled` are now `platform.audit.retentionDays` / `audit.cleanupEnabled`.
+
+**Before upgrading:** No manual action required. Migration `V059` moves any admin-configured `auditLog` values into `audit` and removes the legacy block automatically on startup. Update any external tooling that reads `platform.auditLog` to read `platform.audit` instead.

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -185,8 +185,8 @@ The Integrations page now shows each integration's status as a colored pill (**C
 
 The audit log now supports a configurable retention policy.
 
-- **Daily cleanup job** runs on the server (once on boot, then every 24 hours) and deletes daily JSONL files older than `auditLog.retentionDays`. Set `cleanupEnabled: false` to disable, or `retentionDays: -1` to keep entries forever.
-- **Default**: 365 days. New installations get this via migration `V049__add_audit_log_retention`.
+- **Daily cleanup job** runs on the server (once on boot, then every 24 hours) and deletes daily JSONL files older than `audit.retentionDays`. Set `audit.cleanupEnabled: false` to disable, or `retentionDays: -1` to keep entries forever.
+- **Default**: 365 days. Retention now lives in the unified `audit` config block (migrated automatically from the former `auditLog` block by `V059`).
 - **Audit Log page** shows a retention badge in the header (`Retain 365 days`) and a "Run cleanup now" link to trigger the job manually.
 - **New endpoints**: `GET /api/admin/audit-log/retention`, `POST /api/admin/audit-log/retention/run`.
 

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -200,7 +200,7 @@ The audit log now captures the security-relevant events that compliance reviews 
 - **Global safety net**: any other mutating admin request (POST/PUT/PATCH/DELETE) is recorded automatically, so new endpoints are covered without extra wiring.
 - **Richer entries**: each entry now records an `actor` (id, username, groups, authenticated), a `result` (`success`/`failure`), and a `source` (`web`/`admin`/`api`/`mcp`). The Audit Log page adds **Result** and **Source** columns and filters.
 - **CSV export**: an **Export CSV** button (and `GET /api/admin/audit-log/export`) downloads the currently filtered entries.
-- **Privacy & SIEM options** (`platform.json` → `audit`, added by migration `V057__add_audit_options`): `includeEmail` (default `false`) masks email-shaped identifiers; `verbosity` (`metadata`/`request`/`full`) controls how much request detail the safety net records; `winstonMirror` (default `false`) also emits entries to the structured logger (`component: audit`) for SIEM forwarding.
+- **Privacy & SIEM options** (`platform.json` → `audit`, added by migration `V059__add_audit_options`): `includeEmail` (default `false`) masks email-shaped identifiers; `verbosity` (`metadata`/`request`/`full`) controls how much request detail the safety net records; `winstonMirror` (default `false`) also emits entries to the structured logger (`component: audit`) for SIEM forwarding.
 
 ## Recent Activity Feed on Overview Dashboard
 

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -190,6 +190,18 @@ The audit log now supports a configurable retention policy.
 - **Audit Log page** shows a retention badge in the header (`Retain 365 days`) and a "Run cleanup now" link to trigger the job manually.
 - **New endpoints**: `GET /api/admin/audit-log/retention`, `POST /api/admin/audit-log/retention/run`.
 
+## Audit Log — Authentication, OAuth, and User Events + CSV Export
+
+The audit log now captures the security-relevant events that compliance reviews (SOC 2, ISO 27001, EU AI Act) expect, not just configuration changes:
+
+- **Authentication events**: successful and failed logins (local, LDAP, NTLM, OIDC) and logouts are recorded with the actor, outcome, and source. Failed logins capture the attempted username even though no session exists.
+- **OAuth clients & API keys**: creating, updating, deleting, and rotating client secrets, plus generating static API keys. Secrets and keys are never written to the log.
+- **User management**: creating, updating, and deleting user accounts. Passwords are never written to the log.
+- **Global safety net**: any other mutating admin request (POST/PUT/PATCH/DELETE) is recorded automatically, so new endpoints are covered without extra wiring.
+- **Richer entries**: each entry now records an `actor` (id, username, groups, authenticated), a `result` (`success`/`failure`), and a `source` (`web`/`admin`/`api`/`mcp`). The Audit Log page adds **Result** and **Source** columns and filters.
+- **CSV export**: an **Export CSV** button (and `GET /api/admin/audit-log/export`) downloads the currently filtered entries.
+- **Privacy & SIEM options** (`platform.json` → `audit`, added by migration `V057__add_audit_options`): `includeEmail` (default `false`) masks email-shaped identifiers; `verbosity` (`metadata`/`request`/`full`) controls how much request detail the safety net records; `winstonMirror` (default `false`) also emits entries to the structured logger (`component: audit`) for SIEM forwarding.
+
 ## Recent Activity Feed on Overview Dashboard
 
 The admin Overview now shows a **Recent activity** card listing the eight most recent audit log entries (action pill, summary, admin, resource, relative time). Clicking "View all" jumps to the filtered Audit Log page.

--- a/server/middleware/auditLogger.js
+++ b/server/middleware/auditLogger.js
@@ -1,5 +1,6 @@
 import configCache from '../configCache.js';
 import { logAudit } from '../services/AuditLogService.js';
+import { getContext } from '../utils/requestContext.js';
 
 /**
  * Global audit middleware — a blanket safety net that records mutating HTTP
@@ -29,7 +30,8 @@ const EXCLUDED_SEGMENTS = [
   'pages'
 ];
 
-const SENSITIVE_KEY_RE = /pass(word)?|secret|token|api[-_]?key|clientsecret|credential/i;
+const SENSITIVE_KEY_RE =
+  /pass(word)?|pwd|secret|token|api[-_]?key|client[-_]?secret|credential|priv(ate)?[-_]?key|passphrase|signing|\bpin\b|\botp\b|\bmfa\b|salt|authoriz|cookie|bearer/i;
 
 function getAuditConfig() {
   try {
@@ -45,7 +47,7 @@ function getAuditConfig() {
  * e.g. /api/admin/apps/my-app -> { resource: 'apps', resourceId: 'my-app' }
  *      /api/integrations/jira  -> { resource: 'integrations', resourceId: 'jira' }
  */
-function deriveResource(req) {
+export function deriveResource(req) {
   const path = (req.originalUrl || req.url || '').split('?')[0];
   const segments = path.split('/').filter(Boolean);
   const apiIdx = segments.indexOf('api');
@@ -61,11 +63,14 @@ function deriveResource(req) {
 
 function isExcluded(req) {
   const path = (req.originalUrl || req.url || '').split('?')[0];
+  // Admin mutations are always audit-worthy; never exclude them (otherwise a
+  // shared segment like 'pages' would silently skip /api/admin/pages CRUD).
+  if (path.includes('/api/admin/')) return false;
   const segments = path.split('/').filter(Boolean);
   return segments.some(s => EXCLUDED_SEGMENTS.includes(s));
 }
 
-function redact(value) {
+export function redact(value) {
   if (Array.isArray(value)) return value.map(redact);
   if (value && typeof value === 'object') {
     const out = {};
@@ -85,6 +90,15 @@ export function auditLogger() {
     const path = req.originalUrl || req.url || '';
     if (!path.includes('/api/')) return next();
     if (isExcluded(req)) return next();
+
+    // Only the safety net for AUTHENTICATED actors. Unauthenticated requests
+    // would let anyone flood the audit log with attacker-chosen paths; the
+    // security-relevant anonymous events (login attempts) have explicit hooks.
+    if (!req.user || req.user.id === 'anonymous') return next();
+
+    // Capture the requestId synchronously while we're still inside the request's
+    // async context — the res 'finish' callback may run on a later tick.
+    const requestId = getContext()?.requestId;
 
     res.on('finish', () => {
       try {
@@ -109,7 +123,7 @@ export function auditLogger() {
           }
         }
 
-        logAudit({ req, action, resource, resourceId, summary, result });
+        logAudit({ req, action, resource, resourceId, summary, result, requestId });
       } catch {
         // Never let audit logging affect the response lifecycle.
       }

--- a/server/middleware/auditLogger.js
+++ b/server/middleware/auditLogger.js
@@ -1,0 +1,122 @@
+import configCache from '../configCache.js';
+import { logAudit } from '../services/AuditLogService.js';
+
+/**
+ * Global audit middleware — a blanket safety net that records mutating HTTP
+ * requests that are not covered by an explicit logAudit() call.
+ *
+ * Explicit semantic hooks (auth, oauth clients, users, config CRUD, etc.) set
+ * `req._auditLogged` via logAudit(); this middleware skips those so we don't
+ * write a duplicate, coarser entry for the same request.
+ */
+
+const METHOD_ACTION = {
+  POST: 'create',
+  PUT: 'update',
+  PATCH: 'update',
+  DELETE: 'delete'
+};
+
+// Read/streaming/high-volume paths that should never be audited as mutations.
+const EXCLUDED_SEGMENTS = [
+  'chat',
+  'inference',
+  'sessions',
+  'magic-prompts',
+  'short-links',
+  'feedback',
+  'translations',
+  'pages'
+];
+
+const SENSITIVE_KEY_RE = /pass(word)?|secret|token|api[-_]?key|clientsecret|credential/i;
+
+function getAuditConfig() {
+  try {
+    const platform = configCache.getPlatform ? configCache.getPlatform() : {};
+    return platform?.audit || {};
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Derive a coarse { resource, resourceId } from the request path.
+ * e.g. /api/admin/apps/my-app -> { resource: 'apps', resourceId: 'my-app' }
+ *      /api/integrations/jira  -> { resource: 'integrations', resourceId: 'jira' }
+ */
+function deriveResource(req) {
+  const path = (req.originalUrl || req.url || '').split('?')[0];
+  const segments = path.split('/').filter(Boolean);
+  const apiIdx = segments.indexOf('api');
+  const rest = apiIdx >= 0 ? segments.slice(apiIdx + 1) : segments;
+  if (rest.length === 0) return { resource: 'unknown', resourceId: '' };
+
+  let idx = 0;
+  if (rest[0] === 'admin') idx = 1; // skip the 'admin' prefix
+  const resource = rest[idx] || 'unknown';
+  const resourceId = rest[idx + 1] || '';
+  return { resource, resourceId };
+}
+
+function isExcluded(req) {
+  const path = (req.originalUrl || req.url || '').split('?')[0];
+  const segments = path.split('/').filter(Boolean);
+  return segments.some(s => EXCLUDED_SEGMENTS.includes(s));
+}
+
+function redact(value) {
+  if (Array.isArray(value)) return value.map(redact);
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = SENSITIVE_KEY_RE.test(k) ? '***REDACTED***' : redact(v);
+    }
+    return out;
+  }
+  return value;
+}
+
+export function auditLogger() {
+  return (req, res, next) => {
+    const action = METHOD_ACTION[req.method];
+    if (!action) return next();
+
+    const path = req.originalUrl || req.url || '';
+    if (!path.includes('/api/')) return next();
+    if (isExcluded(req)) return next();
+
+    res.on('finish', () => {
+      try {
+        // An explicit logAudit() already covered this request.
+        if (req._auditLogged) return;
+
+        const verbosity = getAuditConfig().verbosity || 'metadata';
+        const { resource, resourceId } = deriveResource(req);
+        const result = res.statusCode < 400 ? 'success' : 'failure';
+
+        let summary = `${req.method} ${path.split('?')[0]} -> ${res.statusCode}`;
+        if (
+          (verbosity === 'request' || verbosity === 'full') &&
+          req.body &&
+          typeof req.body === 'object' &&
+          Object.keys(req.body).length > 0
+        ) {
+          try {
+            summary += ` body=${JSON.stringify(redact(req.body)).slice(0, 500)}`;
+          } catch {
+            // ignore body serialization issues
+          }
+        }
+
+        logAudit({ req, action, resource, resourceId, summary, result });
+      } catch {
+        // Never let audit logging affect the response lifecycle.
+      }
+    });
+
+    next();
+  };
+}
+
+export default auditLogger;

--- a/server/middleware/oidcAuth.js
+++ b/server/middleware/oidcAuth.js
@@ -10,6 +10,7 @@ import logger from '../utils/logger.js';
 import { buildServerPath } from '../utils/basePath.js';
 import { getAuthCookieOptions } from '../utils/cookieSettings.js';
 import { decodeIdTokenClaims } from '../utils/oidcIdToken.js';
+import { logAudit } from '../services/AuditLogService.js';
 
 // Store configured providers
 const configuredProviders = new Map();
@@ -737,6 +738,21 @@ export function createOidcCallbackHandler(providerName) {
           },
           sessionId
         );
+
+        logAudit({
+          req,
+          action: 'login',
+          resource: 'auth',
+          resourceId: user.id,
+          summary: `OIDC login succeeded (provider: ${providerName})`,
+          source: 'web',
+          actor: {
+            id: user.id,
+            username: user.username ?? user.name ?? user.email ?? user.id,
+            groups: user.groups || [],
+            authenticated: true
+          }
+        });
 
         // Check if there's an OAuth authorization flow in progress
         // If so, redirect back to the OAuth authorize endpoint to complete the flow

--- a/server/middleware/setup.js
+++ b/server/middleware/setup.js
@@ -19,6 +19,8 @@ import tokenStorageService from '../services/TokenStorageService.js';
 import logger from '../utils/logger.js';
 import { runWithContext, setContext } from '../utils/requestContext.js';
 import activityTracker from '../telemetry/ActivityTracker.js';
+import { auditLogger } from './auditLogger.js';
+import { randomUUID } from 'crypto';
 
 /**
  * Middleware to verify the Content-Length header before parsing the body.
@@ -409,7 +411,8 @@ export function setupMiddleware(app, platformConfig = {}) {
       {
         ip: req.ip,
         userId: undefined,
-        oauthClientId: undefined
+        oauthClientId: undefined,
+        requestId: randomUUID()
       },
       () => next()
     );
@@ -652,4 +655,9 @@ export function setupMiddleware(app, platformConfig = {}) {
     }
     next();
   });
+
+  // Global audit safety net. Registered after authentication so req.user is
+  // available; records mutating HTTP requests not covered by an explicit
+  // logAudit() call (which sets req._auditLogged to suppress duplicates).
+  app.use(auditLogger());
 }

--- a/server/migrations/V057__add_audit_options.js
+++ b/server/migrations/V057__add_audit_options.js
@@ -1,0 +1,33 @@
+/**
+ * Migration V057 — Add audit logging options to platform.json
+ *
+ * Introduces the `audit` configuration block that controls the expanded audit
+ * logging system (auth events, OAuth clients, users, and the global HTTP audit
+ * safety net):
+ *
+ *   - audit.includeEmail   When false (default), email-shaped actor identifiers
+ *                          are masked in audit entries for privacy.
+ *   - audit.verbosity      'metadata' (default), 'request', or 'full' — controls
+ *                          how much request detail the global middleware records.
+ *   - audit.winstonMirror  When true, audit entries are also emitted to the
+ *                          structured logger (component: 'audit') for SIEM routing.
+ *
+ * Existing admin-configured values are preserved; only missing keys get defaults.
+ */
+export const version = '057';
+export const description = 'add_audit_options';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  ctx.setDefault(platform, 'audit.includeEmail', false);
+  ctx.setDefault(platform, 'audit.verbosity', 'metadata');
+  ctx.setDefault(platform, 'audit.winstonMirror', false);
+
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Added audit options (includeEmail, verbosity, winstonMirror) to platform.json');
+}

--- a/server/migrations/V059__add_audit_options.js
+++ b/server/migrations/V059__add_audit_options.js
@@ -1,10 +1,11 @@
 /**
- * Migration V059 — Add audit logging options to platform.json
+ * Migration V059 — Consolidate audit config into a single `audit` block
  *
- * Introduces the `audit` configuration block that controls the expanded audit
- * logging system (auth events, OAuth clients, users, and the global HTTP audit
- * safety net):
+ * The expanded audit logging system uses one platform.json block, `audit`,
+ * for both retention and behavior/privacy:
  *
+ *   - audit.retentionDays  Daily JSONL files older than this are cleaned up.
+ *   - audit.cleanupEnabled Toggle for the retention cleanup job.
  *   - audit.includeEmail   When false (default), email-shaped actor identifiers
  *                          are masked in audit entries for privacy.
  *   - audit.verbosity      'metadata' (default), 'request', or 'full' — controls
@@ -12,7 +13,10 @@
  *   - audit.winstonMirror  When true, audit entries are also emitted to the
  *                          structured logger (component: 'audit') for SIEM routing.
  *
- * Existing admin-configured values are preserved; only missing keys get defaults.
+ * Retention previously lived in a separate top-level `auditLog` block (added by
+ * V049). This migration moves any admin-configured values from `auditLog` into
+ * `audit`, then removes the legacy block. Existing values are preserved; only
+ * missing keys get defaults.
  */
 export const version = '059';
 export const description = 'add_audit_options';
@@ -24,10 +28,23 @@ export async function precondition(ctx) {
 export async function up(ctx) {
   const platform = await ctx.readJson('config/platform.json');
 
+  // Carry forward retention settings from the legacy `auditLog` block (V049).
+  const legacy = platform.auditLog || {};
+  ctx.setDefault(
+    platform,
+    'audit.retentionDays',
+    Number.isFinite(legacy.retentionDays) ? legacy.retentionDays : 365
+  );
+  ctx.setDefault(platform, 'audit.cleanupEnabled', legacy.cleanupEnabled !== false);
+
+  // Behavior / privacy defaults.
   ctx.setDefault(platform, 'audit.includeEmail', false);
   ctx.setDefault(platform, 'audit.verbosity', 'metadata');
   ctx.setDefault(platform, 'audit.winstonMirror', false);
 
+  // Remove the now-consolidated legacy block.
+  ctx.removeKey(platform, 'auditLog');
+
   await ctx.writeJson('config/platform.json', platform);
-  ctx.log('Added audit options (includeEmail, verbosity, winstonMirror) to platform.json');
+  ctx.log('Consolidated audit config into the `audit` block and removed legacy `auditLog`');
 }

--- a/server/migrations/V059__add_audit_options.js
+++ b/server/migrations/V059__add_audit_options.js
@@ -1,5 +1,5 @@
 /**
- * Migration V057 — Add audit logging options to platform.json
+ * Migration V059 — Add audit logging options to platform.json
  *
  * Introduces the `audit` configuration block that controls the expanded audit
  * logging system (auth events, OAuth clients, users, and the global HTTP audit
@@ -14,7 +14,7 @@
  *
  * Existing admin-configured values are preserved; only missing keys get defaults.
  */
-export const version = '057';
+export const version = '059';
 export const description = 'add_audit_options';
 
 export async function precondition(ctx) {

--- a/server/routes/admin/apps.js
+++ b/server/routes/admin/apps.js
@@ -16,7 +16,7 @@ import { buildServerPath } from '../../utils/basePath.js';
 import { validateIdForPath, validateIdsForPath } from '../../utils/pathSecurity.js';
 import logger from '../../utils/logger.js';
 import { removeMarketplaceInstallation } from '../../utils/installationCleanup.js';
-import { logAdminAction } from '../../services/AuditLogService.js';
+import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
 
 /**
@@ -631,7 +631,7 @@ export default function registerAdminAppsRoutes(app) {
           admin: req.user?.username ?? req.user?.name ?? req.user?.id ?? 'unknown'
         });
       }
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'update',
         resource: 'app',
@@ -745,7 +745,7 @@ export default function registerAdminAppsRoutes(app) {
       await fs.mkdir(appsDir, { recursive: true });
       await fs.writeFile(appFilePath, JSON.stringify(newApp, null, 2));
       await configCache.refreshAppsCache();
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'create',
         resource: 'app',
@@ -837,7 +837,7 @@ export default function registerAdminAppsRoutes(app) {
       const appFilePath = join(appsDir, filename);
       await fs.writeFile(appFilePath, JSON.stringify(app, null, 2));
       await configCache.refreshAppsCache();
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'toggle',
         resource: 'app',
@@ -963,7 +963,7 @@ export default function registerAdminAppsRoutes(app) {
         }
 
         await configCache.refreshAppsCache();
-        await logAdminAction({
+        await logAudit({
           req,
           action: 'toggle',
           resource: 'app',
@@ -1065,7 +1065,7 @@ export default function registerAdminAppsRoutes(app) {
       await fs.unlink(appFilePath);
       await configCache.refreshAppsCache();
       await removeMarketplaceInstallation('app', appId);
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'delete',
         resource: 'app',

--- a/server/routes/admin/auditLog.js
+++ b/server/routes/admin/auditLog.js
@@ -9,6 +9,9 @@ import { sendInternalError } from '../../utils/responseHelpers.js';
 import { buildCsv } from '../../utils/csv.js';
 import configCache from '../../configCache.js';
 
+// Upper bound on rows returned by the CSV export to keep memory bounded.
+const MAX_EXPORT_ROWS = 100000;
+
 function getRetentionSettings() {
   const platform = configCache.getPlatform ? configCache.getPlatform() : {};
   const cfg = platform?.auditLog || {};
@@ -65,7 +68,9 @@ export default function registerAdminAuditLogRoutes(app) {
     try {
       const { from, to, actor, resource, action, result: outcome, source } = req.query;
 
-      const { entries } = await queryAuditLog({
+      // Cap the export so a wide date range can't build an unbounded CSV string
+      // in memory. Admins can narrow the date range to export more granularly.
+      const { entries, total } = await queryAuditLog({
         from,
         to,
         actor,
@@ -73,9 +78,12 @@ export default function registerAdminAuditLogRoutes(app) {
         action,
         result: outcome,
         source,
-        limit: Number.MAX_SAFE_INTEGER,
+        limit: MAX_EXPORT_ROWS,
         offset: 0
       });
+      if (total > MAX_EXPORT_ROWS) {
+        res.setHeader('X-Audit-Export-Truncated', `${total - MAX_EXPORT_ROWS}`);
+      }
 
       const headers = [
         'ts',

--- a/server/routes/admin/auditLog.js
+++ b/server/routes/admin/auditLog.js
@@ -14,7 +14,7 @@ const MAX_EXPORT_ROWS = 100000;
 
 function getRetentionSettings() {
   const platform = configCache.getPlatform ? configCache.getPlatform() : {};
-  const cfg = platform?.auditLog || {};
+  const cfg = platform?.audit || {};
   return {
     retentionDays: Number.isFinite(cfg.retentionDays)
       ? cfg.retentionDays

--- a/server/routes/admin/auditLog.js
+++ b/server/routes/admin/auditLog.js
@@ -6,6 +6,7 @@ import {
   getAuditLogRetentionDefault
 } from '../../services/AuditLogService.js';
 import { sendInternalError } from '../../utils/responseHelpers.js';
+import { buildCsv } from '../../utils/csv.js';
 import configCache from '../../configCache.js';
 
 function getRetentionSettings() {
@@ -26,14 +27,26 @@ export default function registerAdminAuditLogRoutes(app) {
    */
   app.get(buildServerPath('/api/admin/audit-log'), adminAuth, async (req, res) => {
     try {
-      const { from, to, admin, resource, action, limit, offset } = req.query;
+      const {
+        from,
+        to,
+        actor,
+        resource,
+        action,
+        result: outcome,
+        source,
+        limit,
+        offset
+      } = req.query;
 
       const result = await queryAuditLog({
         from,
         to,
-        admin,
+        actor,
         resource,
         action,
+        result: outcome,
+        source,
         limit: limit ? parseInt(limit, 10) : 50,
         offset: offset ? parseInt(offset, 10) : 0
       });
@@ -41,6 +54,61 @@ export default function registerAdminAuditLogRoutes(app) {
       res.json(result);
     } catch (error) {
       return sendInternalError(res, error, 'query audit log');
+    }
+  });
+
+  /**
+   * GET /api/admin/audit-log/export
+   * Export audit log entries as CSV using the current filters.
+   */
+  app.get(buildServerPath('/api/admin/audit-log/export'), adminAuth, async (req, res) => {
+    try {
+      const { from, to, actor, resource, action, result: outcome, source } = req.query;
+
+      const { entries } = await queryAuditLog({
+        from,
+        to,
+        actor,
+        resource,
+        action,
+        result: outcome,
+        source,
+        limit: Number.MAX_SAFE_INTEGER,
+        offset: 0
+      });
+
+      const headers = [
+        'ts',
+        'actor',
+        'authenticated',
+        'action',
+        'resource',
+        'resourceId',
+        'result',
+        'source',
+        'ip',
+        'requestId',
+        'summary'
+      ];
+      const rows = entries.map(e => [
+        e.ts,
+        e.actor?.username ?? e.admin ?? '',
+        e.actor?.authenticated ?? '',
+        e.action,
+        e.resource,
+        e.resourceId,
+        e.result ?? 'success',
+        e.source ?? '',
+        e.ip ?? '',
+        e.requestId ?? '',
+        e.summary ?? ''
+      ]);
+
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader('Content-Disposition', 'attachment; filename="audit-log.csv"');
+      res.send(buildCsv(headers, rows));
+    } catch (error) {
+      return sendInternalError(res, error, 'export audit log');
     }
   });
 

--- a/server/routes/admin/auth.js
+++ b/server/routes/admin/auth.js
@@ -17,6 +17,7 @@ import {
   sendErrorResponse
 } from '../../utils/responseHelpers.js';
 import { isLastAdmin } from '../../utils/adminRescue.js';
+import { logAudit } from '../../services/AuditLogService.js';
 
 /**
  * @swagger
@@ -430,6 +431,14 @@ export default function registerAdminAuthRoutes(app) {
         authMethods: authMethods.join(', ')
       });
 
+      logAudit({
+        req,
+        action: 'create',
+        resource: 'user',
+        resourceId: userId,
+        summary: `Created user "${username}"`
+      });
+
       // Return user without password hash
       const { passwordHash: _passwordHash, ...userResponse } = newUser;
       res.json({ user: userResponse });
@@ -561,6 +570,14 @@ export default function registerAdminAuthRoutes(app) {
 
       logger.info('Updated user', { component: 'AdminAuth', username: user.username, userId });
 
+      logAudit({
+        req,
+        action: 'update',
+        resource: 'user',
+        resourceId: userId,
+        summary: `Updated user "${user.username}"`
+      });
+
       // Return user without password hash
       // eslint-disable-next-line no-unused-vars
       const { passwordHash, ...userResponse } = user;
@@ -660,6 +677,14 @@ export default function registerAdminAuthRoutes(app) {
       await configCache.refreshCacheEntry('config/users.json');
 
       logger.info('Deleted user', { component: 'AdminAuth', username, userId });
+
+      logAudit({
+        req,
+        action: 'delete',
+        resource: 'user',
+        resourceId: userId,
+        summary: `Deleted user "${username}"`
+      });
 
       res.json({ message: 'User deleted successfully' });
     } catch (error) {

--- a/server/routes/admin/backup.js
+++ b/server/routes/admin/backup.js
@@ -12,7 +12,7 @@ import { resolveAndValidatePath } from '../../utils/pathSecurity.js';
 import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 import { runConfigMigrations } from '../../migrations/runner.js';
-import { logAdminAction } from '../../services/AuditLogService.js';
+import { logAudit } from '../../services/AuditLogService.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -238,7 +238,7 @@ export async function exportConfig(req, res) {
     archive.append(JSON.stringify(metadata, null, 2), { name: 'backup-metadata.json' });
 
     await archive.finalize();
-    await logAdminAction({
+    await logAudit({
       req,
       action: 'export',
       resource: 'backup',
@@ -363,7 +363,7 @@ export async function importConfig(req, res) {
     // Count imported files
     const importedFiles = await getAllFiles(contentsPath);
 
-    await logAdminAction({
+    await logAudit({
       req,
       action: 'import',
       resource: 'backup',

--- a/server/routes/admin/changes.js
+++ b/server/routes/admin/changes.js
@@ -7,7 +7,7 @@ import configCache from '../../configCache.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import { join } from 'path';
 import { getRootDir } from '../../pathUtils.js';
-import { logAdminAction } from '../../services/AuditLogService.js';
+import { logAudit } from '../../services/AuditLogService.js';
 import logger from '../../utils/logger.js';
 
 const VALID_RESOURCES = [
@@ -145,7 +145,7 @@ export default function registerAdminChangesRoutes(app) {
             return sendBadRequest(res, `Rollback not supported for: ${resource}`);
         }
 
-        await logAdminAction({
+        await logAudit({
           req,
           action: 'update',
           resource,

--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -9,7 +9,7 @@ import { buildServerPath } from '../../utils/basePath.js';
 import tokenStorageService from '../../services/TokenStorageService.js';
 import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
-import { logAdminAction } from '../../services/AuditLogService.js';
+import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
 
 /**
@@ -706,7 +706,7 @@ export default function registerAdminConfigRoutes(app) {
         after: mergedConfig,
         admin: req.user?.username ?? req.user?.name ?? req.user?.id ?? 'unknown'
       });
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'update',
         resource: 'platform',

--- a/server/routes/admin/features.js
+++ b/server/routes/admin/features.js
@@ -8,7 +8,7 @@ import configCache from '../../configCache.js';
 import { resolveFeatures, featureCategories, featureRegistry } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
-import { logAdminAction } from '../../services/AuditLogService.js';
+import { logAudit } from '../../services/AuditLogService.js';
 
 export default function registerAdminFeaturesRoutes(app) {
   /**
@@ -110,7 +110,7 @@ export default function registerAdminFeaturesRoutes(app) {
         updates
       });
 
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'update',
         resource: 'feature',

--- a/server/routes/admin/groups.js
+++ b/server/routes/admin/groups.js
@@ -13,7 +13,7 @@ import {
   sendBadRequest,
   sendErrorResponse
 } from '../../utils/responseHelpers.js';
-import { logAdminAction } from '../../services/AuditLogService.js';
+import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
 
 /**
@@ -588,7 +588,7 @@ export default function registerAdminGroupRoutes(app) {
 
       logger.info('Created new group', { component: 'AdminGroups', name, id });
 
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'create',
         resource: 'group',
@@ -738,7 +738,7 @@ export default function registerAdminGroupRoutes(app) {
         after: group,
         admin: req.user?.username ?? req.user?.name ?? req.user?.id ?? 'unknown'
       });
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'update',
         resource: 'group',
@@ -873,7 +873,7 @@ export default function registerAdminGroupRoutes(app) {
 
       logger.info('Deleted group', { component: 'AdminGroups', groupName, groupId });
 
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'delete',
         resource: 'group',

--- a/server/routes/admin/models.js
+++ b/server/routes/admin/models.js
@@ -16,7 +16,7 @@ import {
   sendBadRequest,
   sendErrorResponse
 } from '../../utils/responseHelpers.js';
-import { logAdminAction } from '../../services/AuditLogService.js';
+import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
 
 export default function registerAdminModelsRoutes(app) {
@@ -211,7 +211,7 @@ export default function registerAdminModelsRoutes(app) {
           admin: req.user?.username ?? req.user?.name ?? req.user?.id ?? 'unknown'
         });
       }
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'update',
         resource: 'model',
@@ -280,7 +280,7 @@ export default function registerAdminModelsRoutes(app) {
       }
       await fs.writeFile(modelFilePath, JSON.stringify(newModel, null, 2));
       await configCache.refreshModelsCache();
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'create',
         resource: 'model',
@@ -327,7 +327,7 @@ export default function registerAdminModelsRoutes(app) {
       const modelFilePath = join(rootDir, 'contents', 'models', `${modelId}.json`);
       await fs.writeFile(modelFilePath, JSON.stringify(model, null, 2));
       await configCache.refreshModelsCache();
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'toggle',
         resource: 'model',
@@ -382,7 +382,7 @@ export default function registerAdminModelsRoutes(app) {
       }
 
       await configCache.refreshModelsCache();
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'toggle',
         resource: 'model',
@@ -443,7 +443,7 @@ export default function registerAdminModelsRoutes(app) {
           admin: req.user?.username ?? req.user?.name ?? req.user?.id ?? 'unknown'
         });
       }
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'delete',
         resource: 'model',

--- a/server/routes/admin/oauthClients.js
+++ b/server/routes/admin/oauthClients.js
@@ -12,6 +12,7 @@ import { buildServerPath } from '../../utils/basePath.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import configCache from '../../configCache.js';
 import { validateIdForPath } from '../../utils/pathSecurity.js';
+import { logAudit } from '../../services/AuditLogService.js';
 import logger from '../../utils/logger.js';
 
 /**
@@ -265,6 +266,14 @@ export default function registerAdminOAuthRoutes(app) {
 
       const newClient = await createOAuthClient(clientData, clientsFilePath, createdBy);
 
+      logAudit({
+        req,
+        action: 'create',
+        resource: 'oauthClient',
+        resourceId: newClient.clientId,
+        summary: `Created OAuth client "${newClient.name}"`
+      });
+
       // Return client with plain text secret (only time it's shown)
       res.status(201).json({
         success: true,
@@ -365,6 +374,14 @@ export default function registerAdminOAuthRoutes(app) {
 
       const updatedClient = await updateOAuthClient(clientId, updates, clientsFilePath, updatedBy);
 
+      logAudit({
+        req,
+        action: 'update',
+        resource: 'oauthClient',
+        resourceId: clientId,
+        summary: `Updated OAuth client "${updatedClient.name || clientId}"`
+      });
+
       res.json({
         success: true,
         message: 'OAuth client updated successfully',
@@ -429,6 +446,14 @@ export default function registerAdminOAuthRoutes(app) {
       const deletedBy = req.user?.id || 'admin';
 
       await deleteOAuthClient(clientId, clientsFilePath, deletedBy);
+
+      logAudit({
+        req,
+        action: 'delete',
+        resource: 'oauthClient',
+        resourceId: clientId,
+        summary: `Deleted OAuth client ${clientId}`
+      });
 
       res.json({
         success: true,
@@ -496,6 +521,14 @@ export default function registerAdminOAuthRoutes(app) {
         const rotatedBy = req.user?.id || 'admin';
 
         const result = await rotateClientSecret(clientId, clientsFilePath, rotatedBy);
+
+        logAudit({
+          req,
+          action: 'update',
+          resource: 'oauthClient',
+          resourceId: clientId,
+          summary: `Rotated client secret for ${clientId}`
+        });
 
         res.json({
           success: true,
@@ -601,6 +634,14 @@ export default function registerAdminOAuthRoutes(app) {
         }
 
         const apiKeyResult = generateStaticApiKey(client, expirationDays);
+
+        logAudit({
+          req,
+          action: 'create',
+          resource: 'oauthToken',
+          resourceId: clientId,
+          summary: `Generated static API key for ${clientId} (expires in ${expirationDays} days)`
+        });
 
         res.json({
           success: true,

--- a/server/routes/admin/prompts.js
+++ b/server/routes/admin/prompts.js
@@ -6,7 +6,7 @@ import { getRootDir } from '../../pathUtils.js';
 import configCache from '../../configCache.js';
 import { contentAdminAuth } from '../../middleware/contentAdminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
-import { logAdminAction } from '../../services/AuditLogService.js';
+import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
 import {
   validateIdForPath,
@@ -554,7 +554,7 @@ export default function registerAdminPromptsRoutes(app) {
           admin: req.user?.username ?? req.user?.name ?? req.user?.id ?? 'unknown'
         });
       }
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'update',
         resource: 'prompt',
@@ -686,7 +686,7 @@ export default function registerAdminPromptsRoutes(app) {
       }
       await fs.writeFile(promptFilePath, JSON.stringify(newPrompt, null, 2));
       await configCache.refreshPromptsCache();
-      await logAdminAction({
+      await logAudit({
         req,
         action: 'create',
         resource: 'prompt',
@@ -798,7 +798,7 @@ export default function registerAdminPromptsRoutes(app) {
         const promptFilePath = join(rootDir, 'contents', 'prompts', `${promptId}.json`);
         await fs.writeFile(promptFilePath, JSON.stringify(prompt, null, 2));
         await configCache.refreshPromptsCache();
-        await logAdminAction({
+        await logAudit({
           req,
           action: 'toggle',
           resource: 'prompt',
@@ -953,7 +953,7 @@ export default function registerAdminPromptsRoutes(app) {
         }
 
         await configCache.refreshPromptsCache();
-        await logAdminAction({
+        await logAudit({
           req,
           action: 'toggle',
           resource: 'prompt',
@@ -1084,7 +1084,7 @@ export default function registerAdminPromptsRoutes(app) {
             admin: req.user?.username ?? req.user?.name ?? req.user?.id ?? 'unknown'
           });
         }
-        await logAdminAction({
+        await logAudit({
           req,
           action: 'delete',
           resource: 'prompt',

--- a/server/routes/admin/sources.js
+++ b/server/routes/admin/sources.js
@@ -19,7 +19,7 @@ import { buildServerPath } from '../../utils/basePath.js';
 import { requireFeature } from '../../featureRegistry.js';
 import { validateIdForPath } from '../../utils/pathSecurity.js';
 import logger from '../../utils/logger.js';
-import { logAdminAction } from '../../services/AuditLogService.js';
+import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
 
 /**
@@ -722,7 +722,7 @@ export default function registerAdminSourcesRoutes(app) {
         // Refresh cache
         await configCache.refreshSourcesCache();
 
-        await logAdminAction({
+        await logAudit({
           req,
           action: 'create',
           resource: 'source',
@@ -877,7 +877,7 @@ export default function registerAdminSourcesRoutes(app) {
         await saveSourcesConfig(updatedSources);
         await configCache.refreshSourcesCache();
 
-        await logAdminAction({
+        await logAudit({
           req,
           action: 'update',
           resource: 'source',
@@ -1015,7 +1015,7 @@ export default function registerAdminSourcesRoutes(app) {
         await saveSourcesConfig(updatedSources);
         await configCache.refreshSourcesCache();
 
-        await logAdminAction({
+        await logAudit({
           req,
           action: 'delete',
           resource: 'source',

--- a/server/routes/admin/usage.js
+++ b/server/routes/admin/usage.js
@@ -10,6 +10,7 @@ import { getTrackingMode, reloadConfig } from '../../usageTracker.js';
 import { getDailyRollups, getMonthlyRollups, runRollups } from '../../services/UsageAggregator.js';
 import { readEvents } from '../../services/UsageEventLog.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
+import { escapeCsvField } from '../../utils/csv.js';
 
 function parseRange(range) {
   if (!range) return { startDate: null, endDate: null, granularity: 'daily' };
@@ -37,14 +38,6 @@ function parseRange(range) {
       granularity: 'monthly'
     };
   }
-}
-
-function escapeCsvField(value) {
-  const str = String(value ?? '');
-  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
-    return `"${str.replace(/"/g, '""')}"`;
-  }
-  return str;
 }
 
 export default function registerAdminUsageRoutes(app) {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -13,6 +13,7 @@ import { buildServerPath } from '../utils/basePath.js';
 import logger from '../utils/logger.js';
 import { sendBadRequest, sendAuthRequired, sendErrorResponse } from '../utils/responseHelpers.js';
 import { recordAuthEvent } from '../telemetry/metrics.js';
+import { logAudit } from '../services/AuditLogService.js';
 import { getAuthCookieOptions, getClearAuthCookieOptions } from '../utils/cookieSettings.js';
 
 /**
@@ -124,9 +125,36 @@ export default function registerAuthRoutes(app) {
         result = await loginUser(sanitizedUsername, sanitizedPassword, localAuthConfig);
         logger.info('[Auth] Local authentication succeeded', { component: 'Auth' });
         recordAuthEvent('local', 'login_success');
+        logAudit({
+          req,
+          action: 'login',
+          resource: 'auth',
+          resourceId: result.user?.id,
+          summary: 'Local login succeeded',
+          source: 'web',
+          actor: {
+            id: result.user?.id ?? 'unknown',
+            username: result.user?.username ?? result.user?.name ?? result.user?.id ?? 'unknown',
+            groups: result.user?.groups || [],
+            authenticated: true
+          }
+        });
       } catch (error) {
         logger.warn('Local authentication failed', { component: 'Auth', error });
         recordAuthEvent('local', 'login_failure');
+        logAudit({
+          req,
+          action: 'login',
+          resource: 'auth',
+          result: 'failure',
+          summary: 'Local login failed',
+          source: 'web',
+          actor: {
+            id: sanitizedUsername || 'unknown',
+            username: sanitizedUsername || 'unknown',
+            authenticated: false
+          }
+        });
         return sendErrorResponse(
           res,
           401,
@@ -241,6 +269,19 @@ export default function registerAuthRoutes(app) {
             error: error.message
           });
           recordAuthEvent('ldap', 'login_failure');
+          logAudit({
+            req,
+            action: 'login',
+            resource: 'auth',
+            result: 'failure',
+            summary: `LDAP login failed (provider: ${sanitizedProvider})`,
+            source: 'web',
+            actor: {
+              id: sanitizedUsername || 'unknown',
+              username: sanitizedUsername || 'unknown',
+              authenticated: false
+            }
+          });
           return sendErrorResponse(res, 401, 'Invalid credentials');
         }
       } else {
@@ -270,9 +311,38 @@ export default function registerAuthRoutes(app) {
         }
 
         if (!result) {
+          recordAuthEvent('ldap', 'login_failure');
+          logAudit({
+            req,
+            action: 'login',
+            resource: 'auth',
+            result: 'failure',
+            summary: 'LDAP login failed',
+            source: 'web',
+            actor: {
+              id: sanitizedUsername || 'unknown',
+              username: sanitizedUsername || 'unknown',
+              authenticated: false
+            }
+          });
           return sendErrorResponse(res, 401, 'Invalid credentials');
         }
       }
+
+      logAudit({
+        req,
+        action: 'login',
+        resource: 'auth',
+        resourceId: result.user?.id,
+        summary: 'LDAP login succeeded',
+        source: 'web',
+        actor: {
+          id: result.user?.id ?? 'unknown',
+          username: result.user?.username ?? result.user?.name ?? result.user?.id ?? 'unknown',
+          groups: result.user?.groups || [],
+          authenticated: true
+        }
+      });
 
       // Set HTTP-only cookie for authentication
       res.cookie('authToken', result.token, getAuthCookieOptions(result.expiresIn * 1000, req));
@@ -411,6 +481,21 @@ export default function registerAuthRoutes(app) {
 
       const result = await processNtlmLogin(req, ntlmAuthConfig);
 
+      logAudit({
+        req,
+        action: 'login',
+        resource: 'auth',
+        resourceId: result.user?.id,
+        summary: 'NTLM login succeeded',
+        source: 'web',
+        actor: {
+          id: result.user?.id ?? 'unknown',
+          username: result.user?.username ?? result.user?.name ?? result.user?.id ?? 'unknown',
+          groups: result.user?.groups || [],
+          authenticated: true
+        }
+      });
+
       // Set HTTP-only cookie for authentication
       res.cookie('authToken', result.token, getAuthCookieOptions(result.expiresIn * 1000, req));
 
@@ -456,6 +541,16 @@ export default function registerAuthRoutes(app) {
     // Clear the authentication cookie
     res.clearCookie('authToken', getClearAuthCookieOptions(req));
     recordAuthEvent(req.user?.authMode || 'unknown', 'logout');
+    if (req.user && req.user.id !== 'anonymous') {
+      logAudit({
+        req,
+        action: 'logout',
+        resource: 'auth',
+        resourceId: req.user.id,
+        summary: 'Logout',
+        source: 'web'
+      });
+    }
 
     // Clear NTLM session flag to prevent auto-relogin
     if (req.session) {

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -150,8 +150,8 @@ export default function registerAuthRoutes(app) {
           summary: 'Local login failed',
           source: 'web',
           actor: {
-            id: sanitizedUsername || 'unknown',
-            username: sanitizedUsername || 'unknown',
+            id: sanitizedUsername,
+            username: sanitizedUsername,
             authenticated: false
           }
         });
@@ -277,8 +277,8 @@ export default function registerAuthRoutes(app) {
             summary: `LDAP login failed (provider: ${sanitizedProvider})`,
             source: 'web',
             actor: {
-              id: sanitizedUsername || 'unknown',
-              username: sanitizedUsername || 'unknown',
+              id: sanitizedUsername,
+              username: sanitizedUsername,
               authenticated: false
             }
           });
@@ -320,8 +320,8 @@ export default function registerAuthRoutes(app) {
             summary: 'LDAP login failed',
             source: 'web',
             actor: {
-              id: sanitizedUsername || 'unknown',
-              username: sanitizedUsername || 'unknown',
+              id: sanitizedUsername,
+              username: sanitizedUsername,
               authenticated: false
             }
           });

--- a/server/server.js
+++ b/server/server.js
@@ -646,6 +646,13 @@ if (cluster.isPrimary && workerCount > 1) {
     } catch {
       // Triggers may not have been initialized
     }
+    // Flush any buffered audit entries so we don't lose them on shutdown.
+    try {
+      const { flushAuditLog } = await import('./services/AuditLogService.js');
+      await flushAuditLog();
+    } catch {
+      // Audit flush failures are logged within the service
+    }
     await shutdownTelemetry();
     process.exit(0);
   };

--- a/server/server.js
+++ b/server/server.js
@@ -380,7 +380,7 @@ if (cluster.isPrimary && workerCount > 1) {
   try {
     const { startAuditCleanupScheduler } = await import('./services/AuditLogService.js');
     const platform = configCache.getPlatform ? configCache.getPlatform() : {};
-    startAuditCleanupScheduler(platform?.auditLog || {});
+    startAuditCleanupScheduler(platform?.audit || {});
   } catch (error) {
     logger.warn('Failed to start audit log cleanup scheduler', { component: 'Server', error });
   }

--- a/server/services/AuditLogService.js
+++ b/server/services/AuditLogService.js
@@ -15,7 +15,20 @@ const FLUSH_INTERVAL_MS = 5000;
 // exceeded we drop the oldest entries and emit a single overflow warning.
 const MAX_QUEUE = 10000;
 
-const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// Linear-time email-shape detection. A regex like /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+// backtracks polynomially on attacker-supplied login usernames (CodeQL ReDoS),
+// so we use string scanning instead.
+function isEmailShaped(value) {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  if (/\s/.test(value)) return false; // single linear test, no backtracking
+  const at = value.indexOf('@');
+  if (at <= 0) return false; // need a non-empty local part
+  if (value.indexOf('@', at + 1) !== -1) return false; // exactly one '@'
+  const domain = value.slice(at + 1);
+  const dot = domain.indexOf('.');
+  // dot must be present and neither leading nor trailing in the domain
+  return dot > 0 && dot < domain.length - 1;
+}
 
 // In-memory write buffer. High-volume middleware writes are batched and
 // flushed on an interval (and on shutdown) so we don't hit the disk on every
@@ -34,8 +47,8 @@ function getAuditConfig() {
 }
 
 function maskEmail(value) {
-  if (typeof value === 'string' && EMAIL_RE.test(value)) {
-    return value.split('@')[0];
+  if (isEmailShaped(value)) {
+    return value.slice(0, value.indexOf('@'));
   }
   return value;
 }

--- a/server/services/AuditLogService.js
+++ b/server/services/AuditLogService.js
@@ -3,48 +3,205 @@ import { join, dirname } from 'path';
 import { randomUUID } from 'crypto';
 import { getRootDir } from '../pathUtils.js';
 import logger from '../utils/logger.js';
+import configCache from '../configCache.js';
+import { getContext } from '../utils/requestContext.js';
+import { validateAuditEntry } from '../validators/auditEntrySchema.js';
 
 const AUDIT_LOG_DIR = 'data/audit-log';
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_RETENTION_DAYS = 365;
+const FLUSH_INTERVAL_MS = 5000;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// In-memory write buffer. High-volume middleware writes are batched and
+// flushed on an interval (and on shutdown) so we don't hit the disk on every
+// request. queryAuditLog() flushes first so reads stay consistent.
+let queue = [];
+let flushTimer = null;
+
+function getAuditConfig() {
+  try {
+    const platform = configCache.getPlatform ? configCache.getPlatform() : {};
+    return platform?.audit || {};
+  } catch {
+    return {};
+  }
+}
+
+function maskEmail(value) {
+  if (typeof value === 'string' && EMAIL_RE.test(value)) {
+    return value.split('@')[0];
+  }
+  return value;
+}
 
 /**
- * Log an admin action to the append-only audit log.
- * Each day gets its own JSONL file at contents/data/audit-log/YYYY-MM-DD.jsonl.
+ * Build the actor object for an audit entry. Prefers an explicit actor (used
+ * for pre-auth events such as a failed login) and otherwise reads from
+ * req.user. Honors audit.includeEmail (default false) by masking email-shaped
+ * identifiers.
+ */
+function buildActor(req, explicitActor) {
+  const includeEmail = getAuditConfig().includeEmail === true;
+  const src = explicitActor || req?.user || {};
+  const id = src.id ?? 'unknown';
+  let username = src.username ?? src.name ?? src.id ?? 'unknown';
+  if (!includeEmail) username = maskEmail(username);
+  const authenticated =
+    typeof src.authenticated === 'boolean'
+      ? src.authenticated
+      : Boolean(src.id && src.id !== 'anonymous');
+  return {
+    id,
+    username,
+    groups: Array.isArray(src.groups) ? src.groups : [],
+    authenticated
+  };
+}
+
+/**
+ * Derive the audit source from the request when not provided explicitly.
+ */
+function deriveSource(req) {
+  if (!req) return 'web';
+  if (req.user?.isOAuthClient || req.user?.authMethod === 'oauth') return 'api';
+  const url = req.originalUrl || req.baseUrl || req.url || '';
+  if (url.includes('/api/admin/')) return 'admin';
+  return 'web';
+}
+
+function scheduleFlush() {
+  if (flushTimer) return;
+  flushTimer = setTimeout(() => {
+    flushTimer = null;
+    flushAuditLog().catch(error =>
+      logger.error('Failed to flush audit log', {
+        component: 'AuditLogService',
+        error: error.message
+      })
+    );
+  }, FLUSH_INTERVAL_MS);
+  // Don't let a pending flush keep the process alive on shutdown.
+  if (typeof flushTimer.unref === 'function') flushTimer.unref();
+}
+
+/**
+ * Flush the buffered audit entries to their daily JSONL files. Entries are
+ * grouped by date so a flush spanning midnight lands in the correct files.
+ *
+ * @returns {Promise<number>} number of entries written
+ */
+export async function flushAuditLog() {
+  if (queue.length === 0) return 0;
+  const pending = queue;
+  queue = [];
+
+  const byDate = new Map();
+  for (const entry of pending) {
+    const date = entry.ts.slice(0, 10);
+    if (!byDate.has(date)) byDate.set(date, []);
+    byDate.get(date).push(entry);
+  }
+
+  let count = 0;
+  try {
+    for (const [date, entries] of byDate) {
+      const filePath = join(getRootDir(), 'contents', AUDIT_LOG_DIR, `${date}.jsonl`);
+      await fs.mkdir(dirname(filePath), { recursive: true });
+      const lines = entries.map(e => JSON.stringify(e)).join('\n') + '\n';
+      await fs.appendFile(filePath, lines, 'utf8');
+      count += entries.length;
+    }
+  } catch (error) {
+    // Re-buffer the entries we failed to write so they aren't lost.
+    queue = pending.concat(queue);
+    throw error;
+  }
+  return count;
+}
+
+/**
+ * Log an audit event to the append-only audit log. Entries are buffered and
+ * flushed every few seconds (and on shutdown). Each day gets its own JSONL
+ * file at contents/data/audit-log/YYYY-MM-DD.jsonl.
  *
  * @param {Object} options
- * @param {Object} options.req - Express request object
- * @param {string} options.action - 'create' | 'update' | 'delete' | 'toggle' | 'import' | 'export'
- * @param {string} options.resource - 'app' | 'group' | 'model' | 'prompt' | 'platform' | 'backup' | 'source' | 'feature' | 'provider'
- * @param {string} options.resourceId - ID of the affected resource
- * @param {string} options.summary - Human-readable summary of the action
+ * @param {Object} [options.req] - Express request object
+ * @param {string} options.action - 'create' | 'update' | 'delete' | 'toggle' | 'import' | 'export' | 'login' | 'logout'
+ * @param {string} options.resource - Affected resource type (e.g. 'app', 'auth', 'user', 'oauthClient')
+ * @param {string} [options.resourceId] - ID of the affected resource
+ * @param {string} [options.summary] - Human-readable summary of the action
+ * @param {'success'|'failure'} [options.result='success'] - Outcome of the action
+ * @param {string} [options.source] - 'web' | 'mcp' | 'api' | 'admin' (derived from req when omitted)
+ * @param {Object} [options.actor] - Explicit actor for pre-auth events (e.g. failed login)
+ * @returns {Object|null} the buffered entry, or null on failure
  */
-export async function logAdminAction({ req, action, resource, resourceId, summary }) {
+export function logAudit({
+  req,
+  action,
+  resource,
+  resourceId,
+  summary,
+  result = 'success',
+  source,
+  actor
+} = {}) {
   try {
     const entry = {
       id: randomUUID(),
       ts: new Date().toISOString(),
-      admin: req.user?.username ?? req.user?.name ?? req.user?.id ?? 'unknown',
+      actor: buildActor(req, actor),
       action,
       resource,
       resourceId: resourceId || '',
-      summary,
-      ip: req.ip
+      summary: summary || '',
+      result,
+      source: source || deriveSource(req),
+      requestId: getContext()?.requestId || randomUUID(),
+      ip: req?.ip
     };
 
-    const date = entry.ts.slice(0, 10);
-    const filePath = join(getRootDir(), 'contents', AUDIT_LOG_DIR, `${date}.jsonl`);
-    await fs.mkdir(dirname(filePath), { recursive: true });
-    await fs.appendFile(filePath, JSON.stringify(entry) + '\n', 'utf8');
+    const validation = validateAuditEntry(entry);
+    if (!validation.success) {
+      logger.warn('Audit entry failed validation; writing anyway', {
+        component: 'AuditLogService',
+        error: validation.error
+      });
+    }
+
+    queue.push(entry);
+    scheduleFlush();
+
+    // Mark the request so the global audit middleware doesn't emit a duplicate
+    // coarse entry for the same request — explicit calls are authoritative.
+    if (req) req._auditLogged = true;
+
+    if (getAuditConfig().winstonMirror === true) {
+      logger.info('audit', {
+        component: 'audit',
+        audit: true,
+        action: entry.action,
+        resource: entry.resource,
+        resourceId: entry.resourceId,
+        result: entry.result,
+        source: entry.source,
+        actor: { id: entry.actor.id, authenticated: entry.actor.authenticated },
+        requestId: entry.requestId
+      });
+    }
+
+    return entry;
   } catch (error) {
     // Audit logging should never break the request
-    logger.error('Failed to write audit log entry', {
+    logger.error('Failed to record audit log entry', {
       component: 'AuditLogService',
       action,
       resource,
       resourceId,
       error: error.message
     });
+    return null;
   }
 }
 
@@ -54,9 +211,11 @@ export async function logAdminAction({ req, action, resource, resourceId, summar
  * @param {Object} options
  * @param {string} [options.from] - Start date (YYYY-MM-DD), defaults to 7 days ago
  * @param {string} [options.to] - End date (YYYY-MM-DD), defaults to today
- * @param {string} [options.admin] - Filter by admin username
+ * @param {string} [options.actor] - Filter by actor username
  * @param {string} [options.resource] - Filter by resource type
  * @param {string} [options.action] - Filter by action type
+ * @param {string} [options.result] - Filter by outcome ('success' | 'failure')
+ * @param {string} [options.source] - Filter by source ('web' | 'mcp' | 'api' | 'admin')
  * @param {number} [options.limit=50] - Max entries to return
  * @param {number} [options.offset=0] - Number of entries to skip
  * @returns {Promise<{entries: Array, total: number}>}
@@ -64,12 +223,21 @@ export async function logAdminAction({ req, action, resource, resourceId, summar
 export async function queryAuditLog({
   from,
   to,
-  admin,
+  actor,
   resource,
   action,
+  result,
+  source,
   limit = 50,
   offset = 0
 } = {}) {
+  // Flush buffered entries so reads reflect everything logged so far.
+  try {
+    await flushAuditLog();
+  } catch {
+    // A flush failure is logged elsewhere; continue with what's on disk.
+  }
+
   const now = new Date();
   const toDate = to || now.toISOString().slice(0, 10);
   const fromDate =
@@ -115,16 +283,23 @@ export async function queryAuditLog({
   // Sort newest first
   allEntries.sort((a, b) => b.ts.localeCompare(a.ts));
 
-  // Apply filters
+  // Apply filters. Entries written before the actor migration carry a legacy
+  // `admin` string instead of `actor`, so match both when filtering by actor.
   let filtered = allEntries;
-  if (admin) {
-    filtered = filtered.filter(e => e.admin === admin);
+  if (actor) {
+    filtered = filtered.filter(e => (e.actor?.username ?? e.admin) === actor);
   }
   if (resource) {
     filtered = filtered.filter(e => e.resource === resource);
   }
   if (action) {
     filtered = filtered.filter(e => e.action === action);
+  }
+  if (result) {
+    filtered = filtered.filter(e => (e.result ?? 'success') === result);
+  }
+  if (source) {
+    filtered = filtered.filter(e => e.source === source);
   }
 
   const total = filtered.length;

--- a/server/services/AuditLogService.js
+++ b/server/services/AuditLogService.js
@@ -11,6 +11,9 @@ const AUDIT_LOG_DIR = 'data/audit-log';
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_RETENTION_DAYS = 365;
 const FLUSH_INTERVAL_MS = 5000;
+// Hard cap so a failing disk + high write volume can't exhaust memory. When
+// exceeded we drop the oldest entries and emit a single overflow warning.
+const MAX_QUEUE = 10000;
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -19,6 +22,7 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 // request. queryAuditLog() flushes first so reads stay consistent.
 let queue = [];
 let flushTimer = null;
+let overflowed = false;
 
 function getAuditConfig() {
   try {
@@ -45,9 +49,14 @@ function maskEmail(value) {
 function buildActor(req, explicitActor) {
   const includeEmail = getAuditConfig().includeEmail === true;
   const src = explicitActor || req?.user || {};
-  const id = src.id ?? 'unknown';
+  let id = src.id ?? 'unknown';
   let username = src.username ?? src.name ?? src.id ?? 'unknown';
-  if (!includeEmail) username = maskEmail(username);
+  // Mask email-shaped identifiers in BOTH id and username so includeEmail:false
+  // actually prevents email storage (login actors set id = the attempted email).
+  if (!includeEmail) {
+    id = maskEmail(id);
+    username = maskEmail(username);
+  }
   const authenticated =
     typeof src.authenticated === 'boolean'
       ? src.authenticated
@@ -86,6 +95,22 @@ function scheduleFlush() {
   if (typeof flushTimer.unref === 'function') flushTimer.unref();
 }
 
+// Periodic safety-net flush. The one-shot scheduleFlush() timer clears itself
+// before running, so if a flush throws and re-buffers, nothing re-arms it —
+// this interval guarantees re-buffered entries eventually drain even with no
+// further audit activity. Mirrors UsageEventLog. unref so it never blocks exit.
+const periodicFlush = setInterval(() => {
+  if (queue.length > 0) {
+    flushAuditLog().catch(error =>
+      logger.error('Audit periodic flush error', {
+        component: 'AuditLogService',
+        error: error.message
+      })
+    );
+  }
+}, FLUSH_INTERVAL_MS);
+if (typeof periodicFlush.unref === 'function') periodicFlush.unref();
+
 /**
  * Flush the buffered audit entries to their daily JSONL files. Entries are
  * grouped by date so a flush spanning midnight lands in the correct files.
@@ -105,19 +130,24 @@ export async function flushAuditLog() {
   }
 
   let count = 0;
-  try {
-    for (const [date, entries] of byDate) {
+  let firstError = null;
+  // Write each date independently and only re-buffer the dates that failed, so
+  // a partial failure (e.g. a flush spanning midnight) can't re-write — and
+  // thereby duplicate — entries that already landed on disk.
+  for (const [date, entries] of byDate) {
+    try {
       const filePath = join(getRootDir(), 'contents', AUDIT_LOG_DIR, `${date}.jsonl`);
       await fs.mkdir(dirname(filePath), { recursive: true });
       const lines = entries.map(e => JSON.stringify(e)).join('\n') + '\n';
       await fs.appendFile(filePath, lines, 'utf8');
       count += entries.length;
+    } catch (error) {
+      firstError = firstError || error;
+      // Re-buffer only this date's entries so the next flush retries just them.
+      queue = entries.concat(queue);
     }
-  } catch (error) {
-    // Re-buffer the entries we failed to write so they aren't lost.
-    queue = pending.concat(queue);
-    throw error;
   }
+  if (firstError) throw firstError;
   return count;
 }
 
@@ -135,6 +165,8 @@ export async function flushAuditLog() {
  * @param {'success'|'failure'} [options.result='success'] - Outcome of the action
  * @param {string} [options.source] - 'web' | 'mcp' | 'api' | 'admin' (derived from req when omitted)
  * @param {Object} [options.actor] - Explicit actor for pre-auth events (e.g. failed login)
+ * @param {string} [options.requestId] - Explicit request id (used by the middleware,
+ *   whose res 'finish' callback may run outside the request's async context)
  * @returns {Object|null} the buffered entry, or null on failure
  */
 export function logAudit({
@@ -145,20 +177,25 @@ export function logAudit({
   summary,
   result = 'success',
   source,
-  actor
+  actor,
+  requestId
 } = {}) {
   try {
+    const includeEmail = getAuditConfig().includeEmail === true;
+    // resourceId can carry the attempted identifier (e.g. a login id that is an
+    // email), so honor the same masking as the actor.
+    const safeResourceId = includeEmail ? resourceId || '' : maskEmail(resourceId || '');
     const entry = {
       id: randomUUID(),
       ts: new Date().toISOString(),
       actor: buildActor(req, actor),
       action,
       resource,
-      resourceId: resourceId || '',
+      resourceId: safeResourceId,
       summary: summary || '',
       result,
       source: source || deriveSource(req),
-      requestId: getContext()?.requestId || randomUUID(),
+      requestId: requestId || getContext()?.requestId || randomUUID(),
       ip: req?.ip
     };
 
@@ -171,6 +208,20 @@ export function logAudit({
     }
 
     queue.push(entry);
+    // Bound memory: if the buffer is overflowing (e.g. disk wedged), drop the
+    // oldest entries rather than grow without limit. Warn once per overflow.
+    if (queue.length > MAX_QUEUE) {
+      queue.splice(0, queue.length - MAX_QUEUE);
+      if (!overflowed) {
+        overflowed = true;
+        logger.error('Audit log buffer overflow — dropping oldest entries', {
+          component: 'AuditLogService',
+          max: MAX_QUEUE
+        });
+      }
+    } else {
+      overflowed = false;
+    }
     scheduleFlush();
 
     // Mark the request so the global audit middleware doesn't emit a duplicate

--- a/server/tests/auditEntrySchema.test.js
+++ b/server/tests/auditEntrySchema.test.js
@@ -1,0 +1,71 @@
+/**
+ * Tests for the audit entry Zod schema and validateAuditEntry().
+ */
+import { randomUUID } from 'crypto';
+import { validateAuditEntry } from '../validators/auditEntrySchema.js';
+
+function baseEntry(overrides = {}) {
+  return {
+    id: randomUUID(),
+    ts: new Date().toISOString(),
+    actor: { id: 'u1', username: 'alice', groups: ['users'], authenticated: true },
+    action: 'create',
+    resource: 'app',
+    resourceId: 'my-app',
+    summary: 'Created app',
+    result: 'success',
+    source: 'admin',
+    requestId: randomUUID(),
+    ip: '127.0.0.1',
+    ...overrides
+  };
+}
+
+describe('validateAuditEntry', () => {
+  test('accepts a well-formed entry', () => {
+    const result = validateAuditEntry(baseEntry());
+    expect(result.success).toBe(true);
+  });
+
+  test('rejects an unknown action', () => {
+    const result = validateAuditEntry(baseEntry({ action: 'frobnicate' }));
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/action/);
+  });
+
+  test('rejects an unknown result', () => {
+    const result = validateAuditEntry(baseEntry({ result: 'maybe' }));
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/result/);
+  });
+
+  test('rejects an unknown source', () => {
+    const result = validateAuditEntry(baseEntry({ source: 'carrier-pigeon' }));
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/source/);
+  });
+
+  test('rejects a non-uuid id', () => {
+    const result = validateAuditEntry(baseEntry({ id: 'not-a-uuid' }));
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/id/);
+  });
+
+  test('requires an actor', () => {
+    const entry = baseEntry();
+    delete entry.actor;
+    const result = validateAuditEntry(entry);
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/actor/);
+  });
+
+  test('allows free-form resource names from the middleware', () => {
+    const result = validateAuditEntry(baseEntry({ resource: 'integrations' }));
+    expect(result.success).toBe(true);
+  });
+
+  test('never throws on garbage input', () => {
+    expect(() => validateAuditEntry(null)).not.toThrow();
+    expect(validateAuditEntry(null).success).toBe(false);
+  });
+});

--- a/server/tests/auditLogService.test.js
+++ b/server/tests/auditLogService.test.js
@@ -1,0 +1,130 @@
+/**
+ * Tests for the AuditLogService core: enriched entry shape, defaults, email
+ * masking, buffered writes / flush, and crash-safety on partial input.
+ *
+ * fs.promises is the same object reference whether imported as `{ promises }`
+ * or accessed as `fs.promises`, so spying on it here intercepts the writes the
+ * service performs internally.
+ */
+import { promises as fsp } from 'fs';
+import { jest } from '@jest/globals';
+import configCache from '../configCache.js';
+import { logAudit, flushAuditLog, queryAuditLog } from '../services/AuditLogService.js';
+
+describe('AuditLogService.logAudit', () => {
+  let appendSpy;
+  let auditConfig;
+
+  beforeEach(() => {
+    auditConfig = { includeEmail: false, verbosity: 'metadata', winstonMirror: false };
+    jest.spyOn(configCache, 'getPlatform').mockImplementation(() => ({ audit: auditConfig }));
+    jest.spyOn(fsp, 'mkdir').mockResolvedValue(undefined);
+    appendSpy = jest.spyOn(fsp, 'appendFile').mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    await flushAuditLog().catch(() => {});
+    jest.restoreAllMocks();
+  });
+
+  test('builds an enriched entry with actor and defaults', () => {
+    const req = {
+      ip: '10.0.0.1',
+      originalUrl: '/api/admin/apps/foo',
+      user: { id: 'u1', username: 'alice', groups: ['admin'], authenticated: true }
+    };
+    const entry = logAudit({ req, action: 'create', resource: 'app', resourceId: 'foo' });
+
+    expect(entry).toMatchObject({
+      action: 'create',
+      resource: 'app',
+      resourceId: 'foo',
+      result: 'success', // default
+      source: 'admin', // derived from /api/admin/ URL
+      actor: { id: 'u1', username: 'alice', authenticated: true }
+    });
+    expect(entry.id).toBeTruthy();
+    expect(entry.ts).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+    expect(entry.actor.groups).toEqual(['admin']);
+  });
+
+  test('masks email-shaped usernames when includeEmail is false', () => {
+    const req = { user: { id: 'u2', username: 'bob@example.com', authenticated: true } };
+    const entry = logAudit({ req, action: 'login', resource: 'auth' });
+    expect(entry.actor.username).toBe('bob');
+  });
+
+  test('keeps full email when includeEmail is true', () => {
+    auditConfig.includeEmail = true;
+    const req = { user: { id: 'u2', username: 'bob@example.com', authenticated: true } };
+    const entry = logAudit({ req, action: 'login', resource: 'auth' });
+    expect(entry.actor.username).toBe('bob@example.com');
+  });
+
+  test('honors an explicit actor for pre-auth events', () => {
+    const entry = logAudit({
+      action: 'login',
+      resource: 'auth',
+      result: 'failure',
+      actor: { id: 'mallory', username: 'mallory', authenticated: false }
+    });
+    expect(entry.result).toBe('failure');
+    expect(entry.actor).toMatchObject({ id: 'mallory', authenticated: false });
+  });
+
+  test('derives source web for non-admin requests', () => {
+    const entry = logAudit({
+      req: { originalUrl: '/api/auth/local/login' },
+      action: 'login',
+      resource: 'auth'
+    });
+    expect(entry.source).toBe('web');
+  });
+
+  test('buffers entries and flushes to a dated JSONL file', async () => {
+    logAudit({
+      req: { user: { id: 'u1', username: 'alice', authenticated: true } },
+      action: 'create',
+      resource: 'app',
+      resourceId: 'foo'
+    });
+
+    // Nothing written until flush.
+    expect(appendSpy).not.toHaveBeenCalled();
+
+    const count = await flushAuditLog();
+    expect(count).toBeGreaterThanOrEqual(1);
+    expect(appendSpy).toHaveBeenCalledTimes(1);
+
+    const [filePath, content] = appendSpy.mock.calls[0];
+    const today = new Date().toISOString().slice(0, 10);
+    expect(filePath).toContain(`${today}.jsonl`);
+    expect(content).toContain('"resourceId":"foo"');
+
+    // A second flush with an empty queue is a no-op.
+    expect(await flushAuditLog()).toBe(0);
+  });
+
+  test('marks the request so the middleware can de-dupe', () => {
+    const req = { user: { id: 'u1', username: 'alice', authenticated: true } };
+    logAudit({ req, action: 'update', resource: 'app' });
+    expect(req._auditLogged).toBe(true);
+  });
+
+  test('never throws on partial input', () => {
+    expect(() => logAudit()).not.toThrow();
+    expect(() => logAudit({ action: 'create' })).not.toThrow();
+  });
+
+  test('queryAuditLog flushes the buffer before reading', async () => {
+    logAudit({
+      req: { user: { id: 'u1', username: 'alice', authenticated: true } },
+      action: 'create',
+      resource: 'app'
+    });
+    jest.spyOn(fsp, 'readdir').mockResolvedValue([]);
+    await queryAuditLog({});
+    // The pending entry was flushed as part of the query.
+    expect(appendSpy).toHaveBeenCalled();
+  });
+});

--- a/server/tests/auditLogService.test.js
+++ b/server/tests/auditLogService.test.js
@@ -48,10 +48,30 @@ describe('AuditLogService.logAudit', () => {
     expect(entry.actor.groups).toEqual(['admin']);
   });
 
-  test('masks email-shaped usernames when includeEmail is false', () => {
-    const req = { user: { id: 'u2', username: 'bob@example.com', authenticated: true } };
-    const entry = logAudit({ req, action: 'login', resource: 'auth' });
+  test('masks email-shaped id and username (and resourceId) when includeEmail is false', () => {
+    const req = {
+      user: { id: 'bob@example.com', username: 'bob@example.com', authenticated: true }
+    };
+    const entry = logAudit({
+      req,
+      action: 'login',
+      resource: 'auth',
+      resourceId: 'bob@example.com'
+    });
     expect(entry.actor.username).toBe('bob');
+    expect(entry.actor.id).toBe('bob'); // id must be masked too, not just username
+    expect(entry.resourceId).toBe('bob');
+  });
+
+  test('masks the explicit failed-login actor (attacker-supplied email)', () => {
+    const entry = logAudit({
+      action: 'login',
+      resource: 'auth',
+      result: 'failure',
+      actor: { id: 'attacker@evil.com', username: 'attacker@evil.com', authenticated: false }
+    });
+    expect(entry.actor.id).toBe('attacker');
+    expect(entry.actor.username).toBe('attacker');
   });
 
   test('keeps full email when includeEmail is true', () => {
@@ -102,6 +122,27 @@ describe('AuditLogService.logAudit', () => {
     expect(content).toContain('"resourceId":"foo"');
 
     // A second flush with an empty queue is a no-op.
+    expect(await flushAuditLog()).toBe(0);
+  });
+
+  test('re-buffers entries on flush failure and writes them exactly once on retry', async () => {
+    appendSpy.mockRejectedValueOnce(new Error('ENOSPC'));
+    logAudit({
+      req: { user: { id: 'u1', username: 'alice', authenticated: true } },
+      action: 'create',
+      resource: 'app',
+      resourceId: 'foo'
+    });
+
+    // First flush fails — entry must be retained, not lost.
+    await expect(flushAuditLog()).rejects.toThrow('ENOSPC');
+
+    // Retry succeeds and writes the entry exactly once.
+    const count = await flushAuditLog();
+    expect(count).toBe(1);
+
+    // Queue is now empty — the re-buffered entry was not duplicated, so a
+    // subsequent flush is a no-op.
     expect(await flushAuditLog()).toBe(0);
   });
 

--- a/server/tests/auditLogger.test.js
+++ b/server/tests/auditLogger.test.js
@@ -1,0 +1,107 @@
+/**
+ * Tests for the global audit safety-net middleware: path/method/auth gating,
+ * the admin carve-out, resource derivation, and sensitive-field redaction.
+ */
+import { EventEmitter } from 'events';
+import { jest } from '@jest/globals';
+import configCache from '../configCache.js';
+import { auditLogger, deriveResource, redact } from '../middleware/auditLogger.js';
+
+function makeReqRes({
+  method = 'POST',
+  url = '/api/admin/apps/foo',
+  user = { id: 'u1', username: 'alice', authenticated: true }
+} = {}) {
+  const req = { method, originalUrl: url, url, user, body: {} };
+  const res = new EventEmitter();
+  res.statusCode = 200;
+  return { req, res };
+}
+
+describe('auditLogger gating', () => {
+  const mw = auditLogger();
+
+  beforeEach(() => {
+    jest.spyOn(configCache, 'getPlatform').mockReturnValue({ audit: { verbosity: 'metadata' } });
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  test('registers a finish listener for authenticated admin mutations', () => {
+    const { req, res } = makeReqRes();
+    const onSpy = jest.spyOn(res, 'on');
+    const next = jest.fn();
+    mw(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(onSpy).toHaveBeenCalledWith('finish', expect.any(Function));
+  });
+
+  test('skips non-mutating methods (reads)', () => {
+    const { req, res } = makeReqRes({ method: 'GET' });
+    const onSpy = jest.spyOn(res, 'on');
+    mw(req, res, jest.fn());
+    expect(onSpy).not.toHaveBeenCalled();
+  });
+
+  test('skips unauthenticated / anonymous requests (anti-flood)', () => {
+    const { req, res } = makeReqRes({ user: { id: 'anonymous' } });
+    const onSpy = jest.spyOn(res, 'on');
+    mw(req, res, jest.fn());
+    expect(onSpy).not.toHaveBeenCalled();
+  });
+
+  test('still audits admin paths even when a segment is in the exclusion list', () => {
+    const { req, res } = makeReqRes({ url: '/api/admin/pages/home' });
+    const onSpy = jest.spyOn(res, 'on');
+    mw(req, res, jest.fn());
+    expect(onSpy).toHaveBeenCalledWith('finish', expect.any(Function));
+  });
+
+  test('excludes high-volume non-admin segments (e.g. /api/pages)', () => {
+    const { req, res } = makeReqRes({ url: '/api/pages/home' });
+    const onSpy = jest.spyOn(res, 'on');
+    mw(req, res, jest.fn());
+    expect(onSpy).not.toHaveBeenCalled();
+  });
+
+  test('skips non-api paths', () => {
+    const { req, res } = makeReqRes({ url: '/healthz' });
+    const onSpy = jest.spyOn(res, 'on');
+    mw(req, res, jest.fn());
+    expect(onSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('deriveResource', () => {
+  const cases = [
+    ['/api/admin/apps/my-app', { resource: 'apps', resourceId: 'my-app' }],
+    ['/api/admin/apps', { resource: 'apps', resourceId: '' }],
+    ['/api/integrations/jira', { resource: 'integrations', resourceId: 'jira' }],
+    ['/api/admin/auth/users/u1?x=1', { resource: 'auth', resourceId: 'users' }],
+    ['/notapi/', { resource: 'notapi', resourceId: '' }]
+  ];
+  test.each(cases)('%s', (url, expected) => {
+    expect(deriveResource({ originalUrl: url })).toEqual(expected);
+  });
+});
+
+describe('redact', () => {
+  test('redacts sensitive keys, recursing into nested objects and arrays', () => {
+    const out = redact({
+      name: 'ok',
+      password: 'p',
+      nested: { clientSecret: 's', apiKey: 'k', keep: 1 },
+      list: [{ token: 't' }, { fine: 2 }],
+      privateKey: 'x',
+      authorization: 'Bearer z'
+    });
+    expect(out.name).toBe('ok');
+    expect(out.password).toBe('***REDACTED***');
+    expect(out.nested.clientSecret).toBe('***REDACTED***');
+    expect(out.nested.apiKey).toBe('***REDACTED***');
+    expect(out.nested.keep).toBe(1);
+    expect(out.list[0].token).toBe('***REDACTED***');
+    expect(out.list[1].fine).toBe(2);
+    expect(out.privateKey).toBe('***REDACTED***');
+    expect(out.authorization).toBe('***REDACTED***');
+  });
+});

--- a/server/tests/csv.test.js
+++ b/server/tests/csv.test.js
@@ -1,0 +1,44 @@
+/**
+ * Tests for the shared CSV helpers — quoting and spreadsheet formula-injection
+ * neutralization.
+ */
+import { escapeCsvField, buildCsv } from '../utils/csv.js';
+
+describe('escapeCsvField', () => {
+  test('passes through plain values', () => {
+    expect(escapeCsvField('hello')).toBe('hello');
+    expect(escapeCsvField(42)).toBe('42');
+    expect(escapeCsvField(null)).toBe('');
+  });
+
+  test('quotes values containing comma, quote, CR or newline', () => {
+    expect(escapeCsvField('a,b')).toBe('"a,b"');
+    expect(escapeCsvField('a"b')).toBe('"a""b"');
+    expect(escapeCsvField('a\nb')).toBe('"a\nb"');
+    expect(escapeCsvField('a\rb')).toBe('"a\rb"');
+  });
+
+  test('neutralizes formula-injection prefixes', () => {
+    expect(escapeCsvField('=HYPERLINK("http://evil")')).toBe('"\'=HYPERLINK(""http://evil"")"');
+    expect(escapeCsvField('+1')).toBe("'+1");
+    expect(escapeCsvField('-1')).toBe("'-1");
+    expect(escapeCsvField('@cmd')).toBe("'@cmd");
+  });
+});
+
+describe('buildCsv', () => {
+  test('builds header + rows', () => {
+    const csv = buildCsv(
+      ['a', 'b'],
+      [
+        ['1', '2'],
+        ['x,y', '3']
+      ]
+    );
+    expect(csv).toBe('a,b\n1,2\n"x,y",3\n');
+  });
+
+  test('header-only when no rows', () => {
+    expect(buildCsv(['a', 'b'], [])).toBe('a,b\n');
+  });
+});

--- a/server/utils/csv.js
+++ b/server/utils/csv.js
@@ -4,14 +4,20 @@
 
 /**
  * Escape a single CSV field. Wraps the value in double quotes and doubles any
- * embedded quotes when it contains a comma, quote, or newline.
+ * embedded quotes when it contains a comma, quote, CR, or newline. Also guards
+ * against spreadsheet formula injection: a value starting with =, +, -, @, or a
+ * tab is prefixed with a single quote so Excel/Sheets/LibreOffice treat it as
+ * text rather than executing it as a formula.
  *
  * @param {*} value - Value to render as a CSV field
  * @returns {string}
  */
 export function escapeCsvField(value) {
-  const str = String(value ?? '');
-  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+  let str = String(value ?? '');
+  if (/^[=+\-@\t\r]/.test(str)) {
+    str = `'${str}`;
+  }
+  if (str.includes(',') || str.includes('"') || str.includes('\n') || str.includes('\r')) {
     return `"${str.replace(/"/g, '""')}"`;
   }
   return str;

--- a/server/utils/csv.js
+++ b/server/utils/csv.js
@@ -1,0 +1,31 @@
+/**
+ * Shared CSV helpers for admin export endpoints.
+ */
+
+/**
+ * Escape a single CSV field. Wraps the value in double quotes and doubles any
+ * embedded quotes when it contains a comma, quote, or newline.
+ *
+ * @param {*} value - Value to render as a CSV field
+ * @returns {string}
+ */
+export function escapeCsvField(value) {
+  const str = String(value ?? '');
+  if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Build a CSV document from a header row and an array of row arrays.
+ *
+ * @param {string[]} headers - Column headers
+ * @param {Array<Array<*>>} rows - Row values (each inner array is one row)
+ * @returns {string}
+ */
+export function buildCsv(headers, rows) {
+  const headerLine = headers.map(escapeCsvField).join(',');
+  const body = rows.map(row => row.map(escapeCsvField).join(',')).join('\n');
+  return body ? `${headerLine}\n${body}\n` : `${headerLine}\n`;
+}

--- a/server/validators/auditEntrySchema.js
+++ b/server/validators/auditEntrySchema.js
@@ -1,0 +1,60 @@
+import { z } from 'zod';
+
+/**
+ * Schema for a single audit-log entry.
+ *
+ * `action`, `result`, and `source` are constrained to known enums. `resource`
+ * is intentionally a free-form string: the global audit middleware derives
+ * resource names from request paths, so the set is open-ended.
+ */
+export const auditActions = [
+  'create',
+  'update',
+  'delete',
+  'toggle',
+  'import',
+  'export',
+  'login',
+  'logout'
+];
+
+export const auditResults = ['success', 'failure'];
+
+export const auditSources = ['web', 'mcp', 'api', 'admin'];
+
+export const auditActorSchema = z.object({
+  id: z.string().min(1),
+  username: z.string(),
+  groups: z.array(z.string()).default([]),
+  authenticated: z.boolean()
+});
+
+export const auditEntrySchema = z.object({
+  id: z.string().uuid(),
+  ts: z.string().datetime(),
+  actor: auditActorSchema,
+  action: z.enum(auditActions),
+  resource: z.string().min(1),
+  resourceId: z.string().default(''),
+  summary: z.string().default(''),
+  result: z.enum(auditResults).default('success'),
+  source: z.enum(auditSources).default('web'),
+  requestId: z.string().optional(),
+  ip: z.string().optional()
+});
+
+/**
+ * Validate an audit entry. Returns `{ success, error }` and never throws so it
+ * can be used as a warn-and-still-write gate.
+ *
+ * @param {Object} entry
+ * @returns {{ success: boolean, error?: string }}
+ */
+export function validateAuditEntry(entry) {
+  const result = auditEntrySchema.safeParse(entry);
+  if (result.success) return { success: true };
+  return {
+    success: false,
+    error: result.error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join('; ')
+  };
+}

--- a/server/validators/index.js
+++ b/server/validators/index.js
@@ -1,5 +1,13 @@
 import { z } from 'zod';
 
+export {
+  auditEntrySchema,
+  validateAuditEntry,
+  auditActions,
+  auditResults,
+  auditSources
+} from './auditEntrySchema.js';
+
 export const startSessionSchema = {
   body: z.object({
     sessionId: z.string().min(1),

--- a/server/validators/platformConfigSchema.js
+++ b/server/validators/platformConfigSchema.js
@@ -172,15 +172,12 @@ export const platformConfigSchema = z
       })
       .default({}),
     cloudStorage: cloudStorageConfigSchema.default({}),
-    auditLog: z
-      .object({
-        retentionDays: z.number().default(365),
-        cleanupEnabled: z.boolean().default(true)
-      })
-      .passthrough()
-      .default({}),
+    // Single source of truth for audit logging: retention + behavior + privacy.
+    // (The legacy top-level `auditLog` block is migrated into here by V059.)
     audit: z
       .object({
+        retentionDays: z.number().default(365),
+        cleanupEnabled: z.boolean().default(true),
         includeEmail: z.boolean().default(false),
         verbosity: z.enum(['metadata', 'request', 'full']).default('metadata'),
         winstonMirror: z.boolean().default(false)

--- a/server/validators/platformConfigSchema.js
+++ b/server/validators/platformConfigSchema.js
@@ -171,7 +171,22 @@ export const platformConfigSchema = z
           )
       })
       .default({}),
-    cloudStorage: cloudStorageConfigSchema.default({})
+    cloudStorage: cloudStorageConfigSchema.default({}),
+    auditLog: z
+      .object({
+        retentionDays: z.number().default(365),
+        cleanupEnabled: z.boolean().default(true)
+      })
+      .passthrough()
+      .default({}),
+    audit: z
+      .object({
+        includeEmail: z.boolean().default(false),
+        verbosity: z.enum(['metadata', 'request', 'full']).default('metadata'),
+        winstonMirror: z.boolean().default(false)
+      })
+      .passthrough()
+      .default({})
   })
   .passthrough();
 


### PR DESCRIPTION
## Summary

Closes the gaps in audit logging (#1463) so the platform meets compliance-grade auditing expectations — **who logged in / failed to log in**, **who issued or rotated an OAuth client / API key**, **who created/deleted a user** — building on the admin-action audit log shipped in 5.4.0 rather than rewriting it.

## What changed

**Core service (`AuditLogService`)**
- Renamed `logAdminAction` → `logAudit`; replaced the flat `admin` string with a richer **`actor`** (id, username, groups, authenticated) and added **`result`** (`success`/`failure`), **`source`** (`web`/`admin`/`api`/`mcp`), and **`requestId`**.
- Buffered writes flushed on an interval and on shutdown (mirrors `UsageEventLog`); `queryAuditLog` flushes first so reads stay consistent.
- Entries validated against a new Zod schema (warn-and-still-write).
- Optional winston mirror (`component: 'audit'`) for SIEM forwarding and `includeEmail` masking for privacy.

**Coverage**
- New global `auditLogger` middleware records mutating HTTP requests not covered by an explicit hook; explicit `logAudit` calls set `req._auditLogged` to de-duplicate.
- Explicit hooks: auth (login success/failure + logout across local / LDAP / NTLM / OIDC), OAuth client create/update/delete/rotate-secret/generate-token, and user create/update/delete. **Secrets and passwords are never logged.**

**Admin UI & API**
- Audit Log page: **Actor / Result / Source** columns and filters, plus an **Export CSV** button.
- New `GET /api/admin/audit-log/export`; shared CSV helper (`utils/csv.js`) reused by the usage export.

**Config & migration**
- `platform.json` → `audit` block (`includeEmail`, `verbosity`, `winstonMirror`) added via migration **V057** and the platform config schema.

## Testing

- `auditEntrySchema.test.js` + `auditLogService.test.js` — entry shape, defaults, email masking, buffered flush/no-op, crash-safety on partial input (17 tests passing).
- End-to-end against a booted dev server: failed login → `result=failure` entry queryable; admin login → `actor=admin`; user create produces exactly one entry (middleware de-dup verified); CSV export returns all columns.
- Server boots clean; migration V057 applied; lint passes (0 errors).

## ⚠️ Breaking changes (clean break, per request — no compat shims)

- Audit entries now use **`actor`** instead of `admin`.
- The audit-log query param **`admin`** is renamed to **`actor`**.
- Pre-existing JSONL files written before this change remain readable: the query layer and admin UI fall back to the legacy `admin` field when `actor` is absent.

## Deviations from the literal issue spec

- Daily JSONL files retained (not a single `audit-events.jsonl`) to preserve the existing retention/cleanup; buffered writes added instead.
- Before/after diffs remain in `ChangeHistoryService` (linked by resource/id), not duplicated into the audit record.
- Marketplace/tools/agents and MCP hooks deferred to a follow-up.

https://claude.ai/code/session_01VvmuneQMxJpKWUDgH7rffg

---
_Generated by [Claude Code](https://claude.ai/code/session_01VvmuneQMxJpKWUDgH7rffg)_