### PR TITLE
docs: detailed Tiptap editor implementation plan (#1609)

### DIFF
--- a/concepts/2026-06-16 Tiptap Editor Implementation Plan.md
+++ b/concepts/2026-06-16 Tiptap Editor Implementation Plan.md
@@ -1,0 +1,262 @@
+# Tiptap Editor — Detailed Implementation Plan
+
+**Date:** 2026-06-16
+**Status:** Plan for review (no code yet)
+**Tracking issue:** [#1609](https://github.com/intrafind/ihub-apps/issues/1609)
+**Companion to:** [`concepts/2026-06-16 Tiptap Editor Integration.md`](./2026-06-16%20Tiptap%20Editor%20Integration.md) (research + concept, merged in #1608)
+
+> This document turns the merged concept into an actionable, file-level
+> implementation plan with per-phase task lists, a Quill→Tiptap API map, the
+> exact npm packages, the feature-flag/rollout strategy, acceptance criteria,
+> and a test plan. It is written to be split into one tracking issue per phase.
+
+---
+
+## 0. Executive summary
+
+- **Goal:** Replace the Quill-based **Canvas** editor (`client/src/features/canvas/`)
+  with a Tiptap (ProseMirror) editor, keep all AI traffic inside iHub, and add
+  local DOCX/PDF — without sending any document data to Tiptap Cloud.
+- **What is unblocked today (OSS, public npm):** Phases 1–3 and an OSS agentic
+  layer. `@tiptap/react@3.x` and `@tiptap/starter-kit@3.x` install from the
+  public registry (verified: v3.26.1).
+- **What is blocked (external):** Phase 4's **Tiptap Pro** AI Agent / AI Toolkit
+  (`@tiptap-pro/*`) return **404 on the public registry** — they need a paid
+  subscription + private-registry token. This is the Phase 0 procurement gate
+  from the concept doc; it cannot be resolved inside the build environment.
+- **Recommended rollout:** New code lives in `client/src/features/editor/`
+  behind a per-app feature flag (`app.features.editor === true`), running
+  **side by side** with the existing Canvas. Quill is removed only in the final
+  cutover (Phase 5), once parity is verified.
+
+### Decision gates (must be answered by a human)
+
+| Gate | Question | Blocks |
+| --- | --- | --- |
+| **G0 — Licensing** | Buy a Tiptap subscription incl. AI Agent + AI Toolkit add-on? Confirm private-registry token works in CI/Docker/binary/**air-gapped** builds, and whether Pro AI phones home at runtime. | Phase 4 (Pro path) |
+| **G1 — Routing** | Resolver reuses the app-chat endpoint (Path A) vs. a dedicated agent route (Path B). Plan defaults to **A**. | Phase 4 |
+| **G2 — Agentic fallback** | If G0 is "no", build the OSS agentic layer on the MIT core (Path B-OSS) instead. | Phase 4 scope |
+| **G3 — Persistence** | Keep `sessionStorage`-only, or add backend document persistence (separate effort)? | Out of scope here; flagged as follow-up |
+
+---
+
+## 1. Current state — concrete inventory
+
+All under `client/src/features/canvas/`:
+
+| File | Role | Migration note |
+| --- | --- | --- |
+| `pages/AppCanvas.jsx` | Page: split chat/editor panes, settings, panel resize, voice commands, content-from-chat redirect. | Fork to `pages/AppEditor.jsx`; swap `CanvasEditor`→`TiptapEditor`, `quillRef`→`editor` instance. |
+| `components/CanvasEditor.jsx` | Wraps `react-quill` (Snow theme) + custom clipboard (copy/cut/paste as md/html). | Replace with `TiptapEditor.jsx` (`useEditor` + `EditorContent`). |
+| `components/QuillToolbar.jsx` / `.css` | Toolbar: headings, B/I/U/strike, lists, blockquote, code, link, undo/redo, char count, export, voice. | Replace with `EditorToolbar.jsx` driven by Tiptap commands; add BubbleMenu. |
+| `components/CanvasVoiceInput.jsx` | Dictation; `quill.insertText()` at cursor; Ctrl/Cmd+M; `useVoiceRecognition` + Azure. | Reimplement as `EditorVoiceInput.jsx` using `editor.chain().focus().insertContent()`. |
+| `components/ExportMenu.jsx` | Copy text/markdown/html; print-to-PDF. Uses `useClipboard`, `useFeatureFlags`. | Reuse almost verbatim; feed it editor HTML/JSON. Extend in Phase 2 (DOCX). |
+| `components/FloatingToolbox.jsx` | AI quick-actions (continue/summarize/expand/tone/translate/grammar…). | Reuse verbatim — it's editor-agnostic (`onAction(id, description)`). |
+| `components/CanvasChatPanel.jsx` | AI chat sidebar; `onInsertAnswer` inserts into editor. | Reuse; rewire `onInsertAnswer` to Tiptap insert. |
+| `components/CanvasContentConfirmationModal.jsx` | Replace/append/cancel modal for incoming content. | Reuse verbatim. |
+| `hooks/useCanvas.js` | Content state (+`sessionStorage`), selection, `handleEditAction` (prompt builder), `applyEditResult` (Quill insert). | Fork to `useEditorDocument.js`; keep prompt builder; rewrite selection + `applyEditResult` against Tiptap. |
+| `hooks/useCanvasContent.js`, `useCanvasEditing.js`, `useCanvasEditResult.js` | Older/auxiliary hooks (some overlap with `useCanvas.js`). | Consolidate; only `applyEditResult` semantics need a Tiptap rewrite. |
+
+**Wiring facts that matter:**
+
+- Canvas is enabled **per app** via `app.features.canvas === true`
+  (`SharedAppHeader.jsx:127`, `AppChat.jsx:374`). The new editor will use a
+  parallel flag `app.features.editor === true`.
+- Route is `/apps/:appId/canvas` → lazy `SafeAppCanvas` (`App.jsx:364`). Canvas
+  is a **sub-route of `/apps`**, which is already in `knownRoutes`
+  (`runtimeBasePath.js:36`). **No `knownRoutes` change is required** unless we
+  introduce a new top-level path (we won't — new route is `/apps/:appId/editor`).
+- AI already routes through iHub: `useAppChat` → SSE; `handleEditAction` builds a
+  prompt, sets `window.pendingEdit`, calls `handlePromptSubmit`; the completed
+  assistant message is applied via `applyEditResult`. **No backend changes needed
+  for the OSS AI path.**
+- Persistence is `sessionStorage` only (`ai_hub_canvas_content_{appId}`). Same
+  model retained; new keys `ai_hub_editor_content_{appId}`.
+- Reusable export libs already in `client/package.json`: `docx@^9.5.3`,
+  `mammoth@^1.11.0`, `marked`, `turndown`, `dompurify`, `file-saver`,
+  plus `client/src/utils/exportFormats.js`, `markdownUtils.js`.
+
+---
+
+## 2. Packages
+
+**Phase 1–3 (public npm, MIT — no licensing):**
+
+```
+@tiptap/react @tiptap/pm @tiptap/starter-kit
+@tiptap/extension-link @tiptap/extension-placeholder
+@tiptap/extension-underline @tiptap/extension-text-align
+@tiptap/extension-table @tiptap/extension-table-row
+@tiptap/extension-table-cell @tiptap/extension-table-header
+@tiptap/extension-character-count
+@tiptap/extension-bubble-menu @tiptap/extension-floating-menu
+```
+(All pinned to the same `3.x` minor; StarterKit already bundles bold/italic/
+strike/heading/lists/blockquote/code/history.)
+
+**Phase 4 (Pro — requires G0):**
+```
+@tiptap-pro/extension-ai-agent          (client)
+@tiptap-pro/extension-ai-agent-server   (server, if Path B)
+@tiptap-pro/extension-ai-changes        (accept/reject diff UI)
+```
+> Installed only from Tiptap's private registry with a build-time token; **404
+> on public npm**. Vendoring/offline-mirror story must be proven in G0 before
+> any of this is added to `package.json`.
+
+**Removed in Phase 5:** `react-quill@^2.0.0`.
+
+---
+
+## 3. Quill → Tiptap API map (the core of the rewrite)
+
+| Concern | Quill (current) | Tiptap (target) |
+| --- | --- | --- |
+| Mount | `<ReactQuill value onChange .../>` | `const editor = useEditor({extensions, content})` + `<EditorContent editor={editor}/>` |
+| Get HTML | `quill.root.innerHTML` | `editor.getHTML()` |
+| Get/set JSON | n/a (HTML only) | `editor.getJSON()` / `editor.commands.setContent(json)` |
+| Plain text | strip tags via regex | `editor.getText()` |
+| Selection | `onChangeSelection` → `{index,length}` | `editor.on('selectionUpdate')` → `editor.state.selection.{from,to}`; text via `editor.state.doc.textBetween(from,to,' ')` |
+| Insert at cursor | `quill.insertText(i, txt)` | `editor.chain().focus().insertContent(txt).run()` |
+| Insert HTML | `clipboard.dangerouslyPasteHTML` | `editor.chain().focus().insertContent(html).run()` (HTML string parsed by PM) |
+| Replace selection | `deleteText` + `updateContents(delta)` | `editor.chain().focus().deleteRange({from,to}).insertContent(content).run()` |
+| Char count | `quill.getLength()` | `CharacterCount` extension → `editor.storage.characterCount.characters()` |
+| Undo/redo | `history` module | StarterKit history → `editor.commands.undo()/redo()` |
+| Toolbar bind | `#quill-toolbar` container | buttons call `editor.chain().focus().toggleBold()...run()`; active state via `editor.isActive('bold')` |
+| Clipboard md/html | custom copy/cut/paste handlers | `editorProps.handlePaste/transformPastedHTML` + `turndown` for md copy |
+
+**`applyEditResult` rewrite (key behavioral parity):**
+- `action === 'suggest'` → no document mutation (unchanged).
+- Markdown detection via existing `isMarkdown()`; convert with `markdownToHtml()`
+  then `insertContent(html)`.
+- If a range is selected: `deleteRange({from,to})` then `insertContent`.
+- Else append at end with spacing; move cursor to end.
+
+---
+
+## 4. Phased plan
+
+### Phase 0 — Licensing & POC spike  *(gate G0/G1; partly external)*
+- **In-repo (doable now):** throwaway branch — Tiptap core + StarterKit rendering
+  in a sandbox route; wire the **OSS** resolver to an existing app-chat endpoint
+  against a local LLM; confirm streamed edits land in the doc. Prove the
+  resolver ↔ `ChatRequest` mapping (de-risks Path A).
+- **External (cannot do in this env):** obtain subscription quote (AI Agent +
+  AI Toolkit add-on); verify private-registry token in CI/Docker/binary/
+  **air-gapped** builds; confirm no runtime phone-home; confirm custom-LLM
+  resolver is allowed on the purchased tier.
+- **Exit:** G0/G1 answered in writing; routing decision recorded.
+
+### Phase 1 — Core editor swap (no AI net-new) — *fully unblocked*
+**New:** `client/src/features/editor/`
+- `components/TiptapEditor.jsx` — `useEditor` + `EditorContent`, StarterKit +
+  link/underline/placeholder/text-align/table/character-count; processing
+  overlay; exposes editor via ref/callback for the page.
+- `components/EditorToolbar.jsx` (+ css) — command buttons w/ active states; char
+  count; export + voice slots. Port BubbleMenu for inline format on selection.
+- `components/EditorVoiceInput.jsx` — see Phase 3.
+- `hooks/useEditorDocument.js` — fork of `useCanvas.js`: `sessionStorage`
+  (`ai_hub_editor_content_{appId}`), selection state, prompt builder
+  (`handleEditAction` reused verbatim), Tiptap `applyEditResult`.
+- `pages/AppEditor.jsx` — fork of `AppCanvas.jsx`; reuses `CanvasChatPanel`,
+  `FloatingToolbox`, `CanvasContentConfirmationModal`, `ExportMenu`,
+  `SharedAppHeader`.
+
+**Edits:**
+- `client/src/App.jsx` — add lazy route `apps/:appId/editor` → `SafeAppEditor`
+  (mirror `SafeAppCanvas`).
+- `SharedAppHeader.jsx` — add `mode="editor"`; gate a "Open in editor" button on
+  `app.features.editor === true` (parallel to `canvas`).
+- Reuse `ExportMenu` for HTML/Markdown/print (feed `editor.getHTML()`).
+
+**Acceptance:** With `features.editor:true`, `/apps/:appId/editor` loads; type/
+format/list/table/link/undo-redo work; char count correct; content persists in
+session; existing FloatingToolbox + chat-insert AI actions work end-to-end via
+iHub chat; **Canvas remains fully functional** for other apps. Lint/format clean;
+bundle delta measured.
+
+### Phase 2 — Local DOCX / PDF — *unblocked*
+- **Export DOCX:** `editor.getJSON()` → `docx` builder. New
+  `client/src/utils/tiptapDocx.js`: map paragraph, heading 1–3, bold/italic/
+  underline/strike, bullet/ordered lists, blockquote, codeBlock, link, tables.
+  Save via `file-saver`.
+- **Import DOCX:** `mammoth.convertToHtml()` → HTML → `editor.commands.setContent(html)`.
+- **PDF:** keep browser-print (parity); optionally evaluate server-side render
+  later (out of scope).
+- **Edits:** extend `ExportMenu.jsx` with "Download .docx" + an import control;
+  gate behind existing `export` feature flag.
+- **Acceptance:** round-trip a fixture set (headings, nested lists, table, bold/
+  italic/links, blockquote, code) DOCX→editor→DOCX with acceptable fidelity;
+  fidelity gaps (nested tables, footnotes) documented as known limits.
+
+### Phase 3 — Dictation extension — *unblocked*
+- `EditorVoiceInput.jsx`: reuse `useVoiceRecognition` + `azureRecognitionService`;
+  on final transcript `editor.chain().focus().insertContent(text + ' ').run()`;
+  preserve Ctrl/Cmd+M toggle, interim transcript UX, `VoiceFeedback`. Detect
+  focus via the editor's ProseMirror DOM (replace the `.ql-editor` check).
+- **Acceptance:** Ctrl/Cmd+M toggles dictation; transcript inserts at cursor;
+  manual/automatic modes match Canvas behavior.
+
+### Phase 4 — AI Agent / Toolkit  *(GATED on G0; or Path B-OSS)*
+- **Path A (Pro, default if G0=yes):** add `@tiptap-pro/extension-ai-agent`
+  (+ `-ai-changes`); implement a **resolver** that POSTs to the app-chat
+  endpoint (`/api/apps/{editorAppId}/chat/{chatId}`, SSE) and maps agent
+  messages ↔ `ChatRequest`; map tool calls to read/write/patch; surface
+  accept/reject via the changes extension; gate by group permissions; record
+  token usage like normal chat.
+- **Path B-OSS (if G0=no):** build read/write/patch as custom Tiptap commands +
+  a lightweight diff/accept-reject UI over the MIT core; reuse the existing
+  `handleEditAction` prompt set; no Tiptap cost, more code.
+- **Acceptance:** agent can read the doc, propose ranged edits, user accepts/
+  rejects; all LLM calls visible in iHub usage; no data leaves iHub.
+
+### Phase 5 — Cutover & cleanup — *after parity sign-off*
+- Point `app.features.canvas` apps at the new editor (or migrate the flag);
+  remove `react-quill`, `QuillToolbar.*`, and dead Canvas components/hooks.
+- If the public route path changes at the top level, update `knownRoutes`
+  (`runtimeBasePath.js`) — **not needed** for `/apps/:appId/editor`.
+- `npm run lint:fix && npm run format:fix`; `/document-feature` changelog entry;
+  update `docs/` (canvas/editor docs).
+
+---
+
+## 5. i18n
+New keys under an `editor.*` namespace mirroring existing `canvas.*` keys
+(toolbar labels, placeholder, voice tooltips, export labels, processing). Add to
+all locale files; the `i18n-checker` agent should pass with no hardcoded strings.
+
+## 6. Testing
+- **Unit:** `tiptapDocx.js` mappers; `applyEditResult` (selection vs append vs
+  suggest); markdown detection paths.
+- **Component:** toolbar command toggles + active states; char count; dictation
+  insert.
+- **E2E (Playwright):** load `/apps/:appId/editor`; type+format; run a
+  FloatingToolbox action against a stub/local model; DOCX export+reimport; verify
+  Canvas still works for canvas-flagged apps.
+- **Build:** `timeout 10s node server/server.js` smoke; measure client bundle
+  delta (Tiptap > Quill — confirm acceptable; both lazy-loaded).
+
+## 7. Risks
+- **Pro licensing / air-gapped registry** — biggest unknown (G0).
+- **DOCX fidelity** with our own libs vs Tiptap Conversion — fixtures required.
+- **Resolver ↔ ChatRequest impedance** — spike in Phase 0 before committing Path A.
+- **Bundle size** — Tiptap heavier than Quill; keep route lazy-loaded.
+- **No backend persistence** — follow-up (G3).
+
+## 8. Effort (carried from concept, refined)
+| Phase | Effort | Blocked? |
+| --- | --- | --- |
+| 0 POC + licensing | 2–4 d (+ procurement lead time) | partly external |
+| 1 Core editor | 3–5 d | no |
+| 2 DOCX/PDF local | 4–6 d | no |
+| 3 Dictation | 1 d | no |
+| 4 AI Agent/Toolkit | 5–10 d | **yes (G0)** |
+| 5 Cutover/cleanup | 2–3 d | after parity |
+
+## 9. Suggested issue breakdown (sub-issues of #1609)
+1. Phase 0 spike + licensing sign-off (G0/G1).
+2. Phase 1 core editor swap behind `features.editor` flag.
+3. Phase 2 local DOCX/PDF.
+4. Phase 3 dictation extension.
+5. Phase 4 agentic AI (Pro **or** OSS, per G0/G2).
+6. Phase 5 cutover + remove Quill.

--- a/concepts/2026-06-16 Tiptap Editor Implementation Plan.md
+++ b/concepts/2026-06-16 Tiptap Editor Implementation Plan.md
@@ -31,12 +31,12 @@
 
 ### Decision gates (must be answered by a human)
 
-| Gate | Question | Blocks |
+| Gate | Question | Status |
 | --- | --- | --- |
-| **G0 — Licensing** | Buy a Tiptap subscription incl. AI Agent + AI Toolkit add-on? Confirm private-registry token works in CI/Docker/binary/**air-gapped** builds, and whether Pro AI phones home at runtime. | Phase 4 (Pro path) |
-| **G1 — Routing** | Resolver reuses the app-chat endpoint (Path A) vs. a dedicated agent route (Path B). Plan defaults to **A**. | Phase 4 |
-| **G2 — Agentic fallback** | If G0 is "no", build the OSS agentic layer on the MIT core (Path B-OSS) instead. | Phase 4 scope |
-| **G3 — Persistence** | Keep `sessionStorage`-only, or add backend document persistence (separate effort)? | Out of scope here; flagged as follow-up |
+| **G0 — Licensing** | Buy a Tiptap subscription incl. AI Agent + AI Toolkit add-on? | **DECIDED: no.** Build the AI layer OSS on the MIT core. |
+| **G1 — Routing** | Resolver reuses the app-chat endpoint vs. a dedicated agent route. | Reuse `/api/apps/:appId/chat/:chatId` (default A). |
+| **G2 — Agentic design** | How to build the OSS agentic layer (G0=no). | **DECIDED: OSS.** See [OSS Agentic AI Layer doc](./2026-06-16%20Tiptap%20OSS%20Agentic%20AI%20Layer.md) — Option A (4a) then Option C (4b). |
+| **G3 — Persistence** | Keep `sessionStorage`-only, or add backend document persistence? | Open follow-up (may be pulled forward for true agentic editing). |
 
 ---
 
@@ -197,18 +197,30 @@ bundle delta measured.
 - **Acceptance:** Ctrl/Cmd+M toggles dictation; transcript inserts at cursor;
   manual/automatic modes match Canvas behavior.
 
-### Phase 4 — AI Agent / Toolkit  *(GATED on G0; or Path B-OSS)*
-- **Path A (Pro, default if G0=yes):** add `@tiptap-pro/extension-ai-agent`
-  (+ `-ai-changes`); implement a **resolver** that POSTs to the app-chat
-  endpoint (`/api/apps/{editorAppId}/chat/{chatId}`, SSE) and maps agent
-  messages ↔ `ChatRequest`; map tool calls to read/write/patch; surface
-  accept/reject via the changes extension; gate by group permissions; record
-  token usage like normal chat.
-- **Path B-OSS (if G0=no):** build read/write/patch as custom Tiptap commands +
-  a lightweight diff/accept-reject UI over the MIT core; reuse the existing
-  `handleEditAction` prompt set; no Tiptap cost, more code.
-- **Acceptance:** agent can read the doc, propose ranged edits, user accepts/
-  rejects; all LLM calls visible in iHub usage; no data leaves iHub.
+### Phase 4 — Agentic AI layer  *(OSS — decided: no Tiptap Pro license)*
+**Decision recorded:** we will **not** buy Tiptap Pro. Phase 4 is built entirely
+on the MIT core + iHub's own backend. Full design in
+[`2026-06-16 Tiptap OSS Agentic AI Layer.md`](./2026-06-16%20Tiptap%20OSS%20Agentic%20AI%20Layer.md).
+
+- **4a (ship first):** single-shot **structured edit ops** via iHub `outputSchema`
+  → client maps to ProseMirror transactions → **accept/reject suggestion UI**.
+  No server code changes (config only). Upgrades the existing FloatingToolbox/
+  chat-insert actions from "insert blob" to "diff + accept/reject".
+- **Suggestion layer (shared):** custom ProseMirror insert/delete marks +
+  optional `prosemirror-changeset` diffing; review/accept-reject UI (replaces
+  Pro's AI Changes).
+- **4b (faithful agent):** generalize the `ask_user` clarification pause/resume
+  into a **client-executed tool protocol** (new `tool.client.request` event +
+  `clientExecuted` tool flag in `ToolExecutor`), so document read/search/replace/
+  insert/delete tools run in the browser inside iHub's existing agentic loop
+  (`continueWithToolExecution`). Replaces Pro's AI Agent + AI Toolkit.
+- **Fallback (Option B):** server-side agent loop over a document mirror, if the
+  client-tool protocol proves too costly.
+- Gate by group permissions (existing `chatAuthRequired` + app `tools`); record
+  usage like normal chat.
+- **Acceptance:** agent reads the doc and proposes ranged edits; user accepts/
+  rejects per change; all LLM calls visible in iHub usage; **no data leaves iHub**
+  and only MIT packages are used (air-gapped-safe).
 
 ### Phase 5 — Cutover & cleanup — *after parity sign-off*
 - Point `app.features.canvas` apps at the new editor (or migrate the flag);

--- a/concepts/2026-06-16 Tiptap OSS Agentic AI Layer.md
+++ b/concepts/2026-06-16 Tiptap OSS Agentic AI Layer.md
@@ -1,0 +1,221 @@
+# Tiptap Editor — OSS Agentic AI Layer (no Tiptap Pro license)
+
+**Date:** 2026-06-16
+**Status:** Design for review (no code yet)
+**Tracking issue:** [#1609](https://github.com/intrafind/ihub-apps/issues/1609)
+**Part of the Tiptap feature set:**
+- [`2026-06-16 Tiptap Editor Integration.md`](./2026-06-16%20Tiptap%20Editor%20Integration.md) — research/concept (merged #1608)
+- [`2026-06-16 Tiptap Editor Implementation Plan.md`](./2026-06-16%20Tiptap%20Editor%20Implementation%20Plan.md) — phased file-level plan
+- **this doc** — Phase 4 detailed design, OSS path (replaces Tiptap Pro AI Agent / AI Toolkit)
+
+---
+
+## 1. Decision recorded
+
+**We will NOT buy the Tiptap Pro subscription.** Therefore the agentic AI layer
+(AI Agent + AI Toolkit equivalent) must be **built on the Tiptap MIT core + iHub's
+own LLM backend**. `@tiptap-pro/*` packages (404 on public npm, private-registry
+token, possible runtime phone-home, air-gapped risk) are **out**.
+
+This resolves the concept doc's gates: **G0 = no license**, **G2 = OSS path**.
+
+## 2. What Tiptap Pro gives us — and what we must rebuild
+
+| Pro capability | What it does | Our OSS replacement |
+| --- | --- | --- |
+| **AI Agent** (`extension-ai-agent`) | Cursor-like loop: LLM reads doc, calls tools to edit, iterates; pluggable `resolver` to your backend. | iHub's existing **server-side agentic loop** (`ToolExecutor.continueWithToolExecution`, max-iteration loop) + a new **client-side tool-execution protocol** so document tools run in the browser. |
+| **AI Toolkit** | Structured read/write/patch tools, schema-aware chunked reads, streamed edits, read/write boundary, audit log. | A set of **document tools** (read/search/replace/insert/delete) we define ourselves; reads chunked by ProseMirror nodes; audit via existing `actionTracker` tool events + `usageTracker`. |
+| **AI Changes** (`extension-ai-changes`) | Track-changes UI: proposed edits as diffs, accept/reject per change. | A **ProseMirror suggestions layer** we build with Decorations + insertion/deletion marks (optionally `prosemirror-changeset` for diffing) and an accept/reject UI. |
+
+Everything else (permissions, cost/usage tracking, local/vLLM/LM Studio support,
+provider adapters) is **already** in iHub and is reused unchanged.
+
+## 3. The core constraint
+
+From the pipeline audit (`server/services/chat/*`, `server/actionTracker.js`,
+`server/sse.js`, `client/src/shared/hooks/useEventSource.js`):
+
+- iHub tools **always execute server-side** (`ToolExecutor.executeToolCall` →
+  `runTool`). The client never sees raw tool calls.
+- SSE is **one-way** (server→client).
+- The **only** pause/resume round-trip to the client is the `ask_user`
+  **clarification** tool: `executeClarificationTool()` emits a
+  `clarification` SSE event (`actionTracker.trackClarification`), the loop
+  pauses, the client collects input and posts it back, and the loop resumes.
+
+**The document lives in the browser.** So document-editing tools cannot run on
+the server's normal tool path — they must either (a) be applied client-side, or
+(b) run server-side against a server-held *copy* of the document. Three options
+follow.
+
+## 4. Three architectures (with recommendation)
+
+### Option A — Single-shot structured edits *(recommended Phase 4a — ship first)*
+The LLM returns, in **one response**, a structured list of edit operations
+(via iHub **`outputSchema`**). The client maps each op to a ProseMirror
+transaction and renders them as **proposed suggestions** (accept/reject). No new
+server protocol.
+
+- **Op schema (example):**
+  ```json
+  {
+    "operations": [
+      { "type": "replace", "anchor": "<unique quoted text>", "with": "<new text>", "reason": "..." },
+      { "type": "insertAfter", "anchor": "<quoted text>", "content": "..." },
+      { "type": "delete", "anchor": "<quoted text>" },
+      { "type": "appendToEnd", "content": "..." }
+    ]
+  }
+  ```
+- **Anchoring:** match `anchor` against `editor.getText()` / node text; if unique,
+  map to `{from,to}`; if ambiguous/missing, surface as a skipped op (no silent
+  failure). (Avoids trusting absolute offsets the model can't see reliably.)
+- **Reuses:** chat endpoint, structured output (`RequestBuilder.js:298` →
+  adapter `response_format`/schema), permissions, usage tracking. Zero backend
+  changes beyond a "Document Editor" app config.
+- **Covers:** the FloatingToolbox quick-actions (rewrite/expand/translate/grammar
+  on selection), "summarize the doc", "continue writing" — i.e. the existing
+  Canvas AI surface, upgraded from "insert blob" to **diff + accept/reject**.
+- **Limits:** not truly multi-step; the model edits from a single snapshot and
+  cannot "look again" after a change. Good for 80% of editing actions.
+
+### Option B — Server-side agent loop over a document mirror
+Client sends the document (Tiptap JSON or Markdown) at request start; the
+server's agentic loop runs document tools (`replace`, `insert`, `search`)
+against an **in-memory server copy**, streaming a patch set back; client applies
+the final patch as suggestions.
+
+- **Reuses:** the full existing `processChatWithTools` / `continueWithToolExecution`
+  loop **as-is** — document tools are just normal server-side tools operating on
+  the in-memory doc string.
+- **Cost:** server needs a faithful document model. Markdown interchange is
+  simple but lossy (tables/marks); ProseMirror-JSON interchange needs the **same
+  schema on the server** (`prosemirror-model`) — heavier, and risks client/server
+  schema drift + double-application bugs.
+- **Verdict:** viable, lowest *protocol* effort, but introduces a server-side doc
+  model we'd otherwise not need. Keep as fallback if Option C's protocol work is
+  deemed too large.
+
+### Option C — Client-executed tools via a generalized pause/resume *(recommended Phase 4b — the faithful agent)*
+Generalize the `ask_user` clarification mechanism into a **generic client-tool
+protocol**, so the LLM's document tools execute **in the browser** against the
+live Tiptap doc — exactly mirroring Tiptap Pro's resolver model, but on iHub's
+own loop.
+
+**Protocol (new, built on existing primitives):**
+1. Document tools are registered as **`clientExecuted: true`** tools (new flag in
+   the tool definition; analogous to `passthrough`/`ask_user` special-casing in
+   `ToolExecutor`).
+2. When the LLM calls one, the server emits a new SSE event
+   `tool.client.request` `{ callId, toolName, args }` (mirrors
+   `trackClarification`) and **pauses the loop** (same mechanism as
+   `hasClarificationRequest`).
+3. The client executes the tool against Tiptap (read/search/replace/insert),
+   producing a result (e.g. `{ ok: true, matched: 1, newSelectionText: "..." }`),
+   and **POSTs it back** as a tool result for `callId` (mirrors the clarification
+   answer round-trip).
+4. The server resumes `continueWithToolExecution`, feeding the tool result to the
+   LLM, and the loop continues until the model stops (max-iteration cap already
+   exists, line ~1214).
+5. Edits land as **suggestions** (the §5 layer); user accepts/rejects at the end
+   (or per-step).
+
+- **Tools (AI-Toolkit equivalent):** `read_document(range?)` (chunked by nodes),
+  `get_selection`, `search(query)`, `replace_range({from,to}|anchor, content)`,
+  `insert({at|anchor}, content)`, `delete(range|anchor)`,
+  `set_heading/format(...)`. Read tools are free; write tools produce suggestions.
+- **Read/write boundary:** enforce per-tool (e.g. read-only mode disables write
+  tools); gate the whole tool set by group permissions (existing
+  `chatAuthRequired` + app `tools` gating).
+- **Pros:** true multi-step agent; document stays only in the browser; no
+  server-side doc model; reuses iHub's loop, permissions, adapters, usage.
+- **Cons:** new (small) bidirectional protocol + client tool runtime. This is the
+  one genuinely new piece of infrastructure — but it's a **generalization of code
+  that already exists** (`ask_user`), and it's broadly useful beyond the editor.
+
+### Recommendation
+**Ship Option A first (4a)** for immediate value and low risk, then **build
+Option C (4b)** for the real agent. Treat Option B as the fallback if the
+client-tool protocol proves too costly. A/C share the suggestion UI (§5) and the
+"Document Editor" app config, so 4a is not throwaway.
+
+## 5. Suggestion / accept-reject layer (MIT, shared by A and C)
+
+This replaces Pro's **AI Changes** extension.
+
+- **Representation:** custom ProseMirror **marks** `suggestion_insert` /
+  `suggestion_delete` (and a node-level attr for block changes), rendered with
+  distinct styling; or a Decoration set for non-persisted preview. Each change
+  carries a `changeId` + metadata (tool/call origin, reason).
+- **Diffing:** for "replace selection" we know the range directly; for free-form
+  rewrites use **`prosemirror-changeset`** (MIT) to compute a minimal diff between
+  the pre-edit and post-edit doc, then map to insert/delete marks.
+- **UI:** a review panel / inline controls: **Accept** (strip insert marks to
+  plain content, remove deleted ranges), **Reject** (inverse), Accept-all /
+  Reject-all. Mirrors the current `CanvasContentConfirmationModal` UX but at the
+  granularity of individual changes.
+- **Audit:** emit existing `tool.call.start/end` events for each applied op;
+  record usage via `usageTracker` exactly like normal chat.
+
+## 6. Routing & server changes
+
+- **App config:** add a `contents/apps/document-editor.json` (or per-app
+  `features.editor`) whose `tools` list is the document tool set, and (for 4a) an
+  `outputSchema` for the op list. Reuses `/api/apps/:appId/chat/:chatId`.
+- **4a:** **no server code changes** beyond config — pure structured output.
+- **4b:** localized server changes in `server/services/chat/ToolExecutor.js`:
+  - add `clientExecuted` tool handling alongside `ask_user`/`passthrough`;
+  - new event `tool.client.request` in `shared/unifiedEventSchema.js` +
+    `actionTracker` emitter + `server/sse.js` passthrough;
+  - a resume path that injects the client-returned tool result into
+    `continueWithToolExecution` (model the `ask_user` answer round-trip).
+- **Client:** a `useEditorAgent` hook that (4a) sends the doc + request and
+  applies the returned ops as suggestions; (4b) additionally registers a
+  client-tool runtime that handles `tool.client.request` events, executes against
+  the Tiptap editor, and POSTs results back.
+
+## 7. Security / privacy / on-prem
+
+- All LLM traffic stays on iHub adapters (incl. local/vLLM/LM Studio) — **no data
+  to Tiptap Cloud, no Pro runtime check, air-gapped-safe** (only MIT packages from
+  public npm, mirrorable).
+- Document content travels only client→iHub (4a/C never send the doc to a third
+  party). Option B keeps a transient server copy for the loop's duration.
+- Tool gating + group permissions reuse the existing chat authorization path
+  (`chatAuthRequired`, app `tools`/permissions).
+
+## 8. Risks specific to the OSS path
+
+- **Anchor reliability (4a):** models must quote existing text exactly; mitigate
+  with fuzzy/normalized matching + explicit "could not locate" reporting.
+- **Client-tool protocol correctness (4b):** pause/resume + callId bookkeeping;
+  reuse the `ask_user` precedent and cap iterations. Handle disconnect mid-loop.
+- **Suggestion layer complexity:** track-changes is non-trivial; start with
+  replace-range granularity, add changeset diffing incrementally.
+- **Multiple concurrent suggestions / collaboration:** out of scope (no backend
+  doc persistence yet — see G3 follow-up).
+
+## 9. Effort (OSS Phase 4, replaces the Pro estimate)
+
+| Item | Effort |
+| --- | --- |
+| 4a — structured ops + suggestion apply + accept/reject UI | 4–6 d |
+| 5 — suggestion/changeset layer (shared, MIT) | 3–5 d |
+| 4b — client-tool protocol (server pause/resume + client runtime) | 5–8 d |
+| 4b — document tool set (read/search/replace/insert/delete) | 3–4 d |
+| Doc-editor app config + permissions + usage wiring | 1–2 d |
+
+(Comparable to the Pro estimate, with **$0 licensing** and no air-gapped registry
+risk; the extra build cost buys full control and on-prem safety.)
+
+## 10. Open questions for sign-off
+
+1. **Phase 4a scope first, then 4b?** (recommended) or jump straight to the full
+   client-tool agent (4b)?
+2. **Suggestion granularity** for v1: replace-range only, or full changeset
+   diffing from the start?
+3. **Dedicated "Document Editor" app** vs. enabling the editor agent on any app
+   with `features.editor`?
+4. **Backend document persistence** (G3) — still a follow-up, or pull forward
+   because real agentic editing benefits from server-held doc state (also unlocks
+   Option B and collaboration)?


### PR DESCRIPTION
## Summary

Adds a detailed, file-level **implementation plan** for replacing the Quill-based Canvas editor with Tiptap (issue #1609), as a companion to the merged research/concept doc from #1608.

**Per the scoping decision, this PR is plan-only — no code yet.** It exists to be reviewed before implementation, then split into one sub-issue per phase.

New file: `concepts/2026-06-16 Tiptap Editor Implementation Plan.md`

## What the plan covers

- **Concrete inventory** of every `client/src/features/canvas/` file and its migration target.
- **Quill→Tiptap API map** (the core of the rewrite: selection, insert, replace, char count, clipboard).
- **Exact npm packages** per phase, pinned to Tiptap 3.x.
- **Rollout strategy:** new code in `client/src/features/editor/` behind a per-app `features.editor` flag, running side by side with Canvas; Quill removed only at final cutover.
- **Per-phase task lists + acceptance criteria**, i18n, test plan, risks, effort, and a suggested sub-issue breakdown.

## Key findings driving the plan

- ✅ **Phases 1–3 are fully unblocked** — `@tiptap/react@3.26.1` + `@tiptap/starter-kit` install from public npm; the existing AI quick-actions/chat already route through iHub's own chat API, so the OSS agentic surface needs **no backend changes**.
- ⛔ **Phase 4 (Tiptap Pro AI Agent/Toolkit) is blocked** — `@tiptap-pro/*` returns **404 on the public registry**; it needs a paid subscription + private-registry token (the Phase 0 procurement/air-gapped gate). An OSS fallback path is documented.
- ℹ️ Route stays a sub-route of `/apps`, so **no `runtimeBasePath.js` `knownRoutes` change** is required.

## Decision gates flagged for a human

- **G0 — Licensing:** buy Tiptap Pro + AI Toolkit? private-registry token in air-gapped builds? runtime phone-home?
- **G1 — Routing:** reuse app-chat endpoint (Path A, default) vs. dedicated agent route.
- **G2 — Agentic fallback** if G0 = no.
- **G3 — Backend document persistence** (currently `sessionStorage` only) — follow-up.

https://claude.ai/code/session_01Bd5eKZn26kQUXenEsUmvbV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bd5eKZn26kQUXenEsUmvbV)_