### PR TITLE
Fix high idle GPU usage in chat by scoping layer promotion to streaming

### DIFF
--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -550,7 +550,7 @@ function ChatMessage({
             : contentToRender;
         return (
           <div className="flex flex-col">
-            <StreamingMarkdown content={mdContent} hasCitations={!!message.citations} />
+            <StreamingMarkdown content={mdContent} hasCitations={!!message.citations} streaming />
             {message.searchStatus && message.loading && (
               <SearchStatusIndicator status={message.searchStatus} />
             )}

--- a/client/src/features/chat/components/StreamingMarkdown.css
+++ b/client/src/features/chat/components/StreamingMarkdown.css
@@ -1,7 +1,4 @@
 .streaming-markdown {
-  /* Use hardware acceleration for rendering */
-  will-change: transform;
-  transform: translateZ(0);
   white-space: normal;
   display: inline-block;
   box-sizing: content-box;
@@ -161,6 +158,18 @@
     background-color: rgb(209, 250, 229);
     color: rgb(4, 120, 87);
   }
+}
+
+/*
+ * GPU-accelerate rendering ONLY while a message is actively streaming. Applying
+ * this to every .streaming-markdown permanently promoted each finished message to
+ * its own compositor layer, so an old chat parked dozens of layers in GPU memory
+ * and saturated the compositor budget at idle. Only one message streams at a time,
+ * so scoping the hint to .is-streaming keeps the streaming benefit with no idle cost.
+ */
+.streaming-markdown.is-streaming {
+  will-change: transform;
+  transform: translateZ(0);
 }
 
 /* Hide interactive UI elements when printing */

--- a/client/src/features/chat/components/StreamingMarkdown.jsx
+++ b/client/src/features/chat/components/StreamingMarkdown.jsx
@@ -17,8 +17,12 @@ import './StreamingMarkdown.css';
  * @param {Object} props
  * @param {string} props.content - Markdown content to render
  * @param {boolean} [props.hasCitations] - Whether content may contain cite tags
+ * @param {boolean} [props.streaming] - Whether the message is actively streaming.
+ *   While true the container is GPU-promoted (will-change/translateZ) for smooth
+ *   incremental updates; once streaming ends the promotion is dropped so finished
+ *   messages don't each hold a permanent compositor layer.
  */
-function StreamingMarkdown({ content, hasCitations }) {
+function StreamingMarkdown({ content, hasCitations, streaming = false }) {
   const containerRef = useRef(null);
   const [htmlContent, setHtmlContent] = useState('');
   const [renderKey, setRenderKey] = useState(0);
@@ -75,7 +79,9 @@ function StreamingMarkdown({ content, hasCitations }) {
     <div
       key={renderKey}
       ref={containerRef}
-      className="markdown-content break-words whitespace-normal streaming-markdown"
+      className={`markdown-content break-words whitespace-normal streaming-markdown${
+        streaming ? ' is-streaming' : ''
+      }`}
       dangerouslySetInnerHTML={{ __html: htmlContent }} // sanitized with DOMPurify before setState
     />
   );

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -469,3 +469,10 @@ Highlights:
 - Fixes a latent bug where large-context models (e.g. Claude Opus) requested their full context window as the output cap, which could cause provider errors.
 
 Admins editing models will see two fields (Context Window, Max Output Tokens) instead of one Token Limit.
+
+## Fix — High GPU Usage When Viewing Long Chats
+
+Open chat conversations no longer keep the GPU busy while idle. Every rendered assistant message was permanently promoted to its own GPU compositor layer, so a long or old conversation parked dozens of layers in video memory and saturated the browser's compositing budget even when nothing was happening on screen.
+
+- The GPU-acceleration hint is now applied only to the single message that is actively streaming, where it actually helps smooth incremental rendering, and is dropped once the response completes.
+- Measured effect: an idle chat now promotes **zero** extra compositor layers regardless of length (previously up to the browser's layer cap). No configuration change required.


### PR DESCRIPTION
## Problem

Open chat conversations consumed a lot of GPU **while idle** — even an old chat with no streaming and nothing changing on screen.

Root cause: every assistant message renders a `.streaming-markdown` container, and that class carried `will-change: transform` + `transform: translateZ(0)` unconditionally. Those two declarations permanently promote each element to its own GPU compositor layer. Combined with no list virtualization (`ChatMessageList` mounts every message), a long/old conversation parks dozens of permanent layers in GPU memory and saturates the browser's compositing budget at idle. Cost scales with conversation length.

## Verification (before fixing)

Reproduced the real chat DOM in headless Chromium and counted actual composited layers via CDP `LayerTree`:

| Messages (N) | promotion ON (old) | promotion OFF |
|---|---|---|
| 1  | 1 layer | 0 |
| 5  | 5 layers | 0 |
| 20 | 18 layers (hits compositor cap) | 0 |
| 40 | 18 layers (capped) | 0 |

One GPU layer per message, 1:1 — flatlining at ~18 is Chromium hitting its layer/GPU-memory budget, exactly the "old chat = a lot of GPU" symptom.

## Fix

Scope the GPU-acceleration hint to a new `.is-streaming` modifier applied **only while a message is actively streaming** (where it genuinely helps smooth incremental rendering), and drop it once the response completes:

- `StreamingMarkdown` now takes a `streaming` prop and adds `is-streaming` to the container when true.
- `ChatMessage` passes `streaming` from its loading branch; finished messages render without it.
- `StreamingMarkdown.css` moves `will-change`/`translateZ` from the base `.streaming-markdown` rule to `.streaming-markdown.is-streaming`.

Only one message streams at a time, so the streaming benefit is fully preserved with zero idle cost.

## Verification (after fixing)

| Messages (N) | OLD: all promoted | NEW: idle chat | NEW: 1 msg streaming |
|---|---|---|---|
| 1  | 1 | **0** | 1 |
| 5  | 5 | **0** | 1 |
| 20 | 18 | **0** | (1 when on-screen) |
| 40 | 18 | **0** | (1 when on-screen) |

Idle chats now promote zero extra compositor layers regardless of length.

## Notes
- No config change required.
- `npx eslint` / `npx prettier` clean on the changed files (0 errors; remaining warnings are pre-existing).
- Other `StreamingMarkdown` consumers (marketplace preview) render without the streaming prop, so they correctly get no promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018SEmrP9CCzefjB1LxEpr4p

---
_Generated by [Claude Code](https://claude.ai/code/session_018SEmrP9CCzefjB1LxEpr4p)_