### PR TITLE
feat: new start page, collapsible left sidebar, and compact apps browser

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -37,6 +37,7 @@
           'login',
           'pages',
           'prompts',
+          'chats',
           'settings',
           'teams',
           'workflows',

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,8 +5,10 @@ import { initializeBasePath, getBasePath } from './utils/runtimeBasePath';
 import lazyWithRetry from './utils/lazyWithRetry';
 import Layout from './shared/components/Layout';
 import AppsList from './features/apps/pages/AppsList';
+import StartPage from './features/apps/pages/StartPage';
 import PromptsList from './features/prompts/pages/PromptsList';
 import AppRouterWrapper from './features/apps/components/AppRouterWrapper';
+const ChatHistoryPage = lazyWithRetry(() => import('./features/chat/pages/ChatHistoryPage'));
 // Lazy load workflow components
 const WorkflowsPage = lazyWithRetry(() => import('./features/workflows/pages/WorkflowsPage'));
 const SetupWizard = lazyWithRetry(() => import('./features/setup/SetupWizard'));
@@ -170,6 +172,7 @@ const TeamsAuthEnd = lazyWithRetry(() => import('./features/teams/TeamsAuthEnd')
 
 // Create safe versions of components that need error boundaries
 const SafeAppsList = withSafeRoute(AppsList);
+const SafeStartPage = withSafeRoute(StartPage);
 const SafeAppRouterWrapper = withSafeRoute(AppRouterWrapper);
 const SafeAppCanvas = withSafeRoute(AppCanvas);
 const SafeUnifiedPage = withSafeRoute(UnifiedPage);
@@ -347,10 +350,23 @@ function App() {
             index
             element={
               <SetupCheck>
-                <SafeAppsList />
+                <SafeStartPage />
               </SetupCheck>
             }
           />
+          {/* Apps browser — full list with search/filter */}
+          <Route path="apps" element={<SafeAppsList />} />
+          {/* Chat history page — feature-flagged, uses mock data */}
+          {featureFlags.isEnabled('chatHistory', false) && (
+            <Route
+              path="chats"
+              element={
+                <Suspense fallback={<AdminLoading />}>
+                  <ChatHistoryPage />
+                </Suspense>
+              }
+            />
+          )}
           {uiConfig?.promptsList?.enabled !== false &&
             featureFlags.isEnabled('promptsLibrary', true) && (
               <Route path="prompts" element={<SafePromptsList />} />

--- a/client/src/features/admin/components/AdminSidebar.jsx
+++ b/client/src/features/admin/components/AdminSidebar.jsx
@@ -7,13 +7,18 @@ import {
   ChevronDoubleLeftIcon,
   ChevronDoubleRightIcon,
   MagnifyingGlassIcon,
-  XMarkIcon
+  XMarkIcon,
+  ArrowLeftIcon
 } from '@heroicons/react/24/outline';
 import { useSidebar } from '../contexts/SidebarContext';
 import { getAdminNavSections } from './AdminSidebarNavData';
 import { usePlatformConfig } from '../../../shared/contexts/PlatformConfigContext';
+import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
 import { useAuth } from '../../../shared/contexts/AuthContext';
 import useFeatureFlags from '../../../shared/hooks/useFeatureFlags';
+import { getLocalizedContent } from '../../../utils/localizeContent';
+import { buildAssetUrl } from '../../../utils/runtimeBasePath';
+import IHubLogo from '../../../shared/components/IHubLogo';
 
 // Sections visible to content-admin-only users
 const CONTENT_ADMIN_SECTIONS = new Set(['overview', 'aiWorkspace']);
@@ -189,12 +194,33 @@ function SidebarContent({ sections }) {
 }
 
 export default function AdminSidebar({ onMobileToggle }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const currentLanguage = i18n.language;
   const { platformConfig } = usePlatformConfig();
+  const { uiConfig } = useUIConfig();
   const { user } = useAuth();
   const featureFlags = useFeatureFlags();
   const { isCollapsed, isMobileOpen, toggle, closeMobile } = useSidebar();
   const drawerRef = useRef(null);
+
+  const logoSrc = uiConfig?.header?.logo?.url ? buildAssetUrl(uiConfig.header.logo.url) : null;
+  const logoAlt = getLocalizedContent(uiConfig?.header?.logo?.alt, currentLanguage) || 'iHub';
+  const brandTitle =
+    uiConfig?.header?.titleLight || uiConfig?.header?.titleBold ? (
+      <>
+        <span className="font-light">
+          {getLocalizedContent(uiConfig.header.titleLight, currentLanguage)}
+        </span>
+        <span className="font-extrabold">
+          {getLocalizedContent(uiConfig.header.titleBold, currentLanguage)}
+        </span>
+      </>
+    ) : (
+      <>
+        <span className="font-light">iHub </span>
+        <span className="font-extrabold">Apps</span>
+      </>
+    );
 
   const adminPages = platformConfig?.admin?.pages || {};
   const showAdminPage = key => adminPages[key] !== false;
@@ -233,6 +259,92 @@ export default function AdminSidebar({ onMobileToggle }) {
 
   const sidebarBody = (
     <>
+      {/* Branded header — mirrors the user-facing sidebar */}
+      {isCollapsed ? (
+        <div className="flex flex-col items-center gap-1.5 pt-4 pb-2">
+          <Link
+            to="/"
+            title={t('admin.sidebar.backToApp', 'Back to iHub')}
+            className="rounded-lg p-0.5 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            {logoSrc ? (
+              <img src={logoSrc} alt={logoAlt} className="w-7 h-7 object-contain" />
+            ) : (
+              <IHubLogo size={28} />
+            )}
+          </Link>
+          <button
+            type="button"
+            onClick={toggle}
+            aria-label={t('admin.sidebar.expand', 'Expand sidebar')}
+            className="w-10 h-10 flex items-center justify-center rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            <ChevronDoubleRightIcon className="w-5 h-5" aria-hidden="true" />
+          </button>
+        </div>
+      ) : (
+        <div className="px-4 pt-4 pb-2 flex items-center gap-2.5">
+          <Link
+            to="/"
+            title={t('admin.sidebar.backToApp', 'Back to iHub')}
+            className="flex items-center gap-2.5 flex-1 min-w-0 rounded-lg -ml-1 pl-1 py-1 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          >
+            {logoSrc ? (
+              <img src={logoSrc} alt={logoAlt} className="w-8 h-8 object-contain flex-none" />
+            ) : (
+              <div className="flex-none">
+                <IHubLogo size={30} />
+              </div>
+            )}
+            <div className="flex-1 min-w-0 leading-tight">
+              <div className="text-base text-gray-900 dark:text-gray-100 truncate">
+                {brandTitle}
+              </div>
+              <div className="text-[10px] text-gray-400 tracking-wide uppercase">
+                {t('admin.sidebar.adminPanel', 'Admin Panel')}
+              </div>
+            </div>
+          </Link>
+          <button
+            type="button"
+            onClick={toggle}
+            aria-label={t('admin.sidebar.collapse', 'Collapse sidebar')}
+            className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 transition-colors flex-none"
+          >
+            <ChevronDoubleLeftIcon className="w-5 h-5" aria-hidden="true" />
+          </button>
+        </div>
+      )}
+
+      {/* Back to the main app */}
+      <div className={`${isCollapsed ? 'px-2' : 'px-3'} pb-2`}>
+        {isCollapsed ? (
+          <div className="relative group">
+            <Link
+              to="/"
+              aria-label={t('admin.sidebar.backToApp', 'Back to iHub')}
+              className="flex items-center justify-center h-9 w-9 mx-auto rounded-md text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+            >
+              <ArrowLeftIcon className="w-5 h-5 shrink-0" aria-hidden="true" />
+            </Link>
+            <div
+              className="absolute left-full top-1/2 -translate-y-1/2 ml-2 px-2 py-1 rounded bg-gray-900 dark:bg-gray-700 text-white text-xs whitespace-nowrap z-50 opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity"
+              role="tooltip"
+            >
+              {t('admin.sidebar.backToApp', 'Back to iHub')}
+            </div>
+          </div>
+        ) : (
+          <Link
+            to="/"
+            className="flex items-center gap-2.5 px-3 py-2 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+          >
+            <ArrowLeftIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+            <span>{t('admin.sidebar.backToApp', 'Back to iHub')}</span>
+          </Link>
+        )}
+      </div>
+
       {/* Search stub */}
       {!isCollapsed && (
         <div className="px-3 py-2 border-b border-gray-200 dark:border-gray-700">
@@ -251,26 +363,6 @@ export default function AdminSidebar({ onMobileToggle }) {
       )}
 
       <SidebarContent sections={sections} />
-
-      {/* Collapse toggle */}
-      <div className="border-t border-gray-200 dark:border-gray-700 p-2">
-        <button
-          type="button"
-          onClick={toggle}
-          aria-label={
-            isCollapsed
-              ? t('admin.sidebar.expand', 'Expand sidebar')
-              : t('admin.sidebar.collapse', 'Collapse sidebar')
-          }
-          className="flex items-center justify-center w-full h-9 rounded-md text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
-        >
-          {isCollapsed ? (
-            <ChevronDoubleRightIcon className="w-5 h-5" aria-hidden="true" />
-          ) : (
-            <ChevronDoubleLeftIcon className="w-5 h-5" aria-hidden="true" />
-          )}
-        </button>
-      </div>
     </>
   );
 
@@ -279,7 +371,7 @@ export default function AdminSidebar({ onMobileToggle }) {
       {/* Desktop sidebar */}
       <aside
         className={`hidden md:flex flex-col h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 transition-all duration-200 shrink-0 ${
-          isCollapsed ? 'w-16' : 'w-64'
+          isCollapsed ? 'w-[72px]' : 'w-[284px]'
         }`}
       >
         <nav
@@ -321,6 +413,17 @@ export default function AdminSidebar({ onMobileToggle }) {
         </div>
 
         <nav className="flex flex-col flex-1 overflow-hidden">
+          {/* Back to the main app */}
+          <div className="px-3 pt-3 pb-1">
+            <Link
+              to="/"
+              onClick={closeMobile}
+              className="flex items-center gap-2.5 px-3 py-2 rounded-md text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+            >
+              <ArrowLeftIcon className="w-4 h-4 shrink-0" aria-hidden="true" />
+              <span>{t('admin.sidebar.backToApp', 'Back to iHub')}</span>
+            </Link>
+          </div>
           {/* Search stub (always expanded in mobile) */}
           <div className="px-3 py-2 border-b border-gray-200 dark:border-gray-700">
             <button

--- a/client/src/features/admin/components/StartPageCustomization.jsx
+++ b/client/src/features/admin/components/StartPageCustomization.jsx
@@ -1,0 +1,114 @@
+import { useState, useEffect } from 'react';
+import { fetchApps } from '../../../api';
+import { getLocalizedContent } from '../../../utils/localizeContent';
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Start page configuration. Currently lets an admin pick the default app used
+ * for the start page's chat input (uiConfig.startPage.defaultAppId).
+ */
+function StartPageCustomization({ config, onUpdate, t }) {
+  const { i18n } = useTranslation();
+  const currentLanguage = i18n.language;
+  const [apps, setApps] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    fetchApps()
+      .then(data => {
+        if (mounted && Array.isArray(data)) setApps(data);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const defaultAppId = config?.defaultAppId || '';
+  const showDefaultApp = config?.showDefaultApp !== false;
+
+  return (
+    <div className="p-6">
+      <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">
+        {t('admin.ui.startPage.title', 'Start Page Configuration')}
+      </h3>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
+        {t(
+          'admin.ui.startPage.description',
+          'Configure the personalized start page shown to users.'
+        )}
+      </p>
+
+      <div className="max-w-lg space-y-6">
+        {/* Toggle: show the default chat app input at all */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              {t('admin.ui.startPage.showDefaultApp', 'Show default chat app')}
+            </span>
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {t(
+                'admin.ui.startPage.showDefaultAppHelp',
+                'When off, the start page shows the greeting and apps but no chat input.'
+              )}
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={showDefaultApp}
+            onClick={() => onUpdate({ showDefaultApp: !showDefaultApp })}
+            className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 ${
+              showDefaultApp ? 'bg-indigo-600' : 'bg-gray-200 dark:bg-gray-600'
+            }`}
+          >
+            <span
+              aria-hidden="true"
+              className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                showDefaultApp ? 'translate-x-5' : 'translate-x-0'
+              }`}
+            />
+          </button>
+        </div>
+
+        {/* Default app selector */}
+        <div>
+          <label
+            htmlFor="startPage-defaultApp"
+            className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+          >
+            {t('admin.ui.startPage.defaultApp', 'Default chat app')}
+          </label>
+          <select
+            id="startPage-defaultApp"
+            value={defaultAppId}
+            disabled={loading || !showDefaultApp}
+            onChange={e => onUpdate({ defaultAppId: e.target.value || undefined })}
+            className="block w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 dark:text-gray-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            <option value="">
+              {t('admin.ui.startPage.firstAvailable', 'First available app (automatic)')}
+            </option>
+            {apps.map(app => (
+              <option key={app.id} value={app.id}>
+                {getLocalizedContent(app.name, currentLanguage) || app.id}
+              </option>
+            ))}
+          </select>
+          <p className="mt-2 text-xs text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.ui.startPage.defaultAppHelp',
+              'The app whose chat input is shown on the start page. When unset, the first app the user can access is used.'
+            )}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default StartPageCustomization;

--- a/client/src/features/admin/pages/AdminUICustomization.jsx
+++ b/client/src/features/admin/pages/AdminUICustomization.jsx
@@ -6,6 +6,7 @@ import AssetManager from '../components/AssetManager';
 import StyleEditor from '../components/StyleEditor';
 import ContentEditor from '../components/ContentEditor';
 import PwaCustomization from '../components/PwaCustomization';
+import StartPageCustomization from '../components/StartPageCustomization';
 import { makeAdminApiCall } from '../../../api/adminApi';
 import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
 
@@ -112,6 +113,7 @@ function AdminUICustomization() {
 
   const tabs = [
     { id: 'header', label: t('admin.ui.tabs.header', 'Header'), icon: '🎨' },
+    { id: 'startPage', label: t('admin.ui.tabs.startPage', 'Start Page'), icon: '🏠' },
     { id: 'footer', label: t('admin.ui.tabs.footer', 'Footer'), icon: '📄' },
     { id: 'assets', label: t('admin.ui.tabs.assets', 'Assets'), icon: '🖼️' },
     { id: 'styles', label: t('admin.ui.tabs.styles', 'Styles'), icon: '🎯' },
@@ -279,6 +281,13 @@ function AdminUICustomization() {
             <HeaderCustomization
               config={config.header || {}}
               onUpdate={updates => updateConfig('header', updates)}
+              t={t}
+            />
+          )}
+          {activeTab === 'startPage' && (
+            <StartPageCustomization
+              config={config.startPage || {}}
+              onUpdate={updates => updateConfig('startPage', updates)}
               t={t}
             />
           )}

--- a/client/src/features/apps/pages/AppChat.jsx
+++ b/client/src/features/apps/pages/AppChat.jsx
@@ -21,6 +21,7 @@ import useAppChat from '../../chat/hooks/useAppChat';
 import useVoiceCommands from '../../voice/hooks/useVoiceCommands';
 import useAppSettings from '../../../shared/hooks/useAppSettings';
 import useFileUploadHandler from '../../../shared/hooks/useFileUploadHandler';
+import { consumePendingChatStart } from '../../chat/startChatHandoff';
 import useMagicPrompt from '../../../shared/hooks/useMagicPrompt';
 import { useIntegrationAuth } from '../../chat/hooks/useIntegrationAuth';
 import useNextcloudEmbedAttachments from '../../nextcloud-embed/hooks/useNextcloudEmbedAttachments';
@@ -340,6 +341,17 @@ function AppChat({ preloadedApp = null }) {
     [models, selectedModel]
   );
   useNextcloudEmbedAttachments(fileUploadHandler, app, currentModelObject);
+
+  // Consume any attachments handed off from the start page. The message text
+  // and auto-send still arrive via the `prefill` / `send=true` query params;
+  // here we only restore the already-processed file payload so the auto-send
+  // includes it.
+  useEffect(() => {
+    const handoff = consumePendingChatStart(appId);
+    if (handoff?.files) {
+      fileUploadHandler.setSelectedFile(handoff.files);
+    }
+  }, [appId]); // eslint-disable-line @eslint-react/exhaustive-deps
 
   // Check document token size against model context window and warn user if needed
   useEffect(() => {
@@ -2026,7 +2038,7 @@ function AppChat({ preloadedApp = null }) {
   }
 
   return (
-    <div className="flex flex-col h-[calc(100vh-6rem)] max-h-[calc(100vh-6rem)] min-h-0 overflow-hidden pt-4 pb-2">
+    <div className="flex flex-col h-full max-h-full min-h-0 overflow-hidden px-4 md:px-6 pt-4 pb-2">
       {/* Shared App Header */}
       <SharedAppHeader
         app={app}

--- a/client/src/features/apps/pages/AppsList.jsx
+++ b/client/src/features/apps/pages/AppsList.jsx
@@ -1,26 +1,30 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { fetchApps } from '../../../api';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import { useTranslation } from 'react-i18next';
 import { getLocalizedContent } from '../../../utils/localizeContent';
-import { createFavoriteItemHelpers } from '../../../utils/favoriteItems';
+import useFavorites from '../../../shared/hooks/useFavorites';
 import { getRecentAppIds } from '../../../utils/recentApps';
 import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
 import { useAuth } from '../../../shared/contexts/AuthContext';
 import Icon from '../../../shared/components/Icon';
-import AppCard from '../../../shared/components/AppCard';
 import NextcloudSelectionBanner from '../../nextcloud-embed/components/NextcloudSelectionBanner';
 
 // Instead of fixed values, we'll calculate based on viewport
 function AppsList() {
   const { t, i18n } = useTranslation();
   const currentLanguage = i18n.language;
+  const navigate = useNavigate();
   const { resetHeaderColor, uiConfig } = useUIConfig();
   const { user, isAuthenticated } = useAuth();
 
-  // Create favorite apps helpers
-  const { getFavorites: getFavoriteApps, toggleFavorite: toggleFavoriteApp } =
-    createFavoriteItemHelpers('ihub_favorite_apps');
+  // Favorite apps (kept in sync across components + tabs by the hook)
+  const {
+    favorites: favoriteApps,
+    isFavorite,
+    toggleFavorite
+  } = useFavorites('ihub_favorite_apps');
 
   // Get search configuration from UI config with defaults
   const searchConfig = useMemo(() => {
@@ -58,7 +62,6 @@ function AppsList() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
   const [searchTerm, setSearchTerm] = useState('');
-  const [favoriteApps, setFavoriteApps] = useState([]);
   const [displayCount, setDisplayCount] = useState(0);
   const [selectedCategory, setSelectedCategory] = useState('all');
   const recentAppIds = useMemo(() => getRecentAppIds(), []);
@@ -100,9 +103,10 @@ function AppsList() {
   const gridRef = useRef(null);
   const containerRef = useRef(null);
 
-  // Calculate how many apps can fit in the viewport
+  // Calculate how many apps can fit in the viewport. The compact row layout is
+  // much denser than the old banner cards, so we can show far more at once.
   const calculateVisibleAppCount = useCallback(() => {
-    if (!gridRef.current || !containerRef.current) return 9; // Default fallback
+    if (!gridRef.current || !containerRef.current) return 24; // Default fallback
 
     const gridRect = gridRef.current.getBoundingClientRect();
     const containerRect = containerRef.current.getBoundingClientRect();
@@ -112,17 +116,16 @@ function AppsList() {
     const headerHeight = gridRect.top - containerRect.top;
     const availableHeight = window.innerHeight - headerHeight - 120; // 120px for load more button and padding
 
-    // Approximate height of each app card (you may need to adjust this)
-    const appCardHeight = 250; // Typical height in pixels including margins
+    // Approximate height of each compact app row (including the 12px grid gap).
+    const appCardHeight = 78;
 
-    // Calculate visible rows based on available height
-    const visibleRows = Math.max(1, Math.floor(availableHeight / appCardHeight));
+    // Calculate visible rows based on available height (with a little buffer).
+    const visibleRows = Math.max(1, Math.floor(availableHeight / appCardHeight) + 1);
 
-    // Calculate columns based on screen width (matches the grid-cols classes)
-    let columns = 1;
-    if (window.innerWidth >= 1024)
-      columns = 3; // lg breakpoint
-    else if (window.innerWidth >= 640) columns = 2; // sm breakpoint
+    // Columns follow the auto-fill grid (min 320px per column) within the
+    // available grid width, so the count matches what's actually rendered.
+    const gridWidth = gridRect.width || containerRect.width;
+    const columns = Math.max(1, Math.floor(gridWidth / 320));
 
     return visibleRows * columns;
   }, []);
@@ -177,13 +180,9 @@ function AppsList() {
           return;
         }
 
-        // Load favorite apps from localStorage
-        const favorites = getFavoriteApps();
-
         // Batch our state updates to prevent multiple renders
         if (isMounted) {
           setApps(appsData);
-          setFavoriteApps(favorites);
           setError(null);
 
           // Calculate visible app count after data is loaded
@@ -254,16 +253,9 @@ function AppsList() {
     (e, appId) => {
       e.preventDefault(); // Stop event propagation to avoid navigating to the app
       e.stopPropagation();
-
-      const newStatus = toggleFavoriteApp(appId);
-      // Update the favorite apps list in state
-      if (newStatus) {
-        setFavoriteApps(prev => [...prev, appId]);
-      } else {
-        setFavoriteApps(prev => prev.filter(id => id !== appId));
-      }
+      toggleFavorite(appId);
     },
-    [toggleFavoriteApp]
+    [toggleFavorite]
   );
 
   // Load more apps handler
@@ -471,65 +463,57 @@ function AppsList() {
   }
 
   return (
-    <div ref={containerRef} className="container mx-auto py-8 px-4 flex flex-col">
+    <div ref={containerRef} className="min-h-full bg-gray-50 dark:bg-gray-900 px-6 py-10">
       <NextcloudSelectionBanner />
-      <div className="text-center mb-8">
-        <h1 className="text-3xl font-bold mb-2 flex items-center justify-center">
-          <Icon
-            name={uiConfig?.icons?.appsListLogo || 'apps-svg-logo'}
-            className="text-indigo-600 w-[4rem] h-[4rem] mr-2"
-          />
-          {/* Use title from UI config if available, otherwise use translation */}
-          {uiConfig?.appsList?.title
-            ? getLocalizedContent(uiConfig.appsList.title, currentLanguage)
-            : t('pages.appsList.title')}
-        </h1>
-        <p className="text-gray-600 dark:text-gray-400">
-          {uiConfig?.appsList?.subtitle
-            ? getLocalizedContent(uiConfig.appsList.subtitle, currentLanguage)
-            : t('pages.appsList.subtitle')}
-        </p>
-      </div>
+      <div className="max-w-6xl mx-auto">
+        {/* Page header */}
+        <div className="flex flex-col items-center text-center mb-8">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">
+            {uiConfig?.appsList?.title
+              ? getLocalizedContent(uiConfig.appsList.title, currentLanguage)
+              : t('pages.appsList.title')}
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            {uiConfig?.appsList?.subtitle
+              ? getLocalizedContent(uiConfig.appsList.subtitle, currentLanguage)
+              : t('pages.appsList.subtitle')}
+          </p>
+        </div>
 
-      {/* Conditional rendering of search based on configuration and app count */}
-      {searchConfig.enabled && apps.length > 3 && (
-        <div
-          className={`flex flex-col sm:flex-row items-stretch gap-4 mb-4 mx-auto ${
-            searchConfig.width || 'w-full sm:w-2/3 lg:w-1/3'
-          }`}
-        >
-          <div className="relative flex-grow">
-            <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-              <Icon name="search" className="h-5 w-5 text-gray-400" />
+        {/* Search + sort */}
+        {searchConfig.enabled && apps.length > 3 && (
+          <div className="flex flex-col sm:flex-row items-stretch gap-3 mb-5 justify-center">
+            <div className="relative" style={{ minWidth: 0, flex: '0 1 440px' }}>
+              <span className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">
+                <Icon name="search" className="h-5 w-5" />
+              </span>
+              <input
+                type="text"
+                placeholder={
+                  getLocalizedContent(searchConfig.placeholder, currentLanguage) ||
+                  t('pages.appsList.searchPlaceholder')
+                }
+                value={searchTerm}
+                onChange={handleSearchChange}
+                className="block w-full pl-12 pr-10 py-3 border border-gray-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 rounded-xl text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-400 bg-white"
+                autoComplete="off"
+                data-lpignore="true"
+                data-1p-ignore="true"
+                aria-label={t('apps.searchApps', 'Search apps')}
+              />
+              {searchTerm && (
+                <button
+                  onClick={clearSearch}
+                  className="absolute inset-y-0 right-0 pr-4 flex items-center text-gray-400 hover:text-gray-600"
+                  aria-label={t('common.clearSearch', 'Clear search')}
+                >
+                  <Icon name="x" className="w-4 h-4" />
+                </button>
+              )}
             </div>
-            <input
-              type="text"
-              placeholder={
-                getLocalizedContent(searchConfig.placeholder, currentLanguage) ||
-                t('pages.appsList.searchPlaceholder')
-              }
-              value={searchTerm}
-              onChange={handleSearchChange}
-              className="block w-full pl-10 pr-10 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 rounded-lg text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-              autoComplete="off"
-              data-lpignore="true"
-              data-1p-ignore="true"
-              aria-label={t('apps.searchApps', 'Search apps')}
-            />
-            {searchTerm && (
-              <button
-                onClick={clearSearch}
-                className="absolute inset-y-0 right-0 pr-4 flex items-center text-gray-400 hover:text-gray-600"
-                aria-label={t('common.clearSearch', 'Clear search')}
-              >
-                <Icon name="x" className="w-5 h-5" />
-              </button>
-            )}
-          </div>
-          {sortConfig.enabled && (
-            <div className="flex-shrink-0">
+            {sortConfig.enabled && (
               <select
-                className="h-full border border-gray-300 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-100 rounded-lg py-2 px-3 w-full sm:w-auto"
+                className="border border-gray-200 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100 rounded-xl py-3 px-4 text-sm font-medium text-gray-600 dark:text-gray-300 cursor-pointer outline-none bg-white"
                 value={sortMethod}
                 onChange={e => setSortMethod(e.target.value)}
                 aria-label={t('apps.sortBy', 'Sort by')}
@@ -538,97 +522,134 @@ function AppsList() {
                 <option value="nameAsc">{t('pages.appsList.sort.nameAsc', 'Name A-Z')}</option>
                 <option value="nameDesc">{t('pages.appsList.sort.nameDesc', 'Name Z-A')}</option>
               </select>
-            </div>
-          )}
-        </div>
-      )}
+            )}
+          </div>
+        )}
 
-      {/* Category filter */}
-      {categoriesConfig.enabled && (
-        <div className="flex flex-wrap gap-2 mb-6 justify-center">
-          {availableCategories.map(category => (
-            <button
-              key={category.id}
-              onClick={() => handleCategorySelect(category.id)}
-              className={`px-4 py-2 rounded-full text-sm font-medium transition-all ${
-                selectedCategory === category.id
-                  ? 'text-white shadow-lg transform scale-105'
-                  : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700'
-              }`}
-              style={{
-                backgroundColor: selectedCategory === category.id ? category.color : undefined
-              }}
-            >
-              {getLocalizedContent(category.name, currentLanguage)}
-            </button>
-          ))}
-        </div>
-      )}
+        {/* Category filter pills */}
+        {categoriesConfig.enabled && availableCategories.length > 0 && (
+          <div className="flex flex-wrap gap-2 mb-7 justify-center">
+            {availableCategories.map(category => (
+              <button
+                key={category.id}
+                onClick={() => handleCategorySelect(category.id)}
+                className={`px-5 py-2 rounded-full text-sm font-semibold transition-all ${
+                  selectedCategory === category.id
+                    ? 'text-white'
+                    : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700'
+                }`}
+                style={{
+                  backgroundColor: selectedCategory === category.id ? '#3a3f47' : undefined
+                }}
+              >
+                {getLocalizedContent(category.name, currentLanguage)}
+              </button>
+            ))}
+          </div>
+        )}
 
-      {displayedApps.length === 0 ? (
-        <div className="text-center py-8">
-          <p className="text-gray-500 dark:text-gray-400">{t('pages.appsList.noApps')}</p>
-          {searchConfig.enabled && apps.length > 3 && searchTerm ? (
-            <button
-              onClick={() => {
-                clearSearch();
-              }}
-              className="mt-4 px-4 py-2 text-indigo-600 border border-indigo-600 rounded hover:bg-indigo-50"
-            >
-              {t('pages.appsList.clearFilters')}
-            </button>
-          ) : null}
-        </div>
-      ) : (
-        <>
-          <div className="flex justify-center w-full">
+        {displayedApps.length === 0 ? (
+          <div className="text-center py-16">
+            <Icon
+              name="search"
+              className="h-10 w-10 text-gray-300 dark:text-gray-600 mx-auto mb-3"
+            />
+            <p className="text-gray-500 dark:text-gray-400">{t('pages.appsList.noApps')}</p>
+            {searchConfig.enabled && apps.length > 3 && searchTerm && (
+              <button
+                onClick={clearSearch}
+                className="mt-4 px-4 py-2 text-indigo-600 border border-indigo-600 rounded-lg hover:bg-indigo-50 text-sm"
+              >
+                {t('pages.appsList.clearFilters')}
+              </button>
+            )}
+          </div>
+        ) : (
+          <>
+            {/* Compact app rows grid */}
             <div
               ref={gridRef}
-              className={`grid gap-6 ${
-                displayedApps.length === 1
-                  ? 'grid-cols-1 max-w-md mx-auto'
-                  : displayedApps.length === 2
-                    ? 'grid-cols-1 sm:grid-cols-2 max-w-2xl mx-auto'
-                    : 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3'
-              }`}
+              className="grid gap-3"
+              style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(320px, 1fr))' }}
               role="list"
-              aria-label="Apps list"
+              aria-label={t('apps.appsList', 'Apps list')}
             >
-              {displayedApps.map(app => (
-                <AppCard
-                  key={app.id}
-                  app={app}
-                  variant="full"
-                  href={`/apps/${app.id}`}
-                  language={currentLanguage}
-                  isFavorite={favoriteApps.includes(app.id)}
-                  isRecent={recentAppIds.includes(app.id)}
-                  onToggleFavorite={handleToggleFavorite}
-                />
-              ))}
+              {displayedApps.map(app => {
+                const name = getLocalizedContent(app.name, currentLanguage) || app.id;
+                const desc = getLocalizedContent(app.description, currentLanguage) || '';
+                const isFav = isFavorite(app.id);
+                const favLabel = isFav
+                  ? t('pages.appsList.unfavorite', 'Remove from favorites')
+                  : t('pages.appsList.favorite', 'Add to favorites');
+                return (
+                  // Stretched-link pattern: a single full-row nav button plus a
+                  // separate favorite button — no nested interactive elements.
+                  <div
+                    key={app.id}
+                    role="listitem"
+                    className="relative flex items-center gap-3 px-4 py-3.5 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-md transition-all group"
+                  >
+                    <button
+                      type="button"
+                      onClick={() => navigate(`/apps/${app.id}`)}
+                      aria-label={name}
+                      className="absolute inset-0 rounded-xl focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                    />
+                    <span
+                      className="w-11 h-11 rounded-xl flex items-center justify-center flex-none text-white pointer-events-none"
+                      style={{ backgroundColor: app.color || '#4f46e5' }}
+                    >
+                      <Icon name={app.icon} size="md" />
+                    </span>
+                    <span className="flex-1 min-w-0 pointer-events-none">
+                      <span className="block font-bold text-[15px] text-gray-900 dark:text-gray-100 truncate">
+                        {name}
+                      </span>
+                      <span className="block text-[13px] text-gray-500 dark:text-gray-400 truncate leading-snug">
+                        {desc}
+                      </span>
+                    </span>
+                    <button
+                      type="button"
+                      onClick={e => handleToggleFavorite(e, app.id)}
+                      aria-pressed={isFav}
+                      aria-label={favLabel}
+                      title={favLabel}
+                      className="relative z-10 w-8 h-8 flex-none flex items-center justify-center rounded-lg opacity-0 group-hover:opacity-100 focus:opacity-100 hover:bg-gray-100 dark:hover:bg-gray-700 transition-all"
+                    >
+                      <Icon
+                        name="star"
+                        size="sm"
+                        className={isFav ? 'text-yellow-400' : 'text-gray-300'}
+                        solid={isFav}
+                      />
+                    </button>
+                  </div>
+                );
+              })}
             </div>
-          </div>
 
-          {/* Load More Button */}
-          {hasMoreApps && (
-            <div className="text-center mt-6">
-              <button
-                onClick={handleLoadMore}
-                className="bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-medium py-2 px-4 border border-indigo-500 rounded shadow-sm transition-colors"
-              >
-                {t('pages.appsList.loadMore', 'Load More')}
-              </button>
-              <p className="text-gray-500 dark:text-gray-400 text-sm mt-2">
-                {t('pages.appsList.showingCountOfTotal', {
-                  defaultValue: 'Showing {{displayed}} of {{total}} apps',
-                  displayed: displayedApps.length,
-                  total: sortedApps.length
-                })}
-              </p>
-            </div>
-          )}
-        </>
-      )}
+            {/* Load More */}
+            {hasMoreApps && (
+              <div className="text-center mt-8">
+                <button
+                  onClick={handleLoadMore}
+                  className="bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-indigo-600 dark:text-indigo-400 font-medium py-2.5 px-6 border border-indigo-500 rounded-xl shadow-sm transition-colors text-sm"
+                >
+                  {t('pages.appsList.loadMore', 'Load More')}
+                </button>
+                <p className="text-gray-400 dark:text-gray-500 text-xs mt-2">
+                  {t('pages.appsList.showingCountOfTotal', {
+                    defaultValue: 'Showing {{displayed}} of {{total}} apps',
+                    displayed: displayedApps.length,
+                    total: sortedApps.length
+                  })}
+                </p>
+              </div>
+            )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/client/src/features/apps/pages/StartPage.jsx
+++ b/client/src/features/apps/pages/StartPage.jsx
@@ -1,0 +1,352 @@
+import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../shared/contexts/AuthContext';
+import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
+import useFeatureFlags from '../../../shared/hooks/useFeatureFlags';
+import Icon from '../../../shared/components/Icon';
+import { fetchAppDetails, fetchModels } from '../../../api';
+import useApps from '../../../shared/hooks/useApps';
+import useFavorites from '../../../shared/hooks/useFavorites';
+import IHubLogo from '../../../shared/components/IHubLogo';
+import { getLocalizedContent } from '../../../utils/localizeContent';
+import { filterModelsForApp, pickInitialModelForApp } from '../../../utils/modelFiltering';
+import { useTranslation } from 'react-i18next';
+import { MOCK_CHATS } from '../../chat/data/mockChats';
+import LoadingSpinner from '../../../shared/components/LoadingSpinner';
+import { buildAssetUrl } from '../../../utils/runtimeBasePath';
+import ChatInput from '../../chat/components/ChatInput';
+import useFileUploadHandler from '../../../shared/hooks/useFileUploadHandler';
+import useVoiceCommands from '../../voice/hooks/useVoiceCommands';
+import { setPendingChatStart } from '../../chat/startChatHandoff';
+
+function timeBasedGreeting(t) {
+  const h = new Date().getHours();
+  if (h < 12) return t('startPage.greetingMorning', 'Good morning');
+  if (h < 18) return t('startPage.greetingAfternoon', 'Good afternoon');
+  return t('startPage.greetingEvening', 'Good evening');
+}
+
+export default function StartPage() {
+  const { t, i18n } = useTranslation();
+  const currentLanguage = i18n.language;
+  const { user } = useAuth();
+  const { uiConfig } = useUIConfig();
+  const featureFlags = useFeatureFlags();
+  const navigate = useNavigate();
+
+  const { apps, loading: appsLoading } = useApps();
+  const { favorites: favoriteAppIds } = useFavorites('ihub_favorite_apps');
+  const [draft, setDraft] = useState('');
+  const [defaultAppDetails, setDefaultAppDetails] = useState(null);
+  const [models, setModels] = useState([]);
+  const [selectedModel, setSelectedModel] = useState(null);
+
+  const inputRef = useRef(null);
+  const formRef = useRef(null);
+  const fileUploadHandler = useFileUploadHandler();
+
+  const chatHistoryEnabled = featureFlags.isEnabled('chatHistory', false);
+
+  // Admins can hide the start-page chat input entirely.
+  const showDefaultApp = uiConfig?.startPage?.showDefaultApp !== false;
+
+  // Voice dictation handler — writes the transcript into the draft, mirroring
+  // the in-app chat behaviour.
+  const { handleVoiceInput, handleVoiceCommand } = useVoiceCommands({
+    setInput: setDraft,
+    currentText: draft,
+    sendMessage: () => formRef.current?.requestSubmit?.()
+  });
+
+  const greeting = useMemo(() => {
+    const base = timeBasedGreeting(t);
+    const name = user?.name || user?.email?.split('@')[0] || '';
+    return name ? `${base}, ${name}` : base;
+  }, [t, user]);
+
+  // Default app: admin-configured via uiConfig.startPage.defaultAppId, else first app
+  const defaultApp = useMemo(() => {
+    const defaultId = uiConfig?.startPage?.defaultAppId;
+    if (defaultId) {
+      const found = apps.find(a => a.id === defaultId);
+      if (found) return found;
+    }
+    return apps[0] || null;
+  }, [apps, uiConfig]);
+
+  // Load the full default-app config so the chat input renders exactly what the
+  // app is configured for (uploads, input mode, placeholder, etc.).
+  useEffect(() => {
+    if (!defaultApp?.id) {
+      setDefaultAppDetails(null);
+      return;
+    }
+    let mounted = true;
+    fetchAppDetails(defaultApp.id)
+      .then(details => {
+        if (mounted && details) setDefaultAppDetails(details);
+      })
+      .catch(() => {});
+    return () => {
+      mounted = false;
+    };
+  }, [defaultApp?.id]);
+
+  // Load models so the start-page input can offer the model selector when the
+  // app allows it (mirrors the in-app chat).
+  useEffect(() => {
+    let mounted = true;
+    fetchModels()
+      .then(data => {
+        if (mounted && Array.isArray(data)) setModels(data);
+      })
+      .catch(() => {});
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  // Models the default app is actually allowed to use.
+  const compatibleModels = useMemo(
+    () => (defaultAppDetails ? filterModelsForApp(models, defaultAppDetails) : []),
+    [models, defaultAppDetails]
+  );
+
+  // Pick an initial model once the app + models are available.
+  useEffect(() => {
+    if (!defaultAppDetails || compatibleModels.length === 0) return;
+    setSelectedModel(prev => {
+      if (prev && compatibleModels.some(m => m.id === prev)) return prev;
+      return pickInitialModelForApp(compatibleModels, defaultAppDetails) || compatibleModels[0].id;
+    });
+  }, [defaultAppDetails, compatibleModels]);
+
+  const showModelSelector =
+    defaultAppDetails?.disallowModelSelection !== true &&
+    defaultAppDetails?.settings?.model?.enabled !== false &&
+    compatibleModels.length > 0;
+
+  const micEnabled =
+    (defaultAppDetails?.inputMode?.microphone?.enabled ??
+      defaultAppDetails?.microphone?.enabled) !== false;
+
+  // Featured apps: favorites first, then by order, max 4
+  const featuredApps = useMemo(() => {
+    const sorted = [...apps].sort((a, b) => {
+      const aFav = favoriteAppIds.includes(a.id);
+      const bFav = favoriteAppIds.includes(b.id);
+      if (aFav && !bFav) return -1;
+      if (!aFav && bFav) return 1;
+      const aOrder = a.order ?? Infinity;
+      const bOrder = b.order ?? Infinity;
+      return aOrder - bOrder;
+    });
+    return sorted.slice(0, 4);
+  }, [apps, favoriteAppIds]);
+
+  const recentChats = chatHistoryEnabled ? MOCK_CHATS.slice(0, 3) : [];
+
+  const uploadConfig = useMemo(
+    () =>
+      defaultAppDetails ? fileUploadHandler.createUploadConfig(defaultAppDetails, null) : undefined,
+    [defaultAppDetails, fileUploadHandler]
+  );
+
+  // Start the chat: carry the message via prefill+send (so refresh/shared links
+  // work) and hand off any attachment payload through the in-memory bridge.
+  const handleSubmit = useCallback(
+    e => {
+      if (e?.preventDefault) e.preventDefault();
+      if (!defaultApp) return;
+      const text = draft.trim();
+      const hasFile = fileUploadHandler.selectedFile != null;
+      if (!text && !hasFile && !defaultAppDetails?.allowEmptyContent) return;
+
+      if (hasFile) {
+        setPendingChatStart({ appId: defaultApp.id, files: fileUploadHandler.selectedFile });
+      }
+
+      const params = new URLSearchParams();
+      if (text) {
+        params.set('prefill', text);
+        params.set('send', 'true');
+      }
+      // Carry the chosen model so the app starts with the same selection.
+      if (selectedModel && selectedModel !== defaultAppDetails?.preferredModel) {
+        params.set('model', selectedModel);
+      }
+      const qs = params.toString();
+      navigate(`/apps/${defaultApp.id}${qs ? `?${qs}` : ''}`);
+    },
+    [draft, defaultApp, defaultAppDetails, fileUploadHandler, navigate, selectedModel]
+  );
+
+  const logoSrc = uiConfig?.header?.logo?.url ? buildAssetUrl(uiConfig.header.logo.url) : null;
+  const logoAlt = getLocalizedContent(uiConfig?.header?.logo?.alt, currentLanguage) || 'iHub';
+
+  return (
+    <div className="min-h-full flex flex-col items-center justify-center px-6 py-12 bg-gray-50 dark:bg-gray-900">
+      <div className="w-full max-w-2xl">
+        {/* Logo + greeting */}
+        <div className="flex flex-col items-center text-center mb-8">
+          {logoSrc ? (
+            <img src={logoSrc} alt={logoAlt} className="w-12 h-12 object-contain mb-4" />
+          ) : (
+            <div className="mb-4">
+              <IHubLogo size={46} />
+            </div>
+          )}
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-gray-100 tracking-tight mb-2">
+            {greeting}!
+          </h1>
+          <p className="text-base text-gray-500 dark:text-gray-400">
+            {t('startPage.subtitle', 'How can I help you today?')}
+          </p>
+        </div>
+
+        {/* Default chat input — renders the real app input (uploads, prompts,
+            placeholder, input mode) and starts the chat on submit. */}
+        {showDefaultApp && defaultApp && (
+          <div className="mb-8">
+            <div className="flex items-center justify-between gap-2 mb-2">
+              <div className="flex items-center gap-2 min-w-0">
+                <span
+                  className="w-6 h-6 rounded-md flex items-center justify-center text-white text-xs flex-none"
+                  style={{ backgroundColor: defaultApp.color || '#4f46e5' }}
+                >
+                  <Icon name={defaultApp.icon} size="sm" className="w-3.5 h-3.5" />
+                </span>
+                <span className="text-sm font-medium text-gray-500 dark:text-gray-400 truncate">
+                  {getLocalizedContent(defaultApp.name, currentLanguage)}
+                </span>
+              </div>
+              <button
+                onClick={() => navigate(`/apps/${defaultApp.id}`)}
+                className="text-sm text-indigo-600 dark:text-indigo-400 font-medium hover:underline flex-none"
+              >
+                {t('startPage.openApp', 'Open full app')} →
+              </button>
+            </div>
+
+            {defaultAppDetails ? (
+              <ChatInput
+                app={defaultAppDetails}
+                value={draft}
+                onChange={e => setDraft(e.target.value)}
+                onSubmit={handleSubmit}
+                isProcessing={false}
+                onCancel={() => {}}
+                inputRef={inputRef}
+                formRef={formRef}
+                uploadConfig={uploadConfig}
+                onFileSelect={fileUploadHandler.handleFileSelect}
+                selectedFile={fileUploadHandler.selectedFile}
+                showUploader={fileUploadHandler.showUploader}
+                onToggleUploader={fileUploadHandler.toggleUploader}
+                allowEmptySubmit={
+                  defaultAppDetails?.allowEmptyContent || fileUploadHandler.selectedFile !== null
+                }
+                onVoiceInput={micEnabled ? handleVoiceInput : undefined}
+                onVoiceCommand={micEnabled ? handleVoiceCommand : undefined}
+                models={compatibleModels}
+                selectedModel={selectedModel}
+                onModelChange={setSelectedModel}
+                showModelSelector={showModelSelector}
+                currentLanguage={currentLanguage}
+              />
+            ) : (
+              // Skeleton shaped like the chat input so the hero doesn't flash a spinner.
+              <div
+                className="border-2 border-gray-200 dark:border-gray-700 rounded-2xl bg-white dark:bg-gray-800 px-5 py-4 animate-pulse"
+                aria-hidden="true"
+              >
+                <div className="h-4 w-2/3 bg-gray-100 dark:bg-gray-700 rounded mb-3" />
+                <div className="flex items-center justify-between">
+                  <div className="h-7 w-7 bg-gray-100 dark:bg-gray-700 rounded-lg" />
+                  <div className="h-9 w-9 bg-gray-100 dark:bg-gray-700 rounded-xl" />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {appsLoading && !defaultApp && (
+          <div className="flex justify-center mb-8">
+            <LoadingSpinner message={t('app.loading')} />
+          </div>
+        )}
+
+        {/* Jump into an app */}
+        {featuredApps.length > 0 && (
+          <div className="mb-7">
+            <div className="flex items-center justify-between mb-3">
+              <span className="text-[11px] font-bold tracking-widest uppercase text-gray-400">
+                {t('startPage.jumpIntoApp', 'Jump into an app')}
+              </span>
+              <button
+                onClick={() => navigate('/apps')}
+                className="text-sm text-indigo-600 dark:text-indigo-400 font-semibold hover:underline"
+              >
+                {t('startPage.browseAllApps', 'Browse all apps')} →
+              </button>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              {featuredApps.map(app => {
+                const name = getLocalizedContent(app.name, currentLanguage) || app.id;
+                const desc = getLocalizedContent(app.description, currentLanguage) || '';
+                return (
+                  <button
+                    key={app.id}
+                    onClick={() => navigate(`/apps/${app.id}`)}
+                    className="flex items-center gap-3 px-4 py-3.5 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-left hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-md transition-all"
+                  >
+                    <span
+                      className="w-10 h-10 rounded-xl flex items-center justify-center flex-none text-white"
+                      style={{ backgroundColor: app.color || '#4f46e5' }}
+                    >
+                      <Icon name={app.icon} size="md" />
+                    </span>
+                    <span className="min-w-0 flex-1">
+                      <span className="block font-semibold text-[14.5px] text-gray-900 dark:text-gray-100 truncate">
+                        {name}
+                      </span>
+                      <span className="block text-[12.5px] text-gray-500 dark:text-gray-400 truncate">
+                        {desc}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {/* Pick up where you left off — feature flagged */}
+        {chatHistoryEnabled && recentChats.length > 0 && (
+          <div>
+            <span className="text-[11px] font-bold tracking-widest uppercase text-gray-400 block mb-3">
+              {t('startPage.pickUpWhereYouLeftOff', 'Pick up where you left off')}
+            </span>
+            <div className="flex flex-wrap gap-2">
+              {recentChats.map(chat => (
+                <button
+                  key={chat.id}
+                  onClick={() => navigate('/chats')}
+                  className="flex items-center gap-2 px-3 py-1.5 rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-700 dark:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600 hover:bg-gray-50 dark:hover:bg-gray-700 transition-all max-w-xs"
+                >
+                  <span
+                    className="w-5 h-5 rounded-md flex items-center justify-center flex-none text-white"
+                    style={{ backgroundColor: chat.appColor || '#4f46e5' }}
+                  >
+                    <Icon name={chat.appIcon} size="sm" className="w-3 h-3" />
+                  </span>
+                  <span className="truncate">{chat.title}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/auth/components/UserAuthMenu.jsx
+++ b/client/src/features/auth/components/UserAuthMenu.jsx
@@ -132,7 +132,7 @@ export default function UserAuthMenu({ variant = 'header', className = '', colla
         className={
           variant === 'header'
             ? 'flex items-center space-x-2 text-white hover:text-white/80 focus:outline-none'
-            : 'flex items-center space-x-2 p-2 rounded-lg hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors'
+            : 'flex items-center space-x-2 p-2 rounded-lg hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 transition-colors w-full min-w-0'
         }
         aria-expanded={showDropdown}
         aria-haspopup="true"

--- a/client/src/features/auth/components/UserAuthMenu.jsx
+++ b/client/src/features/auth/components/UserAuthMenu.jsx
@@ -14,7 +14,7 @@ import { Link } from 'react-router-dom';
  * @param {string} props.className - Additional CSS classes to apply to the root element
  * @returns {JSX.Element|null} The user authentication menu component
  */
-export default function UserAuthMenu({ variant = 'header', className = '' }) {
+export default function UserAuthMenu({ variant = 'header', className = '', collapsed = false }) {
   const { t } = useTranslation();
   const { user, isAuthenticated, logout, authConfig } = useAuth();
   const { platformConfig } = usePlatformConfig();
@@ -150,15 +150,21 @@ export default function UserAuthMenu({ variant = 'header', className = '' }) {
               </>
             ) : (
               <>
-                <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium">
+                <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center text-sm font-medium flex-none">
                   {initials}
                 </div>
-                <div className="hidden sm:block text-left">
-                  <div className="text-sm font-medium text-gray-900">{displayName}</div>
-                  {user?.email && user.email !== displayName && (
-                    <div className="text-xs text-gray-500">{user.email}</div>
-                  )}
-                </div>
+                {!collapsed && (
+                  <div className="hidden sm:block text-left min-w-0">
+                    <div className="text-sm font-medium text-gray-900 dark:text-gray-100 truncate">
+                      {displayName}
+                    </div>
+                    {user?.email && user.email !== displayName && (
+                      <div className="text-xs text-gray-500 dark:text-gray-400 truncate">
+                        {user.email}
+                      </div>
+                    )}
+                  </div>
+                )}
               </>
             )}
           </>
@@ -176,11 +182,13 @@ export default function UserAuthMenu({ variant = 'header', className = '' }) {
             </span>
           </>
         )}
-        <Icon
-          name="chevron-down"
-          size="sm"
-          className={`transition-transform duration-200 ${showDropdown ? 'rotate-180' : ''} ${variant === 'header' ? 'text-white' : 'text-gray-500'}`}
-        />
+        {!collapsed && (
+          <Icon
+            name="chevron-down"
+            size="sm"
+            className={`transition-transform duration-200 ${showDropdown ? 'rotate-180' : ''} ${variant === 'header' ? 'text-white' : 'text-gray-500'}`}
+          />
+        )}
       </button>
 
       {/* Dropdown menu */}
@@ -189,7 +197,18 @@ export default function UserAuthMenu({ variant = 'header', className = '' }) {
           ref={menuRef}
           role="menu"
           aria-label={t('auth.userMenu', 'User menu')}
-          className="absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50"
+          className={
+            variant === 'sidebar'
+              ? // In the sidebar the trigger sits at the very bottom, so the menu
+                // floats upward instead of pushing the layout (which would happen
+                // if it opened downward off-screen). When the rail is collapsed it
+                // gets a fixed width and floats over the content to the right.
+                // Use a comfortable fixed width anchored to the left so the menu
+                // floats over the page content instead of being squeezed into
+                // the (now narrower) account row.
+                `absolute bottom-full mb-2 left-0 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 py-1 z-50`
+              : 'absolute right-0 mt-2 w-64 bg-white dark:bg-gray-800 rounded-lg shadow-lg border border-gray-200 dark:border-gray-700 py-1 z-50'
+          }
         >
           {isAuthenticated ? (
             <>
@@ -233,22 +252,6 @@ export default function UserAuthMenu({ variant = 'header', className = '' }) {
 
               {/* Menu items */}
               <div className="py-1">
-                {/* Profile (placeholder for sidebar variant) */}
-                {variant === 'sidebar' && (
-                  <button
-                    role="menuitem"
-                    tabIndex={-1}
-                    className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center"
-                    onClick={() => {
-                      setShowDropdown(false);
-                      setShowAllGroups(false);
-                    }}
-                  >
-                    <Icon name="user" className="w-4 h-4 mr-3" />
-                    {t('auth.menu.profile', 'Profile')}
-                  </button>
-                )}
-
                 {/* Integrations */}
                 {featureFlags.isEnabled('integrations', true) &&
                   (platformConfig?.cloudStorage?.enabled || platformConfig?.jira?.enabled) && (

--- a/client/src/features/chat/data/mockChats.js
+++ b/client/src/features/chat/data/mockChats.js
@@ -1,0 +1,114 @@
+// Mock chat history data — shown when the `chatHistory` feature flag is enabled.
+// Replace with real API data once chat persistence is implemented.
+export const MOCK_CHATS = [
+  {
+    id: 'c1',
+    title: 'iFinder index transparency & DSGVO',
+    appId: 'assistant',
+    appName: 'iAssistant',
+    appColor: '#4f46e5',
+    appIcon: 'sparkles',
+    group: 'Today',
+    snippet:
+      'iFinder keeps only the personal data it needs to operate: usernames, email addresses, assigned rights and roles…'
+  },
+  {
+    id: 'c2',
+    title: 'Reisekostenabrechnung Oranienburg',
+    appId: 'chat',
+    appName: 'Chat',
+    appColor: '#4f46e5',
+    appIcon: 'chat-bubble',
+    group: 'Today',
+    snippet:
+      "For a round trip of roughly 1,020 km at the German mileage rate of €0.30/km you'd claim about €306…"
+  },
+  {
+    id: 'c3',
+    title: 'Customer follow-up email draft',
+    appId: 'email',
+    appName: 'Email Composer',
+    appColor: '#2563eb',
+    appIcon: 'mail',
+    group: 'Today',
+    snippet: 'Subject: Following up on our iFinder demo — Thank you again for your time last week…'
+  },
+  {
+    id: 'c4',
+    title: 'GDPR vs CCPA clause comparison',
+    appId: 'compare',
+    appName: 'Regulatory Compare',
+    appColor: '#16a34a',
+    appIcon: 'document-search',
+    group: 'Yesterday',
+    snippet:
+      'GDPR requires opt-in consent before processing personal data, while CCPA is largely opt-out…'
+  },
+  {
+    id: 'c5',
+    title: "Lenovo ThinkPad won't boot",
+    appId: 'it',
+    appName: 'IT Support',
+    appColor: '#4f46e5',
+    appIcon: 'cog',
+    group: 'Yesterday',
+    snippet:
+      "Let's start with the basics: Hold the power button for 15 seconds to force a full shutdown…"
+  },
+  {
+    id: 'c6',
+    title: 'FAQ: VPN access for contractors',
+    appId: 'faqgen',
+    appName: 'FAQ Generator',
+    appColor: '#4f46e5',
+    appIcon: 'document',
+    group: 'Yesterday',
+    snippet:
+      'Q: Can external contractors get VPN access? A: Yes, with a sponsored account and manager approval…'
+  },
+  {
+    id: 'c7',
+    title: 'Translate datasheet EN → DE',
+    appId: 'translator',
+    appName: 'Translator',
+    appColor: '#0891b2',
+    appIcon: 'globe',
+    group: 'Last 7 days',
+    snippet: 'Gerne. Senden Sie mir den Text des Datenblatts, und ich übersetze ihn ins Deutsche…'
+  },
+  {
+    id: 'c8',
+    title: 'Difficult feedback conversation prep',
+    appId: 'coach',
+    appName: 'Conversations Coach',
+    appColor: '#4f46e5',
+    appIcon: 'users',
+    group: 'Last 7 days',
+    snippet:
+      "Let's structure it. Open with a specific observation rather than a judgement, describe the impact…"
+  },
+  {
+    id: 'c9',
+    title: 'How to pin an app in iHub',
+    appId: 'supportbot',
+    appName: 'iHub Support Bot',
+    appColor: '#16a34a',
+    appIcon: 'question-mark-circle',
+    group: 'Last 7 days',
+    snippet:
+      'Open the app card and click the star in its top-right corner, or right-click the app in the sidebar…'
+  },
+  {
+    id: 'c10',
+    title: 'Quarterly report summary',
+    appId: 'chat',
+    appName: 'Chat',
+    appColor: '#4f46e5',
+    appIcon: 'chat-bubble',
+    group: 'Last 7 days',
+    snippet:
+      'Q2 highlights: revenue ahead of plan, two major public-sector wins, and the iFinder 6 GA milestone…'
+  }
+];
+
+export const CHAT_GROUPS = ['Today', 'Yesterday', 'Last 7 days', 'Older'];

--- a/client/src/features/chat/pages/ChatHistoryPage.jsx
+++ b/client/src/features/chat/pages/ChatHistoryPage.jsx
@@ -1,0 +1,204 @@
+import { useState, useMemo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import Icon from '../../../shared/components/Icon';
+import { MOCK_CHATS, CHAT_GROUPS } from '../data/mockChats';
+
+// Grouping modes
+const GROUPINGS = ['recent', 'app', 'date'];
+
+function hexToRgba(hex, alpha) {
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+export default function ChatHistoryPage() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const [query, setQuery] = useState('');
+  const [grouping, setGrouping] = useState('date');
+
+  const filteredChats = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return MOCK_CHATS;
+    return MOCK_CHATS.filter(
+      c =>
+        c.title.toLowerCase().includes(q) ||
+        c.appName.toLowerCase().includes(q) ||
+        c.snippet.toLowerCase().includes(q)
+    );
+  }, [query]);
+
+  const histGroups = useMemo(() => {
+    if (grouping === 'recent') {
+      return [{ key: 'all', label: '', showLabel: false, items: filteredChats }];
+    }
+    if (grouping === 'app') {
+      const map = {};
+      filteredChats.forEach(c => {
+        (map[c.appName] = map[c.appName] || []).push(c);
+      });
+      return Object.keys(map).map(k => ({ key: k, label: k, showLabel: true, items: map[k] }));
+    }
+    // date grouping
+    const map = {};
+    filteredChats.forEach(c => {
+      (map[c.group] = map[c.group] || []).push(c);
+    });
+    return CHAT_GROUPS.filter(g => map[g]).map(g => ({
+      key: g,
+      label: g,
+      showLabel: true,
+      items: map[g]
+    }));
+  }, [filteredChats, grouping]);
+
+  const handleClearSearch = useCallback(() => setQuery(''), []);
+
+  const groupingLabels = {
+    recent: t('chatHistory.groupRecent', 'Recent'),
+    app: t('chatHistory.groupByApp', 'By app'),
+    date: t('chatHistory.groupByDate', 'By date')
+  };
+
+  return (
+    <div className="min-h-full bg-gray-50 dark:bg-gray-900 px-6 py-10">
+      <div className="max-w-3xl mx-auto">
+        {/* Header */}
+        <div className="flex items-end justify-between gap-4 mb-6 flex-wrap">
+          <div>
+            <h1 className="text-[26px] font-extrabold text-gray-900 dark:text-gray-100 tracking-tight">
+              {t('chatHistory.title', 'Your chats')}
+            </h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
+              {t('chatHistory.subtitle', '{{count}} conversations across your apps', {
+                count: filteredChats.length
+              })}
+            </p>
+          </div>
+          <button
+            onClick={() => navigate('/')}
+            className="flex items-center gap-2 px-4 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold transition-colors"
+          >
+            <Icon name="plus" size="sm" />
+            {t('sidebar.newChat', 'New chat')}
+          </button>
+        </div>
+
+        {/* Search + grouping */}
+        <div className="flex gap-3 mb-6 flex-wrap">
+          <div className="relative flex-1 min-w-[200px]">
+            <span className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400">
+              <Icon name="search" size="sm" />
+            </span>
+            <input
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder={t('chatHistory.searchPlaceholder', 'Search your chats…')}
+              className="w-full pl-11 pr-10 py-3 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm outline-none focus:border-indigo-400 dark:text-gray-100 dark:placeholder-gray-500"
+            />
+            {query && (
+              <button
+                onClick={handleClearSearch}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+              >
+                <Icon name="x" size="sm" />
+              </button>
+            )}
+          </div>
+
+          {/* Segmented grouping control */}
+          <div className="flex bg-gray-200 dark:bg-gray-700 rounded-xl p-1 gap-0.5">
+            {GROUPINGS.map(g => (
+              <button
+                key={g}
+                onClick={() => setGrouping(g)}
+                className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                  grouping === g
+                    ? 'bg-white dark:bg-gray-800 text-indigo-600 dark:text-indigo-400 shadow-sm'
+                    : 'text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300'
+                }`}
+              >
+                {groupingLabels[g]}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Chat list */}
+        {filteredChats.length === 0 ? (
+          <div className="text-center py-16">
+            <Icon
+              name="chat-bubble"
+              size="xl"
+              className="text-gray-300 dark:text-gray-600 mx-auto mb-3"
+            />
+            <p className="text-gray-500 dark:text-gray-400">
+              {t('chatHistory.noResults', 'No chats match your search')}
+            </p>
+            {query && (
+              <button
+                onClick={handleClearSearch}
+                className="mt-3 text-indigo-600 dark:text-indigo-400 text-sm font-medium hover:underline"
+              >
+                {t('pages.appsList.clearFilters', 'Clear filters')}
+              </button>
+            )}
+          </div>
+        ) : (
+          histGroups.map(group => (
+            <div key={group.key} className="mb-2">
+              {group.showLabel && (
+                <div className="text-[11px] font-bold tracking-widest uppercase text-gray-400 mt-5 mb-2.5 px-1">
+                  {group.label}
+                </div>
+              )}
+              <div className="flex flex-col gap-2.5">
+                {group.items.map(chat => (
+                  <button
+                    key={chat.id}
+                    onClick={() => navigate(`/apps/${chat.appId}`)}
+                    className="flex items-center gap-4 px-4 py-3.5 rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-left hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-md transition-all"
+                  >
+                    <span
+                      className="w-10 h-10 rounded-xl flex items-center justify-center flex-none text-white"
+                      style={{ backgroundColor: chat.appColor || '#4f46e5' }}
+                    >
+                      <Icon name={chat.appIcon} size="md" />
+                    </span>
+                    <span className="flex-1 min-w-0">
+                      <span className="flex items-center gap-2 mb-0.5">
+                        <span className="text-[15px] font-bold text-gray-900 dark:text-gray-100 truncate">
+                          {chat.title}
+                        </span>
+                        <span
+                          className="flex-none text-[11px] font-semibold rounded-full px-2 py-0.5"
+                          style={{
+                            color: chat.appColor,
+                            backgroundColor: hexToRgba(chat.appColor || '#4f46e5', 0.12)
+                          }}
+                        >
+                          {chat.appName}
+                        </span>
+                      </span>
+                      <span className="block text-sm text-gray-500 dark:text-gray-400 truncate leading-snug">
+                        {chat.snippet}
+                      </span>
+                    </span>
+                    <span className="flex-none text-xs text-gray-400 dark:text-gray-500 font-medium whitespace-nowrap">
+                      {chat.group}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/chat/startChatHandoff.js
+++ b/client/src/features/chat/startChatHandoff.js
@@ -1,0 +1,30 @@
+// Lightweight in-memory handoff used to carry a started message (and any
+// already-processed file attachments) from the start page into the target
+// app's chat. Files cannot travel through the URL, so we stash the processed
+// upload payload here and let AppChat consume it on mount. The text + auto-send
+// still flow through the `prefill` / `send=true` query params so a refresh or a
+// shared link keeps working without relying on this volatile state.
+
+let pending = null;
+
+/**
+ * Store a pending handoff for a specific app.
+ * @param {{ appId: string, files?: any }} data
+ */
+export function setPendingChatStart(data) {
+  pending = data || null;
+}
+
+/**
+ * Consume (and clear) the pending handoff if it matches the given app.
+ * @param {string} appId
+ * @returns {{ appId: string, files?: any } | null}
+ */
+export function consumePendingChatStart(appId) {
+  if (pending && pending.appId === appId) {
+    const data = pending;
+    pending = null;
+    return data;
+  }
+  return null;
+}

--- a/client/src/shared/components/AppSidebar.jsx
+++ b/client/src/shared/components/AppSidebar.jsx
@@ -1,0 +1,619 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+import { useUIConfig } from '../contexts/UIConfigContext';
+import useFeatureFlags from '../hooks/useFeatureFlags';
+import useApps from '../hooks/useApps';
+import useFavorites from '../hooks/useFavorites';
+import Icon from './Icon';
+import IHubLogo from './IHubLogo';
+import { getLocalizedContent } from '../../utils/localizeContent';
+import { isActivePath } from '../../utils/pathUtils';
+import { canAccessLink, FEATURE_ROUTES } from '../../utils/pageAccess';
+import { useTranslation } from 'react-i18next';
+import { MOCK_CHATS } from '../../features/chat/data/mockChats';
+import UserAuthMenu from '../../features/auth/components/UserAuthMenu';
+import LanguageSelector from './LanguageSelector';
+import { buildAssetUrl } from '../../utils/runtimeBasePath';
+
+const SIDEBAR_COLLAPSED_KEY = 'ihub_sidebar_collapsed';
+const FAVORITE_APPS_KEY = 'ihub_favorite_apps';
+
+function NavButton({ icon, label, onClick, active }) {
+  return (
+    <button
+      onClick={onClick}
+      aria-current={active ? 'page' : undefined}
+      className={`flex items-center gap-3 w-full px-3 py-2 rounded-lg text-sm font-medium transition-colors text-left ${
+        active
+          ? 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-300'
+          : 'text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800'
+      }`}
+    >
+      <Icon
+        name={icon}
+        size="sm"
+        className={
+          active ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-500 dark:text-gray-400'
+        }
+      />
+      {label}
+    </button>
+  );
+}
+
+function SectionHeader({ label, open, onToggle }) {
+  return (
+    <button
+      onClick={onToggle}
+      className="flex items-center gap-1.5 w-full px-4 py-2 text-left"
+      aria-expanded={open}
+    >
+      <Icon
+        name="chevron-down"
+        size="sm"
+        className={`text-gray-400 transition-transform duration-150 ${open ? '' : '-rotate-90'}`}
+      />
+      <span className="text-[11px] font-bold tracking-widest uppercase text-gray-400">{label}</span>
+    </button>
+  );
+}
+
+export default function AppSidebar({ mobileOpen = false, onMobileClose = () => {} }) {
+  const { t, i18n } = useTranslation();
+  const currentLanguage = i18n.language;
+  const { user, isAuthenticated } = useAuth();
+  const { uiConfig } = useUIConfig();
+  const featureFlags = useFeatureFlags();
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const { apps } = useApps();
+  const { favorites: favoriteAppIds, isFavorite, toggleFavorite } = useFavorites(FAVORITE_APPS_KEY);
+
+  const [collapsed, setCollapsed] = useState(() => {
+    try {
+      return localStorage.getItem(SIDEBAR_COLLAPSED_KEY) === 'true';
+    } catch {
+      return false;
+    }
+  });
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [appsOpen, setAppsOpen] = useState(true);
+  const [recentsOpen, setRecentsOpen] = useState(true);
+
+  const chatHistoryEnabled = featureFlags.isEnabled('chatHistory', false);
+
+  // Navigate and close the mobile drawer (no-op on desktop).
+  const go = useCallback(
+    to => {
+      navigate(to);
+      onMobileClose();
+    },
+    [navigate, onMobileClose]
+  );
+
+  // Close the mobile drawer on Escape.
+  useEffect(() => {
+    if (!mobileOpen) return;
+    const onKey = e => {
+      if (e.key === 'Escape') onMobileClose();
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [mobileOpen, onMobileClose]);
+
+  const toggleCollapsed = useCallback(() => {
+    setCollapsed(prev => {
+      const next = !prev;
+      try {
+        localStorage.setItem(SIDEBAR_COLLAPSED_KEY, String(next));
+      } catch {
+        // ignore storage failures (private mode, etc.)
+      }
+      return next;
+    });
+    setSearchOpen(false);
+    setSearch('');
+  }, []);
+
+  const handleToggleFav = useCallback(
+    (e, appId) => {
+      e.preventDefault();
+      e.stopPropagation();
+      toggleFavorite(appId);
+    },
+    [toggleFavorite]
+  );
+
+  const sidebarApps = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    let list = apps.map(a => ({ ...a, isFav: favoriteAppIds.includes(a.id) }));
+    list.sort((a, b) => {
+      if (a.isFav && !b.isFav) return -1;
+      if (!a.isFav && b.isFav) return 1;
+      return 0;
+    });
+    if (q) {
+      list = list.filter(a => {
+        const name = getLocalizedContent(a.name, currentLanguage) || '';
+        const desc = getLocalizedContent(a.description, currentLanguage) || '';
+        return name.toLowerCase().includes(q) || desc.toLowerCase().includes(q);
+      });
+    }
+    return list.slice(0, 5);
+  }, [apps, favoriteAppIds, search, currentLanguage]);
+
+  const recentChats = useMemo(() => {
+    if (!chatHistoryEnabled) return [];
+    const q = search.trim().toLowerCase();
+    if (!q) return MOCK_CHATS.slice(0, 5);
+    return MOCK_CHATS.filter(
+      c =>
+        c.title.toLowerCase().includes(q) ||
+        c.appName.toLowerCase().includes(q) ||
+        c.snippet.toLowerCase().includes(q)
+    ).slice(0, 5);
+  }, [chatHistoryEnabled, search]);
+
+  const isOnPrompts = location.pathname.startsWith('/prompts');
+  const isOnChats = location.pathname.startsWith('/chats');
+  const isOnApps = location.pathname === '/apps';
+
+  const linkIconFor = url => {
+    if (/^https?:\/\//.test(url)) return 'external-link';
+    if (url.startsWith('mailto:')) return 'mail';
+    if (url.startsWith('/prompts')) return 'sparkles';
+    if (url.startsWith('/pages/')) return 'document';
+    if (url === '/') return 'home';
+    return 'link';
+  };
+
+  // Header links from config (CMS pages, prompts, external), excluding entries
+  // already represented by dedicated buttons. Feature gating + page access apply.
+  const configuredLinks = useMemo(() => {
+    const links = uiConfig?.header?.links;
+    if (!Array.isArray(links)) return [];
+    return links.filter(link => {
+      if (!link?.url) return false;
+      if (link.url === '/' || link.url === '/apps') return false;
+      const featureId = FEATURE_ROUTES[link.url];
+      if (featureId && !featureFlags.isEnabled(featureId, true)) return false;
+      return canAccessLink(link, { uiConfig, isAuthenticated, user });
+    });
+  }, [uiConfig, featureFlags, isAuthenticated, user]);
+
+  const headerTitle = useMemo(() => {
+    if (uiConfig?.header?.titleLight || uiConfig?.header?.titleBold) {
+      return (
+        <>
+          <span className="font-light">
+            {getLocalizedContent(uiConfig.header.titleLight, currentLanguage)}
+          </span>
+          <span className="font-extrabold">
+            {getLocalizedContent(uiConfig.header.titleBold, currentLanguage)}
+          </span>
+        </>
+      );
+    }
+    return (
+      <>
+        <span className="font-light">iHub </span>
+        <span className="font-extrabold">Apps</span>
+      </>
+    );
+  }, [uiConfig, currentLanguage]);
+
+  const logoSrc = uiConfig?.header?.logo?.url ? buildAssetUrl(uiConfig.header.logo.url) : null;
+  const logoAlt = getLocalizedContent(uiConfig?.header?.logo?.alt, currentLanguage) || 'iHub';
+  // Vendor tagline is only shown when configured (no hard-coded vendor name).
+  const tagline = uiConfig?.header?.tagline
+    ? getLocalizedContent(uiConfig.header.tagline, currentLanguage)
+    : null;
+
+  // Plain render helper (not a nested component) to avoid remounting on render.
+  const renderBrandMark = size =>
+    logoSrc ? (
+      <img
+        src={logoSrc}
+        alt={logoAlt}
+        className="object-contain"
+        style={{ width: size, height: size }}
+      />
+    ) : (
+      <IHubLogo size={size} />
+    );
+
+  // ---- Collapsed rail (desktop only) ----
+  const rail = (
+    <aside
+      className="hidden md:flex w-[72px] flex-none flex-col items-center gap-1.5 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 py-4"
+      aria-label={t('sidebar.navigation', 'Navigation')}
+    >
+      <button
+        onClick={() => go('/')}
+        title={t('sidebar.home', 'Home')}
+        aria-label={t('sidebar.home', 'Home')}
+        className="mb-1 rounded-lg p-0.5 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      >
+        {renderBrandMark(28)}
+      </button>
+
+      <button
+        title={t('sidebar.expand', 'Expand sidebar')}
+        aria-label={t('sidebar.expand', 'Expand sidebar')}
+        onClick={toggleCollapsed}
+        className="w-10 h-10 flex items-center justify-center rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      >
+        <Icon name="chevron-right" size="md" />
+      </button>
+
+      <button
+        title={t('sidebar.newChat', 'New chat')}
+        aria-label={t('sidebar.newChat', 'New chat')}
+        onClick={() => go('/')}
+        className="w-10 h-10 flex items-center justify-center rounded-xl bg-indigo-600 text-white hover:bg-indigo-700 transition-colors"
+      >
+        <Icon name="plus" size="md" />
+      </button>
+
+      <button
+        title={t('sidebar.search', 'Search')}
+        aria-label={t('sidebar.search', 'Search')}
+        onClick={() => {
+          setCollapsed(false);
+          try {
+            localStorage.setItem(SIDEBAR_COLLAPSED_KEY, 'false');
+          } catch {
+            // ignore
+          }
+          setSearchOpen(true);
+        }}
+        className="w-10 h-10 flex items-center justify-center rounded-xl text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+      >
+        <Icon name="search" size="md" />
+      </button>
+
+      <button
+        title={t('sidebar.browseApps', 'Browse all apps')}
+        aria-label={t('sidebar.browseApps', 'Browse all apps')}
+        aria-current={isOnApps ? 'page' : undefined}
+        onClick={() => go('/apps')}
+        className={`w-10 h-10 flex items-center justify-center rounded-xl transition-colors ${
+          isOnApps
+            ? 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400'
+            : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
+        }`}
+      >
+        <Icon name="home" size="md" />
+      </button>
+
+      {featureFlags.isEnabled('promptsLibrary', true) && (
+        <button
+          title={t('sidebar.prompts', 'Prompts')}
+          aria-label={t('sidebar.prompts', 'Prompts')}
+          aria-current={isOnPrompts ? 'page' : undefined}
+          onClick={() => go('/prompts')}
+          className={`w-10 h-10 flex items-center justify-center rounded-xl transition-colors ${
+            isOnPrompts
+              ? 'bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400'
+              : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
+          }`}
+        >
+          <Icon name="sparkles" size="md" />
+        </button>
+      )}
+
+      <div className="w-8 h-px bg-gray-200 dark:bg-gray-700 my-1" />
+
+      {apps
+        .filter(a => favoriteAppIds.includes(a.id))
+        .slice(0, 4)
+        .map(app => {
+          const name = getLocalizedContent(app.name, currentLanguage) || app.id;
+          return (
+            <button
+              key={app.id}
+              title={name}
+              aria-label={name}
+              onClick={() => go(`/apps/${app.id}`)}
+              className="w-10 h-10 flex items-center justify-center rounded-xl text-white transition-colors hover:brightness-110"
+              style={{ backgroundColor: app.color || '#4f46e5' }}
+            >
+              <Icon name={app.icon} size="md" />
+            </button>
+          );
+        })}
+
+      <div className="flex-1" />
+
+      <UserAuthMenu variant="sidebar" collapsed className="flex justify-center" />
+    </aside>
+  );
+
+  // ---- Expanded content (shared by desktop-expanded and mobile drawer) ----
+  const expandedContent = (
+    <>
+      {/* Header */}
+      <div className="px-4 pt-4 pb-0 flex items-center gap-2.5">
+        <button
+          onClick={() => go('/')}
+          title={t('sidebar.home', 'Home')}
+          className="flex items-center gap-2.5 flex-1 min-w-0 rounded-lg -ml-1 pl-1 py-1 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-left"
+        >
+          <span className="flex-none">{renderBrandMark(30)}</span>
+          <span className="flex-1 min-w-0 leading-tight">
+            <span className="block text-base text-gray-900 dark:text-gray-100 truncate">
+              {headerTitle}
+            </span>
+            {tagline && (
+              <span className="block text-[10px] text-gray-400 tracking-wide truncate">
+                {tagline}
+              </span>
+            )}
+          </span>
+        </button>
+        {/* Collapse on desktop, close on mobile */}
+        <button
+          title={t('sidebar.collapse', 'Collapse sidebar')}
+          aria-label={t('sidebar.collapse', 'Collapse sidebar')}
+          onClick={() => {
+            if (mobileOpen) onMobileClose();
+            else toggleCollapsed();
+          }}
+          className="w-8 h-8 flex items-center justify-center rounded-lg text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 hover:text-gray-600 dark:hover:text-gray-300 transition-colors flex-none"
+        >
+          <Icon name={mobileOpen ? 'x' : 'chevron-left'} size="sm" />
+        </button>
+      </div>
+
+      {/* New chat + search */}
+      <div className="px-4 pt-3.5 pb-1 flex gap-2">
+        <button
+          onClick={() => go('/')}
+          className="flex-1 flex items-center justify-center gap-2 px-3 py-2.5 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-semibold transition-colors"
+        >
+          <Icon name="plus" size="sm" />
+          {t('sidebar.newChat', 'New chat')}
+        </button>
+        <button
+          onClick={() => {
+            setSearchOpen(s => !s);
+            if (searchOpen) setSearch('');
+          }}
+          title={t('sidebar.searchChatsApps', 'Search chats & apps')}
+          aria-label={t('sidebar.searchChatsApps', 'Search chats & apps')}
+          aria-expanded={searchOpen}
+          className={`w-11 flex items-center justify-center rounded-xl border transition-colors ${
+            searchOpen
+              ? 'border-indigo-300 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600'
+              : 'border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-gray-500 hover:bg-gray-50 dark:hover:bg-gray-800'
+          }`}
+        >
+          <Icon name="search" size="sm" />
+        </button>
+      </div>
+
+      {searchOpen && (
+        <div className="px-4 pb-2">
+          <div className="relative">
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400">
+              <Icon name="search" size="sm" />
+            </span>
+            <input
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder={t('sidebar.searchPlaceholder', 'Search chats & apps')}
+              aria-label={t('sidebar.searchChatsApps', 'Search chats & apps')}
+              autoFocus
+              className="w-full pl-9 pr-3 py-2 rounded-lg border border-indigo-200 dark:border-indigo-700 bg-gray-50 dark:bg-gray-800 text-sm outline-none focus:border-indigo-400 dark:text-gray-100"
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Scrollable middle */}
+      <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col">
+        {/* Nav items */}
+        <nav className="px-2 pt-2 pb-1" aria-label={t('sidebar.navigation', 'Navigation')}>
+          <NavButton
+            icon="home"
+            label={t('sidebar.browseApps', 'Browse all apps')}
+            onClick={() => go('/apps')}
+            active={isOnApps}
+          />
+          {configuredLinks.map(link => {
+            const label = getLocalizedContent(link.name, currentLanguage) || link.url;
+            const isExternal = /^https?:\/\//.test(link.url) || link.url.startsWith('mailto:');
+            return (
+              <NavButton
+                key={link.url}
+                icon={linkIconFor(link.url)}
+                label={label}
+                active={!isExternal && isActivePath(location.pathname, link.url)}
+                onClick={() => {
+                  if (isExternal) {
+                    window.open(link.url, '_blank', 'noopener,noreferrer');
+                    onMobileClose();
+                  } else {
+                    go(link.url);
+                  }
+                }}
+              />
+            );
+          })}
+        </nav>
+
+        {/* Apps section */}
+        <SectionHeader
+          label={t('sidebar.apps', 'Apps')}
+          open={appsOpen}
+          onToggle={() => setAppsOpen(o => !o)}
+        />
+        {appsOpen && (
+          <div className="px-2 pb-2">
+            {sidebarApps.length === 0 && (
+              <p className="text-xs text-gray-400 px-3 py-1">
+                {apps.length === 0
+                  ? t('sidebar.loadingApps', 'Loading…')
+                  : t('sidebar.noAppsMatch', 'No apps match')}
+              </p>
+            )}
+            {sidebarApps.map(app => {
+              const name = getLocalizedContent(app.name, currentLanguage) || app.id;
+              const fav = isFavorite(app.id);
+              const isActive =
+                location.pathname === `/apps/${app.id}` ||
+                location.pathname.startsWith(`/apps/${app.id}/`);
+              return (
+                <div
+                  key={app.id}
+                  className={`flex items-center rounded-lg transition-colors ${
+                    isActive
+                      ? 'bg-indigo-50 dark:bg-indigo-900/30'
+                      : 'hover:bg-gray-100 dark:hover:bg-gray-800'
+                  }`}
+                >
+                  <button
+                    onClick={() => go(`/apps/${app.id}`)}
+                    title={name}
+                    aria-current={isActive ? 'page' : undefined}
+                    className="flex-1 flex items-center gap-2.5 px-3 py-1.5 rounded-lg text-sm font-medium text-gray-700 dark:text-gray-300 text-left min-w-0"
+                  >
+                    <span
+                      className="w-6 h-6 rounded-lg flex items-center justify-center flex-none text-white"
+                      style={{ backgroundColor: app.color || '#4f46e5' }}
+                    >
+                      <Icon name={app.icon} size="sm" className="w-3.5 h-3.5" />
+                    </span>
+                    <span className="flex-1 truncate">{name}</span>
+                  </button>
+                  <button
+                    onClick={e => handleToggleFav(e, app.id)}
+                    aria-pressed={fav}
+                    aria-label={
+                      fav
+                        ? t('pages.appsList.unfavorite', 'Remove from favorites')
+                        : t('pages.appsList.favorite', 'Add to favorites')
+                    }
+                    title={
+                      fav
+                        ? t('pages.appsList.unfavorite', 'Remove from favorites')
+                        : t('pages.appsList.favorite', 'Add to favorites')
+                    }
+                    className="w-8 h-8 flex-none mr-1 rounded-lg flex items-center justify-center text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors"
+                  >
+                    <Icon
+                      name="star"
+                      size="sm"
+                      className={fav ? 'text-yellow-400' : 'text-gray-300'}
+                      solid={fav}
+                    />
+                  </button>
+                </div>
+              );
+            })}
+            <button
+              onClick={() => go('/apps')}
+              className="flex items-center gap-2.5 w-full px-3 py-1.5 mt-1 rounded-lg text-indigo-600 dark:text-indigo-400 text-sm font-semibold hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            >
+              <span className="w-6 h-6 flex items-center justify-center flex-none">
+                <Icon name="home" size="sm" />
+              </span>
+              <span className="flex-1">{t('sidebar.allApps', 'All apps')}</span>
+              <span className="text-[11px] font-bold text-gray-400 bg-gray-100 dark:bg-gray-800 rounded-full px-2 py-0.5">
+                {apps.length}
+              </span>
+            </button>
+          </div>
+        )}
+
+        {/* Recents section — feature-flagged */}
+        {chatHistoryEnabled && (
+          <>
+            <SectionHeader
+              label={t('sidebar.recents', 'Recents')}
+              open={recentsOpen}
+              onToggle={() => setRecentsOpen(o => !o)}
+            />
+            {recentsOpen && (
+              <div className="px-2 pb-2">
+                {recentChats.map(chat => (
+                  <button
+                    key={chat.id}
+                    onClick={() => go('/chats')}
+                    title={chat.title}
+                    className="flex items-center gap-2.5 w-full px-3 py-1.5 rounded-lg text-sm text-gray-700 dark:text-gray-300 text-left transition-colors hover:bg-gray-100 dark:hover:bg-gray-800"
+                  >
+                    <span
+                      className="w-5 h-5 rounded-md flex items-center justify-center flex-none text-white"
+                      style={{ backgroundColor: chat.appColor || '#4f46e5' }}
+                    >
+                      <Icon name={chat.appIcon} size="sm" className="w-3 h-3" />
+                    </span>
+                    <span className="flex-1 truncate text-[13px]">{chat.title}</span>
+                  </button>
+                ))}
+                <button
+                  onClick={() => go('/chats')}
+                  aria-current={isOnChats ? 'page' : undefined}
+                  className="flex items-center gap-2.5 w-full px-3 py-1.5 mt-1 rounded-lg text-indigo-600 dark:text-indigo-400 text-sm font-semibold hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                >
+                  <span className="w-5 h-5 flex items-center justify-center flex-none">
+                    <Icon name="clock" size="sm" />
+                  </span>
+                  <span className="flex-1">{t('sidebar.allChats', 'All chats')}</span>
+                  <span className="text-[11px] font-bold text-gray-400 bg-gray-100 dark:bg-gray-800 rounded-full px-2 py-0.5">
+                    {MOCK_CHATS.length}
+                  </span>
+                </button>
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Account section */}
+      <div className="border-t border-gray-100 dark:border-gray-800 px-2 py-2 flex items-center gap-2">
+        <div className="flex-1 min-w-0">
+          <UserAuthMenu variant="sidebar" />
+        </div>
+        <LanguageSelector variant="sidebar" />
+      </div>
+    </>
+  );
+
+  return (
+    <>
+      {/* Desktop sidebar */}
+      {collapsed ? (
+        rail
+      ) : (
+        <aside
+          className="hidden md:flex w-[284px] flex-none flex-col bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700"
+          aria-label={t('sidebar.navigation', 'Navigation')}
+        >
+          {expandedContent}
+        </aside>
+      )}
+
+      {/* Mobile drawer */}
+      {mobileOpen && (
+        <div className="md:hidden fixed inset-0 z-40" role="dialog" aria-modal="true">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={onMobileClose}
+            aria-hidden="true"
+          />
+          <aside
+            className="absolute inset-y-0 left-0 w-[284px] max-w-[85vw] flex flex-col bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 shadow-xl"
+            aria-label={t('sidebar.navigation', 'Navigation')}
+          >
+            {expandedContent}
+          </aside>
+        </div>
+      )}
+    </>
+  );
+}

--- a/client/src/shared/components/IHubLogo.jsx
+++ b/client/src/shared/components/IHubLogo.jsx
@@ -1,0 +1,35 @@
+import { useId } from 'react';
+
+/**
+ * iHub gradient mark. Used as the fallback brand logo across the user and admin
+ * sidebars and the start page. The gradient id is unique per instance so
+ * multiple logos on the same page don't collide.
+ */
+export default function IHubLogo({ size = 28, className = '' }) {
+  const gradientId = useId();
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 40 40"
+      aria-hidden="true"
+      focusable="false"
+      className={className}
+    >
+      <defs>
+        <linearGradient
+          id={gradientId}
+          x1="6"
+          y1="34"
+          x2="34"
+          y2="6"
+          gradientUnits="userSpaceOnUse"
+        >
+          <stop stopColor="#16a34a" />
+          <stop offset="1" stopColor="#0ea5b7" />
+        </linearGradient>
+      </defs>
+      <path d="M20 5L34 33H27.2L20 17.5L12.8 33H6L20 5Z" fill={`url(#${gradientId})`} />
+    </svg>
+  );
+}

--- a/client/src/shared/components/LanguageSelector.jsx
+++ b/client/src/shared/components/LanguageSelector.jsx
@@ -1,12 +1,25 @@
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useUIConfig } from '../contexts/UIConfigContext';
 import { i18nService } from '../../i18n/i18n';
+import Icon from './Icon';
 
-function LanguageSelector() {
+function LanguageSelector({ variant = 'header' }) {
   const { i18n, t } = useTranslation();
   const { uiConfig, isLoading } = useUIConfig();
   const [isChanging, setIsChanging] = useState(false);
+  const [open, setOpen] = useState(false);
+  const compactRef = useRef(null);
+
+  // Close the compact popover when clicking outside
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = e => {
+      if (compactRef.current && !compactRef.current.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open]);
 
   // Handle language change with error handling
   const changeLanguage = async language => {
@@ -66,12 +79,70 @@ function LanguageSelector() {
     return <div className="language-selector-loading">{t('common.loading', 'Loading...')}</div>;
   }
 
+  // Compact variant for the sidebar: a small button showing just the current
+  // language code (EN/DE); clicking opens a popover with the full names so it
+  // never overlaps the neighbouring user button.
+  if (variant === 'sidebar') {
+    const current = (i18n.language || 'en').split('-')[0];
+    return (
+      <div className="relative flex-none" ref={compactRef}>
+        <button
+          type="button"
+          onClick={() => setOpen(o => !o)}
+          disabled={isChanging}
+          aria-haspopup="menu"
+          aria-expanded={open}
+          aria-label={t('common.selectLanguage', 'Select language')}
+          className="flex items-center gap-1 rounded-lg border border-gray-200 dark:border-gray-700 px-2 py-1.5 text-xs font-semibold text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 focus:outline-none focus:ring-1 focus:ring-indigo-400"
+        >
+          {current.toUpperCase()}
+          <Icon
+            name="chevron-down"
+            size="xs"
+            className={`transition-transform ${open ? 'rotate-180' : ''}`}
+          />
+        </button>
+        {open && (
+          <ul
+            role="menu"
+            className="absolute bottom-full right-0 mb-2 min-w-[8rem] bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 py-1 z-50"
+          >
+            {availableLanguages.map(lang => (
+              <li key={lang.code}>
+                <button
+                  type="button"
+                  role="menuitemradio"
+                  aria-checked={i18n.language === lang.code}
+                  onClick={() => {
+                    changeLanguage(lang.code);
+                    setOpen(false);
+                  }}
+                  className={`flex items-center justify-between w-full px-3 py-2 text-sm text-left hover:bg-gray-100 dark:hover:bg-gray-700 ${
+                    i18n.language === lang.code
+                      ? 'text-indigo-600 dark:text-indigo-400 font-medium'
+                      : 'text-gray-700 dark:text-gray-300'
+                  }`}
+                >
+                  {lang.name}
+                  {i18n.language === lang.code && <Icon name="check" size="sm" />}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    );
+  }
+
+  const selectClassName =
+    'bg-transparent text-white border border-white rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-white cursor-pointer';
+
   return (
     <div className="language-selector">
       <select
         value={i18n.language || 'en'}
         onChange={e => changeLanguage(e.target.value)}
-        className="bg-transparent text-white border border-white rounded px-2 py-1 text-sm focus:outline-none focus:ring-1 focus:ring-white cursor-pointer"
+        className={selectClassName}
         disabled={isChanging}
         aria-label={t('common.selectLanguage', 'Select language')}
       >

--- a/client/src/shared/components/Layout.jsx
+++ b/client/src/shared/components/Layout.jsx
@@ -15,6 +15,9 @@ import useFeatureFlags from '../hooks/useFeatureFlags';
 import { pathnameStartsWith, isActivePath } from '../../utils/pathUtils';
 import { buildAssetUrl } from '../../utils/runtimeBasePath';
 import { useOAuthCallbackCleanup } from '../hooks/useOAuthCallbackCleanup';
+import { canAccessLink as canAccessLinkShared, FEATURE_ROUTES } from '../../utils/pageAccess';
+import AppSidebar from './AppSidebar';
+import IHubLogo from './IHubLogo';
 
 function Layout() {
   const { t, i18n } = useTranslation();
@@ -22,6 +25,7 @@ function Layout() {
   const { headerColor, uiConfig, resetHeaderColor } = useUIConfig();
   const location = useLocation();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [sidebarMobileOpen, setSidebarMobileOpen] = useState(false);
   const [searchParams] = useSearchParams();
   const { user, isAuthenticated } = useAuth();
   const featureFlags = useFeatureFlags();
@@ -30,10 +34,15 @@ function Layout() {
   useOAuthCallbackCleanup();
 
   // Map navigation URLs to feature IDs for gating
-  const featureRoutes = { '/prompts': 'promptsLibrary', '/workflows': 'workflows' };
+  const featureRoutes = FEATURE_ROUTES;
 
   // Update integration settings from URL parameters and retrieve current settings
-  const { showHeader, showFooter, language } = updateSettingsFromUrl(searchParams);
+  const {
+    showHeader,
+    showFooter,
+    language,
+    showSidebar: sidebarSetting
+  } = updateSettingsFromUrl(searchParams);
 
   // Apply language from URL if specified
   useEffect(() => {
@@ -48,10 +57,27 @@ function Layout() {
     return pathnameStartsWith(location.pathname, '/apps/');
   }, [location.pathname]);
 
+  // Show the sidebar on all non-admin, non-special pages
+  const isAdminRoute = pathnameStartsWith(location.pathname, '/admin');
+  const isSetupRoute = pathnameStartsWith(location.pathname, '/setup');
+  const isLoginRoute = location.pathname === '/login';
+  const isTeamsRoute = pathnameStartsWith(location.pathname, '/teams');
+  const isOfficeRoute = pathnameStartsWith(location.pathname, '/office');
+  const isNextcloudRoute = pathnameStartsWith(location.pathname, '/nextcloud');
+  const showSidebar =
+    !isAdminRoute &&
+    !isSetupRoute &&
+    !isLoginRoute &&
+    !isTeamsRoute &&
+    !isOfficeRoute &&
+    !isNextcloudRoute &&
+    showHeader && // respect showHeader=false for embedded contexts
+    sidebarSetting !== false; // respect sidebar=false to disable the left bar
+
   // Store integration settings in localStorage for use by other components
   useEffect(() => {
-    saveIntegrationSettings({ showHeader, showFooter, language });
-  }, [showHeader, showFooter, language]);
+    saveIntegrationSettings({ showHeader, showFooter, showSidebar: sidebarSetting, language });
+  }, [showHeader, showFooter, sidebarSetting, language]);
 
   const headerColorStyle = {
     backgroundColor: headerColor || '#4f46e5',
@@ -62,25 +88,16 @@ function Layout() {
     setMobileMenuOpen(!mobileMenuOpen);
   };
 
-  const canAccessLink = link => {
-    if (!link.url.startsWith('/pages/') || !uiConfig?.pages) return true;
-    const pageId = link.url.replace('/pages/', '');
-    const page = uiConfig.pages[pageId];
-    if (!page) return true;
-    if (page.authRequired && !isAuthenticated) return false;
-    if (Array.isArray(page.allowedGroups)) {
-      if (page.allowedGroups.includes('*')) return true;
-      if (page.allowedGroups.length > 0) {
-        const groups = user?.groups || [];
-        return groups.some(g => page.allowedGroups.includes(g));
-      }
-    }
-    return true;
-  };
+  // Close the mobile sidebar drawer whenever the route changes.
+  useEffect(() => {
+    setSidebarMobileOpen(false);
+  }, [location.pathname]);
+
+  const canAccessLink = link => canAccessLinkShared(link, { uiConfig, isAuthenticated, user });
 
   return (
     <div
-      className={`flex flex-col w-full bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-200 ${pathnameStartsWith(location.pathname, '/admin') ? 'h-screen overflow-hidden' : 'min-h-screen h-full'}`}
+      className={`flex flex-col w-full bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-gray-100 transition-colors duration-200 ${showSidebar || isAdminRoute ? 'h-screen overflow-hidden' : 'min-h-screen h-full'}`}
     >
       <a
         href="#main-content"
@@ -89,133 +106,99 @@ function Layout() {
         {t('accessibility.skipToContent', 'Skip to main content')}
       </a>
 
-      {/* Disclaimer Popup - Only render if enabled (defaults to true) */}
+      {/* Disclaimer Popup */}
       {uiConfig?.disclaimer && uiConfig.disclaimer.enabled !== false && (
         <DisclaimerPopup disclaimer={uiConfig.disclaimer} currentLanguage={currentLanguage} />
       )}
 
-      {/* Global smart search overlay — not shown on admin routes (admin has its own Cmd+K) */}
-      {!pathnameStartsWith(location.pathname, '/admin') && <SmartSearch />}
+      {/* Global smart search overlay — not shown on admin routes */}
+      {!isAdminRoute && <SmartSearch />}
 
-      {showHeader && (
-        <header className="text-white sticky top-0 z-10" style={headerColorStyle}>
-          <div className="relative flex items-stretch h-16">
-            <div className="container mx-auto px-4 flex justify-between items-center">
-              <div className="flex items-center h-full">
-                <Link to="/" onClick={resetHeaderColor} className="flex items-center gap-2.5 py-2">
-                  {uiConfig?.header?.logo?.url && (
-                    <img
-                      src={buildAssetUrl(uiConfig.header.logo.url)}
-                      alt={getLocalizedContent(uiConfig.header.logo.alt, currentLanguage) || 'Logo'}
-                      className="h-7 w-7 flex-shrink-0"
-                    />
+      {/* Sidebar layout (non-admin, non-embedded pages) */}
+      {showSidebar ? (
+        <div className="flex flex-1 min-h-0 overflow-hidden">
+          <AppSidebar
+            mobileOpen={sidebarMobileOpen}
+            onMobileClose={() => setSidebarMobileOpen(false)}
+          />
+          <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+            {/* Mobile top bar — the only way to reach navigation on small screens */}
+            <div className="md:hidden flex items-center gap-2 h-12 px-3 border-b border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 flex-none">
+              <button
+                type="button"
+                onClick={() => setSidebarMobileOpen(true)}
+                aria-label={t('sidebar.openMenu', 'Open navigation')}
+                className="p-1.5 -ml-1 rounded-md text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+              >
+                <Icon name="menu" size="md" />
+              </button>
+              <Link to="/" onClick={resetHeaderColor} className="flex items-center gap-2 min-w-0">
+                {uiConfig?.header?.logo?.url ? (
+                  <img
+                    src={buildAssetUrl(uiConfig.header.logo.url)}
+                    alt={getLocalizedContent(uiConfig.header.logo.alt, currentLanguage) || 'iHub'}
+                    className="h-6 w-6 object-contain flex-none"
+                  />
+                ) : (
+                  <IHubLogo size={24} />
+                )}
+                <span className="text-sm font-semibold truncate">
+                  {uiConfig?.header?.title
+                    ? getLocalizedContent(uiConfig.header.title, currentLanguage)
+                    : 'iHub Apps'}
+                </span>
+              </Link>
+            </div>
+            <main id="main-content" tabIndex={-1} className="flex-1 min-h-0 overflow-y-auto">
+              <Outlet />
+            </main>
+            {/* Slim footer — links shown at the bottom of content pages (not on
+                the app chat, which needs the full height). Disable with
+                footer=false or via UI config. */}
+            {uiConfig?.footer?.enabled !== false && showFooter && !isAppPage && (
+              <footer className="flex-none border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900">
+                <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 px-6 py-2.5 text-xs text-gray-500 dark:text-gray-400">
+                  <span className="truncate">
+                    {uiConfig?.footer?.text
+                      ? getLocalizedContent(uiConfig.footer.text, currentLanguage)
+                      : t('footer.copyright')}
+                  </span>
+                  {uiConfig?.footer?.links && (
+                    <nav
+                      aria-label={t('footer.navigation', 'Footer navigation')}
+                      className="flex flex-wrap items-center gap-x-4 gap-y-1"
+                    >
+                      {uiConfig.footer.links
+                        .filter(link => {
+                          const featureId = featureRoutes[link.url];
+                          if (featureId && !featureFlags.isEnabled(featureId, true)) return false;
+                          return canAccessLink(link);
+                        })
+                        .map((link, index) => (
+                          <Link
+                            key={index}
+                            to={link.url}
+                            onClick={resetHeaderColor}
+                            className="hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+                            target={
+                              link.url.startsWith('http') || link.url.startsWith('mailto:')
+                                ? '_blank'
+                                : undefined
+                            }
+                            rel={link.url.startsWith('http') ? 'noopener noreferrer' : undefined}
+                          >
+                            {getLocalizedContent(link.name, currentLanguage)}
+                          </Link>
+                        ))}
+                    </nav>
                   )}
-                  <div className="flex flex-col leading-tight">
-                    <span className="text-lg tracking-tight">
-                      {uiConfig?.header?.titleLight && (
-                        <span className="font-light">
-                          {getLocalizedContent(uiConfig.header.titleLight, currentLanguage)}
-                        </span>
-                      )}
-                      {uiConfig?.header?.titleBold && (
-                        <span className="font-bold">
-                          {getLocalizedContent(uiConfig.header.titleBold, currentLanguage)}
-                        </span>
-                      )}
-                      {!uiConfig?.header?.titleLight && !uiConfig?.header?.titleBold && (
-                        <span className="font-semibold">
-                          {uiConfig?.header?.title
-                            ? getLocalizedContent(uiConfig.header.title, currentLanguage)
-                            : 'iHub Apps'}
-                        </span>
-                      )}
-                    </span>
-                    {uiConfig?.header?.tagline && (
-                      <span className="text-[9px] text-white/60 font-normal">
-                        {getLocalizedContent(uiConfig.header.tagline, currentLanguage)}
-                      </span>
-                    )}
-                  </div>
-                </Link>
-              </div>
-
-              <nav
-                className="hidden md:flex items-center space-x-6"
-                aria-label={t('common.mainNavigation', 'Main navigation')}
-              >
-                {uiConfig?.header?.links &&
-                  uiConfig.header.links
-                    .filter(link => {
-                      const featureId = featureRoutes[link.url];
-                      if (featureId && !featureFlags.isEnabled(featureId, true)) return false;
-                      return canAccessLink(link);
-                    })
-                    .map((link, index) => (
-                      <Link
-                        key={index}
-                        to={link.url}
-                        onClick={resetHeaderColor}
-                        className={`hover:text-white/80 ${isActivePath(location.pathname, link.url) ? 'underline font-medium' : ''}`}
-                        target={link.url.startsWith('http') ? '_blank' : undefined}
-                        rel={link.url.startsWith('http') ? 'noopener noreferrer' : undefined}
-                      >
-                        {getLocalizedContent(link.name, currentLanguage)}
-                      </Link>
-                    ))}
-              </nav>
-
-              <div className="flex items-center space-x-2">
-                <DarkModeToggle />
-                {uiConfig?.header?.languageSelector?.enabled !== false && <LanguageSelector />}
-                <UserAuthMenu />
-                <button
-                  className="md:hidden text-white"
-                  onClick={toggleMobileMenu}
-                  aria-label={t('common.toggleMenu', 'Toggle menu')}
-                >
-                  <Icon name="menu" size="lg" className="text-white" />
-                </button>
-              </div>
-            </div>
+                </div>
+              </footer>
+            )}
           </div>
-
-          {/* Mobile Menu */}
-          {mobileMenuOpen && (
-            <div className="md:hidden bg-indigo-800 shadow-lg" style={headerColorStyle}>
-              <nav
-                className="container mx-auto px-4 py-3 flex flex-col"
-                aria-label={t('common.mobileNavigation', 'Mobile navigation')}
-              >
-                {uiConfig?.header?.links &&
-                  uiConfig.header.links
-                    .filter(link => {
-                      const featureId = featureRoutes[link.url];
-                      if (featureId && !featureFlags.isEnabled(featureId, true)) return false;
-                      return canAccessLink(link);
-                    })
-                    .map((link, index) => (
-                      <Link
-                        key={index}
-                        to={link.url}
-                        className={`block py-2 ${isActivePath(location.pathname, link.url) ? 'font-medium' : ''}`}
-                        target={link.url.startsWith('http') ? '_blank' : undefined}
-                        rel={link.url.startsWith('http') ? 'noopener noreferrer' : undefined}
-                        onClick={() => {
-                          setMobileMenuOpen(false);
-                          resetHeaderColor();
-                        }}
-                      >
-                        {getLocalizedContent(link.name, currentLanguage)}
-                      </Link>
-                    ))}
-              </nav>
-            </div>
-          )}
-        </header>
-      )}
-
-      {/* Admin routes handle their own layout (sidebar + content); other routes use container */}
-      {pathnameStartsWith(location.pathname, '/admin') ? (
+        </div>
+      ) : isAdminRoute ? (
+        /* Admin routes handle their own layout */
         <main
           id="main-content"
           tabIndex={-1}
@@ -224,57 +207,180 @@ function Layout() {
           <Outlet />
         </main>
       ) : (
-        <main id="main-content" tabIndex={-1} className="flex-grow w-full overflow-y-auto">
-          <div className="container mx-auto px-4">
-            <Outlet />
-          </div>
-        </main>
-      )}
+        /* Embedded / legacy contexts: keep original header + container layout */
+        <>
+          {showHeader && (
+            <header className="text-white sticky top-0 z-10" style={headerColorStyle}>
+              <div className="relative flex items-stretch h-16">
+                <div className="container mx-auto px-4 flex justify-between items-center">
+                  <div className="flex items-center h-full">
+                    <Link
+                      to="/"
+                      onClick={resetHeaderColor}
+                      className="flex items-center gap-2.5 py-2"
+                    >
+                      {uiConfig?.header?.logo?.url && (
+                        <img
+                          src={buildAssetUrl(uiConfig.header.logo.url)}
+                          alt={
+                            getLocalizedContent(uiConfig.header.logo.alt, currentLanguage) || 'Logo'
+                          }
+                          className="h-7 w-7 flex-shrink-0"
+                        />
+                      )}
+                      <div className="flex flex-col leading-tight">
+                        <span className="text-lg tracking-tight">
+                          {uiConfig?.header?.titleLight && (
+                            <span className="font-light">
+                              {getLocalizedContent(uiConfig.header.titleLight, currentLanguage)}
+                            </span>
+                          )}
+                          {uiConfig?.header?.titleBold && (
+                            <span className="font-bold">
+                              {getLocalizedContent(uiConfig.header.titleBold, currentLanguage)}
+                            </span>
+                          )}
+                          {!uiConfig?.header?.titleLight && !uiConfig?.header?.titleBold && (
+                            <span className="font-semibold">
+                              {uiConfig?.header?.title
+                                ? getLocalizedContent(uiConfig.header.title, currentLanguage)
+                                : 'iHub Apps'}
+                            </span>
+                          )}
+                        </span>
+                        {uiConfig?.header?.tagline && (
+                          <span className="text-[9px] text-white/60 font-normal">
+                            {getLocalizedContent(uiConfig.header.tagline, currentLanguage)}
+                          </span>
+                        )}
+                      </div>
+                    </Link>
+                  </div>
 
-      {/* Footer - Only render if enabled (defaults to true) and not on an app page */}
-      {uiConfig?.footer?.enabled !== false && showFooter && !isAppPage && (
-        <footer className="bg-gray-800 dark:bg-gray-950 text-white py-4">
-          <div className="container mx-auto px-4">
-            <div className="flex flex-col md:flex-row justify-between items-center">
-              <div className="mb-4 md:mb-0">
-                <p>
-                  {uiConfig?.footer?.text
-                    ? getLocalizedContent(uiConfig.footer.text, currentLanguage)
-                    : t('footer.copyright')}
-                </p>
+                  <nav
+                    className="hidden md:flex items-center space-x-6"
+                    aria-label={t('common.mainNavigation', 'Main navigation')}
+                  >
+                    {uiConfig?.header?.links &&
+                      uiConfig.header.links
+                        .filter(link => {
+                          const featureId = featureRoutes[link.url];
+                          if (featureId && !featureFlags.isEnabled(featureId, true)) return false;
+                          return canAccessLink(link);
+                        })
+                        .map((link, index) => (
+                          <Link
+                            key={index}
+                            to={link.url}
+                            onClick={resetHeaderColor}
+                            className={`hover:text-white/80 ${isActivePath(location.pathname, link.url) ? 'underline font-medium' : ''}`}
+                            target={link.url.startsWith('http') ? '_blank' : undefined}
+                            rel={link.url.startsWith('http') ? 'noopener noreferrer' : undefined}
+                          >
+                            {getLocalizedContent(link.name, currentLanguage)}
+                          </Link>
+                        ))}
+                  </nav>
+
+                  <div className="flex items-center space-x-2">
+                    <DarkModeToggle />
+                    {uiConfig?.header?.languageSelector?.enabled !== false && <LanguageSelector />}
+                    <UserAuthMenu />
+                    <button
+                      className="md:hidden text-white"
+                      onClick={toggleMobileMenu}
+                      aria-label={t('common.toggleMenu', 'Toggle menu')}
+                    >
+                      <Icon name="menu" size="lg" className="text-white" />
+                    </button>
+                  </div>
+                </div>
               </div>
-              <nav
-                aria-label={t('footer.navigation', 'Footer navigation')}
-                className="flex flex-wrap justify-center gap-4 md:gap-6"
-              >
-                {uiConfig?.footer?.links &&
-                  uiConfig.footer.links
-                    .filter(link => {
-                      const featureId = featureRoutes[link.url];
-                      if (featureId && !featureFlags.isEnabled(featureId, true)) return false;
-                      return canAccessLink(link);
-                    })
-                    .map((link, index) => (
-                      <Link
-                        key={index}
-                        to={link.url}
-                        onClick={resetHeaderColor}
-                        className="hover:text-gray-300"
-                        target={
-                          link.url.startsWith('http') || link.url.startsWith('mailto:')
-                            ? '_blank'
-                            : undefined
-                        }
-                        rel={link.url.startsWith('http') ? 'noopener noreferrer' : undefined}
-                      >
-                        {getLocalizedContent(link.name, currentLanguage)}
-                      </Link>
-                    ))}
-              </nav>
+
+              {mobileMenuOpen && (
+                <div className="md:hidden bg-indigo-800 shadow-lg" style={headerColorStyle}>
+                  <nav
+                    className="container mx-auto px-4 py-3 flex flex-col"
+                    aria-label={t('common.mobileNavigation', 'Mobile navigation')}
+                  >
+                    {uiConfig?.header?.links &&
+                      uiConfig.header.links
+                        .filter(link => {
+                          const featureId = featureRoutes[link.url];
+                          if (featureId && !featureFlags.isEnabled(featureId, true)) return false;
+                          return canAccessLink(link);
+                        })
+                        .map((link, index) => (
+                          <Link
+                            key={index}
+                            to={link.url}
+                            className={`block py-2 ${isActivePath(location.pathname, link.url) ? 'font-medium' : ''}`}
+                            target={link.url.startsWith('http') ? '_blank' : undefined}
+                            rel={link.url.startsWith('http') ? 'noopener noreferrer' : undefined}
+                            onClick={() => {
+                              setMobileMenuOpen(false);
+                              resetHeaderColor();
+                            }}
+                          >
+                            {getLocalizedContent(link.name, currentLanguage)}
+                          </Link>
+                        ))}
+                  </nav>
+                </div>
+              )}
+            </header>
+          )}
+
+          <main id="main-content" tabIndex={-1} className="flex-grow w-full overflow-y-auto">
+            <div className="container mx-auto px-4">
+              <Outlet />
             </div>
-            {/* Disclaimer removed from footer - now shown as a popup */}
-          </div>
-        </footer>
+          </main>
+
+          {uiConfig?.footer?.enabled !== false && showFooter && !isAppPage && (
+            <footer className="bg-gray-800 dark:bg-gray-950 text-white py-4">
+              <div className="container mx-auto px-4">
+                <div className="flex flex-col md:flex-row justify-between items-center">
+                  <div className="mb-4 md:mb-0">
+                    <p>
+                      {uiConfig?.footer?.text
+                        ? getLocalizedContent(uiConfig.footer.text, currentLanguage)
+                        : t('footer.copyright')}
+                    </p>
+                  </div>
+                  <nav
+                    aria-label={t('footer.navigation', 'Footer navigation')}
+                    className="flex flex-wrap justify-center gap-4 md:gap-6"
+                  >
+                    {uiConfig?.footer?.links &&
+                      uiConfig.footer.links
+                        .filter(link => {
+                          const featureId = featureRoutes[link.url];
+                          if (featureId && !featureFlags.isEnabled(featureId, true)) return false;
+                          return canAccessLink(link);
+                        })
+                        .map((link, index) => (
+                          <Link
+                            key={index}
+                            to={link.url}
+                            onClick={resetHeaderColor}
+                            className="hover:text-gray-300"
+                            target={
+                              link.url.startsWith('http') || link.url.startsWith('mailto:')
+                                ? '_blank'
+                                : undefined
+                            }
+                            rel={link.url.startsWith('http') ? 'noopener noreferrer' : undefined}
+                          >
+                            {getLocalizedContent(link.name, currentLanguage)}
+                          </Link>
+                        ))}
+                  </nav>
+                </div>
+              </div>
+            </footer>
+          )}
+        </>
       )}
     </div>
   );

--- a/client/src/shared/hooks/useApps.js
+++ b/client/src/shared/hooks/useApps.js
@@ -1,0 +1,33 @@
+import { useState, useEffect } from 'react';
+import { fetchApps } from '../../api';
+import { useAuth } from '../contexts/AuthContext';
+
+/**
+ * Load the apps the current user can access. Refetches when the authenticated
+ * user changes (login/logout) so the list is never stale after auth changes.
+ *
+ * @returns {{ apps: object[], loading: boolean }}
+ */
+export default function useApps() {
+  const { user, isAuthenticated } = useAuth();
+  const [apps, setApps] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoading(true);
+    fetchApps()
+      .then(data => {
+        if (mounted && Array.isArray(data)) setApps(data);
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (mounted) setLoading(false);
+      });
+    return () => {
+      mounted = false;
+    };
+  }, [isAuthenticated, user?.id]);
+
+  return { apps, loading };
+}

--- a/client/src/shared/hooks/useFavorites.js
+++ b/client/src/shared/hooks/useFavorites.js
@@ -1,0 +1,46 @@
+import { useState, useEffect, useMemo, useCallback } from 'react';
+import { createFavoriteItemHelpers } from '../../utils/favoriteItems';
+
+/**
+ * React hook for localStorage-backed favorites that stays in sync across
+ * components (via the `ihub:favorites-changed` event) and across browser tabs
+ * (via the native `storage` event).
+ *
+ * @param {string} storageKey - localStorage key (e.g. 'ihub_favorite_apps')
+ * @returns {{ favorites: string[], isFavorite: (id:string)=>boolean, toggleFavorite: (id:string)=>boolean }}
+ */
+export default function useFavorites(storageKey) {
+  const helpers = useMemo(() => createFavoriteItemHelpers(storageKey), [storageKey]);
+  const [favorites, setFavorites] = useState(() => helpers.getFavorites());
+
+  useEffect(() => {
+    const refresh = event => {
+      // Same-tab custom event carries the storageKey; ignore other lists.
+      if (event?.detail?.storageKey && event.detail.storageKey !== storageKey) return;
+      // Cross-tab storage event carries `key`; ignore other keys.
+      if (event?.type === 'storage' && event.key && event.key !== storageKey) return;
+      setFavorites(helpers.getFavorites());
+    };
+    window.addEventListener('ihub:favorites-changed', refresh);
+    window.addEventListener('storage', refresh);
+    return () => {
+      window.removeEventListener('ihub:favorites-changed', refresh);
+      window.removeEventListener('storage', refresh);
+    };
+  }, [helpers, storageKey]);
+
+  const toggleFavorite = useCallback(
+    id => {
+      const status = helpers.toggleFavorite(id);
+      // toggleFavorite dispatches the custom event, but update locally too so
+      // the calling component re-renders synchronously.
+      setFavorites(helpers.getFavorites());
+      return status;
+    },
+    [helpers]
+  );
+
+  const isFavorite = useCallback(id => favorites.includes(id), [favorites]);
+
+  return { favorites, isFavorite, toggleFavorite };
+}

--- a/client/src/utils/favoriteItems.js
+++ b/client/src/utils/favoriteItems.js
@@ -50,6 +50,17 @@ export const createFavoriteItemHelpers = storageKey => {
       }
 
       localStorage.setItem(storageKey, JSON.stringify(newFavorites));
+      // Notify other mounted components (e.g. the sidebar and the apps list)
+      // so they can refresh their favorite state without a page reload.
+      try {
+        window.dispatchEvent(
+          new CustomEvent('ihub:favorites-changed', {
+            detail: { storageKey, favorites: newFavorites }
+          })
+        );
+      } catch {
+        // Ignore environments without window/CustomEvent (e.g. SSR/tests)
+      }
       return !isCurrentlyFavorite; // Return the new status
     } catch (error) {
       console.error(`Error toggling favorite item for ${storageKey}:`, error);

--- a/client/src/utils/integrationSettings.js
+++ b/client/src/utils/integrationSettings.js
@@ -26,17 +26,20 @@ function isEmbedMode() {
  */
 export const getIntegrationSettings = () => {
   if (isEmbedMode()) {
-    return { showHeader: false, showFooter: false, language: null };
+    return { showHeader: false, showFooter: false, showSidebar: false, language: null };
   }
   try {
     const savedSettings = localStorage.getItem('ihubIntegrationSettings');
     if (savedSettings) {
-      return JSON.parse(savedSettings);
+      const parsed = JSON.parse(savedSettings);
+      // showSidebar was added later; default to enabled when missing.
+      if (parsed.showSidebar === undefined) parsed.showSidebar = true;
+      return parsed;
     }
   } catch (error) {
     console.error('Error reading integration settings from localStorage:', error);
   }
-  return { showHeader: true, showFooter: true, language: null };
+  return { showHeader: true, showFooter: true, showSidebar: true, language: null };
 };
 
 /**
@@ -77,6 +80,13 @@ export const updateSettingsFromUrl = searchParams => {
     const footerParam = searchParams.get('footer');
     if (footerParam !== null) {
       settings.showFooter = footerParam !== 'false';
+      updated = true;
+    }
+
+    // Update sidebar setting if provided in URL (disable the left navigation bar)
+    const sidebarParam = searchParams.get('sidebar');
+    if (sidebarParam !== null) {
+      settings.showSidebar = sidebarParam !== 'false';
       updated = true;
     }
 

--- a/client/src/utils/pageAccess.js
+++ b/client/src/utils/pageAccess.js
@@ -1,0 +1,35 @@
+/**
+ * Shared navigation/page access helpers.
+ *
+ * Used by both the layout footer and the sidebar so the rules for gating
+ * configured links live in exactly one place.
+ */
+
+// Maps navigation URLs to the feature flag that gates them.
+export const FEATURE_ROUTES = { '/prompts': 'promptsLibrary', '/workflows': 'workflows' };
+
+/**
+ * Whether the current user may see a configured link.
+ *
+ * Only `/pages/*` links carry per-page access rules (authRequired / allowedGroups);
+ * everything else is always visible.
+ *
+ * @param {{url: string}} link
+ * @param {{ uiConfig?: object, isAuthenticated?: boolean, user?: object }} ctx
+ * @returns {boolean}
+ */
+export function canAccessLink(link, { uiConfig, isAuthenticated, user } = {}) {
+  if (!link?.url || !link.url.startsWith('/pages/') || !uiConfig?.pages) return true;
+  const pageId = link.url.replace('/pages/', '');
+  const page = uiConfig.pages[pageId];
+  if (!page) return true;
+  if (page.authRequired && !isAuthenticated) return false;
+  if (Array.isArray(page.allowedGroups)) {
+    if (page.allowedGroups.includes('*')) return true;
+    if (page.allowedGroups.length > 0) {
+      const groups = user?.groups || [];
+      return groups.some(g => page.allowedGroups.includes(g));
+    }
+  }
+  return true;
+}

--- a/client/src/utils/runtimeBasePath.js
+++ b/client/src/utils/runtimeBasePath.js
@@ -22,6 +22,7 @@ export const KNOWN_ROUTES = [
   'login', // Standalone login page
   'pages', // Dynamic content pages
   'prompts', // Prompts listing
+  'chats', // Chat history overview
   'settings', // Settings pages (integrations, etc.)
   'teams', // Microsoft Teams embed routes
   'workflows', // Workflow management and execution

--- a/server/featureRegistry.js
+++ b/server/featureRegistry.js
@@ -104,6 +104,17 @@ export const featureRegistry = [
     default: false
   },
   {
+    id: 'chatHistory',
+    name: { en: 'Chat History', de: 'Chat-Verlauf' },
+    description: {
+      en: 'Show recent chats in the sidebar and a dedicated chat history page (currently uses sample data)',
+      de: 'Zeigt letzte Chats in der Seitenleiste und eine eigene Chat-Verlaufsseite (nutzt derzeit Beispieldaten)'
+    },
+    category: 'preview',
+    default: false,
+    preview: true
+  },
+  {
     id: 'shortLinks',
     name: { en: 'Short Links', de: 'Kurzlinks' },
     description: {

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1909,6 +1909,24 @@
         }
       }
     },
+    "sidebar": {
+      "backToApp": "Zurück zu iHub",
+      "adminPanel": "Admin-Bereich"
+    },
+    "ui": {
+      "tabs": {
+        "startPage": "Startseite"
+      },
+      "startPage": {
+        "title": "Startseiten-Konfiguration",
+        "description": "Konfiguriere die personalisierte Startseite für Nutzer.",
+        "defaultApp": "Standard-Chat-App",
+        "defaultAppHelp": "Die App, deren Chat-Eingabe auf der Startseite angezeigt wird. Ohne Auswahl wird die erste zugängliche App verwendet.",
+        "firstAvailable": "Erste verfügbare App (automatisch)",
+        "showDefaultApp": "Standard-Chat-App anzeigen",
+        "showDefaultAppHelp": "Wenn deaktiviert, zeigt die Startseite die Begrüßung und Apps, aber keine Chat-Eingabe."
+      }
+    },
     "groupSelect": {
       "placeholder": "Gruppen suchen oder Namen eingeben…",
       "empty": "Noch keine Gruppen ausgewählt",
@@ -2519,6 +2537,45 @@
     "showMore": "Mehr anzeigen",
     "showLess": "Weniger anzeigen",
     "configMissing": "Es sind keine iFinder- oder iAssistant-Ziele konfiguriert. Setzen Sie rendererConfig in der App-JSON, um die Aktionsschaltflächen zu aktivieren."
+  },
+  "startPage": {
+    "greetingMorning": "Guten Morgen",
+    "greetingAfternoon": "Guten Tag",
+    "greetingEvening": "Guten Abend",
+    "subtitle": "Wie kann ich dir heute helfen?",
+    "openApp": "App vollständig öffnen",
+    "jumpIntoApp": "In eine App springen",
+    "browseAllApps": "Alle Apps durchsuchen",
+    "pickUpWhereYouLeftOff": "Mach dort weiter, wo du aufgehört hast"
+  },
+  "sidebar": {
+    "navigation": "Navigation",
+    "newChat": "Neuer Chat",
+    "prompts": "Prompts",
+    "browseApps": "Alle Apps durchsuchen",
+    "apps": "Apps",
+    "recents": "Letzte",
+    "allApps": "Alle Apps",
+    "allChats": "Alle Chats",
+    "search": "Suche",
+    "searchPlaceholder": "Chats & Apps durchsuchen",
+    "searchChatsApps": "Chats & Apps durchsuchen",
+    "collapse": "Seitenleiste einklappen",
+    "expand": "Seitenleiste ausklappen",
+    "home": "Startseite",
+    "loadingApps": "Lädt…",
+    "noAppsMatch": "Keine passenden Apps",
+    "openMenu": "Navigation öffnen",
+    "closeMenu": "Navigation schließen"
+  },
+  "chatHistory": {
+    "title": "Deine Chats",
+    "subtitle": "{{count}} Unterhaltungen über deine Apps",
+    "searchPlaceholder": "Chats durchsuchen…",
+    "groupRecent": "Aktuell",
+    "groupByApp": "Nach App",
+    "groupByDate": "Nach Datum",
+    "noResults": "Keine passenden Chats gefunden"
   },
   "transcription": {
     "record": "Audio zum Transkribieren aufnehmen",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1657,6 +1657,24 @@
         }
       }
     },
+    "sidebar": {
+      "backToApp": "Back to iHub",
+      "adminPanel": "Admin Panel"
+    },
+    "ui": {
+      "tabs": {
+        "startPage": "Start Page"
+      },
+      "startPage": {
+        "title": "Start Page Configuration",
+        "description": "Configure the personalized start page shown to users.",
+        "defaultApp": "Default chat app",
+        "defaultAppHelp": "The app whose chat input is shown on the start page. When unset, the first app the user can access is used.",
+        "firstAvailable": "First available app (automatic)",
+        "showDefaultApp": "Show default chat app",
+        "showDefaultAppHelp": "When off, the start page shows the greeting and apps but no chat input."
+      }
+    },
     "groupSelect": {
       "placeholder": "Search groups or type a name…",
       "empty": "No groups selected yet",
@@ -2554,6 +2572,45 @@
     "showMore": "Show more",
     "showLess": "Show less",
     "configMissing": "No iFinder or iAssistant targets are configured. Set rendererConfig in the app JSON to enable the action buttons."
+  },
+  "startPage": {
+    "greetingMorning": "Good morning",
+    "greetingAfternoon": "Good afternoon",
+    "greetingEvening": "Good evening",
+    "subtitle": "How can I help you today?",
+    "openApp": "Open full app",
+    "jumpIntoApp": "Jump into an app",
+    "browseAllApps": "Browse all apps",
+    "pickUpWhereYouLeftOff": "Pick up where you left off"
+  },
+  "sidebar": {
+    "navigation": "Navigation",
+    "newChat": "New chat",
+    "prompts": "Prompts",
+    "browseApps": "Browse all apps",
+    "apps": "Apps",
+    "recents": "Recents",
+    "allApps": "All apps",
+    "allChats": "All chats",
+    "search": "Search",
+    "searchPlaceholder": "Search chats & apps",
+    "searchChatsApps": "Search chats & apps",
+    "collapse": "Collapse sidebar",
+    "expand": "Expand sidebar",
+    "home": "Home",
+    "loadingApps": "Loading…",
+    "noAppsMatch": "No apps match",
+    "openMenu": "Open navigation",
+    "closeMenu": "Close navigation"
+  },
+  "chatHistory": {
+    "title": "Your chats",
+    "subtitle": "{{count}} conversations across your apps",
+    "searchPlaceholder": "Search your chats…",
+    "groupRecent": "Recent",
+    "groupByApp": "By app",
+    "groupByDate": "By date",
+    "noResults": "No chats match your search"
   },
   "transcription": {
     "record": "Record audio to transcribe",


### PR DESCRIPTION
## Summary
- Add personalized **StartPage** (`/`) with time-based greeting, default-app chat input (admin-configured via `uiConfig.startPage.defaultAppId`), featured apps grid (favorites-first, max 4), and recent chats pills
- Add collapsible **AppSidebar** replacing the top header for all normal routes — 284px expanded / 72px icon rail; collapse state persisted to `localStorage`; embedded/Teams/Office contexts (`showHeader=false`) retain original header+footer layout unchanged
- Add **ChatHistoryPage** (`/chats`) with search and grouping by recent/app/date — behind `chatHistory` feature flag (default: `false`, mock data only until real persistence is built)
- Rework **AppsList** to compact horizontal-row layout replacing tall banner cards
- Fix **AppChat** height: `h-[calc(100vh-6rem)]` → `h-full` to fill sidebar-based layout correctly

## Files changed
| File | Change |
|------|--------|
| `client/src/features/apps/pages/StartPage.jsx` | New |
| `client/src/shared/components/AppSidebar.jsx` | New |
| `client/src/features/chat/data/mockChats.js` | New |
| `client/src/features/chat/pages/ChatHistoryPage.jsx` | New |
| `client/src/shared/components/Layout.jsx` | Modified — sidebar layout wiring |
| `client/src/App.jsx` | Modified — new routes |
| `client/src/features/apps/pages/AppsList.jsx` | Modified — compact rows |
| `client/src/features/apps/pages/AppChat.jsx` | Modified — height fix |

## Test plan
- [ ] Visit `/` — see greeting, default app chat input, featured apps, browse-all link
- [ ] Collapse/expand sidebar — icon rail at 72px, expand restores 284px; state persists on reload
- [ ] Toggle `chatHistory` feature flag on — recents section appears in sidebar, `/chats` route accessible
- [ ] Visit `/apps` — compact row layout with star toggle for favorites
- [ ] Open an app chat — fills height correctly with no whitespace gap
- [ ] Embedded embed (`?showHeader=false`) — original layout preserved, no sidebar shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_0164EVzWkYDgSHKmKnm9LbnJ