### PR TITLE
Stop audit log spam from session start (POST /api/session/start)

### DIFF
--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -524,3 +524,10 @@ Open chat conversations no longer keep the GPU busy while idle. Every rendered a
 
 - The GPU-acceleration hint is now applied only to the single message that is actively streaming, where it actually helps smooth incremental rendering, and is dropped once the response completes.
 - Measured effect: an idle chat now promotes **zero** extra compositor layers regardless of length (previously up to the browser's layer cap). No configuration change required.
+
+## Fix — Audit Log No Longer Spammed by Session Starts
+
+The audit log no longer records a `POST /api/session/start -> 200` entry every time an app loads. These high-frequency, low-value entries were drowning out the events admins actually care about (logins and logouts).
+
+- Session-start requests are now excluded from the generic audit safety-net, matching how chat, inference, and page reads are already treated.
+- Login and logout continue to be audited via their own explicit hooks — no change to security-relevant events.

--- a/server/middleware/auditLogger.js
+++ b/server/middleware/auditLogger.js
@@ -19,9 +19,12 @@ const METHOD_ACTION = {
 };
 
 // Read/streaming/high-volume paths that should never be audited as mutations.
+// 'session' (POST /api/session/start) fires on every app load — auditing it
+// floods the log with noise. Login/logout have explicit logAudit() hooks.
 const EXCLUDED_SEGMENTS = [
   'chat',
   'inference',
+  'session',
   'sessions',
   'magic-prompts',
   'short-links',

--- a/server/tests/auditLogger.test.js
+++ b/server/tests/auditLogger.test.js
@@ -63,6 +63,13 @@ describe('auditLogger gating', () => {
     expect(onSpy).not.toHaveBeenCalled();
   });
 
+  test('excludes session start (fires on every app load)', () => {
+    const { req, res } = makeReqRes({ url: '/api/session/start' });
+    const onSpy = jest.spyOn(res, 'on');
+    mw(req, res, jest.fn());
+    expect(onSpy).not.toHaveBeenCalled();
+  });
+
   test('skips non-api paths', () => {
     const { req, res } = makeReqRes({ url: '/healthz' });
     const onSpy = jest.spyOn(res, 'on');


### PR DESCRIPTION
## Problem

The audit log was being flooded with `POST /api/session/start -> 200` entries — one for every authenticated app load — burying the events admins actually care about (logins and logouts).

## Root cause

The generic audit safety-net middleware (`server/middleware/auditLogger.js`) maintains an `EXCLUDED_SEGMENTS` list of high-volume paths that should never be audited as mutations. It contained the **plural** segment `'sessions'`, but the actual route is **singular** — `POST /api/session/start` (`server/routes/sessionRoutes.js`). The mismatch meant the exclusion never fired, so every session start by an authenticated user produced a generic audit entry.

## Fix

- Add `'session'` to `EXCLUDED_SEGMENTS`, alongside the existing `'sessions'`, so session-start requests are skipped — consistent with how `chat`, `inference`, and page reads are already treated.
- Login and logout are **unaffected**: they have their own explicit `logAudit()` hooks in `server/routes/auth.js` (`action: 'login'` / `'logout'`), which set `req._auditLogged` and bypass the generic middleware entirely.

## Testing

- Added a regression test asserting `/api/session/start` registers no `finish` listener (i.e. is excluded).
- `auditLogger.test.js`: 13/13 passing.
- ESLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0199herWfgQmcP8fC1f31SUC)_