### PR TITLE
fix: resolve [object Object] in admin overview page title

### DIFF
--- a/client/src/features/admin/pages/AdminOverview.jsx
+++ b/client/src/features/admin/pages/AdminOverview.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { getLocalizedContent } from '../../../utils/localizeContent';
 import {
   WindowIcon,
   UsersIcon,
@@ -458,11 +459,16 @@ function RecentActivityCard({ entries }) {
 }
 
 export default function AdminOverview() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const { uiConfig } = useUIConfig();
   const { stats, platformInfo, recentActivity, isLoading, isFreshInstance } = useOverviewData();
 
-  const instanceName = uiConfig?.header?.title ?? 'iHub Apps';
+  const currentLanguage = i18n.language;
+  const { titleLight, titleBold, title } = uiConfig?.header ?? {};
+  const instanceName =
+    titleLight || titleBold
+      ? `${getLocalizedContent(titleLight, currentLanguage)}${getLocalizedContent(titleBold, currentLanguage)}`.trim()
+      : getLocalizedContent(title, currentLanguage) || 'iHub Apps';
 
   const statCards = stats
     ? [


### PR DESCRIPTION
## Summary

- `uiConfig.header.title` is a localized object `{ en: "...", de: "..." }` but was used raw (without `getLocalizedContent`) in `AdminOverview.jsx`, causing `[object Object] — Admin` to appear as the page title
- Mirrors the same logic already used in `Layout.jsx`: concatenate `titleLight` + `titleBold` when both are set, otherwise resolve `title` via `getLocalizedContent` with the current i18n language
- Affects any user whose `ui.json` has a `header.title` localized object (default config or NTLM-authenticated setups)

## Test plan

- [ ] Log in as NTLM (or any) admin user and verify the Admin overview title shows the real instance name (e.g. `iHub Apps — Admin`) instead of `[object Object] — Admin`
- [ ] Check with `titleLight`/`titleBold` set (default config) — title should still render correctly
- [ ] Check with a legacy `header.title` localized object — title should resolve to the correct language string

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Wir7Ksw4m52RHH8VkQwr1

---
_Generated by [Claude Code](https://claude.ai/code/session_017Wir7Ksw4m52RHH8VkQwr1)_