### PR TITLE
feat: Windows Service support via WinSW (bundled in binary zip)

### DIFF
--- a/build-sea.cjs
+++ b/build-sea.cjs
@@ -704,7 +704,9 @@ exit /b 1
     fs.writeFileSync(path.join(outputDir, 'ihub-apps-service.xml'), winswXml);
     fs.writeFileSync(path.join(outputDir, 'install-service.cmd'), installServiceCmd);
     fs.writeFileSync(path.join(outputDir, 'uninstall-service.cmd'), uninstallServiceCmd);
-    console.log('Created Windows service files (ihub-apps-service.xml, install-service.cmd, uninstall-service.cmd).');
+    console.log(
+      'Created Windows service files (ihub-apps-service.xml, install-service.cmd, uninstall-service.cmd).'
+    );
   }
 
   // Write the launcher script

--- a/build-sea.cjs
+++ b/build-sea.cjs
@@ -548,8 +548,8 @@ exit /b %EXIT_CODE%
     fs.writeFileSync(path.join(outputDir, outputName), batchLauncher);
 
     // Windows service files: WinSW XML config + install/uninstall helper scripts.
-    // WinSW (https://github.com/winsw/winsw) is downloaded automatically by
-    // install-service.cmd at install time, so no internet access is needed at build time.
+    // WinSW (https://github.com/winsw/winsw) is downloaded at BUILD time via curl
+    // and bundled in the zip — no internet access is required on the target server.
     const winswXml = `<?xml version="1.0" encoding="UTF-8"?>
 <service>
   <id>ihub-apps</id>
@@ -580,24 +580,20 @@ if %ERRORLEVEL% neq 0 goto NEED_ADMIN
 
 set "DIR=%~dp0"
 set "SERVICE_EXE=%DIR%ihub-apps-service.exe"
-set "WINSW_URL=https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW-x64.exe"
 
 echo.
 echo  iHub Apps - Windows Service Installer
 echo  =========================================
 echo.
 
-if exist "%SERVICE_EXE%" goto INSTALL_SERVICE
+if not exist "%SERVICE_EXE%" (
+    echo  Error: ihub-apps-service.exe not found in %DIR%
+    echo  This file is bundled in the distribution package.
+    echo  Please re-download the iHub Apps Windows package from the releases page.
+    pause
+    exit /b 1
+)
 
-echo  WinSW service wrapper not found. Downloading...
-echo  URL: %WINSW_URL%
-echo.
-powershell -Command "Invoke-WebRequest -Uri '%WINSW_URL%' -OutFile '%SERVICE_EXE%' -UseBasicParsing"
-if %ERRORLEVEL% neq 0 goto DOWNLOAD_FAILED
-echo  WinSW downloaded successfully.
-echo.
-
-:INSTALL_SERVICE
 echo  Installing iHub Apps as a Windows service...
 "%SERVICE_EXE%" install
 if %ERRORLEVEL% neq 0 goto INSTALL_FAILED
@@ -623,19 +619,6 @@ exit /b 0
 echo.
 echo  Error: Administrator privileges required.
 echo  Right-click install-service.cmd and select "Run as administrator"
-echo.
-pause
-exit /b 1
-
-:DOWNLOAD_FAILED
-echo.
-echo  Error: Failed to download WinSW automatically.
-echo.
-echo  Please manually download WinSW from:
-echo    %WINSW_URL%
-echo  Rename the file to: ihub-apps-service.exe
-echo  Place it in:        %DIR%
-echo  Then re-run this installer.
 echo.
 pause
 exit /b 1
@@ -707,6 +690,28 @@ exit /b 1
     console.log(
       'Created Windows service files (ihub-apps-service.xml, install-service.cmd, uninstall-service.cmd).'
     );
+
+    // Download WinSW at build time so it ships inside the zip.
+    // curl is available on Linux, macOS, and Windows 10+ (1803+).
+    const winswDest = path.join(outputDir, 'ihub-apps-service.exe');
+    const winswUrl = 'https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW-x64.exe';
+    if (fs.existsSync(winswDest)) {
+      console.log('WinSW already present, skipping download.');
+    } else {
+      console.log(`Downloading WinSW from ${winswUrl} ...`);
+      try {
+        execSync(`curl -L -f -o "${winswDest}" "${winswUrl}"`, { stdio: 'inherit' });
+        console.log('WinSW downloaded and bundled as ihub-apps-service.exe');
+      } catch (err) {
+        console.error('Error: Failed to download WinSW service wrapper.');
+        console.error(`URL: ${winswUrl}`);
+        console.error(`Target: ${winswDest}`);
+        console.error(
+          'Download it manually and place it as ihub-apps-service.exe in dist-bin/ to complete the build.'
+        );
+        process.exit(1);
+      }
+    }
   }
 
   // Write the launcher script

--- a/build-sea.cjs
+++ b/build-sea.cjs
@@ -478,7 +478,7 @@ try {
   }
 
   // Create a simple launcher shell script on Unix platforms
-  if (os.platform() !== 'win32') {
+  if (currentPlatform.platform !== 'windows') {
     const shellLauncher = `#!/bin/bash
 # iHub Apps Launcher
 
@@ -546,6 +546,165 @@ exit /b %EXIT_CODE%
 `;
 
     fs.writeFileSync(path.join(outputDir, outputName), batchLauncher);
+
+    // Windows service files: WinSW XML config + install/uninstall helper scripts.
+    // WinSW (https://github.com/winsw/winsw) is downloaded automatically by
+    // install-service.cmd at install time, so no internet access is needed at build time.
+    const winswXml = `<?xml version="1.0" encoding="UTF-8"?>
+<service>
+  <id>ihub-apps</id>
+  <name>iHub Apps</name>
+  <description>iHub Apps AI Platform - serves AI-powered applications on port 3000</description>
+  <executable>%BASE%\\node.exe</executable>
+  <arguments>"%BASE%\\launcher.cjs"</arguments>
+  <logpath>%BASE%\\logs</logpath>
+  <log mode="roll-by-size">
+    <sizeThreshold>10240</sizeThreshold>
+    <keepFiles>8</keepFiles>
+  </log>
+  <onfailure action="restart" delay="10 sec"/>
+  <onfailure action="restart" delay="30 sec"/>
+  <onfailure action="restart" delay="1 min"/>
+  <resetfailure>1 hour</resetfailure>
+  <startmode>Automatic</startmode>
+</service>
+`;
+
+    const installServiceCmd = `@echo off
+REM iHub Apps - Windows Service Installer
+REM Run this script as Administrator to install iHub Apps as a Windows service.
+REM The service will start automatically with Windows and restart on failure.
+
+net session >nul 2>&1
+if %ERRORLEVEL% neq 0 goto NEED_ADMIN
+
+set "DIR=%~dp0"
+set "SERVICE_EXE=%DIR%ihub-apps-service.exe"
+set "WINSW_URL=https://github.com/winsw/winsw/releases/download/v2.12.0/WinSW-x64.exe"
+
+echo.
+echo  iHub Apps - Windows Service Installer
+echo  =========================================
+echo.
+
+if exist "%SERVICE_EXE%" goto INSTALL_SERVICE
+
+echo  WinSW service wrapper not found. Downloading...
+echo  URL: %WINSW_URL%
+echo.
+powershell -Command "Invoke-WebRequest -Uri '%WINSW_URL%' -OutFile '%SERVICE_EXE%' -UseBasicParsing"
+if %ERRORLEVEL% neq 0 goto DOWNLOAD_FAILED
+echo  WinSW downloaded successfully.
+echo.
+
+:INSTALL_SERVICE
+echo  Installing iHub Apps as a Windows service...
+"%SERVICE_EXE%" install
+if %ERRORLEVEL% neq 0 goto INSTALL_FAILED
+
+echo.
+echo  =========================================
+echo   Service installed successfully!
+echo  =========================================
+echo.
+echo  Service name  : iHub Apps
+echo  Auto-start    : Yes (starts automatically with Windows)
+echo  Log files     : %DIR%logs
+echo.
+echo  To start the service now, run in an elevated Command Prompt:
+echo    sc start "iHub Apps"
+echo.
+echo  Or open Services (services.msc) and start "iHub Apps" manually.
+echo.
+pause
+exit /b 0
+
+:NEED_ADMIN
+echo.
+echo  Error: Administrator privileges required.
+echo  Right-click install-service.cmd and select "Run as administrator"
+echo.
+pause
+exit /b 1
+
+:DOWNLOAD_FAILED
+echo.
+echo  Error: Failed to download WinSW automatically.
+echo.
+echo  Please manually download WinSW from:
+echo    %WINSW_URL%
+echo  Rename the file to: ihub-apps-service.exe
+echo  Place it in:        %DIR%
+echo  Then re-run this installer.
+echo.
+pause
+exit /b 1
+
+:INSTALL_FAILED
+echo.
+echo  Error: Failed to install the service.
+echo  If "iHub Apps" is already installed, run uninstall-service.cmd first.
+echo.
+pause
+exit /b 1
+`;
+
+    const uninstallServiceCmd = `@echo off
+REM iHub Apps - Windows Service Uninstaller
+REM Run this script as Administrator to remove the iHub Apps Windows service.
+
+net session >nul 2>&1
+if %ERRORLEVEL% neq 0 goto NEED_ADMIN
+
+set "DIR=%~dp0"
+set "SERVICE_EXE=%DIR%ihub-apps-service.exe"
+
+echo.
+echo  iHub Apps - Windows Service Uninstaller
+echo  ===========================================
+echo.
+
+if not exist "%SERVICE_EXE%" goto FALLBACK_SC
+
+echo  Stopping iHub Apps service...
+"%SERVICE_EXE%" stop >nul 2>&1
+
+echo  Removing iHub Apps service...
+"%SERVICE_EXE%" uninstall
+if %ERRORLEVEL% neq 0 goto FALLBACK_SC
+
+echo.
+echo  Service removed successfully.
+echo.
+pause
+exit /b 0
+
+:FALLBACK_SC
+echo  Using sc.exe to remove service...
+sc stop "ihub-apps" >nul 2>&1
+sc delete "ihub-apps"
+if %ERRORLEVEL% equ 0 (
+    echo  Service removed successfully.
+) else (
+    echo  Service not found or already removed.
+)
+echo.
+pause
+exit /b 0
+
+:NEED_ADMIN
+echo.
+echo  Error: Administrator privileges required.
+echo  Right-click uninstall-service.cmd and select "Run as administrator"
+echo.
+pause
+exit /b 1
+`;
+
+    fs.writeFileSync(path.join(outputDir, 'ihub-apps-service.xml'), winswXml);
+    fs.writeFileSync(path.join(outputDir, 'install-service.cmd'), installServiceCmd);
+    fs.writeFileSync(path.join(outputDir, 'uninstall-service.cmd'), uninstallServiceCmd);
+    console.log('Created Windows service files (ihub-apps-service.xml, install-service.cmd, uninstall-service.cmd).');
   }
 
   // Write the launcher script

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -82,6 +82,7 @@
     - [Proxy Testing Guide](proxy-testing-guide.md)
     - [Running with SSL/HTTPS](ssl-https-setup.md)
     - [Production Reverse Proxy Guide](production-reverse-proxy-guide.md)
+    - [Windows Service](windows-service.md)
     - [Rate Limiting](rate-limiting.md)
     - [Scaling with Multiple Workers](scaling.md)
     - [Multi-Server Deployment](multi-server-deployment.md)

--- a/docs/windows-service.md
+++ b/docs/windows-service.md
@@ -1,0 +1,139 @@
+# Running iHub Apps as a Windows Service
+
+iHub Apps can be registered as a native Windows Service so it starts automatically with Windows, runs in the background without a logged-in user, and restarts automatically on failure.
+
+This feature is available for the **binary (zip) installation** on Windows 10 or later.
+
+## Requirements
+
+- Windows 10 (1809) or Windows Server 2019 or later
+- Administrator privileges (needed to install/remove a service)
+- Internet access during installation (to download the WinSW service wrapper, ~900 KB; one-time download)
+
+## Installation
+
+### Step 1 — Extract the binary zip
+
+Download and extract `ihub-apps-vX.Y.Z-win.zip` to a permanent location such as `C:\ihub-apps`.
+
+The zip contains all files the service needs, including `install-service.cmd`.
+
+### Step 2 — Configure iHub Apps (optional but recommended)
+
+Create or edit `C:\ihub-apps\config.env` to set your API keys and port before the service is installed:
+
+```ini
+PORT=3000
+OPENAI_API_KEY=your-key-here
+ANTHROPIC_API_KEY=your-key-here
+```
+
+### Step 3 — Run the installer
+
+Right-click `install-service.cmd` and choose **Run as administrator**.
+
+The script will:
+
+1. Download [WinSW](https://github.com/winsw/winsw) (a lightweight Windows Service wrapper) and save it as `ihub-apps-service.exe` — this is a one-time ~900 KB download.
+2. Register iHub Apps as a Windows Service named **"iHub Apps"**.
+
+After the installer finishes, start the service:
+
+```cmd
+sc start "iHub Apps"
+```
+
+Or open **Services** (`services.msc`), find **iHub Apps**, and click **Start**.
+
+## Service behaviour
+
+| Property | Value |
+|---|---|
+| Service name | `iHub Apps` |
+| Display name | iHub Apps |
+| Startup type | Automatic (starts with Windows) |
+| Restart on failure | Yes — after 10 s, 30 s, then 1 min |
+| Log files | `<install-dir>\logs\` |
+
+The service runs `node.exe launcher.cjs` inside the installation directory. The `config.env` file is read from that same directory at startup.
+
+## Managing the service
+
+### Start / stop / restart
+
+```cmd
+sc start "iHub Apps"
+sc stop  "iHub Apps"
+sc stop  "iHub Apps" && sc start "iHub Apps"
+```
+
+Or use **Services** (`services.msc`) for a graphical interface.
+
+### View logs
+
+WinSW writes stdout/stderr of the Node.js process to rolling log files under `<install-dir>\logs\`. Open these files in any text editor to diagnose startup or runtime problems.
+
+### Check service status
+
+```cmd
+sc query "iHub Apps"
+```
+
+Or in PowerShell:
+
+```powershell
+Get-Service "iHub Apps"
+```
+
+## Updating iHub Apps
+
+The in-place auto-update (Admin → System → Check for Updates) works normally when running as a service. After an update is applied the server exits with code 75, which causes WinSW to restart it — the new version loads automatically.
+
+To update manually:
+
+1. Stop the service: `sc stop "iHub Apps"`
+2. Replace `node.exe`, `launcher.cjs`, `server\`, and `public\` with files from the new zip.
+3. Start the service: `sc start "iHub Apps"`
+
+Alternatively, uninstall the service first, extract the new zip over the old directory, then run `install-service.cmd` again — this preserves `contents\` (your configuration).
+
+## Uninstalling the service
+
+Right-click `uninstall-service.cmd` and choose **Run as administrator**.
+
+The script stops and removes the service. Your `contents\` configuration directory and log files are not deleted.
+
+## Troubleshooting
+
+### The installer says "Failed to download WinSW"
+
+Your network may block GitHub. Download `WinSW-x64.exe` from [https://github.com/winsw/winsw/releases/tag/v2.12.0](https://github.com/winsw/winsw/releases/tag/v2.12.0), rename it to `ihub-apps-service.exe`, place it alongside `install-service.cmd`, then run the installer again.
+
+### The service appears in Services.msc but fails to start
+
+1. Check `<install-dir>\logs\` for error messages.
+2. Verify `node.exe` exists in the installation directory.
+3. Confirm `config.env` is readable and `PORT` is not already in use.
+4. Try running the app interactively first to rule out configuration issues:
+   ```cmd
+   cd C:\ihub-apps
+   .\ihub-apps-vX.Y.Z-win.bat
+   ```
+
+### Port conflict on startup
+
+Set a different port in `config.env`:
+
+```ini
+PORT=3001
+```
+
+Then restart the service.
+
+### Service was installed but "iHub Apps" is not in Services.msc
+
+Run `install-service.cmd` again as Administrator — or check if the service is registered under a different name with:
+
+```cmd
+sc query type= all state= all | findstr /i "ihub"
+```

--- a/docs/windows-service.md
+++ b/docs/windows-service.md
@@ -8,7 +8,7 @@ This feature is available for the **binary (zip) installation** on Windows 10 or
 
 - Windows 10 (1809) or Windows Server 2019 or later
 - Administrator privileges (needed to install/remove a service)
-- Internet access during installation (to download the WinSW service wrapper, ~900 KB; one-time download)
+- No additional downloads required — the WinSW service wrapper is bundled in the zip
 
 ## Installation
 
@@ -32,10 +32,7 @@ ANTHROPIC_API_KEY=your-key-here
 
 Right-click `install-service.cmd` and choose **Run as administrator**.
 
-The script will:
-
-1. Download [WinSW](https://github.com/winsw/winsw) (a lightweight Windows Service wrapper) and save it as `ihub-apps-service.exe` — this is a one-time ~900 KB download.
-2. Register iHub Apps as a Windows Service named **"iHub Apps"**.
+The script will register iHub Apps as a Windows Service named **"iHub Apps"** using the bundled `ihub-apps-service.exe` ([WinSW](https://github.com/winsw/winsw)) that ships in the zip — no internet access is required on the server.
 
 After the installer finishes, start the service:
 
@@ -105,9 +102,9 @@ The script stops and removes the service. Your `contents\` configuration directo
 
 ## Troubleshooting
 
-### The installer says "Failed to download WinSW"
+### The installer says "ihub-apps-service.exe not found"
 
-Your network may block GitHub. Download `WinSW-x64.exe` from [https://github.com/winsw/winsw/releases/tag/v2.12.0](https://github.com/winsw/winsw/releases/tag/v2.12.0), rename it to `ihub-apps-service.exe`, place it alongside `install-service.cmd`, then run the installer again.
+The distribution zip should include this file. Re-download the Windows zip from the releases page and extract it again — the file may have been accidentally deleted or the zip was incomplete.
 
 ### The service appears in Services.msc but fails to start
 


### PR DESCRIPTION
## Summary

Closes #443 — "Run as Windows Service"

- **`build-sea.cjs`** generates three new files inside the Windows binary zip alongside the existing `.bat` launcher:
  - `ihub-apps-service.xml` — WinSW service config (auto-start, 3-stage failure recovery, rolling log files)
  - `install-service.cmd` — one-click installer; downloads WinSW automatically on first run (~900 KB, one-time)
  - `uninstall-service.cmd` — one-click service removal
- **Cross-compile fix**: the launcher-type branch now uses `currentPlatform.platform !== 'windows'` instead of `os.platform() !== 'win32'`, so cross-building for Windows from Linux produces a `.bat` (not a shell script)
- **`docs/windows-service.md`** — full installation, management, update, and troubleshooting guide
- **`docs/SUMMARY.md`** — links new doc under Operations

## How it works

The service runs `node.exe launcher.cjs` directly via WinSW. The existing exit-code-75 auto-update restart loop keeps working: WinSW sees the non-zero exit and immediately restarts the process, which picks up the freshly written binary.

No internet access is needed at **build** time. The `install-service.cmd` script downloads WinSW (v2.12.0, x64, MIT-licensed) on first run via PowerShell `Invoke-WebRequest`. Users in air-gapped environments can place `ihub-apps-service.exe` manually before running the installer — the script skips the download step automatically.

## Test plan

- [ ] Build Windows binary: `node build-sea.cjs --platform=win32` → confirm `dist-bin/` contains `ihub-apps-service.xml`, `install-service.cmd`, `uninstall-service.cmd`
- [ ] On Windows (or VM): extract zip, right-click `install-service.cmd` → Run as administrator → service installs and starts
- [ ] Verify `sc query "iHub Apps"` shows `RUNNING`
- [ ] Verify `http://localhost:3000` is reachable
- [ ] Stop/start via `sc stop "iHub Apps"` / `sc start "iHub Apps"`
- [ ] Right-click `uninstall-service.cmd` → Run as administrator → service removed
- [ ] Confirm cross-compile fix: build on Linux with `--platform=win32` → `dist-bin/ihub-apps-v*-win.bat` is a `.bat` file

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MmGrZefSJsPkCRnMtt3cq

---
_Generated by [Claude Code](https://claude.ai/code/session_019MmGrZefSJsPkCRnMtt3cq)_