### PR TITLE
feat(office): always show Add email button in context strip header

### DIFF
--- a/client/src/features/office/components/chat/OfficeContextStrip.jsx
+++ b/client/src/features/office/components/chat/OfficeContextStrip.jsx
@@ -213,8 +213,8 @@ function OfficeContextStrip({
           />
         </button>
 
-        {/* Always show pin controls in the header, even when collapsed */}
-        {!expanded && hasPinControls && (
+        {/* Always show add-email button in the header, collapsed or expanded */}
+        {hasPinControls && (
           <PinnedEmailsBar
             pinned={[]}
             onUnpin={() => {}}
@@ -245,13 +245,13 @@ function OfficeContextStrip({
             />
           )}
 
-          {(hasPinned || hasPinControls) && (
+          {hasPinned && (
             <PinnedEmailsBar
               pinned={pinnedList}
               onUnpin={onUnpin}
               onClearAll={onClearPinned}
               onAddEmails={onAddEmails}
-              canAddEmails={canAddEmails}
+              canAddEmails={false}
               addEmailsLoading={addEmailsLoading}
               addEmailsDisabled={addEmailsDisabled}
               embedded

--- a/server/defaults/workflows/stellungnahmen-review-ifinder.json
+++ b/server/defaults/workflows/stellungnahmen-review-ifinder.json
@@ -39,7 +39,10 @@
           "queryLanguage": "de",
           "agentProfileId": "law-consultation-agent",
           "maxFulltextChars": 50000,
-          "filter": ["sourceLocations.label:bmg", "sourceLocations.label:Public"]
+          "filter": [
+            "sourceLocations.label:bmg",
+            "sourceLocations.label:Public"
+          ]
         },
         "inputVariables": [
           {
@@ -269,7 +272,10 @@
         "maxPerTopic": 25,
         "maxTotalDocs": 200,
         "fetchFulltext": false,
-        "extraQueries": ["$.data.userPrompt", "*"]
+        "extraQueries": [
+          "$.data.userPrompt",
+          "*"
+        ]
       }
     },
     {
@@ -334,7 +340,9 @@
               }
             }
           },
-          "required": ["done"]
+          "required": [
+            "done"
+          ]
         }
       },
       "execution": {
@@ -541,7 +549,9 @@
                     "type": "string"
                   }
                 },
-                "required": ["summary"]
+                "required": [
+                  "summary"
+                ]
               }
             },
             "quotes": {
@@ -553,11 +563,18 @@
                     "type": "string"
                   }
                 },
-                "required": ["text"]
+                "required": [
+                  "text"
+                ]
               }
             }
           },
-          "required": ["organisation", "title", "demandedChanges", "quotes"]
+          "required": [
+            "organisation",
+            "title",
+            "demandedChanges",
+            "quotes"
+          ]
         }
       },
       "execution": {
@@ -603,11 +620,17 @@
                     "type": "string"
                   }
                 },
-                "required": ["summary"]
+                "required": [
+                  "summary"
+                ]
               }
             }
           },
-          "required": ["organisation", "title", "demandedChanges"]
+          "required": [
+            "organisation",
+            "title",
+            "demandedChanges"
+          ]
         },
         "inputPath": "$.data._extractionOutput",
         "sourcePath": "$.data._currentDoc",
@@ -705,7 +728,9 @@
         "y": 2240
       },
       "config": {
-        "outputVariables": ["finalReport"]
+        "outputVariables": [
+          "finalReport"
+        ]
       }
     }
   ],

--- a/server/defaults/workflows/stellungnahmen-review-ifinder.json
+++ b/server/defaults/workflows/stellungnahmen-review-ifinder.json
@@ -39,10 +39,7 @@
           "queryLanguage": "de",
           "agentProfileId": "law-consultation-agent",
           "maxFulltextChars": 50000,
-          "filter": [
-            "sourceLocations.label:bmg",
-            "sourceLocations.label:Public"
-          ]
+          "filter": ["sourceLocations.label:bmg", "sourceLocations.label:Public"]
         },
         "inputVariables": [
           {
@@ -272,10 +269,7 @@
         "maxPerTopic": 25,
         "maxTotalDocs": 200,
         "fetchFulltext": false,
-        "extraQueries": [
-          "$.data.userPrompt",
-          "*"
-        ]
+        "extraQueries": ["$.data.userPrompt", "*"]
       }
     },
     {
@@ -340,9 +334,7 @@
               }
             }
           },
-          "required": [
-            "done"
-          ]
+          "required": ["done"]
         }
       },
       "execution": {
@@ -549,9 +541,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "summary"
-                ]
+                "required": ["summary"]
               }
             },
             "quotes": {
@@ -563,18 +553,11 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "text"
-                ]
+                "required": ["text"]
               }
             }
           },
-          "required": [
-            "organisation",
-            "title",
-            "demandedChanges",
-            "quotes"
-          ]
+          "required": ["organisation", "title", "demandedChanges", "quotes"]
         }
       },
       "execution": {
@@ -620,17 +603,11 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "summary"
-                ]
+                "required": ["summary"]
               }
             }
           },
-          "required": [
-            "organisation",
-            "title",
-            "demandedChanges"
-          ]
+          "required": ["organisation", "title", "demandedChanges"]
         },
         "inputPath": "$.data._extractionOutput",
         "sourcePath": "$.data._currentDoc",
@@ -728,9 +705,7 @@
         "y": 2240
       },
       "config": {
-        "outputVariables": [
-          "finalReport"
-        ]
+        "outputVariables": ["finalReport"]
       }
     }
   ],


### PR DESCRIPTION
## Summary

- The "Add email(s)" button in the Outlook context strip header now appears regardless of whether the strip is expanded or collapsed
- Previously it was only shown in the header when the strip was collapsed (`!expanded`); users had to expand the strip to access it when it was open
- The duplicate add button inside the expanded pinned-emails section is suppressed (`canAddEmails={false}`) since the persistent header button covers that action
- The expanded pinned-emails section now only renders when there are actual pinned emails to display (`hasPinned`), since pin controls live in the header

**Incidental change:** The CI auto-linter reformatted `server/defaults/workflows/stellungnahmen-review-ifinder.json` (array compaction). This is enforced by the project linter and re-applies automatically on every push, so it is included here rather than fighting the formatter in a loop.

## Test plan

- [ ] Open Outlook taskpane with an email loaded
- [ ] Verify "Add email(s)" button is visible in the strip header when the strip is **collapsed**
- [ ] Verify "Add email(s)" button is visible in the strip header when the strip is **expanded**
- [ ] Add an email — confirm it appears in the pinned list (expanded view)
- [ ] Collapse the strip — confirm the add button stays visible and clicking it pins another email
- [ ] Confirm no duplicate add button appears inside the expanded pinned-emails section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjueXrxw4XfK99AaQVw3qz