### PR TITLE
fix: include Outlook email context in live token-count estimate

### DIFF
--- a/client/src/features/chat/components/ChatInput.jsx
+++ b/client/src/features/chat/components/ChatInput.jsx
@@ -75,6 +75,11 @@ function ChatInput({
   clarificationPending = false, // When true, input is disabled waiting for clarification answer
   // Document token size warning
   fileTokenWarning = null,
+  // Additional context text contributed by the host (e.g. Outlook email body +
+  // pinned emails) that will be appended to the outgoing message. Included in
+  // the live token-count estimate so the context-window indicator reflects what
+  // will actually be sent to the LLM.
+  extraContextText = '',
   // Optional override for the auto-grow textarea cap. Defaults to 5 lines
   // (~150 px) in single-line mode and 12 lines in multiline mode. The
   // Outlook taskpane passes 3 so the input doesn't dominate the small
@@ -133,23 +138,29 @@ function ChatInput({
   // Debounce the typed-message estimate so we don't run the tokenizer on every
   // keystroke (matters for large pasted text).
   const valueTokens = useEstimatedTokenCount(value || '', { debounceMs: 300 });
+  // Host-injected context (e.g. Outlook email body + pinned emails) that will
+  // be appended to the outgoing message but isn't reflected in `value` or
+  // `fileContent`. Debounced lightly since it only changes when the user
+  // navigates emails or pins/unpins — not on every keystroke.
+  const extraContextTokens = useEstimatedTokenCount(extraContextText || '', { debounceMs: 150 });
 
   // Estimate how much of the model's context window the pending input (typed
-  // message + attached document content) would consume. This is a live,
-  // client-side estimate using the shared tokenizer; the provider-reported
-  // count after each turn is authoritative. Only shown when the model exposes
-  // a context window and the user has actually entered/attached something.
+  // message + attached document content + host context) would consume. This is
+  // a live, client-side estimate using the shared tokenizer; the
+  // provider-reported count after each turn is authoritative. Only shown when
+  // the model exposes a context window and the user has actually
+  // entered/attached something.
   const contextUsage = useMemo(() => {
     const contextWindow = selectedModelData?.contextWindow;
     if (!contextWindow) return null;
-    const inputTokens = valueTokens + fileTokens;
+    const inputTokens = valueTokens + fileTokens + extraContextTokens;
     if (inputTokens === 0) return null;
     return computeContextUsage({
       contextWindow,
       inputTokens,
       maxOutputTokens: selectedModelData?.maxOutputTokens || 0
     });
-  }, [selectedModelData, fileTokens, valueTokens]);
+  }, [selectedModelData, fileTokens, valueTokens, extraContextTokens]);
 
   // Determine input mode configuration
   const inputMode = app?.inputMode;

--- a/client/src/features/chat/components/ChatInput.jsx
+++ b/client/src/features/chat/components/ChatInput.jsx
@@ -144,12 +144,12 @@ function ChatInput({
   // navigates emails or pins/unpins — not on every keystroke.
   const extraContextTokens = useEstimatedTokenCount(extraContextText || '', { debounceMs: 150 });
 
-  // Estimate how much of the model's context window the pending input (typed
-  // message + attached document content + host context) would consume. This is
-  // a live, client-side estimate using the shared tokenizer; the
-  // provider-reported count after each turn is authoritative. Only shown when
-  // the model exposes a context window and the user has actually
-  // entered/attached something.
+  // Estimate how much of the model's context window the pending input would
+  // consume. This is a live, client-side estimate using the shared tokenizer;
+  // the provider-reported count after each turn is authoritative. Only shown
+  // when the model exposes a context window and inputTokens is non-zero.
+  // Note: extraContextTokens (e.g. Outlook email body / pinned emails) can make
+  // inputTokens non-zero even when no text has been typed and no files attached.
   const contextUsage = useMemo(() => {
     const contextWindow = selectedModelData?.contextWindow;
     if (!contextWindow) return null;

--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
+import { useState, useRef, useCallback, useEffect, useMemo } from 'react';
 import { useNavigate, Navigate } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import ChatMessageList from '../../chat/components/ChatMessageList';
@@ -21,7 +21,10 @@ import {
   displayReplyFormWithAssistantResponse,
   displayNewEmailFormWithAssistantResponse
 } from '../utilities/replyForm';
-import { buildPromptTemplate } from '../utilities/buildChatApiMessages';
+import {
+  buildPromptTemplate,
+  combineUserTextWithEmailContext
+} from '../utilities/buildChatApiMessages';
 import {
   fetchCurrentMailContext,
   fetchCurrentOutlookItemContext,
@@ -80,6 +83,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   const fileUploadHandler = useFileUploadHandler();
   const mailSnapshot = useOutlookMailContextSnapshot();
   const currentModel = models.find(m => m.id === selectedModel) || null;
+
   const uploadConfig = fileUploadHandler.createUploadConfig(selectedApp, currentModel);
 
   const [inputValue, setInputValue] = useState('');
@@ -94,6 +98,21 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   // wiped on new-chat / app-switch alongside the chat history.
   const [pinnedEmails, setPinnedEmails] = useState([]);
   const [addEmailsLoading, setAddEmailsLoading] = useState(false);
+
+  // Build the email-context text that will be appended to the outgoing message
+  // so ChatInput can include it in the live token-count estimate. This mirrors
+  // what combineUserTextWithEmailContext does at send time but with an empty
+  // userText so we only get the email blocks (the typed text is already counted
+  // separately by ChatInput).
+  const emailContextText = useMemo(() => {
+    const currentBodyText = mailSnapshot.includeBody ? (mailSnapshot.ctx?.bodyText || '') : '';
+    return combineUserTextWithEmailContext({
+      userText: '',
+      currentBodyText,
+      currentItemId: mailSnapshot.ctx?.itemId,
+      pinned: pinnedEmails
+    });
+  }, [mailSnapshot.includeBody, mailSnapshot.ctx, pinnedEmails]);
   // itemId of the email currently open in Outlook. Lets us hide the
   // "Add this email" affordance once it's already in the pin list, and
   // dedupe in the prompt builder.
@@ -638,6 +657,10 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
                   setHostContextFlags(prev => ({ ...(prev || {}), [key]: value }))
                 }
                 clarificationPending={adapter.clarificationPending}
+                // Include email body + pinned emails in the live token estimate
+                // so the context-window indicator accounts for what will actually
+                // be sent to the LLM.
+                extraContextText={emailContextText}
                 // Keep the input from dominating the small Outlook task pane;
                 // long prompts scroll inside the 3-line box. Issue #1467.
                 maxRows={3}

--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -105,7 +105,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   // userText so we only get the email blocks (the typed text is already counted
   // separately by ChatInput).
   const emailContextText = useMemo(() => {
-    const currentBodyText = mailSnapshot.includeBody ? (mailSnapshot.ctx?.bodyText || '') : '';
+    const currentBodyText = mailSnapshot.includeBody ? mailSnapshot.ctx?.bodyText || '' : '';
     return combineUserTextWithEmailContext({
       userText: '',
       currentBodyText,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4074,9 +4074,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4094,9 +4091,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4114,9 +4108,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4134,9 +4125,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4154,9 +4142,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4174,9 +4159,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -11702,9 +11684,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11726,9 +11705,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11750,9 +11726,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11774,9 +11747,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Summary

- The live context-window usage indicator in `ChatInput` was only counting tokens for typed text and manually attached files, ignoring the email body and pinned emails injected by the Outlook adapter at send time
- `OfficeChatPanel` now computes the email-context text (body + pinned email blocks) using the same `combineUserTextWithEmailContext` logic as the adapter, and passes it to `ChatInput` as `extraContextText`
- `ChatInput` tokenizes `extraContextText` independently (debounced at 150 ms, since email changes are infrequent) and adds those tokens to the `inputTokens` sum used by `computeContextUsage`

## Test plan

- [ ] Open Outlook taskpane with an email that has a body — the token count indicator should increase compared to before this fix
- [ ] Toggle "Include body" off via the context strip — the token count should drop back to just the typed text
- [ ] Pin additional emails via "Add this email" — token count should increase for each pinned email's body
- [ ] Unpin emails — token count should decrease accordingly
- [ ] In regular web app (no Outlook context), token counting behavior is unchanged (`extraContextText` defaults to `''`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q92rwPS6eHzGPQiJh5Joog

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q92rwPS6eHzGPQiJh5Joog)_