### PR TITLE
feat(outlook): split button for "Add to email" with New Email option

### DIFF
--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -969,7 +969,11 @@ function ChatMessage({
                     aria-expanded={insertDropdownOpen}
                     title={t('office.insertOptions', 'More options')}
                   >
-                    <Icon name={insertDropdownOpen ? 'chevronUp' : 'chevronDown'} size="sm" className="text-white" />
+                    <Icon
+                      name={insertDropdownOpen ? 'chevronUp' : 'chevronDown'}
+                      size="sm"
+                      className="text-white"
+                    />
                   </button>
 
                   {insertDropdownOpen && (

--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -67,6 +67,7 @@ function ChatMessage({
   compact = false, // New prop to indicate compact mode (for widget or mobile)
   onOpenInCanvas,
   onInsert,
+  onInsertNew = null,
   insertAction = null, // { variant: 'icon'|'primary', labelKey: string } — Office host promotes the per-message insert action to a labelled primary button; web app default keeps the legacy icon button on the action row.
   isLatestAssistantMessage = false, // Keeps the primary insert button always-visible on the most recent assistant response inside small Outlook panes.
   canvasEnabled = false,
@@ -99,6 +100,8 @@ function ChatMessage({
   const [editedContent, setEditedContent] = useState(getEditableContent());
   const editTextareaRef = useRef(null);
   const [showActions, setShowActions] = useState(false);
+  const [insertDropdownOpen, setInsertDropdownOpen] = useState(false);
+  const insertDropdownRef = useRef(null);
   const [copied, setCopied] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
   const [showFeedbackForm, setShowFeedbackForm] = useState(false);
@@ -133,6 +136,19 @@ function ChatMessage({
     document.addEventListener('mousedown', handleClick);
     return () => document.removeEventListener('mousedown', handleClick);
   }, []);
+
+  // Close insert dropdown on outside click
+  useEffect(() => {
+    const handleClick = e => {
+      if (insertDropdownRef.current && !insertDropdownRef.current.contains(e.target)) {
+        setInsertDropdownOpen(false);
+      }
+    };
+    if (insertDropdownOpen) {
+      document.addEventListener('mousedown', handleClick);
+      return () => document.removeEventListener('mousedown', handleClick);
+    }
+  }, [insertDropdownOpen]);
 
   // Auto-grow the edit textarea and clamp at a soft max-height (60vh, capped at 480px).
   // Mirrors the autosize pattern used by ChatInput / ClarificationInput.
@@ -924,21 +940,74 @@ function ChatMessage({
               isLatestAssistantMessage || showActions ? 'opacity-100' : 'opacity-60'
             }`}
           >
-            <button
-              type="button"
-              onClick={() => onInsert(message.content)}
-              className="inline-flex w-full items-center justify-center gap-2 px-3 py-2 rounded-md text-sm font-semibold bg-indigo-600 text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 transition-colors"
-            >
-              <Icon name="arrow-right" size="sm" className="text-white" />
-              <span>
-                {t(
-                  insertAction.labelKey || 'office.insertIntoDocument',
-                  insertAction.labelKey === 'office.insertIntoEmail'
-                    ? 'Add to email'
-                    : 'Add to document'
-                )}
-              </span>
-            </button>
+            <div className="relative flex w-full" ref={insertDropdownRef}>
+              {/* Main action button */}
+              <button
+                type="button"
+                onClick={() => onInsert(message.content)}
+                className={`inline-flex flex-1 items-center justify-center gap-2 px-3 py-2 text-sm font-semibold bg-indigo-600 text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 transition-colors ${onInsertNew ? 'rounded-l-md' : 'rounded-md'}`}
+              >
+                <Icon name="arrow-right" size="sm" className="text-white" />
+                <span>
+                  {t(
+                    insertAction.labelKey || 'office.insertIntoDocument',
+                    insertAction.labelKey === 'office.insertIntoEmail'
+                      ? 'Add to email'
+                      : 'Add to document'
+                  )}
+                </span>
+              </button>
+
+              {/* Dropdown toggle — only shown when a "new email" handler is wired up */}
+              {onInsertNew && (
+                <>
+                  <button
+                    type="button"
+                    onClick={() => setInsertDropdownOpen(prev => !prev)}
+                    className="inline-flex items-center px-2 py-2 rounded-r-md text-sm font-semibold bg-indigo-700 text-white shadow-sm hover:bg-indigo-800 border-l border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 transition-colors"
+                    aria-haspopup="menu"
+                    aria-expanded={insertDropdownOpen}
+                    title={t('office.insertOptions', 'More options')}
+                  >
+                    <Icon name={insertDropdownOpen ? 'chevronUp' : 'chevronDown'} size="sm" className="text-white" />
+                  </button>
+
+                  {insertDropdownOpen && (
+                    <div
+                      role="menu"
+                      className="absolute bottom-full mb-1 right-0 z-50 w-48 rounded-md bg-white dark:bg-gray-800 shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+                    >
+                      <div className="py-1">
+                        <button
+                          type="button"
+                          role="menuitem"
+                          onClick={() => {
+                            onInsert(message.content);
+                            setInsertDropdownOpen(false);
+                          }}
+                          className="flex w-full items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                        >
+                          <Icon name="arrow-right" size="sm" />
+                          {t('office.replyToEmail', 'Reply to email')}
+                        </button>
+                        <button
+                          type="button"
+                          role="menuitem"
+                          onClick={() => {
+                            onInsertNew(message.content);
+                            setInsertDropdownOpen(false);
+                          }}
+                          className="flex w-full items-center gap-2 px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
+                        >
+                          <Icon name="pencil" size="sm" />
+                          {t('office.newEmail', 'New email')}
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
           </div>
         )}
 

--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -690,6 +690,11 @@ function ChatMessage({
   // Don't apply bubble styling when showing ClarificationCard (it has its own styling)
   const hasPendingClarification = message.clarification && !message.clarificationAnswered;
   const showBubble = !hasPendingClarification;
+  // Dropdown is email-specific: only show it when both onInsertNew is provided AND the
+  // insert action is for email (not Word/PowerPoint). This keeps the rounding and the
+  // dropdown chevron in sync regardless of how future hosts wire onInsertNew.
+  const showInsertDropdown =
+    Boolean(onInsertNew) && insertAction?.labelKey === 'office.insertIntoEmail';
 
   return (
     <div
@@ -941,11 +946,11 @@ function ChatMessage({
             }`}
           >
             <div className="relative flex w-full" ref={insertDropdownRef}>
-              {/* Main action button */}
+              {/* Main action button — square-right when the chevron is shown, fully rounded otherwise */}
               <button
                 type="button"
                 onClick={() => onInsert(message.content)}
-                className={`inline-flex flex-1 items-center justify-center gap-2 px-3 py-2 text-sm font-semibold bg-indigo-600 text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 transition-colors ${onInsertNew ? 'rounded-l-md' : 'rounded-md'}`}
+                className={`inline-flex flex-1 items-center justify-center gap-2 px-3 py-2 text-sm font-semibold bg-indigo-600 text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-1 transition-colors ${showInsertDropdown ? 'rounded-l-md' : 'rounded-md'}`}
               >
                 <Icon name="arrow-right" size="sm" className="text-white" />
                 <span>
@@ -958,8 +963,8 @@ function ChatMessage({
                 </span>
               </button>
 
-              {/* Dropdown toggle — only shown when a "new email" handler is wired up */}
-              {onInsertNew && (
+              {/* Dropdown toggle — email hosts only (showInsertDropdown is false for Word/PowerPoint) */}
+              {showInsertDropdown && (
                 <>
                   <button
                     type="button"

--- a/client/src/features/chat/components/ChatMessageList.jsx
+++ b/client/src/features/chat/components/ChatMessageList.jsx
@@ -23,6 +23,7 @@ function ChatMessageList({
   compact = false,
   onOpenInCanvas,
   onInsert,
+  onInsertNew = null,
   insertAction = null,
   canvasEnabled = false,
   // Integration auth props
@@ -173,6 +174,7 @@ function ChatMessageList({
                 compact={compact}
                 onOpenInCanvas={onOpenInCanvas}
                 onInsert={onInsert}
+                onInsertNew={onInsertNew}
                 insertAction={insertAction}
                 isLatestAssistantMessage={index === lastAssistantIndex}
                 canvasEnabled={canvasEnabled}

--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -17,7 +17,10 @@ import useOfficeChatAdapter from '../hooks/useOfficeChatAdapter';
 import useOutlookMailContextSnapshot from '../hooks/useOutlookMailContextSnapshot';
 import useAppSettings from '../../../shared/hooks/useAppSettings';
 import useFileUploadHandler from '../../../shared/hooks/useFileUploadHandler';
-import { displayReplyFormWithAssistantResponse } from '../utilities/replyForm';
+import {
+  displayReplyFormWithAssistantResponse,
+  displayNewEmailFormWithAssistantResponse
+} from '../utilities/replyForm';
 import { buildPromptTemplate } from '../utilities/buildChatApiMessages';
 import {
   fetchCurrentMailContext,
@@ -271,6 +274,10 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
 
   const handleInsert = useCallback(content => {
     displayReplyFormWithAssistantResponse(content);
+  }, []);
+
+  const handleInsertNew = useCallback(content => {
+    displayNewEmailFormWithAssistantResponse(content);
   }, []);
 
   const submitMessage = useCallback(
@@ -555,6 +562,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
                 editable={true}
                 compact={true}
                 onInsert={handleInsert}
+                onInsertNew={handleInsertNew}
                 insertAction={embeddedHost?.insertAction}
                 appId={selectedApp?.id}
                 chatId={chatIdRef.current}

--- a/client/src/features/office/utilities/replyForm.js
+++ b/client/src/features/office/utilities/replyForm.js
@@ -50,3 +50,29 @@ export function displayReplyFormWithAssistantResponse(assistantMarkdownText) {
 
   window.alert('Insert is not supported for this item type.');
 }
+
+export function displayNewEmailFormWithAssistantResponse(assistantMarkdownText) {
+  if (!isOutlookMailItemAvailable()) {
+    window.alert('Insert is only available when you open this add-in from an email in Outlook.');
+    return;
+  }
+
+  const html = marked.parse(assistantMarkdownText);
+
+  if (typeof Office.context.mailbox.displayNewMessageFormAsync === 'function') {
+    Office.context.mailbox.displayNewMessageFormAsync({ htmlBody: html }, result => {
+      if (result.status === Office.AsyncResultStatus.Failed) {
+        console.error('[iHub] displayNewMessageFormAsync failed:', result.error);
+        window.alert('Could not open new email form. ' + (result.error?.message || ''));
+      }
+    });
+    return;
+  }
+
+  if (typeof Office.context.mailbox.displayNewMessageForm === 'function') {
+    Office.context.mailbox.displayNewMessageForm({ htmlBody: html });
+    return;
+  }
+
+  window.alert('Creating a new email is not supported for this Outlook version.');
+}

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -146,6 +146,9 @@
     "showTaskPane": "Aufgabenbereich anzeigen",
     "insertIntoEmail": "In E-Mail einfügen",
     "insertIntoDocument": "In Dokument einfügen",
+    "insertOptions": "Weitere Optionen",
+    "replyToEmail": "Auf E-Mail antworten",
+    "newEmail": "Neue E-Mail",
     "pinned": {
       "addEmails": "E-Mail(s) hinzufügen",
       "addEmailsTooltip": "Die geöffnete E-Mail – oder alle in Outlook ausgewählten E-Mails – an den Chat anhängen",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -131,6 +131,9 @@
     "showTaskPane": "Show Task Pane",
     "insertIntoEmail": "Add to email",
     "insertIntoDocument": "Add to document",
+    "insertOptions": "More options",
+    "replyToEmail": "Reply to email",
+    "newEmail": "New email",
     "pinned": {
       "addEmails": "Add email(s)",
       "addEmailsTooltip": "Attach the open email — or every email you've selected in Outlook — to the chat",


### PR DESCRIPTION
## Summary

- The **"Add to email"** button in the Outlook taskpane is now a **split button**
- Direct click still inserts the AI response as a **reply** (unchanged behaviour)
- A small **chevron (▾)** opens a dropdown with two choices:
  - **Reply to email** — same as the direct click
  - **New email** — opens a blank compose form pre-filled with the AI response

This is especially useful when users have generated multiple responses and want to start a fresh message rather than replying to the current one.

## Changes

| File | What changed |
|------|--------------|
| `client/src/features/office/utilities/replyForm.js` | Added `displayNewEmailFormWithAssistantResponse()` using `Office.context.mailbox.displayNewMessageFormAsync` |
| `client/src/features/chat/components/ChatMessage.jsx` | Split button UI with dropdown; `onInsertNew` prop; click-outside handler |
| `client/src/features/chat/components/ChatMessageList.jsx` | Threads `onInsertNew` prop down to `ChatMessage` |
| `client/src/features/office/components/OfficeChatPanel.jsx` | `handleInsertNew` callback wired to `onInsertNew` |
| `shared/i18n/en.json` + `de.json` | Added `office.insertOptions`, `office.replyToEmail`, `office.newEmail` keys |

## Test plan

- [ ] In Outlook taskpane (read mode): click "Add to email" directly → reply form opens pre-filled
- [ ] Click the chevron → dropdown appears with "Reply to email" and "New email"
- [ ] Click "Reply to email" from dropdown → same as direct click
- [ ] Click "New email" from dropdown → blank compose window opens pre-filled
- [ ] Click outside the dropdown → dropdown closes
- [ ] In Word taskpane (non-Outlook): button renders as before (no dropdown, full rounded corners)
- [ ] German locale: dropdown labels show translated strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0182Tm7FCo4MDFyRvx5vRbx7

---
_Generated by [Claude Code](https://claude.ai/code/session_0182Tm7FCo4MDFyRvx5vRbx7)_