### PR TITLE
fix: new email button uses wrong Office.js availability guard

### DIFF
--- a/client/src/features/office/utilities/replyForm.js
+++ b/client/src/features/office/utilities/replyForm.js
@@ -1,6 +1,7 @@
 /* global Office */
 
 import { isOutlookMailItemAvailable } from './outlookMailContext';
+import { isMailboxAvailable } from './officeCapabilities';
 import { marked } from 'marked';
 
 export function displayReplyFormWithAssistantResponse(assistantMarkdownText) {
@@ -52,8 +53,8 @@ export function displayReplyFormWithAssistantResponse(assistantMarkdownText) {
 }
 
 export function displayNewEmailFormWithAssistantResponse(assistantMarkdownText) {
-  if (!isOutlookMailItemAvailable()) {
-    window.alert('Insert is only available when you open this add-in from an email in Outlook.');
+  if (!isMailboxAvailable()) {
+    window.alert('Creating a new email is only available in Outlook.');
     return;
   }
 


### PR DESCRIPTION
## Summary

- `displayNewEmailFormWithAssistantResponse` was guarded by `isOutlookMailItemAvailable()`, which checks for `Office.context.mailbox.item` (a currently-selected email item)
- Creating a new email does **not** require a mail item to be open — only `Office.context.mailbox` itself needs to be present
- Switched to `isMailboxAvailable()` so the "New email" action works even when no email is open in the reading pane
- Updated the alert message to accurately describe what is required

## Root cause

The two insert functions have different prerequisites:
- **Reply** (`displayReplyFormWithAssistantResponse`) — correctly requires an open email item to reply to
- **New email** (`displayNewEmailFormWithAssistantResponse`) — incorrectly required an open email item; the `displayNewMessageFormAsync` / `displayNewMessageForm` API is a mailbox-level call that works without a selected item

## Test plan

- [ ] Open Outlook task pane **without** an email selected (viewing inbox list) → clicking "New email" should open a new compose form
- [ ] Open Outlook task pane **with** an email selected → "Reply to email" still works, "New email" opens a new compose form with the AI response in the body
- [ ] Verify the wrong-context alert message reads "Creating a new email is only available in Outlook." instead of the misleading reply-specific message

Fixes the regression from #1637.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013R4jYXYuJxeCmbW46AiNiq

---
_Generated by [Claude Code](https://claude.ai/code/session_013R4jYXYuJxeCmbW46AiNiq)_