### PR TITLE
fix(office): restore Add email button visibility broken by #1635

### DIFF
--- a/client/src/features/office/components/chat/OfficeContextStrip.jsx
+++ b/client/src/features/office/components/chat/OfficeContextStrip.jsx
@@ -213,8 +213,8 @@ function OfficeContextStrip({
           />
         </button>
 
-        {/* Always show add-email button in the header, collapsed or expanded */}
-        {hasPinControls && (
+        {/* Show add-email button in the header when collapsed so it's always reachable */}
+        {!expanded && hasPinControls && (
           <PinnedEmailsBar
             pinned={[]}
             onUnpin={() => {}}
@@ -245,13 +245,13 @@ function OfficeContextStrip({
             />
           )}
 
-          {hasPinned && (
+          {(hasPinned || hasPinControls) && (
             <PinnedEmailsBar
               pinned={pinnedList}
               onUnpin={onUnpin}
               onClearAll={onClearPinned}
               onAddEmails={onAddEmails}
-              canAddEmails={false}
+              canAddEmails={canAddEmails}
               addEmailsLoading={addEmailsLoading}
               addEmailsDisabled={addEmailsDisabled}
               embedded


### PR DESCRIPTION
## Summary

PR #1635 moved the "Add email(s)" button from the expanded-content area to a compact header slot for all states. The problem: in the **expanded** state (the default when an email is open), the compact header button was only supposed to appear in the collapsed state — so in practice the button was invisible in the most common scenario.

The fix reverts to the pre-#1635 logic that already achieved "always visible":

- **Collapsed strip:** compact "Add email(s)" button in the header row (unchanged)
- **Expanded strip:** full-size "Add email(s)" button inside the expanded content area (restored via `canAddEmails={canAddEmails}` and `hasPinned || hasPinControls` guard)

## Root cause

In `OfficeContextStrip.jsx`, PR #1635 made two changes that together hid the button:

1. Changed `{!expanded && hasPinControls && ...}` → `{hasPinControls && ...}` in the header (intended to show it always), **but** also…
2. Changed `{(hasPinned || hasPinControls) && ... canAddEmails={canAddEmails}}` → `{hasPinned && ... canAddEmails={false}}` in the expanded section

Change (2) removed the button from the expanded content area. Change (1) was supposed to compensate by moving it to the header — but the collapsedMode compact button in the header was still gated on `!expanded` (there was no such gate in the new code, but the expanded section button was gone). Net result: in the expanded state (default with email open), the button vanished.

## Test plan

- [ ] Open Outlook task pane on a mail item → strip is expanded by default → "Add email(s)" button visible in expanded content area
- [ ] Collapse the strip manually → "Add email(s)" compact button visible in header row
- [ ] Send a message (auto-collapse) → strip collapses → compact button visible in header
- [ ] Add an email via the button → button shows "Already added" / is disabled (single-select mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019CiezSNtCdvsmPMBWpbBoW

---
_Generated by [Claude Code](https://claude.ai/code/session_019CiezSNtCdvsmPMBWpbBoW)_