### PR TITLE
fix: ensure add-email button stays visible with long email subjects

### DIFF
--- a/client/src/features/office/components/chat/OfficeContextStrip.jsx
+++ b/client/src/features/office/components/chat/OfficeContextStrip.jsx
@@ -191,7 +191,7 @@ function OfficeContextStrip({
         <button
           type="button"
           onClick={() => setOverrideExpanded(!expanded)}
-          className="flex-1 flex items-center gap-2 text-left hover:bg-slate-50 transition-colors rounded-md px-1 py-0.5 -ml-1"
+          className="flex-1 min-w-0 flex items-center gap-2 text-left hover:bg-slate-50 transition-colors rounded-md px-1 py-0.5 -ml-1"
           aria-expanded={expanded}
           aria-label={expanded ? 'Collapse email context' : 'Expand email context'}
           title={expanded ? 'Collapse email context' : 'Expand email context'}
@@ -215,17 +215,19 @@ function OfficeContextStrip({
 
         {/* Show add-email button in the header when collapsed so it's always reachable */}
         {!expanded && hasPinControls && (
-          <PinnedEmailsBar
-            pinned={[]}
-            onUnpin={() => {}}
-            onClearAll={() => {}}
-            onAddEmails={onAddEmails}
-            canAddEmails={canAddEmails}
-            addEmailsLoading={addEmailsLoading}
-            addEmailsDisabled={addEmailsDisabled}
-            embedded
-            collapsedMode
-          />
+          <div className="flex-shrink-0">
+            <PinnedEmailsBar
+              pinned={[]}
+              onUnpin={() => {}}
+              onClearAll={() => {}}
+              onAddEmails={onAddEmails}
+              canAddEmails={canAddEmails}
+              addEmailsLoading={addEmailsLoading}
+              addEmailsDisabled={addEmailsDisabled}
+              embedded
+              collapsedMode
+            />
+          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary

- Add `min-w-0` to the collapse/expand button in `OfficeContextStrip` so it can shrink past its natural content width when the email subject is very long
- Wrap the `PinnedEmailsBar` in the collapsed header with a `flex-shrink-0` div so the "Add email(s)" button is never squeezed out of view

## Root cause

In a flex row, `flex-1` on the collapse button allows it to grow but also means the browser uses `min-width: auto` — the element won't shrink below its minimum content size. Without `min-w-0`, a very long subject line could prevent the button from shrinking, leaving no room for the sibling `PinnedEmailsBar`. Additionally, `PinnedEmailsBar` had no `flex-shrink-0` protection, so it could be squashed by the button. These two classes together guarantee the title truncates and the "Add email(s)" button stays always visible.

## Test plan
- [ ] Open Outlook taskpane with an email that has a very long subject line
- [ ] Verify the strip is collapsed and the "Add email(s)" button is visible alongside the subject
- [ ] Verify the subject truncates with ellipsis rather than overflowing
- [ ] Verify the button still works (attaches the email to chat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6QqgojpH2RQQ3Dr68jCPT

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6QqgojpH2RQQ3Dr68jCPT)_