### PR TITLE
fix: return admins to their page after mid-session re-login

### DIFF
--- a/client/src/api/adminApi.js
+++ b/client/src/api/adminApi.js
@@ -99,24 +99,33 @@ export const makeAdminApiCall = async (url, options = {}) => {
       return response;
     }
   } catch (error) {
+    const status = error.response?.status;
+
     // Handle admin-specific auth failures
-    if (error.response?.status === 401 || error.response?.status === 403) {
-      // Clear invalid admin tokens
+    if (status === 401 || status === 403) {
+      // Clear the anonymous-mode admin token if present; it is no longer valid.
       if (adminToken) {
         localStorage.removeItem('adminToken');
       }
 
-      // For auth failures, redirect appropriately based on the auth mode
-      if (window.location.pathname.startsWith('/admin')) {
-        const authToken = localStorage.getItem('authToken');
-        // If we have a regular auth token, this suggests a permission issue
-        if (authToken) {
-          // User is authenticated but doesn't have admin permissions
-          window.location.href = buildPath('/admin'); // Will show appropriate error message
-        } else {
-          // User is not authenticated, redirect to login
-          window.location.href = buildPath('/');
-        }
+      if (status === 401) {
+        // Session expired or token invalid. Trigger the global re-authentication
+        // flow instead of hard-redirecting away from the admin area. The
+        // `authTokenExpired` handler stores the current URL and shows the auth
+        // gate overlay, returning the user to exactly where they were after they
+        // log back in — so an admin re-prompted mid-session lands back on the
+        // admin page, not the app home.
+        //
+        // The shared apiClient interceptor already dispatches this for JSON
+        // requests, but FormData requests use raw fetch and bypass that
+        // interceptor, so we dispatch here to cover both paths. Dispatching is
+        // idempotent: handleTokenExpired guards against re-entry and the auth
+        // gate won't re-show while it is already visible.
+        window.dispatchEvent(new CustomEvent('authTokenExpired'));
+      } else if (window.location.pathname.startsWith('/admin')) {
+        // 403: authenticated but lacking admin permission. Send the user to the
+        // admin root, which renders an "Admin Access Required" message.
+        window.location.href = buildPath('/admin');
       }
     }
     throw error;

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -531,3 +531,10 @@ The audit log no longer records a `POST /api/session/start -> 200` entry every t
 
 - Session-start requests are now excluded from the generic audit safety-net, matching how chat, inference, and page reads are already treated.
 - Login and logout continue to be audited via their own explicit hooks — no change to security-relevant events.
+
+## Fix — Session Expiry in the Admin Area Returns You to the Same Page
+
+When an admin's session expires while they are working in the admin panel, signing back in through the login dialog now returns them to the admin page they were on, instead of dropping them on the application home screen.
+
+- Previously an expired session triggered a hard redirect to the home page the moment an admin request failed, so the login dialog opened on the home screen and admins had to navigate all the way back into the admin area after re-authenticating.
+- The admin panel now uses the same in-place re-authentication as the rest of the app: the login dialog appears over the current page, and after signing in the admin stays exactly where they were. This also covers file-upload (multipart) admin requests, which previously bypassed the re-authentication prompt entirely.


### PR DESCRIPTION
## Problem

While working in the admin panel, if an admin's session expired, the auth gate popped up — but after logging back in they landed on the **application home screen** instead of the admin page they were on.

## Root cause

When an admin request returns `401`, two things race:

1. The shared `apiClient` response interceptor (`client/src/api/client.js`) **removes `authToken`** from `localStorage` and dispatches `authTokenExpired`. The `authTokenExpired` handler (`AuthContext.jsx`) stores the current `/admin/...` URL and shows the auth-gate overlay **in place** — the correct, location-preserving path.
2. The rejected promise then reaches `makeAdminApiCall`'s catch (`client/src/api/adminApi.js`), which decided where to redirect by reading `localStorage.getItem('authToken')`. But step 1 had **already cleared it**, so the `else` ("not authenticated") branch always won and ran `window.location.href = buildPath('/')`.

That hard navigation to `/` discarded the admin page and pre-empted the in-place overlay. The auth gate's username/password login never consumes the stored return URL (only OIDC/NTLM and React's `loginLocal` do), so the admin finished on the home screen.

## Fix

In `makeAdminApiCall`'s `401` handler, dispatch `authTokenExpired` instead of hard-redirecting. The existing handler stores the current URL and shows the auth-gate overlay over the current page, so the admin stays on the admin page through re-authentication and lands back there after signing in.

- Dispatching here also covers **FormData (multipart) admin requests**, which use raw `fetch` and bypass the shared interceptor — previously those `401`s triggered no re-auth prompt at all.
- Dispatching is idempotent: `handleTokenExpired` guards against re-entry and the gate won't re-show while already visible.
- `403` (authenticated but lacking admin permission) still routes to `/admin`, which renders the "Admin Access Required" message.

## Files changed

- `client/src/api/adminApi.js` — replace the `401` hard-redirect-to-home with an `authTokenExpired` dispatch; keep `403 → /admin`.
- `docs/releases/5.4.0/features.md` — changelog entry.

## Testing notes

Dependencies (ESLint/Prettier) are not installed in this environment, so automated lint could not be run; the change was syntax-checked with `node --check` and hand-formatted to the project's Prettier config (single quotes, semicolons, 2-space, 100-col). Suggested manual verification:

1. Log in as an admin, open an admin sub-page (e.g. `/admin/apps`).
2. Expire/clear the session token server-side (or wait for expiry).
3. Trigger an admin request; confirm the login dialog appears **over the admin page**.
4. Log back in and confirm you remain on `/admin/apps` rather than being sent to `/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUDUJujaBrASQ2xrL4Ryso

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUDUJujaBrASQ2xrL4Ryso)_