### PR TITLE
Fix MSG file uploads: load mimetypes config and dedupe Outlook MIME type

### DIFF
--- a/client/src/features/upload/components/UnifiedUploader.jsx
+++ b/client/src/features/upload/components/UnifiedUploader.jsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Uploader from './Uploader';
 import '../components/ImageUpload.css';
@@ -8,7 +9,8 @@ import {
   processDocumentFile,
   formatAcceptAttribute,
   processTiffFile,
-  extractAudioFromVideo
+  extractAudioFromVideo,
+  loadMimetypesConfig
 } from '../utils/fileProcessing';
 
 /**
@@ -25,6 +27,26 @@ const UnifiedUploader = ({
   children
 }) => {
   const { t } = useTranslation();
+
+  // Load the server mimetypes config so the file picker's `accept` attribute
+  // gets real file extensions (e.g. `.msg`, `.eml`, `.xlsx`). Without it the
+  // module falls back to a minimal DEFAULT_CONFIG that only knows a handful of
+  // extensions; non-standard MIME types like `application/vnd.ms-outlook` then
+  // reach the OS dialog without a matching extension, so `.msg` files appear
+  // greyed out and cannot be selected. `.eml` survives because its MIME type
+  // (`message/rfc822`) is recognised by the OS even without the extension.
+  // The load is cached/idempotent; the state flip forces a single re-render so
+  // the synchronous format helpers below recompute against the loaded config.
+  const [, setMimetypesLoaded] = useState(false);
+  useEffect(() => {
+    let active = true;
+    loadMimetypesConfig().finally(() => {
+      if (active) setMimetypesLoaded(true);
+    });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   // Image upload configuration
   const imageConfig = config.imageUpload || {};

--- a/client/src/features/upload/utils/fileProcessing.js
+++ b/client/src/features/upload/utils/fileProcessing.js
@@ -625,11 +625,7 @@ export const processDocumentFile = async file => {
     fileExtension === '.xls'
   ) {
     content = await processXlsxFile(file);
-  } else if (
-    file.type === 'application/vnd.ms-outlook' ||
-    file.type === 'application/x-msg' ||
-    fileExtension === '.msg'
-  ) {
+  } else if (file.type === 'application/vnd.ms-outlook' || fileExtension === '.msg') {
     content = await processMsgFile(file);
   } else if (
     file.type === 'image/tif' ||

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -538,3 +538,10 @@ When an admin's session expires while they are working in the admin panel, signi
 
 - Previously an expired session triggered a hard redirect to the home page the moment an admin request failed, so the login dialog opened on the home screen and admins had to navigate all the way back into the admin area after re-authenticating.
 - The admin panel now uses the same in-place re-authentication as the rest of the app: the login dialog appears over the current page, and after signing in the admin stays exactly where they were. This also covers file-upload (multipart) admin requests, which previously bypassed the re-authentication prompt entirely.
+
+## Fix — Outlook `.msg` Files Can Now Be Selected for Upload
+
+Uploading Outlook `.msg` email files now works. In the file picker, `.msg` files appeared greyed out and could not be selected even on apps that listed MSG as a supported format, while `.eml` files worked.
+
+- The upload component never loaded the server's MIME-type configuration, so the file picker's accepted-types list was built from a minimal built-in fallback that omitted the `.msg` file extension. Because the Outlook MIME types (`application/vnd.ms-outlook`) are not recognised by the operating system's file dialog, `.msg` files had no matching rule and were blocked. `.eml` was unaffected because its MIME type (`message/rfc822`) is understood by the OS even without the extension. The component now loads the full configuration, so every configured format — `.msg`, `.eml`, `.xlsx`, `.pptx`, OpenOffice formats, and more — is correctly offered in the file picker.
+- The MSG format also no longer appears twice when configuring an app's upload formats. `.msg` had been registered under two MIME types (`application/vnd.ms-outlook` and a redundant `application/x-msg`), producing duplicate "MSG" entries in the admin upload-format selector. The duplicate is removed automatically on upgrade (migration **V064**); `application/vnd.ms-outlook` remains the single canonical type.

--- a/server/defaults/apps/file-analysis.json
+++ b/server/defaults/apps/file-analysis.json
@@ -57,7 +57,6 @@
         "application/vnd.ms-excel",
         "application/vnd.ms-powerpoint",
         "application/vnd.ms-outlook",
-        "application/x-msg",
         "application/vnd.oasis.opendocument.text",
         "application/vnd.oasis.opendocument.spreadsheet",
         "application/vnd.oasis.opendocument.presentation"

--- a/server/defaults/config/mimetypes.json
+++ b/server/defaults/config/mimetypes.json
@@ -68,7 +68,6 @@
         "application/vnd.ms-excel",
         "application/vnd.ms-powerpoint",
         "application/vnd.ms-outlook",
-        "application/x-msg",
         "application/vnd.oasis.opendocument.text",
         "application/vnd.oasis.opendocument.spreadsheet",
         "application/vnd.oasis.opendocument.presentation"
@@ -247,11 +246,6 @@
       "category": "documents"
     },
     "application/vnd.ms-outlook": {
-      "extensions": [".msg"],
-      "displayName": "MSG",
-      "category": "documents"
-    },
-    "application/x-msg": {
       "extensions": [".msg"],
       "displayName": "MSG",
       "category": "documents"

--- a/server/migrations/V064__dedupe_msg_mimetype.js
+++ b/server/migrations/V064__dedupe_msg_mimetype.js
@@ -1,0 +1,88 @@
+/**
+ * Migration V064 — Deduplicate the MSG (Outlook) MIME type
+ *
+ * `.msg` files were registered under two MIME types: `application/vnd.ms-outlook`
+ * (the de-facto standard Outlook type) and the non-standard `application/x-msg`.
+ * Both mapped to the same `.msg` extension and "MSG" display name, so the admin
+ * upload-format selector rendered "MSG (.msg)" twice and apps listing both ended
+ * up with a redundant entry.
+ *
+ * Browsers never emit `application/x-msg`, and `.msg` selection/processing relies
+ * on the file extension anyway, so the extra type adds nothing. This migration
+ * removes `application/x-msg` from existing installations:
+ *
+ *   1. config/mimetypes.json — drop it from every category list and from the
+ *      `mimeTypes` detail map.
+ *   2. apps/*.json — drop it from any `upload.*.supportedFormats` array.
+ *
+ * `application/vnd.ms-outlook` remains as the single canonical MSG type.
+ */
+
+export const version = '064';
+export const description = 'dedupe_msg_mimetype';
+
+const LEGACY_MSG_TYPE = 'application/x-msg';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/mimetypes.json');
+}
+
+export async function up(ctx) {
+  // 1. Clean config/mimetypes.json
+  const mimetypes = await ctx.readJson('config/mimetypes.json');
+  let mimetypesChanged = false;
+
+  if (mimetypes?.categories && typeof mimetypes.categories === 'object') {
+    for (const category of Object.values(mimetypes.categories)) {
+      if (Array.isArray(category?.mimeTypes) && category.mimeTypes.includes(LEGACY_MSG_TYPE)) {
+        category.mimeTypes = category.mimeTypes.filter(type => type !== LEGACY_MSG_TYPE);
+        mimetypesChanged = true;
+      }
+    }
+  }
+
+  if (
+    mimetypes?.mimeTypes &&
+    Object.prototype.hasOwnProperty.call(mimetypes.mimeTypes, LEGACY_MSG_TYPE)
+  ) {
+    delete mimetypes.mimeTypes[LEGACY_MSG_TYPE];
+    mimetypesChanged = true;
+  }
+
+  if (mimetypesChanged) {
+    await ctx.writeJson('config/mimetypes.json', mimetypes);
+    ctx.log(`Removed ${LEGACY_MSG_TYPE} from config/mimetypes.json`);
+  }
+
+  // 2. Clean apps/*.json upload.*.supportedFormats
+  const appFiles = await ctx.listFiles('apps', '*.json');
+  if (Array.isArray(appFiles)) {
+    let migrated = 0;
+    for (const file of appFiles) {
+      const app = await ctx.readJson(`apps/${file}`);
+      const upload = app?.upload;
+      if (!upload || typeof upload !== 'object') continue;
+
+      let appChanged = false;
+      for (const section of Object.values(upload)) {
+        if (
+          Array.isArray(section?.supportedFormats) &&
+          section.supportedFormats.includes(LEGACY_MSG_TYPE)
+        ) {
+          section.supportedFormats = section.supportedFormats.filter(
+            type => type !== LEGACY_MSG_TYPE
+          );
+          appChanged = true;
+        }
+      }
+
+      if (appChanged) {
+        await ctx.writeJson(`apps/${file}`, app);
+        migrated++;
+      }
+    }
+    if (migrated > 0) {
+      ctx.log(`Removed ${LEGACY_MSG_TYPE} from supportedFormats in ${migrated} app(s)`);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Customers reported that Outlook `.msg` email files "are not working" on upload, while `.eml` works. Investigation found two related bugs.

### Bug 1 — `.msg` files can't be selected in the file picker (the real blocker)

`loadMimetypesConfig()` in `client/src/features/upload/utils/fileProcessing.js` was **defined but never called** anywhere. So the module's config cache stayed `null` and `getConfig()` permanently returned the minimal hardcoded `DEFAULT_CONFIG` (only ~13 MIME types). That fallback has **no `.msg` / `.eml` / `.xlsx` / … extension mappings**, so `formatAcceptAttribute()` built the file input's `accept` attribute from **MIME types only**.

The OS file dialog does not recognise the Outlook MIME types (`application/vnd.ms-outlook`, `application/x-msg`), so with no `.msg` extension token present, `.msg` files were **greyed out / unselectable**. `.eml` worked anyway because `message/rfc822` **is** an OS-recognised type that maps to `.eml` without needing the extension — which is exactly why `.eml` worked but `.msg` didn't.

**Fix:** `UnifiedUploader` now loads the server mimetypes config on mount and re-renders once it resolves, so the `accept` attribute includes every configured extension (`.msg`, `.eml`, `.xlsx`, `.pptx`, OpenDocument, …). The endpoint (`/api/configs/mimetypes`) is public, so this also works for anonymous users.

### Bug 2 — MSG listed twice in the admin upload-format selector

`.msg` was registered under two MIME types — `application/vnd.ms-outlook` and the redundant, non-standard `application/x-msg` — both mapping to the same `.msg` extension and "MSG" display name. The admin `MimeTypeSelector` renders one row per MIME type, so "MSG (.msg)" appeared twice.

**Fix:** Removed `application/x-msg` (browsers never emit it; `.msg` selection/processing relies on the extension anyway). `application/vnd.ms-outlook` remains the single canonical MSG type.

## Changes

- `client/src/features/upload/components/UnifiedUploader.jsx` — load mimetypes config on mount; re-render when ready.
- `client/src/features/upload/utils/fileProcessing.js` — drop the dead `application/x-msg` branch in document routing.
- `server/defaults/config/mimetypes.json` — remove `application/x-msg` (category list + detail entry).
- `server/defaults/apps/file-analysis.json` — remove `application/x-msg` from `supportedFormats`.
- `server/migrations/V064__dedupe_msg_mimetype.js` — strip `application/x-msg` from existing installations' `mimetypes.json` and app `supportedFormats`.
- `docs/releases/5.4.0/features.md` — changelog entry.

## Testing notes

- JSON validated and changed JS syntax-checked (`node --check`). ESLint could not run in this environment (deps not installed — missing `globals`), so a lint pass on a populated checkout is recommended before merge.
- Manual verification suggested: on an app with MSG enabled, open the file picker and confirm `.msg` files are now selectable and parse to text; confirm the admin upload-format selector shows a single "MSG (.msg)" entry; confirm migration V064 runs on an existing `contents/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012giDGDsBj9zYzDhqusHewr

---
_Generated by [Claude Code](https://claude.ai/code/session_012giDGDsBj9zYzDhqusHewr)_