### PR TITLE
fix(upload): construct MsgReader across CJS/ESM interop shapes

### DIFF
--- a/client/src/features/upload/utils/fileProcessing.js
+++ b/client/src/features/upload/utils/fileProcessing.js
@@ -150,9 +150,20 @@ export const loadMammoth = async () => {
   return mammoth;
 };
 
-// Lazy load MSGReader only when needed
+// Lazy load MSGReader only when needed.
+// @kenjiuno/msgreader is a CommonJS module that exposes the MsgReader class as
+// its default export (it sets both `__esModule` and `exports.default`). Because
+// of that double-default, bundler CJS/ESM interop can surface the constructor at
+// mod.default, mod.default.default, or mod itself depending on the build. Pick
+// the first candidate that is actually a constructor so it works everywhere.
 export const loadMsgReader = async () => {
-  const MsgReader = await import('@kenjiuno/msgreader');
+  const mod = await import('@kenjiuno/msgreader');
+  const MsgReader = [mod?.default?.default, mod?.default, mod].find(
+    candidate => typeof candidate === 'function'
+  );
+  if (!MsgReader) {
+    throw new Error('msg-reader-unavailable');
+  }
   return MsgReader;
 };
 
@@ -522,7 +533,7 @@ export const processXlsxFile = async file => {
 export const processMsgFile = async file => {
   const arrayBuffer = await file.arrayBuffer();
   const MsgReader = await loadMsgReader();
-  const msgReader = new MsgReader.default(arrayBuffer);
+  const msgReader = new MsgReader(arrayBuffer);
   const fileData = msgReader.getFileData();
 
   // Extract text content from MSG file

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -545,3 +545,7 @@ Uploading Outlook `.msg` email files now works. In the file picker, `.msg` files
 
 - The upload component never loaded the server's MIME-type configuration, so the file picker's accepted-types list was built from a minimal built-in fallback that omitted the `.msg` file extension. Because the Outlook MIME types (`application/vnd.ms-outlook`) are not recognised by the operating system's file dialog, `.msg` files had no matching rule and were blocked. `.eml` was unaffected because its MIME type (`message/rfc822`) is understood by the OS even without the extension. The component now loads the full configuration, so every configured format — `.msg`, `.eml`, `.xlsx`, `.pptx`, OpenOffice formats, and more — is correctly offered in the file picker.
 - The MSG format also no longer appears twice when configuring an app's upload formats. `.msg` had been registered under two MIME types (`application/vnd.ms-outlook` and a redundant `application/x-msg`), producing duplicate "MSG" entries in the admin upload-format selector. The duplicate is removed automatically on upgrade (migration **V064**); `application/vnd.ms-outlook` remains the single canonical type.
+
+## Fix — Outlook `.msg` Files Now Process After Selection
+
+Once a `.msg` file could be selected, uploading it still failed with an "Error processing file" message and the email's contents were never extracted. Selecting and uploading an Outlook `.msg` email now reads its subject, sender, recipients, and body as expected.


### PR DESCRIPTION
## Summary

Uploading a `.msg` (Outlook) file crashed in the UI with:

```
Error processing file: TypeError: (intermediate value).default is not a constructor
    at processMsgFile (...)
```

After #1649 made `.msg` files *selectable*, actually uploading one failed at the point where the `MsgReader` class is instantiated.

### Root cause

`@kenjiuno/msgreader` is a **CommonJS** module that exposes its `MsgReader` class as the default export and sets both `__esModule: true` and `exports.default = MsgReader`. Because of this double-default, the bundler's CJS/ESM interop wraps the dynamic `import()` so that `mod.default` is the re-export **object** (`{ __esModule, default, …named }`), not the class — the real constructor lives at `mod.default.default`.

The previous code did `new MsgReader.default(arrayBuffer)`, which evaluated to `new <object>()` → "is not a constructor".

This contrasts with the sibling loaders (`loadJSZip`, `loadUTIF`) that correctly use `.default`: those packages assign the class directly to `module.exports` without `__esModule`, so there is no extra wrapping.

### Fix

`loadMsgReader()` now resolves the constructor by picking the first candidate among `mod.default.default`, `mod.default`, and `mod` that is actually a function, then `processMsgFile()` calls `new MsgReader(arrayBuffer)`. This is robust to however a given build (dev vs prod) surfaces the default export.

## Verification

Reproduced the interop empirically against the installed package (Node's CJS→ESM interop mirrors the failing production bundle's double-default shape):

```
typeof mod.default            = object
typeof mod.default.default    = function
OLD `new mod.default()`       = THROWS: mod.default is not a constructor
NEW `new MsgReader()`         = works; getFileData fn = true
```

Also confirmed the rest of `processMsgFile` is correct against the library's types: the constructor accepts `ArrayBuffer | DataView` (an `ArrayBuffer` is passed), and the `getFileData()` fields used (`subject`, `senderName`, `senderEmail`, `recipients[]`, `body`) all match `FieldsData`.

## Scope

Single-file change: `client/src/features/upload/utils/fileProcessing.js`. No dependency or config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLNwSktLzDYmBSVLxuh2JE

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLNwSktLzDYmBSVLxuh2JE)_