### PR TITLE
fix(renderer): pin classic JSX runtime so dynamic components render

### DIFF
--- a/client/src/shared/components/ReactComponentRenderer.jsx
+++ b/client/src/shared/components/ReactComponentRenderer.jsx
@@ -175,7 +175,13 @@ UserComponent;
           }
 
           transformed = transformMethod(fullCode, {
-            presets: ['react'],
+            // Force the classic JSX runtime so Babel emits React.createElement
+            // calls. The execution context below only injects `React`; it does
+            // not provide the react/jsx-runtime imports (_jsx/_jsxs) that the
+            // automatic runtime relies on. Newer @babel/standalone builds
+            // default to the automatic runtime, which produced
+            // "_jsxs is not defined" at render time.
+            presets: [['react', { runtime: 'classic' }]],
             plugins: []
           });
         } catch (babelError) {

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -557,3 +557,9 @@ Uploading an Outlook `.msg` email that has no plain-text part — most newslette
 - The body is resolved across every format Outlook may store it in: plain text, HTML (`PidTagHtml` / `PidTagBodyHtml`), and compressed RTF. HTML and RTF bodies are flattened to readable text, decoded using the message's declared code page so accented characters and umlauts survive.
 - Sender and recipient lines now prefer real SMTP addresses (e.g. `name@company.com`) over the internal Exchange directory address (`/O=EXCHANGELABS/...`) that Outlook stores for internal mail.
 - The extracted headers now also include the message **Date** and a list of **attachment names** (names only, not their content) for additional context.
+
+## Fix — Custom Rendered Components (e.g. NDA Risk Analyzer) No Longer Fail to Display
+
+Apps that render their results with a custom React component — such as the NDA Risk Analyzer's color-coded risk report — now display correctly again. Affected components had stopped rendering and showed a blank result or a `_jsxs is not defined` error in the browser console.
+
+- The in-browser JSX compiler used by dynamic page and result renderers now pins the classic React runtime. A newer build of the underlying Babel library had begun defaulting to a different JSX runtime that expects helper imports the sandbox does not provide, which broke any custom-rendered component. No configuration change is required.


### PR DESCRIPTION
## Summary

The NDA Risk Analyzer (and any other custom JSX result renderer or dynamic `.jsx` page) stopped rendering, failing at runtime with:

```
ReferenceError: _jsxs is not defined
    at UserComponent (...)
```

### Root cause

`ReactComponentRenderer` compiles JSX in the browser with `@babel/standalone` loaded from a CDN, using `presets: ['react']`. Recent `@babel/standalone` builds (Babel 8) changed the React preset to default to the **automatic** JSX runtime. The automatic runtime emits `_jsx` / `_jsxs` calls and expects them to be imported from `react/jsx-runtime`.

The renderer's execution sandbox only injects `React` (plus hooks) into a `new Function(...)` scope and strips all `import` statements, so `_jsx` / `_jsxs` are undefined — hence the crash.

### Fix

Pin the **classic** runtime explicitly so Babel emits `React.createElement`, which the sandbox already provides:

```js
presets: [['react', { runtime: 'classic' }]],
```

This is independent of which `@babel/standalone` version the CDN serves.

## Changes

- `client/src/shared/components/ReactComponentRenderer.jsx` — force `runtime: 'classic'` in the Babel transform, with an explanatory comment.
- `docs/releases/5.4.0/features.md` — changelog entry for the fix.

## Testing

- Verified there is only one in-browser JSX compile site, so the single change covers all dynamic renderers and pages.
- Lint could not run in this environment (dev dependencies not installed); the change is a scoped options tweak with no syntax impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzoH66cPKoNpV1qoujDL8W

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzoH66cPKoNpV1qoujDL8W)_