### PR TITLE
feat(chat): add ephemeral option so chats are never stored

### DIFF
--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -576,6 +576,29 @@ function AppFormEditor({
                     </p>
                   </div>
                 )}
+
+                {/* Ephemeral chat - Only for chat apps */}
+                {(app.type === 'chat' || !app.type) && (
+                  <div className="col-span-6">
+                    <div className="flex items-center">
+                      <input
+                        type="checkbox"
+                        checked={app.ephemeral === true}
+                        onChange={e => handleInputChange('ephemeral', e.target.checked)}
+                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+                      />
+                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                        {t('admin.apps.edit.ephemeral', 'Ephemeral chat')}
+                      </label>
+                    </div>
+                    <p className="mt-1 ml-6 text-xs text-gray-500 dark:text-gray-400">
+                      {t(
+                        'admin.apps.edit.ephemeralHelp',
+                        'When enabled, the chat is never stored. Messages exist only while the chat is open and are discarded when you switch apps or reload.'
+                      )}
+                    </p>
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/client/src/features/admin/pages/AdminAppEditPage.jsx
+++ b/client/src/features/admin/pages/AdminAppEditPage.jsx
@@ -97,6 +97,7 @@ function AdminAppEditPage() {
         },
         allowEmptyContent: false,
         sendChatHistory: true,
+        ephemeral: false,
         category: 'utility',
         inputMode: {
           type: 'singleline',
@@ -169,6 +170,7 @@ function AdminAppEditPage() {
         },
         allowEmptyContent: data.allowEmptyContent ?? false,
         sendChatHistory: data.sendChatHistory ?? true,
+        ephemeral: data.ephemeral ?? false,
         inputMode: {
           type: 'singleline',
           rows: 5,

--- a/client/src/features/apps/components/AppConfigForm.jsx
+++ b/client/src/features/apps/components/AppConfigForm.jsx
@@ -9,6 +9,7 @@ function AppConfigForm({
   selectedStyle,
   selectedOutputFormat,
   sendChatHistory,
+  ephemeral,
   temperature,
   thinkingEnabled,
   thinkingBudget,
@@ -19,6 +20,7 @@ function AppConfigForm({
   onStyleChange,
   onOutputFormatChange,
   onSendChatHistoryChange,
+  onEphemeralChange,
   onTemperatureChange,
   onThinkingEnabledChange,
   onThinkingBudgetChange,
@@ -181,6 +183,21 @@ function AppConfigForm({
               className="rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-indigo-500 h-4 w-4 mr-2"
             />
             {t('appConfig.includeChatHistory', 'Include chat history in requests')}
+          </label>
+        </div>
+      )}
+
+      {/* Ephemeral Chat Toggle */}
+      {app?.settings?.ephemeral?.enabled !== false && (
+        <div className="flex items-center">
+          <label className="flex items-center text-sm font-medium text-gray-700 dark:text-gray-300 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={ephemeral === true}
+              onChange={e => onEphemeralChange?.(e.target.checked)}
+              className="rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-indigo-500 h-4 w-4 mr-2"
+            />
+            {t('appConfig.ephemeral', 'Ephemeral chat (never stored)')}
           </label>
         </div>
       )}

--- a/client/src/features/apps/components/SharedAppHeader.jsx
+++ b/client/src/features/apps/components/SharedAppHeader.jsx
@@ -28,6 +28,7 @@ function SharedAppHeader({
   selectedStyle,
   selectedOutputFormat,
   sendChatHistory,
+  ephemeral,
   temperature,
   thinkingEnabled,
   thinkingBudget,
@@ -39,6 +40,7 @@ function SharedAppHeader({
   onStyleChange,
   onOutputFormatChange,
   onSendChatHistoryChange,
+  onEphemeralChange,
   onTemperatureChange,
   onThinkingEnabledChange,
   onThinkingBudgetChange,
@@ -169,6 +171,7 @@ function SharedAppHeader({
             selectedStyle={selectedStyle}
             selectedOutputFormat={selectedOutputFormat}
             sendChatHistory={sendChatHistory}
+            ephemeral={ephemeral}
             temperature={temperature}
             thinkingEnabled={thinkingEnabled}
             thinkingBudget={thinkingBudget}
@@ -179,6 +182,7 @@ function SharedAppHeader({
             onStyleChange={onStyleChange}
             onOutputFormatChange={onOutputFormatChange}
             onSendChatHistoryChange={onSendChatHistoryChange}
+            onEphemeralChange={onEphemeralChange}
             onTemperatureChange={onTemperatureChange}
             onThinkingEnabledChange={onThinkingEnabledChange}
             onThinkingBudgetChange={onThinkingBudgetChange}

--- a/client/src/features/apps/pages/AppChat.jsx
+++ b/client/src/features/apps/pages/AppChat.jsx
@@ -156,6 +156,7 @@ function AppChat({ preloadedApp = null }) {
     selectedOutputFormat,
     temperature,
     sendChatHistory,
+    ephemeral,
     thinkingEnabled,
     thinkingBudget,
     thinkingThoughts,
@@ -170,6 +171,7 @@ function AppChat({ preloadedApp = null }) {
     setSelectedOutputFormat,
     setTemperature,
     setSendChatHistory,
+    setEphemeral,
     setThinkingEnabled,
     setThinkingBudget,
     setThinkingThoughts,
@@ -434,13 +436,17 @@ function AppChat({ preloadedApp = null }) {
   } = useAppChat({
     appId,
     chatId: chatId.current,
-    onMessageComplete: handleMessageComplete
+    onMessageComplete: handleMessageComplete,
+    // Runtime-selectable: seeded from app.ephemeral but the user can toggle it in
+    // the chat settings. When on, nothing is persisted to browser storage.
+    ephemeral
   });
 
   // Resume conversation from conversation API on mount (iAssistant Conversation)
   const conversationResumed = useRef(false);
   useEffect(() => {
     if (conversationResumed.current || !app || messages.length > 0) return;
+    if (ephemeral) return;
 
     const existingConversationId = getConversationId(appId);
     if (!existingConversationId) return;
@@ -460,7 +466,7 @@ function AppChat({ preloadedApp = null }) {
         clearConversationId(appId);
       }
     })();
-  }, [app, appId, messages.length, loadServerMessages]);
+  }, [app, appId, messages.length, loadServerMessages, ephemeral]);
 
   // Auto-send message if send=true query parameter is present
   const autoSendTriggered = useRef(false);
@@ -1685,6 +1691,7 @@ function AppChat({ preloadedApp = null }) {
         selectedStyle={selectedStyle}
         selectedOutputFormat={selectedOutputFormat}
         sendChatHistory={sendChatHistory}
+        ephemeral={ephemeral}
         temperature={temperature}
         thinkingEnabled={thinkingEnabled}
         thinkingBudget={thinkingBudget}
@@ -1696,6 +1703,7 @@ function AppChat({ preloadedApp = null }) {
         onStyleChange={setSelectedStyle}
         onOutputFormatChange={setSelectedOutputFormat}
         onSendChatHistoryChange={setSendChatHistory}
+        onEphemeralChange={setEphemeral}
         onTemperatureChange={setTemperature}
         onThinkingEnabledChange={setThinkingEnabled}
         onThinkingBudgetChange={setThinkingBudget}
@@ -1786,6 +1794,7 @@ function AppChat({ preloadedApp = null }) {
                   onClarificationSubmit={handleClarificationSubmit}
                   onClarificationSkip={handleClarificationSkip}
                   onDocumentAction={handleDocumentAction}
+                  ephemeral={ephemeral}
                 />
               </div>
               <div className="flex-shrink-0 px-4 pt-2">

--- a/client/src/features/chat/components/CompareModeView.jsx
+++ b/client/src/features/chat/components/CompareModeView.jsx
@@ -30,7 +30,8 @@ const CompareModeView = forwardRef(function CompareModeView(
     onConnectIntegration,
     onClarificationSubmit,
     onClarificationSkip,
-    onDocumentAction
+    onDocumentAction,
+    ephemeral
   },
   ref
 ) {
@@ -102,6 +103,7 @@ const CompareModeView = forwardRef(function CompareModeView(
           onClarificationSubmit={onClarificationSubmit}
           onClarificationSkip={onClarificationSkip}
           onDocumentAction={onDocumentAction}
+          ephemeral={ephemeral}
         />
       ))}
     </div>

--- a/client/src/features/chat/components/ComparePanel.jsx
+++ b/client/src/features/chat/components/ComparePanel.jsx
@@ -38,7 +38,8 @@ const ComparePanel = forwardRef(function ComparePanel(
     onConnectIntegration,
     onClarificationSubmit,
     onClarificationSkip,
-    onDocumentAction
+    onDocumentAction,
+    ephemeral
   },
   ref
 ) {
@@ -53,7 +54,8 @@ const ComparePanel = forwardRef(function ComparePanel(
     onMessageComplete,
     // Compare panels share the same appId; persisting the iAssistant conversationId
     // (which is keyed by appId) would race between the panels. Keep these chats ephemeral.
-    persistConversationId: false
+    persistConversationId: false,
+    ephemeral
   });
 
   // Keep selectedModel in sync if the available models change (e.g. defaults arrive late).

--- a/client/src/features/chat/hooks/useAppChat.js
+++ b/client/src/features/chat/hooks/useAppChat.js
@@ -18,12 +18,15 @@ import { setConversationId } from '../../../utils/chatId';
  * @param {boolean} options.persistConversationId - Whether to persist iAssistant conversationId
  *   to localStorage (keyed by appId). Disable for ephemeral chats (e.g. compare mode panels)
  *   that share an appId so they don't race/overwrite each other. Defaults to true.
+ * @param {boolean} options.ephemeral - When true, chat is never persisted to browser storage
+ *   and no conversationId is stored.
  */
 function useAppChat({
   appId,
   chatId: initialChatId,
   onMessageComplete,
-  persistConversationId = true
+  persistConversationId = true,
+  ephemeral = false
 }) {
   const { t } = useTranslation();
   // Use the chatId directly instead of storing it in a ref
@@ -44,6 +47,9 @@ function useAppChat({
   const isCancellingRef = useRef(false);
   const messageMetadataRef = useRef(null); // Store metadata for the current message
 
+  // Never persist the iAssistant conversationId for ephemeral chats.
+  const shouldPersistConversationId = persistConversationId && !ephemeral;
+
   const {
     messages,
     messagesRef,
@@ -59,7 +65,7 @@ function useAppChat({
     getMessagesForApi,
     loadServerMessages,
     mergeCitations
-  } = useChatMessages(chatId); // Now this will properly react to chatId changes
+  } = useChatMessages(chatId, { ephemeral }); // Now this will properly react to chatId changes
 
   const cleanupEventSourceRef = useRef();
 
@@ -266,7 +272,7 @@ function useAppChat({
           }
           break;
         case 'conversation.id':
-          if (data?.conversationId && appId && persistConversationId) {
+          if (data?.conversationId && appId && shouldPersistConversationId) {
             setConversationId(appId, data.conversationId);
           }
           break;
@@ -361,7 +367,7 @@ function useAppChat({
       onMessageComplete,
       t,
       messagesRef,
-      persistConversationId
+      shouldPersistConversationId
     ]
   );
 

--- a/client/src/features/chat/hooks/useChatMessages.js
+++ b/client/src/features/chat/hooks/useChatMessages.js
@@ -6,9 +6,12 @@ import { useState, useCallback, useRef, useEffect } from 'react';
  * Each new browser tab will start with a new chat session
  *
  * @param {string} chatId - The ID of the current chat for storage purposes
+ * @param {Object} [options] - Additional options
+ * @param {boolean} [options.ephemeral] - When true, messages are never persisted to
+ *   sessionStorage and are reset to empty whenever the chatId changes.
  * @returns {Object} Chat message management functions and state
  */
-function useChatMessages(chatId = 'default') {
+function useChatMessages(chatId = 'default', { ephemeral = false } = {}) {
   // Use sessionStorage for persistence during page refreshes
   const storageKey = `ai_hub_chat_messages_${chatId}`;
 
@@ -17,6 +20,7 @@ function useChatMessages(chatId = 'default') {
 
   // Initialize state from sessionStorage if available
   const loadInitialMessages = () => {
+    if (ephemeral) return [];
     try {
       const storedData = sessionStorage.getItem(storageKey);
       console.log(
@@ -67,6 +71,11 @@ function useChatMessages(chatId = 'default') {
         chatId,
         '- loading messages for new chat'
       );
+      if (ephemeral) {
+        setMessages([]);
+        prevChatIdRef.current = chatId;
+        return;
+      }
       // Load messages for the new chatId
       const newStorageKey = `ai_hub_chat_messages_${chatId}`;
       try {
@@ -95,7 +104,7 @@ function useChatMessages(chatId = 'default') {
       }
     }
     prevChatIdRef.current = chatId;
-  }, [chatId]);
+  }, [chatId, ephemeral]);
 
   // Use a ref to store a copy of messages for read-only operations
   const messagesRef = useRef(messages);
@@ -107,6 +116,15 @@ function useChatMessages(chatId = 'default') {
 
   // Save messages to sessionStorage whenever they change (exclude greeting messages)
   useEffect(() => {
+    if (ephemeral) {
+      // Ephemeral chats are never persisted; clear any stray data.
+      try {
+        sessionStorage.removeItem(storageKey);
+      } catch {
+        /* ignore */
+      }
+      return;
+    }
     try {
       // Filter out greeting messages for persistence
       const persistableMessages = messages.filter(msg => !msg.isGreeting);
@@ -174,7 +192,7 @@ function useChatMessages(chatId = 'default') {
         }
       }
     }
-  }, [messages, storageKey]);
+  }, [messages, storageKey, ephemeral]);
 
   /**
    * Add a user message to the chat

--- a/client/src/shared/hooks/useAppSettings.js
+++ b/client/src/shared/hooks/useAppSettings.js
@@ -17,6 +17,7 @@ function useAppSettings(appId, app) {
   const [selectedOutputFormat, setSelectedOutputFormat] = useState('markdown');
   const [temperature, setTemperature] = useState(0.7);
   const [sendChatHistory, setSendChatHistory] = useState(true);
+  const [ephemeral, setEphemeral] = useState(false);
   const [thinkingEnabled, setThinkingEnabled] = useState(null);
   const [thinkingBudget, setThinkingBudget] = useState(null);
   const [thinkingThoughts, setThinkingThoughts] = useState(null);
@@ -86,6 +87,7 @@ function useAppSettings(appId, app) {
       temperature: app.preferredTemperature || 0.7,
       selectedOutputFormat: app.preferredOutputFormat || 'markdown',
       sendChatHistory: true,
+      ephemeral: app.ephemeral ?? false,
       thinkingEnabled: app.thinking?.enabled ?? null,
       thinkingBudget: app.thinking?.budget ?? null,
       thinkingThoughts: app.thinking?.thoughts ?? null,
@@ -101,6 +103,7 @@ function useAppSettings(appId, app) {
     setTemperature(initialState.temperature);
     setSelectedOutputFormat(initialState.selectedOutputFormat);
     setSendChatHistory(initialState.sendChatHistory);
+    setEphemeral(initialState.ephemeral);
     setThinkingEnabled(initialState.thinkingEnabled);
     setThinkingBudget(initialState.thinkingBudget);
     setThinkingThoughts(initialState.thinkingThoughts);
@@ -128,6 +131,7 @@ function useAppSettings(appId, app) {
       if (savedSettings.temperature) setTemperature(savedSettings.temperature);
       if (savedSettings.sendChatHistory !== undefined)
         setSendChatHistory(savedSettings.sendChatHistory);
+      if (savedSettings.ephemeral !== undefined) setEphemeral(savedSettings.ephemeral);
       if (savedSettings.thinkingEnabled !== undefined)
         setThinkingEnabled(savedSettings.thinkingEnabled);
       if (savedSettings.thinkingBudget !== undefined)
@@ -154,6 +158,7 @@ function useAppSettings(appId, app) {
         selectedOutputFormat,
         temperature,
         sendChatHistory,
+        ephemeral,
         thinkingEnabled,
         thinkingBudget,
         thinkingThoughts,
@@ -172,6 +177,7 @@ function useAppSettings(appId, app) {
     selectedOutputFormat,
     temperature,
     sendChatHistory,
+    ephemeral,
     thinkingEnabled,
     thinkingBudget,
     thinkingThoughts,
@@ -189,6 +195,7 @@ function useAppSettings(appId, app) {
     selectedOutputFormat,
     temperature,
     sendChatHistory,
+    ephemeral,
     thinkingEnabled,
     thinkingBudget,
     thinkingThoughts,
@@ -206,6 +213,7 @@ function useAppSettings(appId, app) {
     setSelectedOutputFormat,
     setTemperature,
     setSendChatHistory,
+    setEphemeral,
     setThinkingEnabled,
     setThinkingBudget,
     setThinkingThoughts,

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -485,7 +485,7 @@ The following fields are specific to chat apps and are not used for redirect or 
 - `settings`, `inputMode`, `upload`, `features`
 - `greeting`, `starterPrompts`, `messagePlaceholder`
 - `allowEmptyContent`, `allowedModels`, `disallowModelSelection`
-- `sources`, `thinking`
+- `sources`, `thinking`, `ephemeral`
 
 ## Basic App Structure
 
@@ -537,6 +537,7 @@ Each app is defined with the following essential properties:
 | `preferredTemperature`  | Number  | Optional. Temperature setting (0.0-2.0) controlling randomness                                                           |
 | `sendChatHistory`       | Boolean | Optional. Whether to include chat history in API requests. Default: `true`                                               |
 | `autoStart`             | Boolean | Optional. Automatically start the chat as soon as the app opens (sends the configured `prompt` without user input). Default: `false` |
+| `ephemeral`             | Boolean | Optional. When `true`, the chat is never stored. Messages exist only in memory while the chat is open and are discarded when the user switches apps or reloads the page. No chat history or iAssistant conversation ID is written to browser storage. This is the default value for the runtime toggle users see in the chat configuration panel (hide it with `settings.ephemeral.enabled: false`). Default: `false` |
 | `allowEmptyContent`     | Boolean | Optional. Allow users to submit the form without entering content in the main input field. Default: `false`              |
 | `allowedModels`         | Array   | Optional. Array of model IDs to restrict which models can be selected for this app                                       |
 | `disallowModelSelection`| Boolean | Optional. Hide the model selector so users cannot change the model. Default: `false`                                     |
@@ -968,6 +969,7 @@ The `thinking` property enables extended thinking for models that support it (e.
 #### Other Options
 
 - `autoStart`: Automatically begin the chat on app open, sending the configured `prompt` immediately
+- `ephemeral`: Never store the chat. Messages live only in memory while the chat is open and are discarded on app switch or reload. Useful for privacy-sensitive apps such as iFinder document chats
 - `allowEmptyContent`: Allow submission without content input
 - `allowedModels`: Restrict which models can be used with this app
 - `disallowModelSelection`: Prevent user from changing the model

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -563,3 +563,13 @@ Uploading an Outlook `.msg` email that has no plain-text part — most newslette
 Apps that render their results with a custom React component — such as the NDA Risk Analyzer's color-coded risk report — now display correctly again. Affected components had stopped rendering and showed a blank result or a `_jsxs is not defined` error in the browser console.
 
 - The in-browser JSX compiler used by dynamic page and result renderers now pins the classic React runtime. A newer build of the underlying Babel library had begun defaulting to a different JSX runtime that expects helper imports the sandbox does not provide, which broke any custom-rendered component. No configuration change is required.
+
+## Ephemeral Chats — Conversations That Are Never Stored
+
+Apps can now be marked **ephemeral** so their chats are never persisted anywhere. Messages exist only in memory while the chat is open and are discarded the moment the user switches to another app or reloads the page — nothing is written to the browser's session/local storage, and for iFinder/iAssistant apps the backend conversation is created as ephemeral so no server-side record is kept.
+
+- Enable it per app with the new **Ephemeral chat** toggle in the admin app editor, or by setting `"ephemeral": true` in the app configuration.
+- End users can also switch it on or off at runtime from the chat's configuration panel (the **Ephemeral chat** checkbox), seeded from the app's default. Admins can hide this control per app with `"settings": { "ephemeral": { "enabled": false } }`.
+- The built-in **iFinder Document Actions** app now ships with ephemeral enabled by default, so document conversations leave no trace.
+- The flag is independent of chat history: when persistent chat history arrives in the future, ephemeral apps will remain opted out.
+- Default is `false`, so all existing apps keep their current behaviour.

--- a/server/adapters/iassistant-conversation.js
+++ b/server/adapters/iassistant-conversation.js
@@ -54,7 +54,8 @@ class IAssistantConversationAdapterClass extends BaseAdapter {
       tools: appConfig.tools || modelConfig.tools || [],
       scope: appConfig.scope || modelConfig.scope,
       labels: appConfig.labels || modelConfig.labels,
-      ephemeral: appConfig.ephemeral ?? modelConfig.ephemeral ?? false,
+      ephemeral:
+        appConfig.ephemeral ?? options.appConfig?.ephemeral ?? modelConfig.ephemeral ?? false,
       extraContext: appConfig.extraContext || modelConfig.extraContext,
       systemPromptPreamble: appConfig.systemPromptPreamble || modelConfig.systemPromptPreamble
     };

--- a/server/defaults/apps/ifinder-document-actions.json
+++ b/server/defaults/apps/ifinder-document-actions.json
@@ -18,6 +18,7 @@
   "preferredStyle": "normal",
   "preferredTemperature": 0.5,
   "sendChatHistory": true,
+  "ephemeral": true,
   "tools": ["iFinder_getMetadata", "iFinder_getContent"],
   "settings": {
     "enabled": true,

--- a/server/validators/appConfigSchema.js
+++ b/server/validators/appConfigSchema.js
@@ -88,6 +88,11 @@ const settingsSchema = z
         enabled: z.boolean().optional().default(true)
       })
       .optional(),
+    ephemeral: z
+      .object({
+        enabled: z.boolean().optional().default(true)
+      })
+      .optional(),
     style: z
       .object({
         enabled: z.boolean().optional().default(true)
@@ -341,6 +346,7 @@ const baseAppConfigSchema = z.object({
   disallowModelSelection: z.boolean().optional().default(false),
   allowEmptyContent: z.boolean().optional().default(false),
   autoStart: z.boolean().optional().default(false),
+  ephemeral: z.boolean().optional().default(false),
   websearch: websearchSchema,
   tools: z.array(z.string()).optional(),
   workflows: z.array(z.string()).optional(),

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -405,6 +405,7 @@
     "title": "Konfiguration",
     "save": "Speichern",
     "cancel": "Abbrechen",
+    "ephemeral": "Flüchtiger Chat (wird nie gespeichert)",
     "model": "Modell",
     "selectModel": "Modell auswählen",
     "defaultModel": "Standardmodell",
@@ -1728,6 +1729,8 @@
       "edit": {
         "autoStart": "Konversation automatisch starten",
         "autoStartHelp": "Wenn aktiviert, startet die App automatisch die Konversation, wenn der Chat geöffnet oder zurückgesetzt wird",
+        "ephemeral": "Flüchtiger Chat",
+        "ephemeralHelp": "Wenn aktiviert, wird der Chat nie gespeichert. Nachrichten existieren nur, solange der Chat geöffnet ist, und werden verworfen, wenn Sie die App wechseln oder neu laden.",
         "mcpTools": {
           "title": "MCP-Server-Tools",
           "desc": "Aktivieren Sie Tools, die von verbundenen MCP-Servern bereitgestellt werden, für diese App.",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1479,6 +1479,8 @@
       "edit": {
         "autoStart": "Auto-start conversation",
         "autoStartHelp": "When enabled, the app will automatically start the conversation when the chat is opened or reset",
+        "ephemeral": "Ephemeral chat",
+        "ephemeralHelp": "When enabled, the chat is never stored. Messages exist only while the chat is open and are discarded when you switch apps or reload.",
         "mcpTools": {
           "title": "MCP server tools",
           "desc": "Enable tools provided by connected MCP servers for this app.",
@@ -1771,6 +1773,7 @@
     "title": "Configuration",
     "save": "Save",
     "cancel": "Cancel",
+    "ephemeral": "Ephemeral chat (never stored)",
     "model": "Model",
     "selectModel": "Select Model",
     "defaultModel": "Default model",


### PR DESCRIPTION
## Summary

Implements #1655 — adds an **ephemeral** option to chats so they are never stored. When enabled, a chat exists only in memory while it is open; switching to another app or reloading the page discards it. Nothing is written to browser storage (no chat messages, no iAssistant conversation ID), and for iFinder/iAssistant apps the backend conversation is created as ephemeral.

The flag is intentionally independent of chat history so it remains meaningful once persistent chat history is introduced.

## What changed

**Config schema** (`server/validators/appConfigSchema.js`)
- New top-level `ephemeral: boolean` (default `false`).
- New `settings.ephemeral.enabled` gate to control whether the runtime toggle is shown to users.

**Client behavior**
- `useChatMessages` — when ephemeral, never reads/writes `sessionStorage`, resets to empty on chat switch, and actively clears any stray persisted data.
- `useAppChat` — forwards `ephemeral`; never persists the iAssistant `conversationId` when ephemeral.
- `AppChat` — skips conversation resume for ephemeral chats.
- Compare mode — `ephemeral` is propagated into each `ComparePanel`.

**Runtime user selection** (per the follow-up requirement)
- Users can toggle **Ephemeral chat** directly from the chat configuration panel. The value is seeded from the app's default (`app.ephemeral`) via `useAppSettings`, and the choice is remembered per app for the session.
- Admins can hide the runtime control per app with `settings.ephemeral.enabled: false`.
- Wired through `SharedAppHeader` → `AppConfigForm`.

**Admin**
- New "Ephemeral chat" toggle in the app editor (`AppFormEditor`), with default wiring in `AdminAppEditPage`.

**Server**
- `iassistant-conversation` adapter: the top-level app `ephemeral` now flows into iAssistant conversation creation, so iFinder/iAssistant backends create the conversation as ephemeral. (`ConversationStateManager` is already in-memory only.)

**iFinder default app**
- `ifinder-document-actions.json` ships with `ephemeral: true`.

**Docs & i18n**
- `docs/apps.md`, changelog entry in `docs/releases/5.4.0/features.md`, and `appConfig.ephemeral` / `admin.apps.edit.ephemeral*` keys in `en.json` / `de.json`.

## Design notes / scope
- The runtime toggle is a **client-side privacy control** (never stored in the browser, deleted on app switch). Server-side iAssistant conversation ephemerality is driven by the **app config** flag, which fully covers the "ephemeral flag is set for the iFinder" requirement from the issue. Threading a per-request runtime override through the full server request pipeline was intentionally left out to keep the change focused; it can be a follow-up if per-session server-side ephemerality is desired for iAssistant apps.

## Verification
- Zod schema accepts both `ephemeral` and `settings.ephemeral.enabled`.
- `prettier` clean; `eslint` reports 0 errors on changed files (only pre-existing warning classes).
- Server boots and loads the iFinder app (with `ephemeral: true`) without validation errors.

Closes #1655

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FMNPC6yF15DXcUpAacfmUY

---
_Generated by [Claude Code](https://claude.ai/code/session_01FMNPC6yF15DXcUpAacfmUY)_