### PR TITLE
feat(workflows): per-node thinking control + fix stellungnahmen-ifinder refine dead-end

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -74,6 +74,41 @@ so admins control reach by listing the right groups on the app and on
 App→App nesting is forbidden: when an agent calls an app internally, all
 `app__*` tools are stripped from the nested call's tool list.
 
+## Per-node thinking override
+
+LLM-backed nodes (`prompt`, `planner`, `verifier`, `query-plan`) accept an
+optional `config.thinking` block that overrides the selected model's thinking
+config **for that node's LLM call only**. It mirrors the model-config
+`thinking` shape:
+
+```jsonc
+// A fast, deterministic JSON decision node — disable reasoning entirely:
+"config": {
+  "thinking": { "enabled": false }
+}
+
+// Gemini 3.x — dial reasoning down instead of off:
+"config": { "thinking": { "enabled": true, "level": "low" } }
+
+// Gemini 2.5 — explicit token budget:
+"config": { "thinking": { "enabled": true, "budget": 512, "thoughts": false } }
+```
+
+Why it matters: thinking models (e.g. the `gemini-flash-latest` alias) count
+reasoning tokens against `maxTokens`. On a node that only needs to emit a small
+JSON verdict, unbounded thinking (`budget: -1`) is both slow (tens of seconds
+per call) and prone to runaway repetition that truncates the JSON. Setting
+`thinking: { enabled: false }` on such a node makes it fast and reliable.
+
+Semantics and limits:
+
+- The node override wins over the model's `thinking` config for that call.
+- Fields are individually optional — set only what you want to change.
+- The adapter gates thinking on `model.thinking.enabled`, so a node can
+  **disable or tune** thinking on a thinking-enabled model, but cannot
+  **force-enable** it on a model whose config has thinking off.
+- No-op for providers that don't support thinking (e.g. Anthropic).
+
 ## Workflow shapes
 
 The Profile editor lets you pick the underlying shape implicitly:

--- a/docs/releases/5.4.0/features.md
+++ b/docs/releases/5.4.0/features.md
@@ -69,6 +69,14 @@ The canonical use is **iFinder corpus discovery**: `iFinder_discover` probes a s
 
 Server startup rebuilds each profile's embedded workflow so it picks up the canonical `synthesize → memory-compose → memory-finalize` chain and a cleaned planner prompt. This fixes profiles where memory was never written (missing `memory-compose` node) or the planner emitted a redundant review task. **V053** also normalizes the `${$.data.currentInboxItem}` template to `.text` so the planner receives real content instead of `"[object Object]"`. The prior definition is snapshotted to `workflow._preMigrationV052Backup`; profiles with `workflow.ref === "external"` are untouched; both migrations are idempotent.
 
+### Per-node thinking control in workflows
+
+Workflow authors can set a `thinking` block on any LLM-backed node (`prompt`, `planner`, `verifier`, `query-plan`) to override the model's reasoning **for that node's call only**. This keeps fast, deterministic decision nodes fast: a node that only emits a small JSON verdict no longer burns tens of seconds — or truncates its own output — on a thinking model's unbounded reasoning.
+
+- Same shape as the model config: `"thinking": { "enabled": false }` turns reasoning off; `{ "enabled": true, "level": "low" }` (Gemini 3) or `{ "enabled": true, "budget": 512 }` (Gemini 2.5) dials it down.
+- Overrides the model per call. It can disable or tune thinking on a thinking-enabled model, but cannot force-enable it on a model that has thinking off; no-op for providers without thinking (e.g. Anthropic).
+- Applied to the `stellungnahmen-review-ifinder` search-refine decision node, which had been spending ~40s per round (and occasionally looping) on the moving `gemini-flash-latest` alias after Google repointed it to a thinking model.
+
 ## Admin experience
 
 ### Redesigned navigation — collapsible left-rail sidebar

--- a/server/defaults/workflows/stellungnahmen-review-ifinder.json
+++ b/server/defaults/workflows/stellungnahmen-review-ifinder.json
@@ -312,12 +312,15 @@
           "de": "Sie sind ein Korpus-Vollständigkeits-Schiedsrichter. Sie prüfen die Kandidatenliste und den Nutzer-Fokus und entscheiden, ob der Korpus breit genug für eine revisionssichere Stellungnahmen-Auswertung ist. Antworten Sie NUR mit JSON."
         },
         "prompt": {
-          "en": "## User focus\n{{userPrompt}}\n\n## Current query plan\nTopics: {{#each _queryPlan.topics}}\"{{this}}\"  {{/each}}\nExpansions: {{#each _queryPlan.expansions}}\"{{this}}\"  {{/each}}\n\n## Candidates so far ({{_corpus.length}} hits in round {{_searchIterations}}/{{_maxSearchIterations}})\n{{#each _corpus}}\n- {{this.displayName}}  ({{this.docId}})  source={{this.sourceName}}  query=\"{{this.matchedQuery}}\"\n{{/each}}\n\n## Decision\nReturn JSON:\n{\n  \"done\": <bool>,                          // true if corpus is sufficient OR you are out of iterations\n  \"reason\": \"<one sentence>\",\n  \"extraTopics\": [\"<additional iFinder query string>\"]  // empty when done=true\n}\n\nRules: if `_searchIterations >= _maxSearchIterations`, ALWAYS return `done: true` (we have hit the cap). Otherwise: if the candidate list clearly misses obvious paragraphs/themes from the user focus, propose 1-3 extra topics; if not, return done=true.",
-          "de": "## Nutzer-Fokus\n{{userPrompt}}\n\n## Aktueller Suchplan\nThemen: {{#each _queryPlan.topics}}\"{{this}}\"  {{/each}}\nErweiterungen: {{#each _queryPlan.expansions}}\"{{this}}\"  {{/each}}\n\n## Bisherige Kandidaten ({{_corpus.length}} Treffer in Runde {{_searchIterations}}/{{_maxSearchIterations}})\n{{#each _corpus}}\n- {{this.displayName}}  ({{this.docId}})  quelle={{this.sourceName}}  query=\"{{this.matchedQuery}}\"\n{{/each}}\n\n## Entscheidung\nJSON zurückgeben:\n{\n  \"done\": <bool>,\n  \"reason\": \"<ein Satz>\",\n  \"extraTopics\": [\"<zusätzliche iFinder-Anfrage>\"]\n}\n\nRegeln: wenn `_searchIterations >= _maxSearchIterations`, IMMER `done: true` zurückgeben (Obergrenze erreicht). Andernfalls: wenn die Kandidatenliste offensichtliche Paragraphen/Themen aus dem Fokus übergeht, 1-3 zusätzliche Themen vorschlagen; sonst `done: true` zurückgeben."
+          "en": "## User focus\n{{userPrompt}}\n\n## Current query plan\nTopics: {{#each _queryPlan.topics}}\"{{this}}\"  {{/each}}\nExpansions: {{#each _queryPlan.expansions}}\"{{this}}\"  {{/each}}\n\n## Candidates so far ({{_corpus.length}} hits in round {{_searchIterations}}/{{_maxSearchIterations}})\n{{#each _corpus}}\n- {{this.displayName}}  ({{this.docId}})  source={{this.sourceName}}  query=\"{{this.matchedQuery}}\"\n{{/each}}\n\n## Decision\nReturn JSON:\n{\n  \"done\": <bool>,                          // true if corpus is sufficient OR you are out of iterations\n  \"reason\": \"<one short sentence, max 25 words — never repeat yourself>\",\n  \"extraTopics\": [\"<additional iFinder query string>\"]  // empty when done=true\n}\n\nRules: if `_searchIterations >= _maxSearchIterations`, ALWAYS return `done: true` (we have hit the cap). Otherwise: if the candidate list clearly misses obvious paragraphs/themes from the user focus, propose 1-3 extra topics; if not, return done=true.",
+          "de": "## Nutzer-Fokus\n{{userPrompt}}\n\n## Aktueller Suchplan\nThemen: {{#each _queryPlan.topics}}\"{{this}}\"  {{/each}}\nErweiterungen: {{#each _queryPlan.expansions}}\"{{this}}\"  {{/each}}\n\n## Bisherige Kandidaten ({{_corpus.length}} Treffer in Runde {{_searchIterations}}/{{_maxSearchIterations}})\n{{#each _corpus}}\n- {{this.displayName}}  ({{this.docId}})  quelle={{this.sourceName}}  query=\"{{this.matchedQuery}}\"\n{{/each}}\n\n## Entscheidung\nJSON zurückgeben:\n{\n  \"done\": <bool>,\n  \"reason\": \"<ein kurzer Satz, max. 25 Wörter — niemals wiederholen>\",\n  \"extraTopics\": [\"<zusätzliche iFinder-Anfrage>\"]\n}\n\nRegeln: wenn `_searchIterations >= _maxSearchIterations`, IMMER `done: true` zurückgeben (Obergrenze erreicht). Andernfalls: wenn die Kandidatenliste offensichtliche Paragraphen/Themen aus dem Fokus übergeht, 1-3 zusätzliche Themen vorschlagen; sonst `done: true` zurückgeben."
         },
         "outputVariable": "_refineDecision",
+        "thinking": {
+          "enabled": false
+        },
         "maxIterations": 1,
-        "maxTokens": 1000,
+        "maxTokens": 1024,
         "outputSchema": {
           "type": "object",
           "properties": {
@@ -755,7 +758,7 @@
       "target": "init-cursor",
       "condition": {
         "type": "expression",
-        "expression": "$.data._refineDecision.done === true || $.data._searchIterations >= $.data._maxSearchIterations"
+        "expression": "$.data._refineDecision.done !== false || $.data._searchIterations >= $.data._maxSearchIterations"
       }
     },
     {

--- a/server/migrations/V065__fix_stellungnahmen_ifinder_refine_decision.js
+++ b/server/migrations/V065__fix_stellungnahmen_ifinder_refine_decision.js
@@ -1,0 +1,107 @@
+export const version = '065';
+export const description = 'fix_stellungnahmen_ifinder_refine_decision';
+
+// Existing installs already have contents/workflows/stellungnahmen-review-ifinder.json
+// on disk (gitignored runtime data), so the fixed server/defaults copy does NOT
+// reach them via performInitialSetup. This migration patches the refine-decision
+// referee node in place to fix a dead-end/loop:
+//
+//   1. Routing resilience — when the LLM decision is unparseable (a truncated
+//      structured-output response becomes a raw string, so `.done` is undefined),
+//      the old `e-refine-done` edge (done === true || iters >= max) did not match
+//      AND the `needs-more` edge did not match → the run silently completed right
+//      after the search. The new `done !== false || …` makes any non-false /
+//      unparseable decision proceed to the document loop.
+//   2. Disable thinking on this fast JSON referee — gemini-flash-latest (a moving
+//      alias now backed by an unbounded-thinking model, budget:-1) spent ~40s and
+//      looped its reason field into a truncated response. Thinking off makes it
+//      fast and terse. (Requires per-node thinking support; a no-op on providers
+//      without thinking.)
+//   3. Cap the output budget so a runaway reason truncates fast (~1-2s) and the
+//      routing fix proceeds, instead of filling a huge buffer. Only lowers a
+//      pathologically-large cap; small/tuned values are left alone.
+//   4. Terse, no-repeat reason hint.
+//
+// All steps are idempotent and match exact known-old values, so admin
+// customizations and already-fixed installs (fresh installs seeded from the fixed
+// defaults) are left untouched.
+
+const WF = 'workflows/stellungnahmen-review-ifinder.json';
+
+const OLD_DONE_EXPR =
+  '$.data._refineDecision.done === true || $.data._searchIterations >= $.data._maxSearchIterations';
+const NEW_DONE_EXPR =
+  '$.data._refineDecision.done !== false || $.data._searchIterations >= $.data._maxSearchIterations';
+
+const REASON_HINTS = [
+  {
+    old: '"reason": "<one sentence>"',
+    new: '"reason": "<one short sentence, max 25 words — never repeat yourself>"'
+  },
+  {
+    old: '"reason": "<ein Satz>"',
+    new: '"reason": "<ein kurzer Satz, max. 25 Wörter — niemals wiederholen>"'
+  }
+];
+
+const MAX_TOKENS = 1024;
+
+export async function precondition(ctx) {
+  return await ctx.fileExists(WF);
+}
+
+export async function up(ctx) {
+  const wf = await ctx.readJson(WF);
+  if (!wf || !Array.isArray(wf.nodes) || !Array.isArray(wf.edges)) {
+    ctx.warn(`${WF} missing nodes/edges; skipping`);
+    return;
+  }
+
+  let changed = false;
+
+  // 1. Routing resilience — only replace the exact known-bad expression.
+  for (const edge of wf.edges) {
+    if (edge?.id === 'e-refine-done' && edge?.condition?.expression === OLD_DONE_EXPR) {
+      edge.condition.expression = NEW_DONE_EXPR;
+      changed = true;
+    }
+  }
+
+  const refine = wf.nodes.find(n => n?.id === 'refine-decision');
+  if (refine && refine.config && typeof refine.config === 'object') {
+    // 2. Disable thinking (only if the node has no thinking block yet).
+    if (refine.config.thinking === undefined) {
+      refine.config.thinking = { enabled: false };
+      changed = true;
+    }
+
+    // 3. Cap an oversized output budget.
+    if (typeof refine.config.maxTokens === 'number' && refine.config.maxTokens > MAX_TOKENS) {
+      refine.config.maxTokens = MAX_TOKENS;
+      changed = true;
+    }
+
+    // 4. Terse, no-repeat reason hint (replace exact old placeholders).
+    if (refine.config.prompt && typeof refine.config.prompt === 'object') {
+      for (const lang of Object.keys(refine.config.prompt)) {
+        const text = refine.config.prompt[lang];
+        if (typeof text !== 'string') continue;
+        let next = text;
+        for (const { old, new: repl } of REASON_HINTS) next = next.replace(old, repl);
+        if (next !== text) {
+          refine.config.prompt[lang] = next;
+          changed = true;
+        }
+      }
+    }
+  }
+
+  if (changed) {
+    await ctx.writeJson(WF, wf);
+    ctx.log(
+      'Patched stellungnahmen-review-ifinder refine-decision (routing, thinking, maxTokens, reason hint)'
+    );
+  } else {
+    ctx.log('stellungnahmen-review-ifinder refine-decision already up to date; no changes');
+  }
+}

--- a/server/services/workflow/WorkflowLLMHelper.js
+++ b/server/services/workflow/WorkflowLLMHelper.js
@@ -21,20 +21,7 @@ import ApiKeyVerifier from '../../utils/ApiKeyVerifier.js';
 import ErrorHandler from '../../utils/ErrorHandler.js';
 import logger from '../../utils/logger.js';
 import { createParser } from 'eventsource-parser';
-
-/**
- * Valid adapter options as defined in BaseAdapter.extractRequestOptions()
- * @type {string[]}
- */
-const VALID_ADAPTER_OPTIONS = [
-  'temperature',
-  'stream',
-  'maxTokens',
-  'tools',
-  'toolChoice',
-  'responseFormat',
-  'responseSchema'
-];
+import { filterAdapterOptions as filterAdapterOptionsPure } from './adapterOptions.js';
 
 /**
  * Default number of retries for transient LLM errors. A brief Google 503
@@ -217,15 +204,7 @@ export class WorkflowLLMHelper {
    * @returns {Object} Filtered options with only valid adapter parameters
    */
   filterAdapterOptions(options = {}) {
-    const filtered = {};
-
-    for (const key of VALID_ADAPTER_OPTIONS) {
-      if (options[key] !== undefined) {
-        filtered[key] = options[key];
-      }
-    }
-
-    return filtered;
+    return filterAdapterOptionsPure(options);
   }
 
   /**

--- a/server/services/workflow/adapterOptions.js
+++ b/server/services/workflow/adapterOptions.js
@@ -1,0 +1,47 @@
+/**
+ * Allowlist + filter for the per-request options a workflow node may forward to
+ * an LLM adapter. Kept as a standalone, dependency-free module so it can be
+ * unit-tested without importing the whole adapter chain.
+ *
+ * Base keys mirror `BaseAdapter.extractRequestOptions()`. The `thinking*` keys
+ * are the per-request thinking overrides the adapters read directly (e.g.
+ * `server/adapters/google.js` reads `options.thinkingEnabled` /
+ * `options.thinkingLevel` / `options.thinkingBudget` / `options.thinkingThoughts`).
+ * They are produced from a node's `thinking` config block by
+ * `thinkingConfigToOptions()` in `./thinkingOptions.js`.
+ *
+ * @type {string[]}
+ */
+export const VALID_ADAPTER_OPTIONS = [
+  'temperature',
+  'stream',
+  'maxTokens',
+  'tools',
+  'toolChoice',
+  'responseFormat',
+  'responseSchema',
+  // Per-node thinking overrides (see thinkingOptions.js).
+  'thinkingEnabled',
+  'thinkingLevel',
+  'thinkingBudget',
+  'thinkingThoughts'
+];
+
+/**
+ * Copy only the allowlisted adapter options from an arbitrary options object.
+ * Undefined values are dropped; `false`/`0` are preserved.
+ *
+ * @param {Object} [options={}] - Raw request options
+ * @returns {Object} Filtered options containing only valid adapter parameters
+ */
+export function filterAdapterOptions(options = {}) {
+  const filtered = {};
+  for (const key of VALID_ADAPTER_OPTIONS) {
+    if (options[key] !== undefined) {
+      filtered[key] = options[key];
+    }
+  }
+  return filtered;
+}
+
+export default { VALID_ADAPTER_OPTIONS, filterAdapterOptions };

--- a/server/services/workflow/executors/PlannerNodeExecutor.js
+++ b/server/services/workflow/executors/PlannerNodeExecutor.js
@@ -18,6 +18,7 @@
 
 import { BaseNodeExecutor } from './BaseNodeExecutor.js';
 import WorkflowLLMHelper from '../WorkflowLLMHelper.js';
+import { thinkingConfigToOptions } from '../thinkingOptions.js';
 import { SubWorkflowMaterializer } from '../SubWorkflowMaterializer.js';
 import { dedupeCitations } from '../citationUtils.js';
 import configCache from '../../../configCache.js';
@@ -1021,7 +1022,9 @@ Output rules:
         temperature: 0.7,
         responseFormat: 'json',
         responseSchema: plannerResponseSchema,
-        maxTokens
+        maxTokens,
+        // Per-node thinking override (no-op when the node sets no `thinking`).
+        ...thinkingConfigToOptions(config.thinking)
       },
       language
     });

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -15,6 +15,7 @@
  */
 
 import { BaseNodeExecutor } from './BaseNodeExecutor.js';
+import { thinkingConfigToOptions } from '../thinkingOptions.js';
 import ChatService from '../../chat/ChatService.js';
 import { normalizeToolName } from '../../../adapters/toolCalling/index.js';
 import { actionTracker } from '../../../actionTracker.js';
@@ -1529,7 +1530,11 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
             maxTokens,
             tools: availableTools.length > 0 && !forceFinish ? availableTools : undefined,
             responseSchema,
-            responseFormat
+            responseFormat,
+            // Per-node thinking override: lets a node disable or dial down the
+            // model's reasoning (e.g. a fast JSON decision node). No-op when the
+            // node declares no `thinking` block.
+            ...thinkingConfigToOptions(config.thinking)
             // Note: user and chatId are intentionally NOT passed here
             // They are not valid adapter options and would corrupt provider request bodies
           },

--- a/server/services/workflow/executors/QueryPlanNodeExecutor.js
+++ b/server/services/workflow/executors/QueryPlanNodeExecutor.js
@@ -20,6 +20,7 @@
 
 import { BaseNodeExecutor } from './BaseNodeExecutor.js';
 import WorkflowLLMHelper from '../WorkflowLLMHelper.js';
+import { thinkingConfigToOptions } from '../thinkingOptions.js';
 import configCache from '../../../configCache.js';
 
 export class QueryPlanNodeExecutor extends BaseNodeExecutor {
@@ -117,7 +118,7 @@ export class QueryPlanNodeExecutor extends BaseNodeExecutor {
           { role: 'user', content: userParts.join('\n\n') }
         ],
         apiKey: apiKeyResult.apiKey,
-        options: { temperature: 0.2 },
+        options: { temperature: 0.2, ...thinkingConfigToOptions(config.thinking) },
         language
       });
       plan = parsePlan(response?.content || '');

--- a/server/services/workflow/executors/VerifierNodeExecutor.js
+++ b/server/services/workflow/executors/VerifierNodeExecutor.js
@@ -21,6 +21,7 @@
 
 import { BaseNodeExecutor } from './BaseNodeExecutor.js';
 import WorkflowLLMHelper from '../WorkflowLLMHelper.js';
+import { thinkingConfigToOptions } from '../thinkingOptions.js';
 import configCache from '../../../configCache.js';
 import logger from '../../../utils/logger.js';
 import { actionTracker } from '../../../actionTracker.js';
@@ -295,7 +296,7 @@ export class VerifierNodeExecutor extends BaseNodeExecutor {
           model,
           messages,
           apiKey: apiKeyResult.apiKey,
-          options: { temperature: 0.3 },
+          options: { temperature: 0.3, ...thinkingConfigToOptions(node.config?.thinking) },
           language
         });
         responseContent = response.content || '';

--- a/server/services/workflow/thinkingOptions.js
+++ b/server/services/workflow/thinkingOptions.js
@@ -1,0 +1,35 @@
+/**
+ * Map a workflow node's `thinking` config block to the per-request adapter
+ * options the LLM adapters understand.
+ *
+ * Node config mirrors the model config `thinking` shape (see
+ * `server/validators/modelConfigSchema.js`):
+ *   - Gemini 3.x: { enabled, level: "minimal"|"low"|"medium"|"high" }
+ *   - Gemini 2.5: { enabled, budget, thoughts }
+ *
+ * The returned object uses the same option keys the chat path forwards
+ * (`thinkingEnabled` / `thinkingLevel` / `thinkingBudget` / `thinkingThoughts`)
+ * and that the Google adapter reads (`server/adapters/google.js`). Only keys
+ * actually present in the node config are emitted, so a node override never
+ * clobbers a model default it didn't mean to set. An empty object means
+ * "no per-node override — use the model's own thinking config".
+ *
+ * Note: the adapter gates thinking on `model.thinking?.enabled`, so a node can
+ * DISABLE or TUNE thinking on a thinking-enabled model, but cannot force-enable
+ * it on a model whose config has thinking off.
+ *
+ * @param {Object|undefined|null} thinking - Node config `thinking` block
+ * @returns {{thinkingEnabled?: boolean, thinkingLevel?: string, thinkingBudget?: number, thinkingThoughts?: boolean}}
+ */
+export function thinkingConfigToOptions(thinking) {
+  if (!thinking || typeof thinking !== 'object') return {};
+
+  const options = {};
+  if (typeof thinking.enabled === 'boolean') options.thinkingEnabled = thinking.enabled;
+  if (thinking.level !== undefined) options.thinkingLevel = thinking.level;
+  if (thinking.budget !== undefined) options.thinkingBudget = thinking.budget;
+  if (typeof thinking.thoughts === 'boolean') options.thinkingThoughts = thinking.thoughts;
+  return options;
+}
+
+export default { thinkingConfigToOptions };

--- a/server/validators/workflowConfigSchema.js
+++ b/server/validators/workflowConfigSchema.js
@@ -137,6 +137,32 @@ const nodeTypeEnum = z.enum([
 ]);
 
 /**
+ * Per-node thinking override schema.
+ *
+ * Mirrors the model config `thinking` shape (see
+ * `server/validators/modelConfigSchema.js`) but every field is optional — a
+ * node may set only what it wants to override. Mapped to per-request adapter
+ * options by `thinkingConfigToOptions()` in
+ * `server/services/workflow/thinkingOptions.js`. `.strict()` catches typos
+ * (e.g. `enabld`) instead of silently ignoring them.
+ *
+ *   - Gemini 3.x: { enabled, level: "minimal"|"low"|"medium"|"high" }
+ *   - Gemini 2.5: { enabled, budget, thoughts }
+ */
+const nodeThinkingSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    level: z
+      .enum(['minimal', 'low', 'medium', 'high', 'MINIMAL', 'LOW', 'MEDIUM', 'HIGH'])
+      .optional(),
+    budget: z.number().int().optional(),
+    thoughts: z.boolean().optional(),
+    chatTemplateKwargs: z.record(z.any()).optional()
+  })
+  .strict()
+  .optional();
+
+/**
  * Node configuration schema
  * Represents a single node in the workflow graph
  */
@@ -182,7 +208,13 @@ export const nodeConfigSchema = z.object({
   config: z
     .object({
       /** Whether this node's progress is visible in the chat step indicator. Defaults to true. */
-      chatVisible: z.boolean().optional()
+      chatVisible: z.boolean().optional(),
+      /**
+       * Optional per-node thinking override for LLM-backed nodes (prompt,
+       * planner, verifier, query-plan). Overrides the model's thinking config
+       * for this node's LLM call only. See nodeThinkingSchema.
+       */
+      thinking: nodeThinkingSchema
     })
     .passthrough()
     .optional(),

--- a/tests/unit/server/workflow/nodeThinkingSchema.test.js
+++ b/tests/unit/server/workflow/nodeThinkingSchema.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect } from '@jest/globals';
+import { nodeConfigSchema } from '../../../../server/validators/workflowConfigSchema.js';
+
+const baseNode = {
+  id: 'refine-decision',
+  type: 'prompt',
+  name: { en: 'Decide' },
+  position: { x: 0, y: 0 }
+};
+
+describe('nodeConfigSchema — per-node thinking', () => {
+  it('accepts a valid thinking override (enabled + level)', () => {
+    const r = nodeConfigSchema.safeParse({
+      ...baseNode,
+      config: { thinking: { enabled: false, level: 'low' } }
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts the Gemini 2.5 budget shape', () => {
+    const r = nodeConfigSchema.safeParse({
+      ...baseNode,
+      config: { thinking: { enabled: true, budget: 512, thoughts: false } }
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts a node with no thinking block at all', () => {
+    const r = nodeConfigSchema.safeParse({ ...baseNode, config: { chatVisible: false } });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects a thinking block with an unknown/typo key', () => {
+    const r = nodeConfigSchema.safeParse({
+      ...baseNode,
+      config: { thinking: { enabld: true } }
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects a non-boolean enabled', () => {
+    const r = nodeConfigSchema.safeParse({
+      ...baseNode,
+      config: { thinking: { enabled: 'yes' } }
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/tests/unit/server/workflow/thinkingOptions.test.js
+++ b/tests/unit/server/workflow/thinkingOptions.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from '@jest/globals';
+import { thinkingConfigToOptions } from '../../../../server/services/workflow/thinkingOptions.js';
+
+describe('thinkingConfigToOptions', () => {
+  it('returns an empty object when no thinking config is given (no override)', () => {
+    expect(thinkingConfigToOptions(undefined)).toEqual({});
+    expect(thinkingConfigToOptions(null)).toEqual({});
+  });
+
+  it('returns an empty object for non-object values', () => {
+    expect(thinkingConfigToOptions('off')).toEqual({});
+    expect(thinkingConfigToOptions(true)).toEqual({});
+    expect(thinkingConfigToOptions(42)).toEqual({});
+  });
+
+  it('maps { enabled: false } to disable thinking for the node', () => {
+    expect(thinkingConfigToOptions({ enabled: false })).toEqual({ thinkingEnabled: false });
+  });
+
+  it('maps { enabled: true } to enable thinking', () => {
+    expect(thinkingConfigToOptions({ enabled: true })).toEqual({ thinkingEnabled: true });
+  });
+
+  it('maps the Gemini 3 level shape', () => {
+    expect(thinkingConfigToOptions({ enabled: true, level: 'low' })).toEqual({
+      thinkingEnabled: true,
+      thinkingLevel: 'low'
+    });
+  });
+
+  it('maps the Gemini 2.5 budget + thoughts shape', () => {
+    expect(thinkingConfigToOptions({ enabled: true, budget: 512, thoughts: false })).toEqual({
+      thinkingEnabled: true,
+      thinkingBudget: 512,
+      thinkingThoughts: false
+    });
+  });
+
+  it('omits keys that are not provided (partial config)', () => {
+    expect(thinkingConfigToOptions({ level: 'high' })).toEqual({ thinkingLevel: 'high' });
+  });
+
+  it('does not emit thinkingEnabled when enabled is not a boolean', () => {
+    expect(thinkingConfigToOptions({ level: 'medium' })).not.toHaveProperty('thinkingEnabled');
+  });
+});

--- a/tests/unit/server/workflow/workflowLlmHelper.thinking.test.js
+++ b/tests/unit/server/workflow/workflowLlmHelper.thinking.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  VALID_ADAPTER_OPTIONS,
+  filterAdapterOptions
+} from '../../../../server/services/workflow/adapterOptions.js';
+
+describe('workflow adapterOptions — per-node thinking', () => {
+  it('includes the thinking keys in the allowlist', () => {
+    expect(VALID_ADAPTER_OPTIONS).toEqual(
+      expect.arrayContaining([
+        'thinkingEnabled',
+        'thinkingLevel',
+        'thinkingBudget',
+        'thinkingThoughts'
+      ])
+    );
+  });
+
+  it('preserves per-node thinking options through the allowlist', () => {
+    const filtered = filterAdapterOptions({
+      temperature: 0.1,
+      maxTokens: 1000,
+      thinkingEnabled: false,
+      thinkingLevel: 'low',
+      thinkingBudget: 512,
+      thinkingThoughts: false
+    });
+    expect(filtered).toMatchObject({
+      thinkingEnabled: false,
+      thinkingLevel: 'low',
+      thinkingBudget: 512,
+      thinkingThoughts: false
+    });
+  });
+
+  it('keeps the original adapter options (temperature, maxTokens, responseSchema)', () => {
+    const filtered = filterAdapterOptions({
+      temperature: 0.5,
+      maxTokens: 2048,
+      responseSchema: { type: 'object' }
+    });
+    expect(filtered).toEqual({
+      temperature: 0.5,
+      maxTokens: 2048,
+      responseSchema: { type: 'object' }
+    });
+  });
+
+  it('strips unknown options', () => {
+    const filtered = filterAdapterOptions({ temperature: 0.5, bogusOption: 'x' });
+    expect(filtered).not.toHaveProperty('bogusOption');
+    expect(filtered).toHaveProperty('temperature', 0.5);
+  });
+});


### PR DESCRIPTION
## What & why

The `stellungnahmen-review-ifinder` workflow stopped running through: it dead-ended right after the iFinder search (silent green "completed", no report), and re-running with a higher token cap just made it hang in a repetition loop for ~40s.

**Root cause:** the `refine-decision` referee node runs on `gemini-flash-latest` — a *moving Google alias* now backed by an unbounded-thinking model (`thinking.budget: -1`). At `temperature 0.1` it degenerates into a repetition loop in its `reason` field, filling the whole output budget and truncating the JSON. `parseStructuredOutput` returns the raw (unparseable) string, so `_refineDecision.done` is `undefined` and **neither** outgoing edge matched → the run silently completed after the search.

Verified via git archaeology that this was **not** caused by the agent-hardening merge (#1647): the Gemini request builder is byte-identical across that work and predates the workflow, and the raw-string fallback predates the workflow too. The trigger is the external alias; the dead-end was a latent design gap.

## Changes

**New capability — per-node thinking control.** LLM-backed nodes (`prompt`, `planner`, `verifier`, `query-plan`) accept an optional `thinking` block that overrides the model's reasoning for that node's call only, mirroring the model-config shape:
- `{ "enabled": false }` (off), `{ "enabled": true, "level": "low" }` (Gemini 3), or `{ "enabled": true, "budget": 512 }` (Gemini 2.5).
- Plumbed via a pure `thinkingConfigToOptions()` mapper + an extracted `adapterOptions` allowlist so the keys survive `WorkflowLLMHelper`'s option filter. Strict `thinking` schema on the node config catches typos. No-op for providers without thinking (e.g. Anthropic); cannot force-enable on a model that has thinking off.

**Fix — `refine-decision`:**
- Routing resilience: `e-refine-done` → `done !== false || iters >= max`, so an unparseable/undefined decision proceeds to the document loop instead of dead-ending.
- `thinking: { enabled: false }`, `maxTokens` 16000 → 1024 (fail fast), terse no-repeat `reason` hint.

**Migration V065** patches existing installs' runtime workflow in place (idempotent; leaves admin customizations and already-fixed/fresh installs untouched).

## Testing
- 17 new unit tests (mapper, allowlist filter, node schema) — all green.
- Existing `WorkflowLLMHelper` retry test still passes.
- Migration verified against a broken fixture: fixes all four changes, idempotent, no-op on fixed installs, leaves `extract-evidence` (16000) untouched.
- Docs (`docs/agents.md`) + changelog (`docs/releases/5.4.0`) updated.

_Re-lands work originally committed on `feat/claude-style-agent-hardening`, which merged as #1647 before this commit landed._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
