### PR TITLE
fix(outlook): keep email + attachment context in sync when switching mails

### DIFF
--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -27,7 +27,6 @@ import {
 } from '../utilities/buildChatApiMessages';
 import {
   fetchCurrentMailContext,
-  fetchCurrentOutlookItemContext,
   fetchSelectedItemsContext
 } from '../utilities/outlookMailContext';
 import {
@@ -115,14 +114,20 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   }, [mailSnapshot.includeBody, mailSnapshot.ctx, pinnedEmails]);
   // itemId of the email currently open in Outlook. Lets us hide the
   // "Add this email" affordance once it's already in the pin list, and
-  // dedupe in the prompt builder.
-  const [currentItemId, setCurrentItemId] = useState(null);
-  // Tracks whether the current Outlook item is a calendar appointment so
-  // we can swap the starter-prompt set (and hide the pin-email controls,
-  // which don't apply to a single meeting). Re-checked on every
-  // ihub:itemchanged event so users moving between Inbox and Calendar see
-  // the right prompts without needing to reopen the taskpane.
-  const [isAppointment, setIsAppointment] = useState(() => isOutlookAppointmentMode());
+  // dedupe in the prompt builder. Derived from the snapshot hook — the
+  // single reader of the Outlook item on every ihub:itemchanged — instead
+  // of a second parallel fetch, so the pin state can never disagree with
+  // the banner about which email is open.
+  const currentItemId = mailSnapshot.ctx?.itemId ?? null;
+  // Whether the current Outlook item is a calendar appointment, used to
+  // swap the starter-prompt set and hide the pin-email controls (which
+  // don't apply to a single meeting). Comes from the snapshot's itemKind;
+  // while the snapshot is (re)loading we fall back to a cheap synchronous
+  // probe of the live item so users moving between Inbox and Calendar see
+  // the right prompts without waiting for the fetch.
+  const isAppointment = mailSnapshot.ctx
+    ? mailSnapshot.ctx.itemKind === 'appointment'
+    : isOutlookAppointmentMode();
   const multiSelectSupported = isMultiSelectBodySupported();
   // Incremented each time a message is sent (manual submit or starter prompt)
   // to trigger auto-collapse of the OfficeContextStrip, giving the user more
@@ -155,34 +160,19 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
     pinnedEmailsRef.current = pinnedEmails;
   }, [pinnedEmails]);
 
-  // Track the currently-open email's itemId so the "Add this email" button
-  // can hide once the user has pinned it. Reading the id alone is cheap —
-  // we don't fetch the body here, that still happens lazily inside
-  // useOfficeChatAdapter.sendMessage. Refreshed on mount and whenever
-  // Outlook switches emails.
+  // Same for the adapter: useOfficeChatAdapter returns a fresh object every
+  // render, so depending on it directly would re-run the listener effect on
+  // every keystroke and streaming chunk. The previous version did exactly
+  // that AND ran a full mail fetch (including attachment downloads) per
+  // render, saturating the Office item API and widening the stale-snapshot
+  // race — the snapshot hook is the single item reader now.
+  const adapterRef = useRef(adapter);
   useEffect(() => {
-    let cancelled = false;
-    const refresh = async () => {
-      // Re-detect appointment mode on every refresh so users moving
-      // between Inbox and Calendar see the right starter prompts and the
-      // pin-email toolbar stays hidden inside meeting items.
-      const apptMode = isOutlookAppointmentMode();
-      if (!cancelled) setIsAppointment(apptMode);
-      try {
-        // For appointments we only need the itemId to track changes —
-        // pulling the full mail context returns "not available". Use the
-        // unified reader so we never miss the calendar item.
-        const ctx = apptMode
-          ? await fetchCurrentOutlookItemContext()
-          : await fetchCurrentMailContext();
-        if (!cancelled) setCurrentItemId(ctx?.itemId ?? null);
-      } catch {
-        if (!cancelled) setCurrentItemId(null);
-      }
-    };
-    refresh();
+    adapterRef.current = adapter;
+  });
+
+  useEffect(() => {
     const handler = () => {
-      refresh();
       // Pinned emails are the whole point of the feature, so they must
       // survive ItemChanged. We only reset the chat history (and the
       // staged input) when the user has nothing pinned — otherwise we'd
@@ -190,16 +180,15 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
       if (pinnedEmailsRef.current.length === 0) {
         chatIdRef.current = `office-${uuidv4()}`;
         selectedStarterPromptRef.current = null;
-        adapter.clearMessages();
+        adapterRef.current.clearMessages();
         setInputValue('');
       }
     };
     document.addEventListener('ihub:itemchanged', handler);
     return () => {
-      cancelled = true;
       document.removeEventListener('ihub:itemchanged', handler);
     };
-  }, [adapter]);
+  }, []);
 
   const handleUnpin = useCallback(itemId => {
     setPinnedEmails(prev => {

--- a/client/src/features/office/hooks/useOutlookMailContextSnapshot.js
+++ b/client/src/features/office/hooks/useOutlookMailContextSnapshot.js
@@ -31,22 +31,31 @@ export function useOutlookMailContextSnapshot() {
   const [includeBody, setIncludeBody] = useState(true);
   // Bumped by ItemChanged so the chat panel can reset its edit state too.
   const [generation, setGeneration] = useState(0);
-  const cancelRef = useRef({ cancelled: false });
+  // Monotonic sequence for context loads. A single click in Outlook fires
+  // both ItemChanged and SelectedItemsChanged (each dispatching
+  // 'ihub:itemchanged'), so loads overlap; only the newest one may publish
+  // its result. Without this, a slow load that started on the previous
+  // email resolves last and clobbers the fresh snapshot with stale
+  // attachments ("not part of this item" errors).
+  const loadSeqRef = useRef(0);
+  const reloadTimerRef = useRef(null);
 
   const hostKind = host?.kind;
 
   useEffect(() => {
-    cancelRef.current = { cancelled: false };
-    const localCancel = cancelRef.current;
+    let disposed = false;
 
     async function load() {
+      const seq = ++loadSeqRef.current;
       setState({ loading: true, ctx: null });
+      let ctx = null;
       try {
-        const ctx = await host.readMessageContext();
-        if (!localCancel.cancelled) setState({ loading: false, ctx });
+        ctx = await host.readMessageContext();
       } catch {
-        if (!localCancel.cancelled) setState({ loading: false, ctx: null });
+        ctx = null;
       }
+      if (disposed || seq !== loadSeqRef.current) return;
+      setState({ loading: false, ctx });
     }
 
     load();
@@ -55,12 +64,29 @@ export function useOutlookMailContextSnapshot() {
       setRemovedAttachmentIds(new Set());
       setIncludeBody(true);
       setGeneration(g => g + 1);
-      load();
+      // Supersede any in-flight load right away and show the loading state,
+      // but debounce the actual read: the second event of the double
+      // dispatch lands within milliseconds, and the short pause also gives
+      // the host time to finish swapping Office.context.mailbox.item.
+      loadSeqRef.current++;
+      setState({ loading: true, ctx: null });
+      if (reloadTimerRef.current) clearTimeout(reloadTimerRef.current);
+      reloadTimerRef.current = setTimeout(() => {
+        reloadTimerRef.current = null;
+        load();
+      }, 150);
     }
 
     document.addEventListener('ihub:itemchanged', onItemChange);
     return () => {
-      localCancel.cancelled = true;
+      // `disposed` keeps every load started by this effect run from
+      // publishing; a re-run's own loads supersede them via the shared
+      // sequence ref.
+      disposed = true;
+      if (reloadTimerRef.current) {
+        clearTimeout(reloadTimerRef.current);
+        reloadTimerRef.current = null;
+      }
       document.removeEventListener('ihub:itemchanged', onItemChange);
     };
     // host is a stable object from EmbeddedHostProvider; depend on kind so we

--- a/client/src/features/office/utilities/outlookMailContext.js
+++ b/client/src/features/office/utilities/outlookMailContext.js
@@ -148,12 +148,20 @@ function getSubjectAsync(item) {
  * strip, chat adapter) can pick the right banner / prompt formatter.
  */
 export async function fetchCurrentOutlookItemContext() {
-  const itemType = getCurrentOutlookItemType();
-  if (itemType === 'appointment' || isOutlookAppointmentItemAvailable()) {
-    return fetchCurrentAppointmentContext();
-  }
-  const ctx = await fetchCurrentMailContext();
-  return { ...ctx, itemKind: 'message' };
+  // The itemType probe and both readers run under the mailbox lock: while a
+  // multi-select loadItemByIdAsync cycle is active, Office.context.mailbox.item
+  // is redirected to the loaded message, so probing outside the lock could
+  // classify a calendar item as mail (or hand the appointment reader a
+  // redirected item). Note fetchCurrentMailContextLocked is called directly —
+  // the public fetchCurrentMailContext would try to take the lock again.
+  return withMailboxLock(async () => {
+    const itemType = getCurrentOutlookItemType();
+    if (itemType === 'appointment' || isOutlookAppointmentItemAvailable()) {
+      return fetchCurrentAppointmentContext();
+    }
+    const ctx = await fetchCurrentMailContextLocked();
+    return { ...ctx, itemKind: 'message' };
+  });
 }
 
 // How often a snapshot read restarts against the new item before giving up
@@ -181,13 +189,15 @@ async function fetchCurrentMailContextLocked() {
     const item = Office.context.mailbox.item;
     const itemId = item.itemId ?? null;
 
-    const snapshot = await readMailSnapshot(item, itemId);
+    const { snapshot, aborted } = await readMailSnapshot(item, itemId);
 
     // Body and attachment content are host round-trips — the user may have
     // selected a different email while we were reading. A torn snapshot
     // (old descriptors, failed content fetches) must never be surfaced:
-    // restart against the item that is now selected.
-    if (getLiveItemId() !== itemId) continue;
+    // restart against the item that is now selected. The `aborted` flag
+    // covers the switch-away-and-back case, where the live itemId matches
+    // again by the time we check but the attachment list was cut short.
+    if (aborted || getLiveItemId() !== itemId) continue;
     return snapshot;
   }
 
@@ -211,6 +221,7 @@ async function readMailSnapshot(item, itemId) {
 
   const descriptors = getAttachmentDescriptors(item);
   const attachments = [];
+  let aborted = false;
 
   for (const d of descriptors) {
     if (!d.id) {
@@ -218,10 +229,15 @@ async function readMailSnapshot(item, itemId) {
       continue;
     }
     // Stop downloading as soon as the selection moves on — the caller
-    // detects the itemId mismatch and retries the whole snapshot, so
-    // finishing these fetches would only produce InvalidAttachmentId
-    // errors against the newly selected item.
-    if (getLiveItemId() !== itemId) break;
+    // retries the whole snapshot, so finishing these fetches would only
+    // produce InvalidAttachmentId errors against the newly selected item.
+    // The explicit flag matters for the switch-away-and-back case: the
+    // live itemId can match the capture again by the time the caller
+    // checks, but the attachment list would be silently truncated.
+    if (getLiveItemId() !== itemId) {
+      aborted = true;
+      break;
+    }
     try {
       const raw = await getAttachmentContentAsync(item, d.id);
       attachments.push({
@@ -240,11 +256,14 @@ async function readMailSnapshot(item, itemId) {
   }
 
   return {
-    available: true,
-    subject,
-    itemId,
-    bodyText,
-    attachments
+    snapshot: {
+      available: true,
+      subject,
+      itemId,
+      bodyText,
+      attachments
+    },
+    aborted
   };
 }
 

--- a/client/src/features/office/utilities/outlookMailContext.js
+++ b/client/src/features/office/utilities/outlookMailContext.js
@@ -19,6 +19,41 @@ export function isOutlookMailItemAvailable() {
 }
 
 /**
+ * All Office mailbox item operations in this module run through this promise
+ * queue. Office.js allows only ONE item to be loaded via `loadItemByIdAsync`
+ * at a time and redirects `Office.context.mailbox.item` to the loaded item
+ * until `unloadAsync` completes — a context read that interleaves with a
+ * load/unload cycle observes the wrong item, and a load started while
+ * another is active fails outright. Serializing every reader keeps the
+ * mailbox state coherent no matter how many callers fire at once (double
+ * ItemChanged/SelectedItemsChanged dispatch, pin-button clicks, sends).
+ */
+let mailboxQueue = Promise.resolve();
+
+function withMailboxLock(fn) {
+  const result = mailboxQueue.then(() => fn());
+  // Keep the chain alive whether the operation succeeds or fails.
+  mailboxQueue = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+}
+
+/**
+ * itemId of the live `Office.context.mailbox.item`, or null when no item is
+ * selected (the user deselected, compose mode, reading pane off). Cheap and
+ * synchronous — safe to call at any frequency.
+ */
+export function getLiveItemId() {
+  try {
+    return Office.context?.mailbox?.item?.itemId ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Returns the lowercased itemType of the currently selected Outlook item,
  * or null if Office.js / mailbox.item is unavailable. Used by the host
  * adapter to pick between the mail and appointment context readers.
@@ -33,9 +68,16 @@ export function getCurrentOutlookItemType() {
   }
 }
 
-function getBodyTextAsync() {
+// The helpers below take the mail item as an explicit argument instead of
+// re-reading `Office.context.mailbox.item` at call time. Office swaps that
+// global whenever the user selects a different email, so a fetch that
+// dereferences it at every await boundary can stitch together a snapshot
+// from two different emails — most visibly by reading email A's attachment
+// descriptors and then requesting their content from email B, which fails
+// with InvalidAttachmentId ("attachment is not part of this item").
+
+function getBodyTextAsync(item) {
   return new Promise((resolve, reject) => {
-    const item = Office.context.mailbox.item;
     if (!item || !item.body) {
       resolve(null);
       return;
@@ -50,9 +92,8 @@ function getBodyTextAsync() {
   });
 }
 
-function getAttachmentContentAsync(attachmentId) {
+function getAttachmentContentAsync(item, attachmentId) {
   return new Promise((resolve, reject) => {
-    const item = Office.context.mailbox.item;
     if (!item || typeof item.getAttachmentContentAsync !== 'function') {
       reject(new Error('getAttachmentContentAsync is not available (requires Mailbox 1.8+).'));
       return;
@@ -67,8 +108,7 @@ function getAttachmentContentAsync(attachmentId) {
   });
 }
 
-function getAttachmentDescriptors() {
-  const item = Office.context.mailbox.item;
+function getAttachmentDescriptors(item) {
   if (!item || !item.attachments || !item.attachments.length) {
     return [];
   }
@@ -82,9 +122,8 @@ function getAttachmentDescriptors() {
   }));
 }
 
-function getSubjectAsync() {
+function getSubjectAsync(item) {
   return new Promise(resolve => {
-    const item = Office.context.mailbox.item;
     if (!item) {
       resolve(null);
       return;
@@ -117,29 +156,60 @@ export async function fetchCurrentOutlookItemContext() {
   return { ...ctx, itemKind: 'message' };
 }
 
+// How often a snapshot read restarts against the new item before giving up
+// when the user keeps switching emails mid-read. Every switch also fires
+// ItemChanged, which triggers a fresh fetch anyway — this just bounds one
+// call.
+const MAX_SNAPSHOT_ATTEMPTS = 3;
+
 export async function fetchCurrentMailContext() {
-  if (!isOutlookMailItemAvailable()) {
-    return {
-      available: false,
-      reason: 'Not running in Outlook with a mail item (Office.js item missing).',
-      attachments: []
-    };
+  return withMailboxLock(fetchCurrentMailContextLocked);
+}
+
+async function fetchCurrentMailContextLocked() {
+  for (let attempt = 0; attempt < MAX_SNAPSHOT_ATTEMPTS; attempt++) {
+    if (!isOutlookMailItemAvailable()) {
+      return {
+        available: false,
+        reason: 'Not running in Outlook with a mail item (Office.js item missing).',
+        attachments: []
+      };
+    }
+
+    // Capture the item exactly once per attempt. Every read below goes
+    // against this capture so one snapshot can never mix two emails.
+    const item = Office.context.mailbox.item;
+    const itemId = item.itemId ?? null;
+
+    const snapshot = await readMailSnapshot(item, itemId);
+
+    // Body and attachment content are host round-trips — the user may have
+    // selected a different email while we were reading. A torn snapshot
+    // (old descriptors, failed content fetches) must never be surfaced:
+    // restart against the item that is now selected.
+    if (getLiveItemId() !== itemId) continue;
+    return snapshot;
   }
 
-  const item = Office.context.mailbox.item;
+  return {
+    available: false,
+    reason: 'Outlook item kept changing while reading; snapshot aborted.',
+    attachments: []
+  };
+}
+
+async function readMailSnapshot(item, itemId) {
   let bodyText = null;
   try {
-    bodyText = await getBodyTextAsync();
+    bodyText = await getBodyTextAsync(item);
   } catch {}
 
   let subject = null;
   try {
-    subject = await getSubjectAsync();
+    subject = await getSubjectAsync(item);
   } catch {}
 
-  const itemId = item.itemId ?? null;
-
-  const descriptors = getAttachmentDescriptors();
+  const descriptors = getAttachmentDescriptors(item);
   const attachments = [];
 
   for (const d of descriptors) {
@@ -147,8 +217,13 @@ export async function fetchCurrentMailContext() {
       attachments.push({ ...d, error: 'Missing attachment id' });
       continue;
     }
+    // Stop downloading as soon as the selection moves on — the caller
+    // detects the itemId mismatch and retries the whole snapshot, so
+    // finishing these fetches would only produce InvalidAttachmentId
+    // errors against the newly selected item.
+    if (getLiveItemId() !== itemId) break;
     try {
-      const raw = await getAttachmentContentAsync(d.id);
+      const raw = await getAttachmentContentAsync(item, d.id);
       attachments.push({
         ...d,
         content: {
@@ -230,11 +305,38 @@ function getLoadedItemBodyTextAsync(loadedItem) {
 function unloadItemAsync(loadedItem) {
   return new Promise(resolve => {
     if (!loadedItem || typeof loadedItem.unloadAsync !== 'function') {
-      resolve();
+      resolve(true);
       return;
     }
-    loadedItem.unloadAsync(() => resolve());
+    loadedItem.unloadAsync(result => {
+      resolve(result?.status !== Office.AsyncResultStatus.Failed);
+    });
   });
+}
+
+/**
+ * Unload a loaded multi-select item, retrying once on failure. This must not
+ * fail silently: while an item is loaded, `Office.context.mailbox.item` is
+ * redirected to it, so a leaked load freezes every subsequent context read
+ * on that email until the taskpane is reloaded (Office.js offers no other
+ * recovery).
+ */
+async function unloadItemWithRetry(loadedItem) {
+  let unloaded = false;
+  try {
+    unloaded = await unloadItemAsync(loadedItem);
+  } catch {}
+  if (!unloaded) {
+    try {
+      unloaded = await unloadItemAsync(loadedItem);
+    } catch {}
+  }
+  if (!unloaded) {
+    console.warn(
+      '[office] unloadAsync failed — Office.context.mailbox.item may stay stale until the taskpane reloads'
+    );
+  }
+  return unloaded;
 }
 
 /**
@@ -249,7 +351,27 @@ function unloadItemAsync(loadedItem) {
  * attachments.
  */
 export async function fetchSelectedItemsContext() {
+  return withMailboxLock(fetchSelectedItemsContextLocked);
+}
+
+async function fetchSelectedItemsContextLocked() {
   const stubs = await getSelectedItemsAsync();
+
+  // Single selection: the selected email is the one open in the reading
+  // pane, which callers already read in full (body + attachments) via
+  // fetchCurrentMailContext. Skip the loadItemByIdAsync/unloadAsync cycle
+  // entirely — it redirects Office.context.mailbox.item to the loaded item
+  // and a failed unload freezes the taskpane on that email — and Microsoft's
+  // multi-select guidance is to avoid loadItemByIdAsync whenever the data is
+  // available another way.
+  if (stubs.length <= 1) {
+    const liveId = getLiveItemId();
+    const only = stubs[0];
+    if (!only || !only.itemId || (liveId && only.itemId === liveId)) {
+      return [];
+    }
+  }
+
   const out = [];
   for (const stub of stubs) {
     if (!stub || !stub.itemId) continue;
@@ -274,9 +396,7 @@ export async function fetchSelectedItemsContext() {
       });
     } finally {
       if (loaded) {
-        try {
-          await unloadItemAsync(loaded);
-        } catch {}
+        await unloadItemWithRetry(loaded);
       }
     }
   }

--- a/docs/releases/5.5.0/breaking-changes.md
+++ b/docs/releases/5.5.0/breaking-changes.md
@@ -1,0 +1,1 @@
+# Breaking Changes — 5.5.0

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,0 +1,15 @@
+# Features — 5.5.0
+
+## Outlook Add-in: Reliable Email and Attachment Sync
+
+The Outlook task pane now follows the selected email reliably. Previously, switching emails could
+leave the previous email's attachments in the context strip — shown as failed ("not part of this
+mail") — while the new email's attachments never appeared, and using "Add email(s)" could freeze
+the pane on the old email entirely. Both required closing and reopening the add-in.
+
+- Switching emails always loads the new email's subject, body, and attachments; a read that
+  overlaps a quick switch is retried against the newly selected email instead of showing stale data.
+- "Add email(s)" no longer freezes the pane: the pinned email is captured without disturbing the
+  live Outlook selection, so the context strip keeps updating as you move between emails.
+- Attachment reads are far less chatty with the Outlook host, improving task-pane responsiveness
+  on emails with large attachments.

--- a/tests/config/jest.config.js
+++ b/tests/config/jest.config.js
@@ -5,14 +5,16 @@ export default {
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
-    // Force a single React copy. Files under client/ would otherwise resolve
+    // Force a single React copy. Files under client/ resolve
     // client/node_modules/react while the test renderer (@testing-library/react
-    // + react-dom from the root) uses the root copy — two React instances make
-    // every real client hook fail with "Invalid hook call".
-    '^react$': '<rootDir>/node_modules/react',
-    '^react/(.*)$': '<rootDir>/node_modules/react/$1',
-    '^react-dom$': '<rootDir>/node_modules/react-dom',
-    '^react-dom/(.*)$': '<rootDir>/node_modules/react-dom/$1'
+    // + react-dom from the root) would use the root copy — two React instances
+    // make every real client hook fail with "Invalid hook call". Pin to the
+    // CLIENT copy so tests exercise the same React major the shipped bundle
+    // is built with.
+    '^react$': '<rootDir>/client/node_modules/react',
+    '^react/(.*)$': '<rootDir>/client/node_modules/react/$1',
+    '^react-dom$': '<rootDir>/client/node_modules/react-dom',
+    '^react-dom/(.*)$': '<rootDir>/client/node_modules/react-dom/$1'
   },
   modulePaths: [
     '<rootDir>/node_modules',

--- a/tests/config/jest.config.js
+++ b/tests/config/jest.config.js
@@ -4,7 +4,15 @@ export default {
   extensionsToTreatAsEsm: ['.jsx'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
-    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
+    // Force a single React copy. Files under client/ would otherwise resolve
+    // client/node_modules/react while the test renderer (@testing-library/react
+    // + react-dom from the root) uses the root copy — two React instances make
+    // every real client hook fail with "Invalid hook call".
+    '^react$': '<rootDir>/node_modules/react',
+    '^react/(.*)$': '<rootDir>/node_modules/react/$1',
+    '^react-dom$': '<rootDir>/node_modules/react-dom',
+    '^react-dom/(.*)$': '<rootDir>/node_modules/react-dom/$1'
   },
   modulePaths: [
     '<rootDir>/node_modules',

--- a/tests/unit/client/outlook-mail-context.test.jsx
+++ b/tests/unit/client/outlook-mail-context.test.jsx
@@ -1,0 +1,362 @@
+/**
+ * Unit tests for client/src/features/office/utilities/outlookMailContext.js
+ *
+ * Regression coverage for the stale-attachment / frozen-context bugs:
+ *   - fetchCurrentMailContext must return an atomic snapshot: when the user
+ *     switches emails mid-read, the fetch retries against the new item
+ *     instead of returning old descriptors whose content fetches fail with
+ *     "The attachment identifier does not exist".
+ *   - fetchSelectedItemsContext must skip the loadItemByIdAsync/unloadAsync
+ *     cycle for a single selection matching the open reading-pane item —
+ *     a failed unload redirects Office.context.mailbox.item to the loaded
+ *     item until the taskpane reloads (the "frozen after Add email(s)" bug).
+ *   - unloadAsync failures must be retried, not swallowed.
+ *   - Context reads are serialized behind the module's mailbox lock so they
+ *     can't interleave with a load/unload cycle.
+ */
+
+import '@testing-library/jest-dom';
+
+const {
+  fetchCurrentMailContext,
+  fetchSelectedItemsContext
+} = require('../../../client/src/features/office/utilities/outlookMailContext');
+
+const SUCCEEDED = 'succeeded';
+const FAILED = 'failed';
+
+function installOfficeMock() {
+  global.Office = {
+    AsyncResultStatus: { Succeeded: SUCCEEDED, Failed: FAILED },
+    CoercionType: { Text: 'text' },
+    context: { mailbox: { item: null } }
+  };
+  return global.Office;
+}
+
+/**
+ * Build a fake read-mode mail item. Attachment content requests behave like
+ * the Outlook host: an id is only served when it belongs to the item that is
+ * CURRENTLY selected (Office.context.mailbox.item), regardless of which item
+ * proxy the call went through — foreign ids fail with the canonical
+ * InvalidAttachmentId message.
+ */
+function makeMailItem({ itemId, subject, bodyText, attachments = [], onBodyRead }) {
+  const item = {
+    itemId,
+    itemType: 'message',
+    subject,
+    attachments: attachments.map(a => ({
+      id: a.id,
+      name: a.name,
+      size: a.size ?? 100,
+      contentType: a.contentType ?? 'application/pdf',
+      attachmentType: 'file',
+      isInline: !!a.isInline
+    })),
+    body: {
+      getAsync: (_coercion, cb) => {
+        setTimeout(() => {
+          onBodyRead?.();
+          cb({ status: SUCCEEDED, value: bodyText });
+        }, 0);
+      }
+    },
+    getAttachmentContentAsync: (id, cb) => {
+      setTimeout(() => {
+        const live = global.Office.context.mailbox.item;
+        const servedByLiveItem = live?.attachments?.some(x => x.id === id);
+        if (!servedByLiveItem) {
+          cb({
+            status: FAILED,
+            error: { message: 'The attachment identifier does not exist.' }
+          });
+          return;
+        }
+        cb({ status: SUCCEEDED, value: { format: 'base64', content: `CONTENT(${id})` } });
+      }, 0);
+    }
+  };
+  return item;
+}
+
+beforeEach(() => {
+  installOfficeMock();
+});
+
+afterEach(() => {
+  delete global.Office;
+});
+
+describe('fetchCurrentMailContext', () => {
+  test('returns a full snapshot (subject, body, attachment content) for a stable item', async () => {
+    const itemA = makeMailItem({
+      itemId: 'A',
+      subject: 'Mail A',
+      bodyText: 'body of A',
+      attachments: [
+        { id: 'a1', name: 'report.pdf' },
+        { id: 'a2', name: 'logo.png', contentType: 'image/png', isInline: true }
+      ]
+    });
+    Office.context.mailbox.item = itemA;
+
+    const ctx = await fetchCurrentMailContext();
+
+    expect(ctx.available).toBe(true);
+    expect(ctx.itemId).toBe('A');
+    expect(ctx.subject).toBe('Mail A');
+    expect(ctx.bodyText).toBe('body of A');
+    expect(ctx.attachments).toHaveLength(2);
+    expect(ctx.attachments[0]).toMatchObject({
+      id: 'a1',
+      content: { format: 'base64', content: 'CONTENT(a1)' }
+    });
+    expect(ctx.attachments.every(a => !a.error)).toBe(true);
+  });
+
+  test('retries against the new item when the selection changes mid-read (no stale invalid attachments)', async () => {
+    const itemB = makeMailItem({
+      itemId: 'B',
+      subject: 'Mail B',
+      bodyText: 'body of B',
+      attachments: [{ id: 'b1', name: 'invoice.pdf' }]
+    });
+    const itemA = makeMailItem({
+      itemId: 'A',
+      subject: 'Mail A',
+      bodyText: 'body of A',
+      attachments: [{ id: 'a1', name: 'report.pdf' }],
+      // Simulate the user selecting email B while A's body is being read:
+      // the host swaps the live item under the in-flight fetch.
+      onBodyRead: () => {
+        global.Office.context.mailbox.item = itemB;
+      }
+    });
+    Office.context.mailbox.item = itemA;
+
+    const ctx = await fetchCurrentMailContext();
+
+    // The old behavior returned A's descriptors with per-attachment
+    // "attachment identifier does not exist" errors. The fetch must instead
+    // restart and deliver B's snapshot.
+    expect(ctx.available).toBe(true);
+    expect(ctx.itemId).toBe('B');
+    expect(ctx.subject).toBe('Mail B');
+    expect(ctx.attachments).toHaveLength(1);
+    expect(ctx.attachments[0]).toMatchObject({
+      id: 'b1',
+      content: { format: 'base64', content: 'CONTENT(b1)' }
+    });
+    expect(ctx.attachments.every(a => !a.error)).toBe(true);
+  });
+
+  test('gives up with available:false when the item keeps changing across every attempt', async () => {
+    // Chain of items where every body read swaps the selection again, so no
+    // attempt ever completes on a stable item.
+    const items = [];
+    for (let i = 0; i < 5; i++) {
+      items.push(
+        makeMailItem({
+          itemId: `item-${i}`,
+          subject: `Mail ${i}`,
+          bodyText: `body ${i}`,
+          onBodyRead: () => {
+            global.Office.context.mailbox.item = items[i + 1] ?? items[i];
+          }
+        })
+      );
+    }
+    // Last item does not swap — but the loop should have given up by then.
+    items[4] = makeMailItem({ itemId: 'item-4', subject: 'Mail 4', bodyText: 'body 4' });
+    Office.context.mailbox.item = items[0];
+
+    const ctx = await fetchCurrentMailContext();
+
+    expect(ctx.available).toBe(false);
+    expect(ctx.attachments).toEqual([]);
+  });
+
+  test('still records per-attachment errors when the item is stable but the host rejects one id', async () => {
+    const itemA = makeMailItem({
+      itemId: 'A',
+      subject: 'Mail A',
+      bodyText: 'body of A',
+      attachments: [
+        { id: 'ok1', name: 'fine.pdf' },
+        { id: 'bad1', name: 'contact.msg' }
+      ]
+    });
+    // Simulate AttachmentTypeNotSupported for one attachment only.
+    const originalGetContent = itemA.getAttachmentContentAsync;
+    itemA.getAttachmentContentAsync = (id, cb) => {
+      if (id === 'bad1') {
+        setTimeout(
+          () => cb({ status: FAILED, error: { message: 'AttachmentTypeNotSupported' } }),
+          0
+        );
+        return;
+      }
+      originalGetContent(id, cb);
+    };
+    Office.context.mailbox.item = itemA;
+
+    const ctx = await fetchCurrentMailContext();
+
+    expect(ctx.available).toBe(true);
+    expect(ctx.attachments).toHaveLength(2);
+    expect(ctx.attachments[0].content).toBeDefined();
+    expect(ctx.attachments[1].error).toBe('AttachmentTypeNotSupported');
+  });
+});
+
+describe('fetchSelectedItemsContext', () => {
+  function installMultiSelectMocks({ stubs, loadedBodies = {}, unloadFailures = {} }) {
+    const calls = { load: [], unload: [] };
+    Office.context.mailbox.getSelectedItemsAsync = cb => {
+      setTimeout(() => cb({ status: SUCCEEDED, value: stubs }), 0);
+    };
+    Office.context.mailbox.loadItemByIdAsync = (itemId, cb) => {
+      calls.load.push(itemId);
+      const loaded = {
+        body: {
+          getAsync: (_c, bodyCb) =>
+            setTimeout(() => bodyCb({ status: SUCCEEDED, value: loadedBodies[itemId] ?? null }), 0)
+        },
+        unloadAsync: unloadCb => {
+          calls.unload.push(itemId);
+          const failuresLeft = unloadFailures[itemId] ?? 0;
+          if (failuresLeft > 0) {
+            unloadFailures[itemId] = failuresLeft - 1;
+            setTimeout(() => unloadCb({ status: FAILED, error: { message: 'unload failed' } }), 0);
+            return;
+          }
+          setTimeout(() => unloadCb({ status: SUCCEEDED }), 0);
+        }
+      };
+      setTimeout(() => cb({ status: SUCCEEDED, value: loaded }), 0);
+    };
+    return calls;
+  }
+
+  test('skips loadItemByIdAsync entirely when the single selected email is the open one', async () => {
+    Office.context.mailbox.item = makeMailItem({ itemId: 'A', subject: 'Mail A', bodyText: 'a' });
+    const calls = installMultiSelectMocks({
+      stubs: [{ itemId: 'A', subject: 'Mail A' }]
+    });
+
+    const out = await fetchSelectedItemsContext();
+
+    expect(out).toEqual([]);
+    expect(calls.load).toEqual([]);
+    expect(calls.unload).toEqual([]);
+  });
+
+  test('loads and unloads each item sequentially for a real multi-selection', async () => {
+    Office.context.mailbox.item = makeMailItem({ itemId: 'A', subject: 'Mail A', bodyText: 'a' });
+    const calls = installMultiSelectMocks({
+      stubs: [
+        { itemId: 'A', subject: 'Mail A' },
+        { itemId: 'B', subject: 'Mail B' }
+      ],
+      loadedBodies: { A: 'body A', B: 'body B' }
+    });
+
+    const out = await fetchSelectedItemsContext();
+
+    expect(out).toEqual([
+      { available: true, subject: 'Mail A', itemId: 'A', bodyText: 'body A', attachments: [] },
+      { available: true, subject: 'Mail B', itemId: 'B', bodyText: 'body B', attachments: [] }
+    ]);
+    expect(calls.load).toEqual(['A', 'B']);
+    expect(calls.unload).toEqual(['A', 'B']);
+  });
+
+  test('retries a failed unloadAsync so a wedged load cannot freeze the taskpane silently', async () => {
+    Office.context.mailbox.item = makeMailItem({ itemId: 'A', subject: 'Mail A', bodyText: 'a' });
+    const unloadFailures = { A: 1 }; // first unload of A fails, retry succeeds
+    const calls = installMultiSelectMocks({
+      stubs: [
+        { itemId: 'A', subject: 'Mail A' },
+        { itemId: 'B', subject: 'Mail B' }
+      ],
+      loadedBodies: { A: 'body A', B: 'body B' },
+      unloadFailures
+    });
+
+    const out = await fetchSelectedItemsContext();
+
+    expect(out).toHaveLength(2);
+    // A unloaded twice (fail + retry), then B once.
+    expect(calls.unload).toEqual(['A', 'A', 'B']);
+  });
+
+  test('takes the load path for a single selection that does NOT match the open item', async () => {
+    Office.context.mailbox.item = makeMailItem({ itemId: 'X', subject: 'Other', bodyText: 'x' });
+    const calls = installMultiSelectMocks({
+      stubs: [{ itemId: 'A', subject: 'Mail A' }],
+      loadedBodies: { A: 'body A' }
+    });
+
+    const out = await fetchSelectedItemsContext();
+
+    expect(out).toEqual([
+      { available: true, subject: 'Mail A', itemId: 'A', bodyText: 'body A', attachments: [] }
+    ]);
+    expect(calls.load).toEqual(['A']);
+    expect(calls.unload).toEqual(['A']);
+  });
+});
+
+describe('mailbox access serialization', () => {
+  test('a context read queued during a multi-select load waits for the unload to finish', async () => {
+    const order = [];
+    const itemA = makeMailItem({
+      itemId: 'A',
+      subject: 'Mail A',
+      bodyText: 'body of A',
+      onBodyRead: () => order.push('context-body-read')
+    });
+    Office.context.mailbox.item = itemA;
+
+    Office.context.mailbox.getSelectedItemsAsync = cb => {
+      setTimeout(
+        () =>
+          cb({
+            status: SUCCEEDED,
+            value: [
+              { itemId: 'B', subject: 'Mail B' },
+              { itemId: 'C', subject: 'Mail C' }
+            ]
+          }),
+        0
+      );
+    };
+    Office.context.mailbox.loadItemByIdAsync = (itemId, cb) => {
+      order.push(`load:${itemId}`);
+      const loaded = {
+        body: {
+          getAsync: (_c, bodyCb) => setTimeout(() => bodyCb({ status: SUCCEEDED, value: 'b' }), 5)
+        },
+        unloadAsync: unloadCb => {
+          setTimeout(() => {
+            order.push(`unload:${itemId}`);
+            unloadCb({ status: SUCCEEDED });
+          }, 5);
+        }
+      };
+      setTimeout(() => cb({ status: SUCCEEDED, value: loaded }), 5);
+    };
+
+    const multiPromise = fetchSelectedItemsContext();
+    const contextPromise = fetchCurrentMailContext();
+    await Promise.all([multiPromise, contextPromise]);
+
+    // The current-mail read must not interleave with the load/unload cycle:
+    // its first host call happens only after the final unload completed.
+    const lastUnload = order.lastIndexOf('unload:C');
+    const bodyRead = order.indexOf('context-body-read');
+    expect(lastUnload).toBeGreaterThanOrEqual(0);
+    expect(bodyRead).toBeGreaterThan(lastUnload);
+  });
+});

--- a/tests/unit/client/outlook-mail-context.test.jsx
+++ b/tests/unit/client/outlook-mail-context.test.jsx
@@ -177,6 +177,49 @@ describe('fetchCurrentMailContext', () => {
     expect(ctx.attachments).toEqual([]);
   });
 
+  test('switch away and back mid-download retries instead of returning a truncated attachment list', async () => {
+    const itemB = makeMailItem({ itemId: 'B', subject: 'Mail B', bodyText: 'body of B' });
+    const itemA = makeMailItem({
+      itemId: 'A',
+      subject: 'Mail A',
+      bodyText: 'body of A',
+      attachments: [
+        { id: 'a1', name: 'first.pdf' },
+        { id: 'a2', name: 'second.pdf' }
+      ]
+    });
+    // While a1's content arrives, the user flips to B and immediately back
+    // to A. The download loop aborts during the B interval, but by the time
+    // the post-read itemId check runs the live item is A again — without the
+    // aborted flag, a snapshot with only a1 missing-in-silence would be
+    // returned as intact.
+    const originalGetContent = itemA.getAttachmentContentAsync;
+    let flipped = false;
+    itemA.getAttachmentContentAsync = (id, cb) => {
+      if (id === 'a1' && !flipped) {
+        flipped = true;
+        setTimeout(() => {
+          global.Office.context.mailbox.item = itemB;
+          cb({ status: SUCCEEDED, value: { format: 'base64', content: 'CONTENT(a1)' } });
+          queueMicrotask(() => {
+            global.Office.context.mailbox.item = itemA;
+          });
+        }, 0);
+        return;
+      }
+      originalGetContent(id, cb);
+    };
+    Office.context.mailbox.item = itemA;
+
+    const ctx = await fetchCurrentMailContext();
+
+    expect(ctx.available).toBe(true);
+    expect(ctx.itemId).toBe('A');
+    expect(ctx.attachments).toHaveLength(2);
+    expect(ctx.attachments.map(a => a.id)).toEqual(['a1', 'a2']);
+    expect(ctx.attachments.every(a => a.content && !a.error)).toBe(true);
+  });
+
   test('still records per-attachment errors when the item is stable but the host rejects one id', async () => {
     const itemA = makeMailItem({
       itemId: 'A',

--- a/tests/unit/client/use-outlook-mail-context-snapshot.test.jsx
+++ b/tests/unit/client/use-outlook-mail-context-snapshot.test.jsx
@@ -1,0 +1,172 @@
+/**
+ * Unit tests for client/src/features/office/hooks/useOutlookMailContextSnapshot.js
+ *
+ * Regression coverage for the stale-attachment bug: a single click in
+ * Outlook fires both ItemChanged and SelectedItemsChanged (both dispatch
+ * 'ihub:itemchanged'), so context loads overlap. The hook must
+ *   - publish only the NEWEST load's result (a slow stale load resolving
+ *     last must not clobber the fresh snapshot),
+ *   - coalesce the double dispatch into a single re-fetch,
+ *   - reset per-email edits (removed attachments, include-body) on change.
+ */
+
+import '@testing-library/jest-dom';
+import { renderHook, act } from '@testing-library/react';
+
+let mockHostImpl;
+jest.mock('../../../client/src/features/office/contexts/EmbeddedHostContext', () => ({
+  useEmbeddedHost: () => mockHostImpl
+}));
+
+const useOutlookMailContextSnapshot =
+  require('../../../client/src/features/office/hooks/useOutlookMailContextSnapshot').default;
+
+function deferred() {
+  let resolve;
+  const promise = new Promise(r => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function dispatchItemChanged() {
+  document.dispatchEvent(new CustomEvent('ihub:itemchanged'));
+}
+
+beforeEach(() => {
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+test('a stale slow load must not clobber the fresh snapshot (last-writer race)', async () => {
+  const loads = [];
+  mockHostImpl = {
+    kind: 'office',
+    readMessageContext: jest.fn(() => {
+      const d = deferred();
+      loads.push(d);
+      return d.promise;
+    })
+  };
+
+  const { result } = renderHook(() => useOutlookMailContextSnapshot());
+  expect(result.current.loading).toBe(true);
+  expect(loads).toHaveLength(1); // mount load (email A) — kept pending: it is slow
+
+  // User clicks email B: Outlook fires ItemChanged AND SelectedItemsChanged.
+  await act(async () => {
+    dispatchItemChanged();
+    dispatchItemChanged();
+  });
+
+  // Double dispatch coalesces into ONE re-fetch after the debounce window.
+  await act(async () => {
+    jest.advanceTimersByTime(150);
+  });
+  expect(loads).toHaveLength(2);
+
+  // Fresh load (email B) resolves first…
+  const ctxB = { available: true, itemId: 'B', subject: 'Mail B', attachments: [] };
+  await act(async () => {
+    loads[1].resolve(ctxB);
+  });
+  expect(result.current.loading).toBe(false);
+  expect(result.current.ctx).toEqual(ctxB);
+
+  // …then the stale mount load (email A) finally resolves. It must be ignored.
+  const ctxA = {
+    available: true,
+    itemId: 'A',
+    subject: 'Mail A',
+    attachments: [{ id: 'a1', name: 'old.pdf', error: 'The attachment identifier does not exist.' }]
+  };
+  await act(async () => {
+    loads[0].resolve(ctxA);
+  });
+  expect(result.current.ctx).toEqual(ctxB);
+  expect(result.current.loading).toBe(false);
+});
+
+test('rapid successive item changes: only the newest load publishes', async () => {
+  const loads = [];
+  mockHostImpl = {
+    kind: 'office',
+    readMessageContext: jest.fn(() => {
+      const d = deferred();
+      loads.push(d);
+      return d.promise;
+    })
+  };
+
+  const { result } = renderHook(() => useOutlookMailContextSnapshot());
+  await act(async () => {
+    loads[0].resolve({ available: true, itemId: 'A', subject: 'Mail A', attachments: [] });
+  });
+  expect(result.current.ctx?.itemId).toBe('A');
+
+  // Switch to B, then to C before B's load resolves.
+  await act(async () => {
+    dispatchItemChanged();
+    jest.advanceTimersByTime(150);
+  });
+  expect(loads).toHaveLength(2);
+
+  await act(async () => {
+    dispatchItemChanged();
+    jest.advanceTimersByTime(150);
+  });
+  expect(loads).toHaveLength(3);
+
+  // B's (superseded) load resolves late — must be dropped, still loading C.
+  await act(async () => {
+    loads[1].resolve({ available: true, itemId: 'B', subject: 'Mail B', attachments: [] });
+  });
+  expect(result.current.loading).toBe(true);
+  expect(result.current.ctx).toBeNull();
+
+  await act(async () => {
+    loads[2].resolve({ available: true, itemId: 'C', subject: 'Mail C', attachments: [] });
+  });
+  expect(result.current.loading).toBe(false);
+  expect(result.current.ctx?.itemId).toBe('C');
+});
+
+test('per-email edits (removed attachments, include-body) reset on item change', async () => {
+  const loads = [];
+  mockHostImpl = {
+    kind: 'office',
+    readMessageContext: jest.fn(() => {
+      const d = deferred();
+      loads.push(d);
+      return d.promise;
+    })
+  };
+
+  const { result } = renderHook(() => useOutlookMailContextSnapshot());
+  await act(async () => {
+    loads[0].resolve({
+      available: true,
+      itemId: 'A',
+      subject: 'Mail A',
+      attachments: [{ id: 'a1', name: 'doc.pdf' }]
+    });
+  });
+
+  act(() => {
+    result.current.removeAttachment('a1');
+    result.current.setIncludeBody(false);
+  });
+  expect(result.current.removedAttachmentIds.has('a1')).toBe(true);
+  expect(result.current.includeBody).toBe(false);
+  const generationBefore = result.current.generation;
+
+  await act(async () => {
+    dispatchItemChanged();
+  });
+  expect(result.current.removedAttachmentIds.size).toBe(0);
+  expect(result.current.includeBody).toBe(true);
+  expect(result.current.generation).toBe(generationBefore + 1);
+});


### PR DESCRIPTION
# Summary

Fixes two critical Outlook task-pane bugs reported from the field:

1. **Stale/invalid attachments on email switch** — selecting another email updated the subject/body in the context strip, but the previous email's attachments stayed visible and were marked failed ("attachment identifier does not exist"); the new email's attachments never appeared. Only closing and reloading the add-in recovered.
2. **Frozen pane after "Add email(s)"** — after pinning the open email, selecting another email no longer updated the context at all; the old email stayed shown and marked as added.

# Root causes

- **Double event dispatch + unsequenced loads.** A single click in Outlook fires both `ItemChanged` and `SelectedItemsChanged` (both registered since #1553, both dispatching `ihub:itemchanged`), so context loads overlapped in `useOutlookMailContextSnapshot` with *last-resolver-wins* semantics. A load that straddled the switch read email A's attachment descriptors, then requested their content from email B — every request failed with `InvalidAttachmentId` — and the poisoned result overwrote the correct one.
- **Torn snapshots.** `fetchCurrentMailContext` re-read `Office.context.mailbox.item` at every await boundary, so one snapshot could mix two emails; errors were baked into state with `available: true` and never re-validated.
- **Leaked `loadItemByIdAsync` loads.** Per the Office.js contract, `loadItemByIdAsync` redirects `Office.context.mailbox.item` to the loaded item until `unloadAsync` succeeds — and `unloadItemAsync` swallowed failures unconditionally. A failed unload froze every subsequent context read on that email (Office.js offers no recovery short of reloading the pane). Nothing serialized context reads against the load/unload window.
- **Amplifier:** `OfficeChatPanel`'s item listener depended on an unstable `adapter` object, so a **full mail fetch including all attachment downloads ran on every render**, saturating the Office item API and making the race reliably reproducible.

# Changes

- `client/src/features/office/utilities/outlookMailContext.js`
  - Capture the mail item once per read attempt and thread it through all helpers; retry the snapshot (bounded) when the live `itemId` changed mid-read — torn snapshots are never surfaced. An explicit `aborted` flag also catches the switch-away-and-back case that would otherwise return a silently truncated attachment list.
  - Serialize all mailbox item operations behind a module-level promise queue so context reads can't interleave with a `loadItemByIdAsync`/`unloadAsync` cycle. The mail-vs-appointment dispatch in `fetchCurrentOutlookItemContext` runs under the same lock so a redirected item can't be misclassified.
  - Check `unloadAsync` results and retry once; warn loudly on persistent failure.
  - Skip the load/unload cycle entirely when a single selected email matches the open reading-pane item (Microsoft's own guidance: avoid `loadItemByIdAsync` when the data is available another way).
- `client/src/features/office/hooks/useOutlookMailContextSnapshot.js`
  - Monotonic load sequence — only the newest load publishes its result.
  - On item change: supersede in-flight loads immediately, show the loading state, and debounce the reload by 150 ms to coalesce the double dispatch and let the host settle.
- `client/src/features/office/components/OfficeChatPanel.jsx`
  - Single-reader architecture: `currentItemId` / `isAppointment` derive from the snapshot hook instead of a second parallel fetch; the chat-reset listener mounts once (refs for the unstable adapter). Removes the full-fetch-per-render storm.
- `tests/config/jest.config.js`
  - Pin `react`/`react-dom` to the **client** copy (React 18, the version the shipped bundle is built with) so real client hooks are testable — two React copies previously made any `renderHook` of client code fail with "Invalid hook call".

# Tests

- **New:** `tests/unit/client/outlook-mail-context.test.jsx` — atomic snapshot retry under mid-read email switch, A→B→A switchback truncation, give-up behavior under constant switching, per-attachment error preservation, single-selection bypass (no `loadItemByIdAsync`), sequential load/unload, unload retry, and mailbox-lock serialization.
- **New:** `tests/unit/client/use-outlook-mail-context-snapshot.test.jsx` — stale slow load must not clobber the fresh snapshot, double-dispatch coalescing, rapid-switch supersession, per-email edit resets.
- `npm run test:ui`: 9 suites, 91 tests pass (13 new). The new suites were verified to fail against the pre-fix code (7/12 originally, plus the switchback test against the first commit) — they pin the fixed behavior, not the implementation.

# Changelog

- `docs/releases/5.5.0/features.md` — admin-facing entry describing the reliability fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RF8t895poEEgjmJCafR4mJ