### PR TITLE
fix(chat): show upload/file answer-source badge when a tool-enabled app replies directly

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -62,3 +62,15 @@ limit — silently fell back to "Based on AI knowledge" even though a file or em
   same conversation can no longer inherit a stale badge.
 - On error/aborted turns the badge is intentionally not shown, since the assistant bubble is an
   error message rather than a real answer.
+
+## Answer-Source Badge Fixed When a Tool-Enabled App Answers an Upload Directly
+
+Uploading a document or image to an app that has tools enabled, then getting an answer straight
+away — the common "summarise this file" case where the model replies without calling a tool — now
+shows the correct "Based on uploaded file" badge instead of "Based on AI knowledge". The badge was
+attached on later tool-loop turns but not on this first, direct reply, so tool-enabled assistants
+kept mislabeling upload-based answers.
+
+- Covers document uploads, image uploads, and email context in tool-enabled apps.
+- The detected source is also cleared when a turn instead pauses for a clarification question or
+  ends in an error, so it can't carry over to the next message.

--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -1047,6 +1047,13 @@ class ToolExecutor {
           collectedToolCalls
         });
         clearTimeout(timeoutId);
+        // Emit the answer-source badge before 'done' (also resets it). The
+        // initial LLM call answering directly from an upload/email context —
+        // with no tool call — is the common case (e.g. "summarise this file").
+        // continueWithToolExecution() finalizes the multi-iteration paths; this
+        // is the first, no-tool-call turn that path never reaches, so without
+        // this finalize the answer silently fell back to "Based on AI knowledge".
+        this.finalizeAnswerSource(chatId);
         actionTracker.trackDone(chatId, { finishReason: finishReason || 'stop' });
         await logInteraction(
           'chat_response',
@@ -1072,6 +1079,9 @@ class ToolExecutor {
           chatId
         });
         clearTimeout(timeoutId);
+        // Terminal answer turn — finalize the source badge before 'done' so an
+        // upload/email answer isn't mislabeled "Based on AI knowledge".
+        this.finalizeAnswerSource(chatId);
         actionTracker.trackDone(chatId, { finishReason: finishReason || 'stop' });
         await logInteraction(
           'chat_response',
@@ -1152,6 +1162,12 @@ class ToolExecutor {
             })
           );
 
+          // Emit the answer-source badge before 'done' (also resets it). A
+          // passthrough tool is a terminal turn, so without this the streamed
+          // answer would show "Based on AI knowledge" even when built on
+          // uploads/email. Matches continueWithToolExecution()'s passthrough path.
+          this.finalizeAnswerSource(chatId);
+
           // Signal that we're done - user needs to send next message for LLM to continue
           actionTracker.trackDone(chatId, {
             finishReason: 'tool_passthrough_complete',
@@ -1166,6 +1182,10 @@ class ToolExecutor {
       // If we had a clarification request, stop here and wait for user input
       if (hasClarificationRequest) {
         clearTimeout(timeoutId);
+        // The turn pauses for user input (not a final answer), so don't emit an
+        // answer source — but clear the bookkeeping so a detected upload/email
+        // source can't leak into the follow-up turn on this chatId.
+        this.resetKnowledgeSources(chatId);
         if (activeRequests.get(chatId) === controller) {
           activeRequests.delete(chatId);
         }
@@ -1226,6 +1246,9 @@ class ToolExecutor {
       if (activeRequests.get(chatId) === controller) {
         activeRequests.delete(chatId);
       }
+      // Clear source bookkeeping so a failed turn can't leak a detected
+      // upload/email source into the next turn on this chatId.
+      this.resetKnowledgeSources(chatId);
     }
   }
 

--- a/tests/unit/server/streaming-answer-source-detection.test.js
+++ b/tests/unit/server/streaming-answer-source-detection.test.js
@@ -1,0 +1,205 @@
+/**
+ * @jest-environment node
+ *
+ * End-to-end detection coverage for the "answer source" badge on the standard
+ * (no-tools) streaming path.
+ *
+ * The existing tool-executor-knowledge-sources test only exercises the
+ * bookkeeping helpers (addKnowledgeSource / getKnowledgeSources /
+ * finalizeAnswerSource). It never drives executeStreamingResponse, so the
+ * actual detection — "does a message carrying fileData/imageData produce an
+ * answer.source event with ['file']?" — has been untested. That detection is
+ * exactly where the recurring "Based on AI knowledge" regression lives.
+ *
+ * This test drives the real StreamingHandler.executeStreamingResponse with a
+ * mocked LLM stream and asserts the emitted answer.source payload.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../../server/pathUtils.js', () => ({
+  getRootDir: () => require('path').join(__dirname, '../../../')
+}));
+
+jest.mock('../../../server/configCache.js', () => ({
+  default: {
+    getPlatform: () => ({}),
+    getApps: () => ({ data: [] }),
+    getModels: () => ({ data: [] })
+  }
+}));
+
+// A fake adapter whose parseResponseStream yields a single completed chunk.
+const fakeAdapter = {
+  parseResponseStream: async function* () {
+    yield { content: ['Hello from the model.'], complete: true, finishReason: 'stop' };
+  }
+};
+
+jest.mock('../../../server/adapters/index.js', () => ({
+  getAdapter: () => fakeAdapter
+}));
+
+jest.mock('../../../server/requestThrottler.js', () => ({
+  throttledFetch: jest.fn(async () => ({ ok: true, body: {} }))
+}));
+
+jest.mock('../../../server/utils.js', () => ({
+  logInteraction: jest.fn()
+}));
+
+jest.mock('../../../server/usageTracker.js', () => ({
+  estimateTokens: jest.fn(() => 0),
+  recordChatRequest: jest.fn(),
+  recordChatResponse: jest.fn()
+}));
+
+jest.mock('../../../server/utils/streamUtils.js', () => ({
+  getReadableStream: jest.fn(x => x)
+}));
+
+jest.mock('../../../server/telemetry.js', () => ({
+  getGenAIInstrumentation: () => ({ isEnabled: () => false })
+}));
+
+jest.mock('../../../server/telemetry/metrics.js', () => ({
+  recordAppUsage: jest.fn(),
+  recordConversation: jest.fn(),
+  recordError: jest.fn(),
+  recordStreamOutcome: jest.fn()
+}));
+
+jest.mock('../../../server/telemetry/ActivityTracker.js', () => ({
+  __esModule: true,
+  default: { recordActivity: jest.fn() }
+}));
+
+jest.mock('../../../server/telemetry/providerMap.js', () => ({
+  resolveProviderName: () => 'openai',
+  resolveOperation: () => 'chat'
+}));
+
+jest.mock('../../../server/services/integrations/ConversationStateManager.js', () => ({
+  __esModule: true,
+  default: { updateParentId: jest.fn() }
+}));
+
+jest.mock('../../../server/services/PromptService.js', () => ({
+  __esModule: true,
+  default: {
+    getPromptSources: jest.fn(() => []),
+    resetPromptSources: jest.fn()
+  }
+}));
+
+import StreamingHandler from '../../../server/services/chat/StreamingHandler.js';
+import { actionTracker } from '../../../server/actionTracker.js';
+
+/**
+ * Capture every SSE event emitted while `fn` runs. Returns all payloads so a
+ * test can assert on both the answer.source event and the terminal done event.
+ */
+async function captureEvents(fn) {
+  const events = [];
+  const listener = e => events.push(e);
+  actionTracker.on('fire-sse', listener);
+  try {
+    await fn();
+  } finally {
+    actionTracker.off('fire-sse', listener);
+  }
+  return events;
+}
+
+function baseArgs(overrides = {}) {
+  return {
+    request: { url: 'https://example.test/v1/chat', headers: {}, body: {} },
+    chatId: overrides.chatId || 'chat-detect-1',
+    buildLogData: () => ({ appId: 'test-app', userSessionId: 'sess-1', user: { id: 'u1' } }),
+    model: { id: 'gpt-test', provider: 'openai', modelId: 'gpt-test' },
+    llmMessages: overrides.llmMessages || [],
+    DEFAULT_TIMEOUT: 30000,
+    getLocalizedError: async key => `err:${key}`,
+    clientLanguage: 'en'
+  };
+}
+
+describe('StreamingHandler answer-source detection (no-tools path)', () => {
+  let handler;
+  beforeEach(() => {
+    handler = new StreamingHandler();
+  });
+
+  it('emits answer.source ["file"] for a single-document upload (fileData with content)', async () => {
+    const llmMessages = [
+      {
+        role: 'user',
+        content: '[File: report.txt (TXT)]\n\nquarterly numbers...\n\nSummarize this',
+        // preprocessMessagesWithFileData preserves fileData on the message
+        fileData: {
+          fileName: 'report.txt',
+          fileType: 'text/plain',
+          content: 'quarterly numbers...'
+        }
+      }
+    ];
+
+    const events = await captureEvents(() =>
+      handler.executeStreamingResponse(baseArgs({ llmMessages, chatId: 'chat-file' }))
+    );
+
+    const answerSource = events.find(e => e.event === 'answer.source');
+    expect(answerSource).toBeDefined();
+    expect(answerSource.sources).toEqual(['file']);
+  });
+
+  it('emits answer.source ["file"] for a single image upload (imageData object)', async () => {
+    const llmMessages = [
+      {
+        role: 'user',
+        content: 'What is in this image?',
+        imageData: { base64: 'AAAA', fileType: 'image/png', type: 'image' }
+      }
+    ];
+
+    const events = await captureEvents(() =>
+      handler.executeStreamingResponse(baseArgs({ llmMessages, chatId: 'chat-img' }))
+    );
+
+    const answerSource = events.find(e => e.event === 'answer.source');
+    expect(answerSource).toBeDefined();
+    expect(answerSource.sources).toEqual(['file']);
+  });
+
+  it('emits answer.source ["file"] for multiple document uploads (fileData array)', async () => {
+    const llmMessages = [
+      {
+        role: 'user',
+        content: 'Compare these',
+        fileData: [
+          { fileName: 'a.txt', fileType: 'text/plain', content: 'aaa' },
+          { fileName: 'b.txt', fileType: 'text/plain', content: 'bbb' }
+        ]
+      }
+    ];
+
+    const events = await captureEvents(() =>
+      handler.executeStreamingResponse(baseArgs({ llmMessages, chatId: 'chat-multi' }))
+    );
+
+    const answerSource = events.find(e => e.event === 'answer.source');
+    expect(answerSource).toBeDefined();
+    expect(answerSource.sources).toEqual(['file']);
+  });
+
+  it('does NOT emit answer.source when the turn is plain text (no upload)', async () => {
+    const llmMessages = [{ role: 'user', content: 'Hello, what is the capital of France?' }];
+
+    const events = await captureEvents(() =>
+      handler.executeStreamingResponse(baseArgs({ llmMessages, chatId: 'chat-plain' }))
+    );
+
+    const answerSource = events.find(e => e.event === 'answer.source');
+    expect(answerSource).toBeUndefined();
+  });
+});

--- a/tests/unit/server/tool-executor-answer-source-detection.test.js
+++ b/tests/unit/server/tool-executor-answer-source-detection.test.js
@@ -1,0 +1,210 @@
+/**
+ * @jest-environment node
+ *
+ * End-to-end detection coverage for the "answer source" badge on the TOOLS
+ * path (processChatWithTools).
+ *
+ * Apps with tools enabled route through ToolExecutor, not StreamingHandler.
+ * The tool loop reads the LLM stream via a Web ReadableStream reader, which
+ * needs the Node environment (jsdom lacks setImmediate). This drives the real
+ * loop with a mocked (no-tool-call) LLM stream and asserts that a fileData /
+ * imageData message produces an answer.source event with ['file'].
+ *
+ * Regression guard: processChatWithTools handles the INITIAL LLM call. When the
+ * model answers directly from an upload (no tool call) it took a terminal path
+ * that emitted 'done' WITHOUT the answer-source badge, so tool-enabled apps
+ * reported "Based on AI knowledge" for uploaded files. continueWithToolExecution
+ * (the multi-iteration loop) was already fixed; this guards the first-call path.
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+
+jest.mock('../../../server/pathUtils.js', () => ({
+  getRootDir: () => require('path').join(__dirname, '../../../')
+}));
+
+jest.mock('../../../server/configCache.js', () => ({
+  default: {
+    getPlatform: () => ({}),
+    getApps: () => ({ data: [] }),
+    getModels: () => ({ data: [] })
+  }
+}));
+
+jest.mock('../../../server/requestThrottler.js', () => ({
+  throttledFetch: jest.fn(async () => ({
+    ok: true,
+    body: (() => {
+      const encoder = new TextEncoder();
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"final":true}\n\n'));
+          controller.close();
+        }
+      });
+    })()
+  }))
+}));
+
+// convertResponseToGeneric turns each SSE data frame into a normalized result.
+// Return a final answer with no tool calls so the loop terminates immediately.
+jest.mock('../../../server/adapters/toolCalling/index.js', () => ({
+  convertResponseToGeneric: jest.fn(async () => ({
+    content: ['Here is your answer.'],
+    finishReason: 'stop',
+    complete: true,
+    tool_calls: []
+  })),
+  normalizeToolName: x => x
+}));
+
+jest.mock('../../../server/adapters/index.js', () => ({
+  createCompletionRequest: jest.fn(),
+  getAdapter: () => ({})
+}));
+
+jest.mock('../../../server/toolLoader.js', () => ({
+  runTool: jest.fn(),
+  getToolsForApp: jest.fn(async () => []),
+  loadTools: jest.fn(async () => [])
+}));
+
+jest.mock('../../../server/tools/askUser.js', () => ({
+  MAX_CLARIFICATIONS_PER_CONVERSATION: 5,
+  validateAskUserParams: jest.fn()
+}));
+
+jest.mock('../../../server/utils.js', () => ({
+  logInteraction: jest.fn(),
+  getErrorDetails: jest.fn(() => ({ message: 'err', code: 'ERR' }))
+}));
+
+jest.mock('../../../server/usageTracker.js', () => ({
+  estimateTokens: jest.fn(() => 0),
+  recordChatRequest: jest.fn(),
+  recordChatResponse: jest.fn()
+}));
+
+jest.mock('../../../server/telemetry.js', () => ({
+  getGenAIInstrumentation: () => ({ isEnabled: () => false })
+}));
+
+jest.mock('../../../server/telemetry/metrics.js', () => ({
+  recordAppUsage: jest.fn(),
+  recordConversation: jest.fn(),
+  recordError: jest.fn(),
+  recordStreamOutcome: jest.fn()
+}));
+
+jest.mock('../../../server/telemetry/ActivityTracker.js', () => ({
+  __esModule: true,
+  default: { recordActivity: jest.fn() }
+}));
+
+jest.mock('../../../server/telemetry/providerMap.js', () => ({
+  resolveProviderName: () => 'openai',
+  resolveOperation: () => 'chat'
+}));
+
+jest.mock('../../../server/services/integrations/ConversationStateManager.js', () => ({
+  __esModule: true,
+  default: { updateParentId: jest.fn() }
+}));
+
+jest.mock('../../../server/services/PromptService.js', () => ({
+  __esModule: true,
+  default: {
+    getPromptSources: jest.fn(() => []),
+    resetPromptSources: jest.fn()
+  }
+}));
+
+import ToolExecutor from '../../../server/services/chat/ToolExecutor.js';
+import { actionTracker } from '../../../server/actionTracker.js';
+
+async function captureEvents(fn) {
+  const events = [];
+  const listener = e => events.push(e);
+  actionTracker.on('fire-sse', listener);
+  try {
+    await fn();
+  } finally {
+    actionTracker.off('fire-sse', listener);
+  }
+  return events;
+}
+
+function prep(llmMessages) {
+  return {
+    request: { url: 'https://example.test/v1/chat', headers: {}, body: {} },
+    model: { id: 'gpt-test', provider: 'openai', modelId: 'gpt-test' },
+    llmMessages,
+    tools: [{ id: 'noop' }],
+    apiKey: 'k',
+    temperature: 0.7,
+    maxTokens: 1024,
+    responseFormat: 'markdown',
+    responseSchema: null,
+    app: { id: 'test-app' },
+    userFileData: null
+  };
+}
+
+describe('ToolExecutor answer-source detection (tools path)', () => {
+  let executor;
+  beforeEach(() => {
+    executor = new ToolExecutor();
+  });
+
+  it('emits answer.source ["file"] for a document upload in an app with tools', async () => {
+    const llmMessages = [
+      {
+        role: 'user',
+        content: '[File: report.txt (TXT)]\n\nnumbers...\n\nSummarize',
+        fileData: { fileName: 'report.txt', fileType: 'text/plain', content: 'numbers...' }
+      }
+    ];
+
+    const events = await captureEvents(() =>
+      executor.processChatWithTools({
+        prep: prep(llmMessages),
+        chatId: 'chat-tools-file',
+        buildLogData: () => ({ appId: 'test-app', userSessionId: 's', user: { id: 'u' } }),
+        DEFAULT_TIMEOUT: 30000,
+        getLocalizedError: async k => `err:${k}`,
+        clientLanguage: 'en',
+        user: { id: 'u' }
+      })
+    );
+
+    const answerSource = events.find(e => e.event === 'answer.source');
+    expect(answerSource).toBeDefined();
+    expect(answerSource.sources).toEqual(['file']);
+  });
+
+  it('emits answer.source ["file"] for an image upload in an app with tools', async () => {
+    const llmMessages = [
+      {
+        role: 'user',
+        content: 'Describe this',
+        imageData: { base64: 'AAAA', fileType: 'image/png', type: 'image' }
+      }
+    ];
+
+    const events = await captureEvents(() =>
+      executor.processChatWithTools({
+        prep: prep(llmMessages),
+        chatId: 'chat-tools-img',
+        buildLogData: () => ({ appId: 'test-app', userSessionId: 's', user: { id: 'u' } }),
+        DEFAULT_TIMEOUT: 30000,
+        getLocalizedError: async k => `err:${k}`,
+        clientLanguage: 'en',
+        user: { id: 'u' }
+      })
+    );
+
+    const answerSource = events.find(e => e.event === 'answer.source');
+    expect(answerSource).toBeDefined();
+    expect(answerSource.sources).toEqual(['file']);
+  });
+});


### PR DESCRIPTION
## Problem

Uploading a document, image, or file to a chat app that has **tools enabled** still showed **"Based on AI knowledge"** instead of "Based on uploaded file" — the recurring answer-source badge bug.

## Root cause

`ToolExecutor.processChatWithTools` handles the **initial** LLM call. It correctly *detects* the upload (`fileData`/`imageData`) and records the `file` source, but its terminal exit paths called `actionTracker.trackDone(...)` **without** first calling `finalizeAnswerSource(chatId)`. Since the badge is emitted by `finalizeAnswerSource`, the client received a `done` with no `answer.source` event and fell back to the LLM-only badge.

This is the **common** case: upload a file to a tool-enabled assistant and ask "summarise this" — the model answers *directly*, without calling a tool, so it exits on the initial-call path (`finishReason !== 'tool_calls' && collectedToolCalls.length === 0`).

The 5.5.0 fix (#1672/#1675) added `finalizeAnswerSource` to every terminal path in `continueWithToolExecution` (the multi-iteration loop) — but that loop is only reached *after* a tool call, so the direct-answer path never got the fix. That's why it was "still" broken.

The no-tools path (`StreamingHandler`) was already correct; this only affected apps with tools.

## Fix

Bring the initial-call terminal paths in `processChatWithTools` in line with the contract already used by `continueWithToolExecution`:

- **finalize the source badge before `done`** on the no-tool-calls, no-valid-tool-calls, and passthrough (streaming tool) paths
- **clear source bookkeeping** on the clarification pause and the error path, so a detected upload/email source can't leak into the next turn

## Tests

Added end-to-end regression coverage that drives the **real** `StreamingHandler` and `ToolExecutor` loops with a mocked LLM stream and asserts the emitted `answer.source` SSE event. Previously only the bookkeeping helpers were unit-tested, so the detection→emit path (where this class of bug lives) was uncovered.

- `tests/unit/server/tool-executor-answer-source-detection.test.js` — tools path (document + image uploads). Confirmed to **fail** without the fix.
- `tests/unit/server/streaming-answer-source-detection.test.js` — standard streaming path (document, image, multi-file, and plain-text negative case).

Full `tests/unit/server` suite: 95 passing (1 pre-existing unrelated `import.meta` transform failure in `locale-override.test.js`, present on the base too). Lint + Prettier clean.

## Changelog

Added an entry to `docs/releases/5.5.0/features.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HN12cc9SN8CjUvHezRXxid

---
_Generated by [Claude Code](https://claude.ai/code/session_01HN12cc9SN8CjUvHezRXxid)_