### PR TITLE
Wire iHub Documentation source into the default Support Bot app

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,5 +1,15 @@
 # Features — 5.5.0
 
+## iHub Support Bot Can Now Answer Questions About the Platform
+
+The bundled **iHub Support Bot** app now references the built-in iHub Documentation source, so it
+can look up and cite the full platform documentation on demand instead of only the short FAQ.
+
+- The documentation is exposed as a tool the model calls on demand, so ordinary questions are not
+  slowed down by loading the full document.
+- Existing installations receive the updated app configuration automatically on upgrade via the
+  configuration migration system; no manual action is required.
+
 ## Outlook Add-in: Reliable Email and Attachment Sync
 
 The Outlook task pane now follows the selected email reliably. Previously, switching emails could

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -195,8 +195,10 @@ Fresh installations ship with a standard **iHub Documentation** source
 (`id: ihub-documentation`). It bundles the complete iHub Apps documentation —
 consolidated from the repository's `docs/` folder — into a single knowledge
 source and is exposed as a tool (`exposeAs: "tool"`), so the model retrieves it
-on demand rather than inflating every prompt. Add it to an app's `sources` list
-to build a self-service help or onboarding assistant.
+on demand rather than inflating every prompt. The bundled **iHub Support Bot**
+app already references it, so it can answer questions about the platform out
+of the box. Add it to any other app's `sources` list to build a self-service
+help or onboarding assistant.
 
 The bundled content is generated from the `docs/` folder by
 `scripts/export-docs-markdown.js` — the same export that produces the standalone

--- a/server/defaults/apps/ihub-support-bot.json
+++ b/server/defaults/apps/ihub-support-bot.json
@@ -23,7 +23,7 @@
   "preferredStyle": "normal",
   "preferredTemperature": 0.3,
   "sendChatHistory": true,
-  "sources": ["faq"],
+  "sources": ["faq", "ihub-documentation"],
   "enabled": true,
   "tools": [],
   "greeting": {

--- a/server/migrations/V067__add_ihub_documentation_to_support_bot.js
+++ b/server/migrations/V067__add_ihub_documentation_to_support_bot.js
@@ -1,0 +1,37 @@
+/**
+ * Migration V067 — Wire the iHub Documentation source into the Support Bot app
+ *
+ * V055 registered the "ihub-documentation" source in config/sources.json, but
+ * the bundled "iHub Support Bot" app never listed it in its `sources` array,
+ * so the bot could not actually reference the consolidated documentation
+ * (GitHub issue #582). This migration adds the source to the existing app's
+ * `sources` array on upgrade. Fresh installs already get the updated app
+ * config via server/defaults/apps/ihub-support-bot.json.
+ */
+
+export const version = '067';
+export const description = 'add_ihub_documentation_to_support_bot';
+
+const APP_FILE = 'apps/ihub-support-bot.json';
+const SOURCE_ID = 'ihub-documentation';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists(APP_FILE);
+}
+
+export async function up(ctx) {
+  const app = await ctx.readJson(APP_FILE);
+
+  if (!Array.isArray(app.sources)) {
+    app.sources = [];
+  }
+
+  if (app.sources.includes(SOURCE_ID)) {
+    ctx.log('iHub Support Bot already references the ihub-documentation source — skipping');
+    return;
+  }
+
+  app.sources.push(SOURCE_ID);
+  await ctx.writeJson(APP_FILE, app);
+  ctx.log('Added ihub-documentation source to iHub Support Bot app');
+}


### PR DESCRIPTION
## Summary

Closes #582.

The consolidated `ihub-documentation` source (full platform docs, generated from `docs/`) was already registered in `config/sources.json` by migration V055, but the bundled **iHub Support Bot** app never actually listed it in its `sources` array. As a result, the support bot could only answer from the small FAQ document rather than the full documentation the issue asked for.

- Add `"ihub-documentation"` to `server/defaults/apps/ihub-support-bot.json`'s `sources` array (fresh installs).
- Add migration `V067__add_ihub_documentation_to_support_bot.js` to wire the source into the app config for existing installations on upgrade (idempotent — skips if already present).
- Update `docs/sources.md` to reflect that the Support Bot ships with the documentation source enabled.
- Add a changelog entry under `docs/releases/5.5.0/features.md`.

The source is `exposeAs: "tool"`, so it's retrieved on demand by the model rather than injected into every prompt — no change to prompt size/latency for unrelated questions.

## Test plan

- [x] Verified `server/defaults/apps/ihub-support-bot.json` still validates against `appConfigSchema`.
- [x] Ran the migration against a temp `contents/` fixture: adds the source on first run, and is a no-op (logs "already references") on a second run.
- [x] `npx eslint` on the changed/added files — no errors.
- [x] Existing `server/tests/migrations-runner.test.js` suite still passes (41/41).
- [ ] Manual end-to-end check in a running dev server (not performed in this session — no server/client build was started).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RAvZ6kV3GzQttLutrP6wEj)_