### PR TITLE
fix(outlook): stop silently dropping unsupported email attachments

### DIFF
--- a/client/src/features/office/components/chat/OfficeMailContextBanner.jsx
+++ b/client/src/features/office/components/chat/OfficeMailContextBanner.jsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import Icon from '../../../../shared/components/Icon';
 import { formatFileSize } from '../../../upload/utils/cloudFileProcessing';
-import { isUnsupportedAttachmentFormat } from '../../utilities/attachmentFormat';
 import { MAILBOX_ATTACHMENT_API_UNAVAILABLE_MESSAGE } from '../../utilities/outlookMailContext';
 
 const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp|svg)$/i;
@@ -16,9 +15,6 @@ function isImageAttachment(att) {
 
 function getAttachmentStatus(att) {
   if (att?.error) return { kind: 'failed', label: att.error };
-  if (isUnsupportedAttachmentFormat(att)) {
-    return { kind: 'unsupported', label: 'This attachment type is not supported yet' };
-  }
   if (att?.content) return { kind: 'attached', label: 'Will be sent' };
   return { kind: 'pending', label: 'Loading...' };
 }
@@ -211,14 +207,6 @@ function OfficeMailContextBanner({
                         <span aria-hidden>•</span>
                         <span className="text-rose-600" title={status.label}>
                           Failed
-                        </span>
-                      </>
-                    )}
-                    {status.kind === 'unsupported' && (
-                      <>
-                        <span aria-hidden>•</span>
-                        <span className="text-amber-600" title={status.label}>
-                          Unsupported
                         </span>
                       </>
                     )}

--- a/client/src/features/office/components/chat/OfficeMailContextBanner.jsx
+++ b/client/src/features/office/components/chat/OfficeMailContextBanner.jsx
@@ -1,6 +1,8 @@
 import { useMemo } from 'react';
 import Icon from '../../../../shared/components/Icon';
 import { formatFileSize } from '../../../upload/utils/cloudFileProcessing';
+import { isUnsupportedAttachmentFormat } from '../../utilities/attachmentFormat';
+import { MAILBOX_ATTACHMENT_API_UNAVAILABLE_MESSAGE } from '../../utilities/outlookMailContext';
 
 const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp|svg)$/i;
 
@@ -14,6 +16,9 @@ function isImageAttachment(att) {
 
 function getAttachmentStatus(att) {
   if (att?.error) return { kind: 'failed', label: att.error };
+  if (isUnsupportedAttachmentFormat(att)) {
+    return { kind: 'unsupported', label: 'This attachment type is not supported yet' };
+  }
   if (att?.content) return { kind: 'attached', label: 'Will be sent' };
   return { kind: 'pending', label: 'Loading...' };
 }
@@ -64,6 +69,12 @@ function OfficeMailContextBanner({
 
   const hasBody = Boolean(ctx?.bodyText && ctx.bodyText.trim().length > 0);
   const hasAttachments = attachments.length > 0;
+  // Older Outlook hosts (pre-Mailbox 1.8) fail every attachment fetch with
+  // the same "API not available" error — show one explanation instead of
+  // repeating it on every row.
+  const attachmentApiUnavailable =
+    hasAttachments &&
+    attachments.every(a => a?.error === MAILBOX_ATTACHMENT_API_UNAVAILABLE_MESSAGE);
 
   if (loading) {
     return (
@@ -167,6 +178,14 @@ function OfficeMailContextBanner({
       {/* Attachments list */}
       {hasAttachments && remainingAttachments.length > 0 && (
         <div className="divide-y divide-slate-100">
+          {attachmentApiUnavailable && (
+            <div className="flex items-start gap-2 px-3 py-1.5 bg-amber-50 text-[11px] text-amber-700">
+              <Icon name="information-circle" size="sm" />
+              <span>
+                Attachments can&apos;t be read on this version of Outlook (requires Mailbox 1.8+).
+              </span>
+            </div>
+          )}
           {remainingAttachments.map(att => {
             const status = getAttachmentStatus(att);
             const isImage = isImageAttachment(att);
@@ -187,11 +206,19 @@ function OfficeMailContextBanner({
                   </div>
                   <div className="text-[11px] text-slate-500 flex items-center gap-1.5">
                     <span>{formatFileSize(Number(att.size) || 0)}</span>
-                    {status.kind === 'failed' && (
+                    {status.kind === 'failed' && !attachmentApiUnavailable && (
                       <>
                         <span aria-hidden>•</span>
                         <span className="text-rose-600" title={status.label}>
                           Failed
+                        </span>
+                      </>
+                    )}
+                    {status.kind === 'unsupported' && (
+                      <>
+                        <span aria-hidden>•</span>
+                        <span className="text-amber-600" title={status.label}>
+                          Unsupported
                         </span>
                       </>
                     )}

--- a/client/src/features/office/utilities/attachmentFormat.js
+++ b/client/src/features/office/utilities/attachmentFormat.js
@@ -34,24 +34,3 @@ export function hasBase64Content(att) {
   if (fmt && fmt !== 'base64') return false;
   return typeof att.content.content === 'string' && att.content.content.length > 0;
 }
-
-// Formats getAttachmentContentAsync can return that this pipeline cannot
-// turn into a file/image payload: `eml` (attached/forwarded email items),
-// `icalendar` (meeting invites) and `url` (OneDrive/SharePoint share links,
-// not binary data). These attachments fetch successfully — they have no
-// `.error` — so without this check they looked "attached" in the review
-// banner while `hasBase64Content` silently dropped them at send time. See
-// issue #1451.
-const UNSUPPORTED_CONTENT_FORMATS = new Set(['eml', 'icalendar', 'url']);
-
-/**
- * True for an attachment that fetched successfully but is in a format this
- * pipeline doesn't convert to LLM-ready content. Distinct from `att.error`
- * (a fetch/network failure) so the UI can show "unsupported" instead of
- * "failed" for these.
- */
-export function isUnsupportedAttachmentFormat(att) {
-  if (!att?.content || att.error) return false;
-  const fmt = String(att.content.format || '').toLowerCase();
-  return UNSUPPORTED_CONTENT_FORMATS.has(fmt);
-}

--- a/client/src/features/office/utilities/attachmentFormat.js
+++ b/client/src/features/office/utilities/attachmentFormat.js
@@ -1,0 +1,57 @@
+// Pure, dependency-free helpers for interpreting Outlook attachment
+// descriptors (as produced by outlookMailContext.js's readMailSnapshot).
+// Kept separate from buildChatApiMessages.js — which pulls in the full
+// document-processing pipeline (pdf.js, mammoth, xlsx, ...) — so this
+// logic can be unit tested directly under plain node without a bundler.
+// See issue #1451.
+
+/**
+ * Strip MIME-type parameters so e.g. `image/jpeg; name="foo.jpg"` collapses to
+ * `image/jpeg`. Outlook (and some Exchange servers) decorate the contentType
+ * with a `name=` parameter which the LLM adapters then send as the `media_type`
+ * — Anthropic rejects anything that isn't a bare MIME type, so without this
+ * step image attachments fail before the model ever sees them.
+ */
+export function sanitizeContentType(ct) {
+  if (!ct || typeof ct !== 'string') return '';
+  return ct.split(';')[0].trim().toLowerCase();
+}
+
+/**
+ * True only when the attachment's `content` blob carries actual binary
+ * data. Outlook's `getAttachmentContentAsync` can return four formats —
+ * `Base64`, `Eml`, `iCalendar`, `Url` — and only `base64` is usable as an
+ * image / file payload. Cloud attachments (OneDrive / SharePoint links)
+ * arrive as `format: 'url'` with `content` set to the share link, which
+ * we previously fed straight into `atob()` and shipped to the LLM as if
+ * it were base64. That was the silent failure path behind issue #1467.
+ */
+export function hasBase64Content(att) {
+  if (!att?.content) return false;
+  const fmt = String(att.content.format || '').toLowerCase();
+  // Office.js returns the enum value verbatim; treat anything other
+  // than the explicit "base64" string as non-base64 to be safe.
+  if (fmt && fmt !== 'base64') return false;
+  return typeof att.content.content === 'string' && att.content.content.length > 0;
+}
+
+// Formats getAttachmentContentAsync can return that this pipeline cannot
+// turn into a file/image payload: `eml` (attached/forwarded email items),
+// `icalendar` (meeting invites) and `url` (OneDrive/SharePoint share links,
+// not binary data). These attachments fetch successfully — they have no
+// `.error` — so without this check they looked "attached" in the review
+// banner while `hasBase64Content` silently dropped them at send time. See
+// issue #1451.
+const UNSUPPORTED_CONTENT_FORMATS = new Set(['eml', 'icalendar', 'url']);
+
+/**
+ * True for an attachment that fetched successfully but is in a format this
+ * pipeline doesn't convert to LLM-ready content. Distinct from `att.error`
+ * (a fetch/network failure) so the UI can show "unsupported" instead of
+ * "failed" for these.
+ */
+export function isUnsupportedAttachmentFormat(att) {
+  if (!att?.content || att.error) return false;
+  const fmt = String(att.content.format || '').toLowerCase();
+  return UNSUPPORTED_CONTENT_FORMATS.has(fmt);
+}

--- a/client/src/features/office/utilities/attachmentFormat.test.js
+++ b/client/src/features/office/utilities/attachmentFormat.test.js
@@ -1,0 +1,110 @@
+#!/usr/bin/env node
+
+/**
+ * Regression tests for Outlook attachment format handling — issue #1451
+ * ("[Outlook] Bug: PDF / Word / .eml attachments fail silently or throw").
+ *
+ * Covers the classification helpers that decide whether an attachment
+ * descriptor (as produced by outlookMailContext.js) is usable content,
+ * an unsupported format (attached email / invite / cloud link), or a
+ * genuine fetch failure. Pure (no React, no Office.js) so it runs under
+ * node directly.
+ *
+ * Run directly: `node client/src/features/office/utilities/attachmentFormat.test.js`.
+ */
+
+import {
+  sanitizeContentType,
+  hasBase64Content,
+  isUnsupportedAttachmentFormat
+} from './attachmentFormat.js';
+
+let failures = 0;
+function check(label, cond, details) {
+  if (!cond) failures += 1;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && details) console.log(`   ${details}`);
+}
+
+console.log('🧪 sanitizeContentType\n');
+{
+  check(
+    'strips trailing name= parameter',
+    sanitizeContentType('image/jpeg; name="foo.jpg"') === 'image/jpeg'
+  );
+  check('lowercases', sanitizeContentType('Application/PDF') === 'application/pdf');
+  check('null → empty string', sanitizeContentType(null) === '');
+  check('non-string → empty string', sanitizeContentType(42) === '');
+}
+
+console.log('\n🧪 hasBase64Content — PDF / Word attachments (issue #1451)\n');
+{
+  const pdf = { content: { format: 'base64', content: 'JVBERi0xLjQK' } };
+  check('base64 PDF content is usable', hasBase64Content(pdf) === true);
+
+  const docx = { content: { format: 'Base64', content: 'UEsDBBQABgAI' } };
+  check('format is case-insensitive', hasBase64Content(docx) === true);
+
+  const missingContent = { content: { format: 'base64', content: '' } };
+  check('empty content string is not usable', hasBase64Content(missingContent) === false);
+
+  const noContent = { name: 'invoice.pdf' };
+  check('attachment with no content field is not usable', hasBase64Content(noContent) === false);
+}
+
+console.log('\n🧪 hasBase64Content — attached .eml / invite / cloud-link attachments\n');
+{
+  const eml = { content: { format: 'eml', content: 'RnJvbTogYUBiLmNvbQ==' } };
+  check('eml-format content is NOT base64-usable', hasBase64Content(eml) === false);
+
+  const invite = { content: { format: 'icalendar', content: 'QkVHSU46VkNBTEVOREFS' } };
+  check('icalendar-format content is NOT base64-usable', hasBase64Content(invite) === false);
+
+  const cloudLink = { content: { format: 'url', content: 'https://contoso.sharepoint.com/x' } };
+  check(
+    'url-format (cloud share link) content is NOT base64-usable — was previously fed to atob()',
+    hasBase64Content(cloudLink) === false
+  );
+}
+
+console.log('\n🧪 isUnsupportedAttachmentFormat\n');
+{
+  const pdf = { content: { format: 'base64', content: 'JVBERi0xLjQK' } };
+  check('a normal PDF is not "unsupported"', isUnsupportedAttachmentFormat(pdf) === false);
+
+  const eml = { name: 'Fwd: Q3 report.eml', content: { format: 'eml', content: 'RnJvbTo=' } };
+  check(
+    'a forwarded .eml attachment IS flagged unsupported (not silently "attached")',
+    isUnsupportedAttachmentFormat(eml) === true
+  );
+
+  const invite = { content: { format: 'icalendar', content: 'QkVHSU4=' } };
+  check(
+    'an .ics invite attachment is flagged unsupported',
+    isUnsupportedAttachmentFormat(invite) === true
+  );
+
+  const cloudLink = { content: { format: 'url', content: 'https://contoso.sharepoint.com/x' } };
+  check(
+    'a OneDrive/SharePoint link attachment is flagged unsupported',
+    isUnsupportedAttachmentFormat(cloudLink) === true
+  );
+
+  const failed = {
+    error: 'Attachment too large to include automatically.',
+    content: { format: 'eml', content: 'RnJvbTo=' }
+  };
+  check(
+    'a fetch failure (.error set) is reported as failed, not unsupported',
+    isUnsupportedAttachmentFormat(failed) === false
+  );
+
+  const pending = { name: 'invoice.pdf' };
+  check(
+    'an attachment with no content yet is not "unsupported"',
+    isUnsupportedAttachmentFormat(pending) === false
+  );
+}
+
+console.log(`\n${failures === 0 ? '✅ all passed' : `❌ ${failures} failed`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/client/src/features/office/utilities/attachmentFormat.test.js
+++ b/client/src/features/office/utilities/attachmentFormat.test.js
@@ -5,19 +5,17 @@
  * ("[Outlook] Bug: PDF / Word / .eml attachments fail silently or throw").
  *
  * Covers the classification helpers that decide whether an attachment
- * descriptor (as produced by outlookMailContext.js) is usable content,
- * an unsupported format (attached email / invite / cloud link), or a
- * genuine fetch failure. Pure (no React, no Office.js) so it runs under
- * node directly.
+ * descriptor (as produced by outlookMailContext.js) carries real binary
+ * document data usable by the document pipeline, vs. a textual/reference
+ * format (attached email, invite, cloud link) handled separately — see
+ * emailAttachmentParsers.js and buildChatApiMessages.js's
+ * buildFileEntryForAttachment. Pure (no React, no Office.js) so it runs
+ * under node directly.
  *
  * Run directly: `node client/src/features/office/utilities/attachmentFormat.test.js`.
  */
 
-import {
-  sanitizeContentType,
-  hasBase64Content,
-  isUnsupportedAttachmentFormat
-} from './attachmentFormat.js';
+import { sanitizeContentType, hasBase64Content } from './attachmentFormat.js';
 
 let failures = 0;
 function check(label, cond, details) {
@@ -54,6 +52,10 @@ console.log('\n🧪 hasBase64Content — PDF / Word attachments (issue #1451)\n'
 
 console.log('\n🧪 hasBase64Content — attached .eml / invite / cloud-link attachments\n');
 {
+  // These formats are handled by dedicated parsers / a link stub instead
+  // (see emailAttachmentParsers.test.js) — hasBase64Content just needs to
+  // keep saying "not raw binary content" so they don't get fed into
+  // base64ToFile/atob() as if they were a PDF/DOCX.
   const eml = { content: { format: 'eml', content: 'RnJvbTogYUBiLmNvbQ==' } };
   check('eml-format content is NOT base64-usable', hasBase64Content(eml) === false);
 
@@ -64,45 +66,6 @@ console.log('\n🧪 hasBase64Content — attached .eml / invite / cloud-link att
   check(
     'url-format (cloud share link) content is NOT base64-usable — was previously fed to atob()',
     hasBase64Content(cloudLink) === false
-  );
-}
-
-console.log('\n🧪 isUnsupportedAttachmentFormat\n');
-{
-  const pdf = { content: { format: 'base64', content: 'JVBERi0xLjQK' } };
-  check('a normal PDF is not "unsupported"', isUnsupportedAttachmentFormat(pdf) === false);
-
-  const eml = { name: 'Fwd: Q3 report.eml', content: { format: 'eml', content: 'RnJvbTo=' } };
-  check(
-    'a forwarded .eml attachment IS flagged unsupported (not silently "attached")',
-    isUnsupportedAttachmentFormat(eml) === true
-  );
-
-  const invite = { content: { format: 'icalendar', content: 'QkVHSU4=' } };
-  check(
-    'an .ics invite attachment is flagged unsupported',
-    isUnsupportedAttachmentFormat(invite) === true
-  );
-
-  const cloudLink = { content: { format: 'url', content: 'https://contoso.sharepoint.com/x' } };
-  check(
-    'a OneDrive/SharePoint link attachment is flagged unsupported',
-    isUnsupportedAttachmentFormat(cloudLink) === true
-  );
-
-  const failed = {
-    error: 'Attachment too large to include automatically.',
-    content: { format: 'eml', content: 'RnJvbTo=' }
-  };
-  check(
-    'a fetch failure (.error set) is reported as failed, not unsupported',
-    isUnsupportedAttachmentFormat(failed) === false
-  );
-
-  const pending = { name: 'invoice.pdf' };
-  check(
-    'an attachment with no content yet is not "unsupported"',
-    isUnsupportedAttachmentFormat(pending) === false
   );
 }
 

--- a/client/src/features/office/utilities/buildChatApiMessages.js
+++ b/client/src/features/office/utilities/buildChatApiMessages.js
@@ -1,11 +1,8 @@
 import { processDocumentFile } from '../../upload/utils/fileProcessing';
-import {
-  sanitizeContentType,
-  hasBase64Content,
-  isUnsupportedAttachmentFormat
-} from './attachmentFormat';
+import { sanitizeContentType, hasBase64Content } from './attachmentFormat';
+import { parseEmlAttachment, parseIcsAttachment } from './emailAttachmentParsers';
 
-export { sanitizeContentType, hasBase64Content, isUnsupportedAttachmentFormat };
+export { sanitizeContentType, hasBase64Content };
 
 export function createUserMessageId() {
   return `msg-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
@@ -149,58 +146,102 @@ function base64ToFile(base64, name, contentType) {
   return new File([bytes], name, { type: contentType });
 }
 
-// Processes non-image attachments through the shared document pipeline.
-// Returns an array of { fileName, fileType, displayType, content?, pageImages? }
-// in the shape RequestBuilder.preprocessMessagesWithFileData expects.
-// Skips cloud attachments (format: 'url') and EML / iCalendar items since
-// the document pipeline expects binary file bytes — see `hasBase64Content`.
+// Builds the { fileName, fileType, displayType, content?, pageImages? }
+// entry (shape RequestBuilder.preprocessMessagesWithFileData expects) for a
+// single non-image attachment, dispatching on the content format Office
+// actually returned rather than assuming everything is a binary document:
+// - `eml` (attached/forwarded emails) and `icalendar` (meeting invites) are
+//   textual formats — parsed directly into readable content.
+// - `url` (OneDrive/SharePoint share links) has no file bytes to read, so
+//   the link itself is sent as a reference instead of being dropped.
+// - anything else goes through the shared binary-document pipeline.
+async function buildFileEntryForAttachment(a) {
+  const format = String(a?.content?.format || '').toLowerCase();
+  const cleanType =
+    sanitizeContentType(a.contentType) || a.contentType || 'application/octet-stream';
+
+  if (format === 'eml') {
+    const text = parseEmlAttachment(a.content.content);
+    if (!text) {
+      console.warn(`[office] attachment ${describeAttachment(a)} could not be parsed as an email`);
+      return null;
+    }
+    return {
+      source: 'local',
+      fileName: a.name,
+      fileType: 'message/rfc822',
+      displayType: 'Email',
+      content: text
+    };
+  }
+
+  if (format === 'icalendar') {
+    const text = parseIcsAttachment(a.content.content);
+    if (!text) {
+      console.warn(`[office] attachment ${describeAttachment(a)} could not be parsed as an invite`);
+      return null;
+    }
+    return {
+      source: 'local',
+      fileName: a.name,
+      fileType: 'text/calendar',
+      displayType: 'Calendar invite',
+      content: text
+    };
+  }
+
+  if (format === 'url') {
+    // Office only exposes the share link for cloud attachments, not the
+    // file bytes — there's nothing to extract, but the link is still
+    // useful context, so it's sent instead of silently dropping the
+    // attachment (previously fed straight into atob() as if it were
+    // base64 — see issue #1467).
+    return {
+      source: 'local',
+      fileName: a.name,
+      fileType: cleanType,
+      displayType: cleanType,
+      content: `[Cloud-hosted attachment — content was not retrieved. Link: ${a.content.content}]`
+    };
+  }
+
+  if (!hasBase64Content(a)) {
+    console.warn(`[office] attachment ${describeAttachment(a)} has an unrecognized content format`);
+    return null;
+  }
+
+  try {
+    const file = base64ToFile(a.content.content, a.name, cleanType);
+    const { content, pageImages } = await processDocumentFile(file);
+    return {
+      source: 'local',
+      fileName: a.name,
+      fileType: cleanType,
+      displayType: cleanType,
+      content: content || undefined,
+      pageImages: pageImages?.length ? pageImages : undefined
+    };
+  } catch (err) {
+    console.warn(
+      `[office] attachment ${describeAttachment(a)} could not be converted to text and was skipped`,
+      err
+    );
+    return null;
+  }
+}
+
+// Processes non-image attachments into file data for the outgoing request.
+// Returns an array of { fileName, fileType, displayType, content?, pageImages? }.
 export async function buildFileDataFromMailAttachments(attachments) {
   if (!attachments?.length) return null;
   const candidates = attachments
     .filter(a => !a?.isInline)
     .filter(a => !isImageAttachment(a))
-    .filter(a => !a.error);
+    .filter(a => !a.error)
+    .filter(a => a?.content?.content);
+  if (!candidates.length) return null;
 
-  // Attachments that fetched fine but are in a format this pipeline can't
-  // convert (eml/icalendar/url) used to be dropped here with no trace at
-  // all — the review banner still showed them as "attached". Log them so
-  // the drop is at least visible, even though the banner is the primary
-  // fix (see OfficeMailContextBanner's use of isUnsupportedAttachmentFormat).
-  candidates
-    .filter(a => !hasBase64Content(a))
-    .forEach(a => {
-      console.warn(`[office] attachment ${describeAttachment(a)} is not supported and was skipped`);
-    });
-
-  const files = candidates.filter(hasBase64Content);
-  if (!files.length) return null;
-
-  const results = await Promise.all(
-    files.map(async a => {
-      try {
-        const cleanType =
-          sanitizeContentType(a.contentType) || a.contentType || 'application/octet-stream';
-        const file = base64ToFile(a.content.content, a.name, cleanType);
-        const { content, pageImages } = await processDocumentFile(file);
-        return {
-          source: 'local',
-          fileName: a.name,
-          fileType: cleanType,
-          displayType: cleanType,
-          content: content || undefined,
-          pageImages: pageImages?.length ? pageImages : undefined
-        };
-      } catch (err) {
-        console.warn(
-          `[office] attachment ${describeAttachment(a)} could not be converted to text` +
-            ' and was skipped',
-          err
-        );
-        return null;
-      }
-    })
-  );
-
+  const results = await Promise.all(candidates.map(buildFileEntryForAttachment));
   const valid = results.filter(Boolean);
   return valid.length ? valid : null;
 }

--- a/client/src/features/office/utilities/buildChatApiMessages.js
+++ b/client/src/features/office/utilities/buildChatApiMessages.js
@@ -1,4 +1,11 @@
 import { processDocumentFile } from '../../upload/utils/fileProcessing';
+import {
+  sanitizeContentType,
+  hasBase64Content,
+  isUnsupportedAttachmentFormat
+} from './attachmentFormat';
+
+export { sanitizeContentType, hasBase64Content, isUnsupportedAttachmentFormat };
 
 export function createUserMessageId() {
   return `msg-${Date.now()}-${Math.floor(Math.random() * 1e9)}`;
@@ -13,16 +20,10 @@ const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp)$/i;
 const IMAGE_MAX_DIMENSION = 1024;
 const IMAGE_REENCODE_QUALITY = 0.8;
 
-/**
- * Strip MIME-type parameters so e.g. `image/jpeg; name="foo.jpg"` collapses to
- * `image/jpeg`. Outlook (and some Exchange servers) decorate the contentType
- * with a `name=` parameter which the LLM adapters then send as the `media_type`
- * — Anthropic rejects anything that isn't a bare MIME type, so without this
- * step image attachments fail before the model ever sees them.
- */
-function sanitizeContentType(ct) {
-  if (!ct || typeof ct !== 'string') return '';
-  return ct.split(';')[0].trim().toLowerCase();
+/** Human-readable "name (content type)" used in skip/failure log lines. */
+function describeAttachment(att) {
+  const contentType = sanitizeContentType(att?.contentType) || att?.contentType || 'unknown type';
+  return `"${att?.name || 'unnamed'}" (${contentType})`;
 }
 
 export function isImageAttachment(att) {
@@ -100,24 +101,6 @@ async function resizeImageBase64(base64Content, contentType, maxDimension) {
 }
 
 /**
- * True only when the attachment's `content` blob carries actual binary
- * data. Outlook's `getAttachmentContentAsync` can return four formats —
- * `Base64`, `Eml`, `iCalendar`, `Url` — and only `base64` is usable as an
- * image / file payload. Cloud attachments (OneDrive / SharePoint links)
- * arrive as `format: 'url'` with `content` set to the share link, which
- * we previously fed straight into `atob()` and shipped to the LLM as if
- * it were base64. That was the silent failure path behind issue #1467.
- */
-function hasBase64Content(att) {
-  if (!att?.content) return false;
-  const fmt = String(att.content.format || '').toLowerCase();
-  // Office.js returns the enum value verbatim; treat anything other
-  // than the explicit "base64" string as non-base64 to be safe.
-  if (fmt && fmt !== 'base64') return false;
-  return typeof att.content.content === 'string' && att.content.content.length > 0;
-}
-
-/**
  * Build the imageData array sent to the LLM from a list of Outlook
  * attachments. Filters out inline images (HTML-signature logos, embedded
  * UI badges, etc.) so they don't silently bloat the request — they're
@@ -173,11 +156,23 @@ function base64ToFile(base64, name, contentType) {
 // the document pipeline expects binary file bytes — see `hasBase64Content`.
 export async function buildFileDataFromMailAttachments(attachments) {
   if (!attachments?.length) return null;
-  const files = attachments
+  const candidates = attachments
     .filter(a => !a?.isInline)
     .filter(a => !isImageAttachment(a))
-    .filter(hasBase64Content)
     .filter(a => !a.error);
+
+  // Attachments that fetched fine but are in a format this pipeline can't
+  // convert (eml/icalendar/url) used to be dropped here with no trace at
+  // all — the review banner still showed them as "attached". Log them so
+  // the drop is at least visible, even though the banner is the primary
+  // fix (see OfficeMailContextBanner's use of isUnsupportedAttachmentFormat).
+  candidates
+    .filter(a => !hasBase64Content(a))
+    .forEach(a => {
+      console.warn(`[office] attachment ${describeAttachment(a)} is not supported and was skipped`);
+    });
+
+  const files = candidates.filter(hasBase64Content);
   if (!files.length) return null;
 
   const results = await Promise.all(
@@ -197,7 +192,8 @@ export async function buildFileDataFromMailAttachments(attachments) {
         };
       } catch (err) {
         console.warn(
-          `[office] attachment "${a?.name}" could not be converted to text and was skipped`,
+          `[office] attachment ${describeAttachment(a)} could not be converted to text` +
+            ' and was skipped',
           err
         );
         return null;

--- a/client/src/features/office/utilities/emailAttachmentParsers.js
+++ b/client/src/features/office/utilities/emailAttachmentParsers.js
@@ -48,18 +48,47 @@ function decodeMimeWords(str) {
 // text/html part. Deliberately simple (no DOMParser) so this module stays
 // dependency-free; `htmlToText` in fileProcessing.js is the DOM-based,
 // more accurate version used for direct HTML file uploads.
+// Named entities this parser understands, decoded in a single regex pass
+// below (see the double-unescaping note).
+const HTML_ENTITIES = { nbsp: ' ', amp: '&', lt: '<', gt: '>', quot: '"', '#39': "'", apos: "'" };
+
 function stripHtmlToText(html) {
-  return html
-    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, '')
+  let text = html;
+
+  // Loop each strip to a fixed point: a single non-recursive pass can
+  // leave a live tag behind when the input nests/overlaps delimiters so
+  // that removing part of it reassembles one (e.g.
+  // "<scr<script>ipt>...</scr</script>ipt>" contains no literal
+  // "<script>...</script>" substring, but removing the inner match once
+  // leaves "<script>...</script>" behind). Repeating until nothing changes
+  // closes that gap.
+  let previous;
+  do {
+    previous = text;
+    text = text.replace(/<(script|style)\b[^>]*>[\s\S]*?<\/\1\s*>/gi, '');
+  } while (text !== previous);
+
+  text = text
     .replace(/<br\s*\/?>/gi, '\n')
-    .replace(/<\/(p|div|tr|li|h[1-6]|table|blockquote)>/gi, '\n')
-    .replace(/<[^>]+>/g, '')
-    .replace(/&nbsp;/gi, ' ')
-    .replace(/&amp;/gi, '&')
-    .replace(/&lt;/gi, '<')
-    .replace(/&gt;/gi, '>')
-    .replace(/&quot;/gi, '"')
-    .replace(/&#39;/g, "'")
+    .replace(/<\/(p|div|tr|li|h[1-6]|table|blockquote)>/gi, '\n');
+
+  do {
+    previous = text;
+    text = text.replace(/<[^>]*>/g, '');
+  } while (text !== previous);
+
+  // Decode all named entities in one pass — resolving each match exactly
+  // once — instead of one independent replace per entity. Sequential
+  // independent replaces would double-unescape: e.g. text that safely
+  // encodes a literal "&lt;" as "&amp;lt;" would, after an `&amp;` -> `&`
+  // pass, read as "&lt;" and then get wrongly decoded to "<" by a later
+  // pass, turning inert text into a live tag delimiter.
+  text = text.replace(
+    /&(nbsp|amp|lt|gt|quot|#39|apos);/gi,
+    (match, name) => HTML_ENTITIES[name.toLowerCase()] ?? match
+  );
+
+  return text
     .replace(/[ \t]+/g, ' ')
     .replace(/ *\n */g, '\n')
     .replace(/\n{3,}/g, '\n\n')

--- a/client/src/features/office/utilities/emailAttachmentParsers.js
+++ b/client/src/features/office/utilities/emailAttachmentParsers.js
@@ -1,0 +1,242 @@
+// Best-effort text extraction for the two Outlook attachment formats that
+// arrive as textual content rather than a binary document: attached/
+// forwarded emails (`format: 'eml'`) and meeting invites
+// (`format: 'icalendar'`). Both are plain-text formats (RFC 5322 / RFC
+// 5545), so — unlike a real PDF/DOCX — there's no reason to treat them as
+// unsupported: we can parse them directly. See issue #1451.
+//
+// Pure (atob/TextDecoder/regex only, no DOM) so this runs — and is
+// unit-tested — under plain node, mirroring `extractMsgContent` in
+// fileProcessing.js for the equivalent binary .msg case.
+
+function decodeBase64ToText(base64) {
+  if (!base64) return '';
+  try {
+    const binary = atob(base64.replace(/\s+/g, ''));
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+    return new TextDecoder('utf-8').decode(bytes);
+  } catch {
+    return '';
+  }
+}
+
+function decodeQuotedPrintable(str) {
+  return str
+    .replace(/=\r?\n/g, '') // soft line break — join wrapped lines
+    .replace(/=([0-9A-Fa-f]{2})/g, (_m, hex) => String.fromCharCode(parseInt(hex, 16)));
+}
+
+function decodeBodyByEncoding(body, encoding) {
+  const enc = (encoding || '').toLowerCase();
+  if (enc === 'base64') return decodeBase64ToText(body);
+  if (enc === 'quoted-printable') return decodeQuotedPrintable(body);
+  return body;
+}
+
+// Minimal RFC 2047 encoded-word decoder for headers like
+// `=?UTF-8?B?RsO2cnN0ZXI=?=` or `=?UTF-8?Q?F=C3=B6rster?=`.
+function decodeMimeWords(str) {
+  if (!str) return str;
+  return str.replace(/=\?[^?]+\?([BbQq])\?([^?]*)\?=\s*/g, (_m, enc, text) => {
+    if (enc.toUpperCase() === 'B') return decodeBase64ToText(text);
+    return decodeQuotedPrintable(text.replace(/_/g, ' '));
+  });
+}
+
+// Regex-only HTML-to-text fallback for eml bodies that only have a
+// text/html part. Deliberately simple (no DOMParser) so this module stays
+// dependency-free; `htmlToText` in fileProcessing.js is the DOM-based,
+// more accurate version used for direct HTML file uploads.
+function stripHtmlToText(html) {
+  return html
+    .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, '')
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/(p|div|tr|li|h[1-6]|table|blockquote)>/gi, '\n')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/[ \t]+/g, ' ')
+    .replace(/ *\n */g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function parseContentTypeHeader(value) {
+  if (!value) return { type: '', params: {} };
+  const parts = value.split(';').map(s => s.trim());
+  const type = (parts.shift() || '').toLowerCase();
+  const params = {};
+  for (const p of parts) {
+    const m = p.match(/^([\w-]+)=(.*)$/);
+    if (m) params[m[1].toLowerCase()] = m[2].replace(/^"|"$/g, '');
+  }
+  return { type, params };
+}
+
+// Unfolds RFC 5322 header continuation lines (indented lines are part of
+// the previous header) and returns a lowercase-keyed map.
+function parseEmailHeaders(headerBlock) {
+  const unfolded = headerBlock.replace(/\r\n/g, '\n').replace(/\n[ \t]+/g, ' ');
+  const headers = {};
+  for (const line of unfolded.split('\n')) {
+    const m = line.match(/^([\w-]+):\s*(.*)$/);
+    if (m) headers[m[1].toLowerCase()] = m[2].trim();
+  }
+  return headers;
+}
+
+// Extracts the readable body from a MIME message part, descending into a
+// multipart/* body to find the first text/plain part (preferred) or
+// text/html part (converted to text). Non-multipart bodies are decoded
+// directly per their own Content-Transfer-Encoding.
+function extractBody(rawBody, contentTypeHeader, transferEncoding) {
+  const { type, params } = parseContentTypeHeader(contentTypeHeader);
+
+  if (type.startsWith('multipart/') && params.boundary) {
+    const segments = rawBody.split(`--${params.boundary}`);
+    // First and last segments are the preamble/epilogue, not real parts.
+    const parts = segments.slice(1, -1);
+    let plainPart = null;
+    let htmlPart = null;
+
+    for (const part of parts) {
+      const trimmed = part.replace(/^\r?\n/, '');
+      const headerEnd = trimmed.search(/\r?\n\r?\n/);
+      if (headerEnd === -1) continue;
+      const partHeaders = parseEmailHeaders(trimmed.slice(0, headerEnd));
+      const partBody = trimmed.slice(headerEnd).replace(/^\r?\n\r?\n/, '');
+      const partContentType = partHeaders['content-type'] || '';
+      const { type: partType } = parseContentTypeHeader(partContentType);
+
+      if (partType.startsWith('multipart/')) {
+        // Nested multipart (e.g. multipart/alternative inside
+        // multipart/mixed) — recurse rather than treating it as a leaf.
+        const nested = extractBody(
+          partBody,
+          partContentType,
+          partHeaders['content-transfer-encoding']
+        );
+        if (nested && !plainPart) plainPart = nested;
+        continue;
+      }
+
+      const decoded = decodeBodyByEncoding(partBody, partHeaders['content-transfer-encoding']);
+      if (partType.startsWith('text/plain') && !plainPart) plainPart = decoded.trim();
+      else if (partType.startsWith('text/html') && !htmlPart) htmlPart = decoded;
+    }
+
+    if (plainPart) return plainPart;
+    if (htmlPart) return stripHtmlToText(htmlPart);
+    return '';
+  }
+
+  const decoded = decodeBodyByEncoding(rawBody, transferEncoding);
+  return type.startsWith('text/html') ? stripHtmlToText(decoded) : decoded.trim();
+}
+
+/**
+ * Parse a base64-encoded attached/forwarded email (`format: 'eml'` from
+ * Office's getAttachmentContentAsync) into a readable "headers + body" text
+ * block, mirroring `extractMsgContent`'s output shape for .msg files.
+ * Returns null if the content can't be decoded/parsed at all.
+ */
+export function parseEmlAttachment(base64Content) {
+  const raw = decodeBase64ToText(base64Content);
+  if (!raw) return null;
+
+  const normalized = raw.replace(/\r\n/g, '\n');
+  const headerEnd = normalized.indexOf('\n\n');
+  if (headerEnd === -1) return null;
+
+  const headers = parseEmailHeaders(normalized.slice(0, headerEnd));
+  const bodyText = extractBody(
+    normalized.slice(headerEnd + 2),
+    headers['content-type'],
+    headers['content-transfer-encoding']
+  );
+
+  const headerLines = [];
+  if (headers.subject) headerLines.push(`Subject: ${decodeMimeWords(headers.subject)}`);
+  if (headers.from) headerLines.push(`From: ${decodeMimeWords(headers.from)}`);
+  if (headers.to) headerLines.push(`To: ${decodeMimeWords(headers.to)}`);
+  if (headers.cc) headerLines.push(`Cc: ${decodeMimeWords(headers.cc)}`);
+  if (headers.date) headerLines.push(`Date: ${headers.date}`);
+
+  const result = [headerLines.join('\n'), bodyText].filter(Boolean).join('\n\n').trim();
+  return result || null;
+}
+
+function unescapeIcsText(value) {
+  return value
+    .replace(/\\n/gi, '\n')
+    .replace(/\\,/g, ',')
+    .replace(/\\;/g, ';')
+    .replace(/\\\\/g, '\\');
+}
+
+function formatIcsDate(value) {
+  // e.g. 20260715T090000Z (date-time) or 20260715 (all-day date).
+  const m = value?.match(/^(\d{4})(\d{2})(\d{2})(T(\d{2})(\d{2})(\d{2})Z?)?$/);
+  if (!m) return value || '';
+  const [, y, mo, d, hasTime, h, mi] = m;
+  return hasTime ? `${y}-${mo}-${d} ${h}:${mi}` : `${y}-${mo}-${d}`;
+}
+
+function formatIcsParticipant(field) {
+  if (!field) return '';
+  const cnMatch = field.params.match(/CN=([^;]+)/i);
+  const mailtoMatch = field.value.match(/mailto:(.+)$/i);
+  const name = cnMatch ? cnMatch[1].replace(/^"|"$/g, '') : '';
+  const email = mailtoMatch ? mailtoMatch[1] : field.value;
+  if (name && email && name !== email) return `${name} <${email}>`;
+  return name || email || '';
+}
+
+/**
+ * Parse a base64-encoded meeting invite (`format: 'icalendar'` from
+ * Office's getAttachmentContentAsync) into a short readable summary
+ * (subject, time, location, organizer, description).
+ * Returns null if the content can't be decoded/parsed at all.
+ */
+export function parseIcsAttachment(base64Content) {
+  const raw = decodeBase64ToText(base64Content);
+  if (!raw) return null;
+
+  // RFC 5545 line folding: a line starting with a space/tab continues the
+  // previous line.
+  const unfolded = raw.replace(/\r\n/g, '\n').replace(/\n[ \t]/g, '');
+  const fields = {};
+  for (const line of unfolded.split('\n')) {
+    const m = line.match(/^([\w-]+)(;[^:]*)?:(.*)$/);
+    if (m) {
+      const key = m[1].toUpperCase();
+      // First VEVENT wins if the .ics has multiple (rare for a single invite).
+      if (!(key in fields)) fields[key] = { params: m[2] || '', value: m[3].trim() };
+    }
+  }
+
+  const lines = [];
+  if (fields.SUMMARY) lines.push(`Meeting: ${unescapeIcsText(fields.SUMMARY.value)}`);
+  if (fields.DTSTART) {
+    const start = formatIcsDate(fields.DTSTART.value);
+    const end = fields.DTEND ? formatIcsDate(fields.DTEND.value) : null;
+    lines.push(`When: ${end ? `${start} – ${end}` : start}`);
+  }
+  if (fields.LOCATION) lines.push(`Location: ${unescapeIcsText(fields.LOCATION.value)}`);
+  if (fields.ORGANIZER) lines.push(`Organizer: ${formatIcsParticipant(fields.ORGANIZER)}`);
+  if (fields.DESCRIPTION) {
+    const description = unescapeIcsText(fields.DESCRIPTION.value).trim();
+    if (description) {
+      lines.push('');
+      lines.push(description);
+    }
+  }
+
+  const result = lines.join('\n').trim();
+  return result || null;
+}

--- a/client/src/features/office/utilities/emailAttachmentParsers.test.js
+++ b/client/src/features/office/utilities/emailAttachmentParsers.test.js
@@ -36,6 +36,17 @@ const MULTIPART_EML =
 const ICS =
   'QkVHSU46VkNBTEVOREFSDQpWRVJTSU9OOjIuMA0KQkVHSU46VkVWRU5UDQpTVU1NQVJZOlF1YXJ0ZXJseSBQbGFubmluZw0KRFRTVEFSVDoyMDI2MDcxNVQwOTAwMDBaDQpEVEVORDoyMDI2MDcxNVQxMDAwMDBaDQpMT0NBVElPTjpDb25mZXJlbmNlIFJvb20gQQ0KT1JHQU5JWkVSO0NOPUphbmUgRG9lOm1haWx0bzpqYW5lQGV4YW1wbGUuY29tDQpERVNDUklQVElPTjpQbGVhc2UgcmV2aWV3IHRoZSBkZWNrXG5iZWZvcmUgdGhlIGNhbGwuDQpFTkQ6VkVWRU5UDQpFTkQ6VkNBTEVOREFSDQo=';
 
+// HTML-only body (no text/plain alternative) exercising the regex-based
+// stripHtmlToText fallback specifically:
+//  - a real <script> block that must be stripped
+//  - a "tag reconstruction" attempt: "<scr<script>ipt>...</scr</script>ipt>"
+//    contains no literal "<script>...</script>" substring, but a single
+//    non-looping strip pass leaves one behind once part of it is removed
+//  - a double-escaped "&amp;lt;script&amp;gt;" that must render as the
+//    literal text "&lt;script&gt;", not decode to a live "<script>" tag
+const HTML_ONLY_EML =
+  'RnJvbTogSmFuZSBEb2UgPGphbmVAZXhhbXBsZS5jb20+DQpUbzogQm9iIFNtaXRoIDxib2JAZXhhbXBsZS5jb20+DQpTdWJqZWN0OiBIVE1MIG9ubHkNCkRhdGU6IFdlZCwgMTcgSnVsIDIwMjYgMDg6MDA6MDAgKzAwMDANCkNvbnRlbnQtVHlwZTogdGV4dC9odG1sOyBjaGFyc2V0PVVURi04DQoNCjxodG1sPjxib2R5PjxzY3JpcHQ+YWxlcnQoMSk8L3NjcmlwdD48cD5IZWxsbyA8Yj5Cb2I8L2I+LDwvcD48c2NyPHNjcmlwdD5pcHQ+YWxlcnQoMik8L3Njcjwvc2NyaXB0PmlwdD48cD5MaXRlcmFsIHRleHQ6ICZhbXA7bHQ7c2NyaXB0JmFtcDtndDs8L3A+PHA+TGluZTE8YnI+TGluZTI8L3A+PC9ib2R5PjwvaHRtbD4NCg==';
+
 console.log('🧪 parseEmlAttachment — simple plain-text email\n');
 {
   const text = parseEmlAttachment(SIMPLE_EML);
@@ -57,6 +68,25 @@ console.log('\n🧪 parseEmlAttachment — multipart/alternative with encoded su
     text
   );
   check('does not leak MIME boundary markers into the output', !text?.includes('BOUNDARY123'));
+}
+
+console.log('\n🧪 parseEmlAttachment — HTML-only body (stripHtmlToText hardening)\n');
+{
+  const text = parseEmlAttachment(HTML_ONLY_EML);
+  check('returns non-null', text !== null, text);
+  check('keeps the visible text', text?.includes('Hello Bob,'), text);
+  check('converts <br> to a newline', text?.includes('Line1\nLine2'), text);
+  check('strips a normal <script> block entirely', !text?.includes('alert(1)'), text);
+  check(
+    'strips a "reconstructed" <script> block left behind by a single non-looping pass',
+    !text?.includes('alert(2)') && !/<script/i.test(text || ''),
+    text
+  );
+  check(
+    'decodes a double-escaped "&amp;lt;script&amp;gt;" to literal text, not a live tag',
+    text?.includes('Literal text: &lt;script&gt;'),
+    text
+  );
 }
 
 console.log('\n🧪 parseEmlAttachment — malformed input\n');

--- a/client/src/features/office/utilities/emailAttachmentParsers.test.js
+++ b/client/src/features/office/utilities/emailAttachmentParsers.test.js
@@ -50,11 +50,7 @@ console.log('\n🧪 parseEmlAttachment — multipart/alternative with encoded su
 {
   const text = parseEmlAttachment(MULTIPART_EML);
   check('returns non-null', text !== null, text);
-  check(
-    'decodes RFC 2047 base64-encoded Subject',
-    text?.includes('Subject: Förster Report'),
-    text
-  );
+  check('decodes RFC 2047 base64-encoded Subject', text?.includes('Subject: Förster Report'), text);
   check(
     'prefers the quoted-printable text/plain part over the HTML part',
     text?.includes('Hello, this is the plain part.'),

--- a/client/src/features/office/utilities/emailAttachmentParsers.test.js
+++ b/client/src/features/office/utilities/emailAttachmentParsers.test.js
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+
+/**
+ * Regression tests for parsing attached emails (.eml) and meeting invites
+ * (.ics/iCalendar) that Outlook exposes via getAttachmentContentAsync —
+ * issue #1451 ("[Outlook] Bug: PDF / Word / .eml attachments fail silently
+ * or throw"). These formats are plain text, so rather than treating them as
+ * "unsupported" and dropping them, they're parsed into readable content —
+ * see buildChatApiMessages.js's buildFileEntryForAttachment.
+ *
+ * Pure (atob/TextDecoder only) so it runs under node directly.
+ *
+ * Run directly: `node client/src/features/office/utilities/emailAttachmentParsers.test.js`.
+ */
+
+import { parseEmlAttachment, parseIcsAttachment } from './emailAttachmentParsers.js';
+
+let failures = 0;
+function check(label, cond, details) {
+  if (!cond) failures += 1;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && details) console.log(`   ${details}`);
+}
+
+// A plain-text, single-part forwarded email.
+const SIMPLE_EML =
+  'RnJvbTogSmFuZSBEb2UgPGphbmVAZXhhbXBsZS5jb20+DQpUbzogQm9iIFNtaXRoIDxib2JAZXhhbXBsZS5jb20+DQpTdWJqZWN0OiBSZTogUTMgbnVtYmVycw0KRGF0ZTogTW9uLCAxNSBKdWwgMjAyNiAwOTowMDowMCArMDAwMA0KQ29udGVudC1UeXBlOiB0ZXh0L3BsYWluOyBjaGFyc2V0PVVURi04DQoNCkhpIEJvYiwNCg0KUGxlYXNlIHNlZSB0aGUgYXR0YWNoZWQgZmlndXJlcyBmb3IgUTMuDQoNClRoYW5rcywNCkphbmUNCg==';
+
+// multipart/alternative with a quoted-printable plain part, an HTML part,
+// and an RFC 2047 base64-encoded Subject header.
+const MULTIPART_EML =
+  'RnJvbTogSmFuZSBEb2UgPGphbmVAZXhhbXBsZS5jb20+DQpUbzogQm9iIFNtaXRoIDxib2JAZXhhbXBsZS5jb20+DQpTdWJqZWN0OiA9P1VURi04P0I/UnNPMmNuTjBaWElnVW1Wd2IzSjA/PQ0KRGF0ZTogVHVlLCAxNiBKdWwgMjAyNiAxMDowMDowMCArMDAwMA0KQ29udGVudC1UeXBlOiBtdWx0aXBhcnQvYWx0ZXJuYXRpdmU7IGJvdW5kYXJ5PSJCT1VOREFSWTEyMyINCg0KLS1CT1VOREFSWTEyMw0KQ29udGVudC1UeXBlOiB0ZXh0L3BsYWluOyBjaGFyc2V0PVVURi04DQpDb250ZW50LVRyYW5zZmVyLUVuY29kaW5nOiBxdW90ZWQtcHJpbnRhYmxlDQoNCkhlbGxvPTJDIHRoaXMgaXMgdGhlIHBsYWluIHBhcnQuDQoNCi0tQk9VTkRBUlkxMjMNCkNvbnRlbnQtVHlwZTogdGV4dC9odG1sOyBjaGFyc2V0PVVURi04DQoNCjxodG1sPjxib2R5PjxwPkhlbGxvLCB0aGlzIGlzIHRoZSA8Yj5odG1sPC9iPiBwYXJ0LjwvcD48L2JvZHk+PC9odG1sPg0KDQotLUJPVU5EQVJZMTIzLS0NCg==';
+
+// A single-VEVENT meeting invite with a CN'd organizer and an escaped
+// newline in DESCRIPTION.
+const ICS =
+  'QkVHSU46VkNBTEVOREFSDQpWRVJTSU9OOjIuMA0KQkVHSU46VkVWRU5UDQpTVU1NQVJZOlF1YXJ0ZXJseSBQbGFubmluZw0KRFRTVEFSVDoyMDI2MDcxNVQwOTAwMDBaDQpEVEVORDoyMDI2MDcxNVQxMDAwMDBaDQpMT0NBVElPTjpDb25mZXJlbmNlIFJvb20gQQ0KT1JHQU5JWkVSO0NOPUphbmUgRG9lOm1haWx0bzpqYW5lQGV4YW1wbGUuY29tDQpERVNDUklQVElPTjpQbGVhc2UgcmV2aWV3IHRoZSBkZWNrXG5iZWZvcmUgdGhlIGNhbGwuDQpFTkQ6VkVWRU5UDQpFTkQ6VkNBTEVOREFSDQo=';
+
+console.log('🧪 parseEmlAttachment — simple plain-text email\n');
+{
+  const text = parseEmlAttachment(SIMPLE_EML);
+  check('returns non-null', text !== null, text);
+  check('includes Subject header', text?.includes('Subject: Re: Q3 numbers'));
+  check('includes From header', text?.includes('From: Jane Doe <jane@example.com>'));
+  check('includes To header', text?.includes('To: Bob Smith <bob@example.com>'));
+  check('includes body text', text?.includes('Please see the attached figures for Q3.'));
+}
+
+console.log('\n🧪 parseEmlAttachment — multipart/alternative with encoded subject\n');
+{
+  const text = parseEmlAttachment(MULTIPART_EML);
+  check('returns non-null', text !== null, text);
+  check(
+    'decodes RFC 2047 base64-encoded Subject',
+    text?.includes('Subject: Förster Report'),
+    text
+  );
+  check(
+    'prefers the quoted-printable text/plain part over the HTML part',
+    text?.includes('Hello, this is the plain part.'),
+    text
+  );
+  check('does not leak MIME boundary markers into the output', !text?.includes('BOUNDARY123'));
+}
+
+console.log('\n🧪 parseEmlAttachment — malformed input\n');
+{
+  check('empty string → null', parseEmlAttachment('') === null);
+  check('garbage (non-base64) → null', parseEmlAttachment('not-base64!!') === null);
+  check(
+    'base64 text with no header/body split → null',
+    parseEmlAttachment(Buffer.from('just one line, no blank line').toString('base64')) === null
+  );
+}
+
+console.log('\n🧪 parseIcsAttachment — meeting invite\n');
+{
+  const text = parseIcsAttachment(ICS);
+  check('returns non-null', text !== null, text);
+  check('includes the meeting subject', text?.includes('Meeting: Quarterly Planning'), text);
+  check(
+    'includes a formatted start/end time',
+    text?.includes('When: 2026-07-15 09:00 – 2026-07-15 10:00'),
+    text
+  );
+  check('includes the location', text?.includes('Location: Conference Room A'));
+  check(
+    'resolves ORGANIZER CN + mailto into "Name <email>"',
+    text?.includes('Organizer: Jane Doe <jane@example.com>'),
+    text
+  );
+  check(
+    'unescapes the ICS-escaped newline in DESCRIPTION',
+    text?.includes('Please review the deck\nbefore the call.'),
+    text
+  );
+}
+
+console.log('\n🧪 parseIcsAttachment — malformed input\n');
+{
+  check('empty string → null', parseIcsAttachment('') === null);
+  check(
+    'base64 text with no recognizable fields → null',
+    parseIcsAttachment(Buffer.from('not an ics file at all').toString('base64')) === null
+  );
+}
+
+console.log(`\n${failures === 0 ? '✅ all passed' : `❌ ${failures} failed`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/client/src/features/office/utilities/outlookMailContext.js
+++ b/client/src/features/office/utilities/outlookMailContext.js
@@ -92,10 +92,25 @@ function getBodyTextAsync(item) {
   });
 }
 
+// Exported so the review banner can recognize this specific failure and
+// collapse it into a single explanatory line instead of repeating it once
+// per attachment (see issue #1451).
+export const MAILBOX_ATTACHMENT_API_UNAVAILABLE_MESSAGE =
+  'getAttachmentContentAsync is not available (requires Mailbox 1.8+).';
+
+// Exported for the same reason as above: the banner needs to tell "too
+// large to fetch" apart from a generic fetch failure.
+export const ATTACHMENT_TOO_LARGE_MESSAGE = 'Attachment too large to include automatically.';
+
+// Attachments larger than this are skipped instead of pulled into memory as
+// base64 — a large PDF/video attachment previously hung the taskpane while
+// downloading, then failed anyway once it reached the document pipeline.
+const MAX_ATTACHMENT_SIZE_BYTES = 20 * 1024 * 1024;
+
 function getAttachmentContentAsync(item, attachmentId) {
   return new Promise((resolve, reject) => {
     if (!item || typeof item.getAttachmentContentAsync !== 'function') {
-      reject(new Error('getAttachmentContentAsync is not available (requires Mailbox 1.8+).'));
+      reject(new Error(MAILBOX_ATTACHMENT_API_UNAVAILABLE_MESSAGE));
       return;
     }
     item.getAttachmentContentAsync(attachmentId, result => {
@@ -237,6 +252,10 @@ async function readMailSnapshot(item, itemId) {
     if (getLiveItemId() !== itemId) {
       aborted = true;
       break;
+    }
+    if (typeof d.size === 'number' && d.size > MAX_ATTACHMENT_SIZE_BYTES) {
+      attachments.push({ ...d, error: ATTACHMENT_TOO_LARGE_MESSAGE });
+      continue;
     }
     try {
       const raw = await getAttachmentContentAsync(item, d.id);

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -73,17 +73,20 @@ limit — silently fell back to "Based on AI knowledge" even though a file or em
 - On error/aborted turns the badge is intentionally not shown, since the assistant bubble is an
   error message rather than a real answer.
 
-## Outlook Add-in: Clear Status for Unsupported Email Attachments
+## Outlook Add-in: Attached Emails and Meeting Invites Are Now Included
 
-Attached/forwarded emails, meeting invites, and OneDrive/SharePoint share links on an email no
-longer look like they'll be sent when they can't be. Previously these fetched successfully and
-showed as "attached" in the review banner, but were silently dropped when the message was sent —
-with no indication to the user that anything was missing.
+Forwarding an email or meeting invite as an attachment now actually sends its content to the
+model. Previously these fetched successfully and showed as "attached" in the review banner, but
+were silently dropped when the message was sent — the model never saw them and the user had no
+indication anything was missing.
 
-- Each attachment now shows one of three clear states: attached, unsupported (for attached emails,
-  invites, and cloud links — not yet convertible to text), or failed.
-- Attachments larger than 20 MB are skipped up front with a "too large" status instead of being
-  downloaded into the task pane, which could previously stall the pane on a large attachment.
+- Attached/forwarded emails (`.eml`) are parsed into their subject, sender, recipients, and body
+  text.
+- Meeting invites (`.ics`) are parsed into a short summary: subject, time, location, and organizer.
+- OneDrive/SharePoint attachments (share links, not the file itself) now include the link as a
+  reference instead of being dropped without a trace.
+- Attachments larger than 20 MB are skipped up front instead of being downloaded into the task
+  pane, which could previously stall the pane on a large attachment.
 - On Outlook hosts older than Mailbox 1.8 (which can't fetch attachment content at all), the
   banner now shows one explanation instead of repeating the same error on every attachment.
 

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -73,6 +73,20 @@ limit — silently fell back to "Based on AI knowledge" even though a file or em
 - On error/aborted turns the badge is intentionally not shown, since the assistant bubble is an
   error message rather than a real answer.
 
+## Outlook Add-in: Clear Status for Unsupported Email Attachments
+
+Attached/forwarded emails, meeting invites, and OneDrive/SharePoint share links on an email no
+longer look like they'll be sent when they can't be. Previously these fetched successfully and
+showed as "attached" in the review banner, but were silently dropped when the message was sent —
+with no indication to the user that anything was missing.
+
+- Each attachment now shows one of three clear states: attached, unsupported (for attached emails,
+  invites, and cloud links — not yet convertible to text), or failed.
+- Attachments larger than 20 MB are skipped up front with a "too large" status instead of being
+  downloaded into the task pane, which could previously stall the pane on a large attachment.
+- On Outlook hosts older than Mailbox 1.8 (which can't fetch attachment content at all), the
+  banner now shows one explanation instead of repeating the same error on every attachment.
+
 ## Answer-Source Badge Fixed When a Tool-Enabled App Answers an Upload Directly
 
 Uploading a document or image to an app that has tools enabled, then getting an answer straight

--- a/server/adapters/index.js
+++ b/server/adapters/index.js
@@ -8,17 +8,18 @@ import VLLMAdapter from './vllm.js';
 import IAssistantConversationAdapter from './iassistant-conversation.js';
 import BedrockAdapter from './bedrock.js';
 
-// Adapter registry
-const adapters = {
-  openai: OpenAIAdapter,
-  'openai-responses': OpenAIResponsesAdapter,
-  anthropic: AnthropicAdapter,
-  google: GoogleAdapter,
-  mistral: MistralAdapter,
-  local: VLLMAdapter, // vLLM uses dedicated adapter with schema sanitization
-  'iassistant-conversation': IAssistantConversationAdapter,
-  bedrock: BedrockAdapter
-};
+function getAdapterRegistry() {
+  return {
+    openai: OpenAIAdapter,
+    'openai-responses': OpenAIResponsesAdapter,
+    anthropic: AnthropicAdapter,
+    google: GoogleAdapter,
+    mistral: MistralAdapter,
+    local: VLLMAdapter, // vLLM uses dedicated adapter with schema sanitization
+    'iassistant-conversation': IAssistantConversationAdapter,
+    bedrock: BedrockAdapter
+  };
+}
 
 /**
  * Get the appropriate adapter for a model
@@ -27,6 +28,7 @@ const adapters = {
  * @throws {Error} If the provider is not registered
  */
 export function getAdapter(provider) {
+  const adapters = getAdapterRegistry();
   const adapter = adapters[provider];
   if (!adapter) {
     throw new Error(

--- a/server/tests/googleAdapter.test.js
+++ b/server/tests/googleAdapter.test.js
@@ -16,7 +16,7 @@ const req = GoogleAdapter.createCompletionRequest(model, messages, 'key', {
 });
 
 assert.strictEqual(req.body.generationConfig.responseMimeType, 'application/json');
-assert.deepStrictEqual(req.body.generationConfig.response_schema, schema);
+assert.deepStrictEqual(req.body.generationConfig.responseSchema, schema);
 logger.info('Google adapter structured output test passed');
 
 // Regression: MCP tool schemas include JSON Schema meta keywords ($schema,

--- a/server/tests/openaiAdapter.test.js
+++ b/server/tests/openaiAdapter.test.js
@@ -9,7 +9,7 @@ const model = {
 };
 const messages = [{ role: 'user', content: 'test' }];
 
-const req = OpenAIAdapter.createCompletionRequest(model, messages, 'key', {
+const req = await OpenAIAdapter.createCompletionRequest(model, messages, 'key', {
   responseFormat: 'json'
 });
 

--- a/tests/config/fileUrlMock.js
+++ b/tests/config/fileUrlMock.js
@@ -1,0 +1,1 @@
+export default '/mocked-asset-url';

--- a/tests/config/jest.config.js
+++ b/tests/config/jest.config.js
@@ -4,6 +4,7 @@ export default {
   extensionsToTreatAsEsm: ['.jsx'],
   moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^(.*)\\?url$': '<rootDir>/tests/config/fileUrlMock.js',
     '\\.(css|less|scss|sass)$': 'identity-obj-proxy',
     // Force a single React copy. Files under client/ resolve
     // client/node_modules/react while the test renderer (@testing-library/react

--- a/tests/unit/client/office-build-chat-api-messages.test.jsx
+++ b/tests/unit/client/office-build-chat-api-messages.test.jsx
@@ -282,7 +282,11 @@ describe('buildFileDataFromMailAttachments', () => {
     expect(out[0].displayType).toBe('application/pdf');
   });
 
-  test('skips cloud file attachments (format: url)', async () => {
+  test('sends cloud attachments (format: url) as a link reference instead of dropping them', async () => {
+    // Office only exposes the share link for OneDrive/SharePoint attachments,
+    // not the file bytes — there's nothing to extract, but silently dropping
+    // it (the old behavior) left the model with no idea the attachment
+    // existed at all. See issue #1451.
     const out = await buildFileDataFromMailAttachments([
       {
         id: 'a1',
@@ -290,6 +294,59 @@ describe('buildFileDataFromMailAttachments', () => {
         contentType: 'application/pdf',
         size: 100_000,
         content: { format: 'url', content: 'https://onedrive.live.com/.../invoice.pdf' }
+      }
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].fileName).toBe('invoice.pdf');
+    expect(out[0].content).toContain('https://onedrive.live.com/.../invoice.pdf');
+  });
+
+  test('parses an attached/forwarded email (format: eml) into readable content', async () => {
+    // Base64 of a plain-text RFC 5322 message (headers + body); see
+    // emailAttachmentParsers.test.js for the full parser test suite.
+    const emlBase64 =
+      'RnJvbTogSmFuZSBEb2UgPGphbmVAZXhhbXBsZS5jb20+DQpUbzogQm9iIFNtaXRoIDxib2JAZXhhbXBsZS5jb20+DQpTdWJqZWN0OiBSZTogUTMgbnVtYmVycw0KRGF0ZTogTW9uLCAxNSBKdWwgMjAyNiAwOTowMDowMCArMDAwMA0KQ29udGVudC1UeXBlOiB0ZXh0L3BsYWluOyBjaGFyc2V0PVVURi04DQoNCkhpIEJvYiwNCg0KUGxlYXNlIHNlZSB0aGUgYXR0YWNoZWQgZmlndXJlcyBmb3IgUTMuDQoNClRoYW5rcywNCkphbmUNCg==';
+    const out = await buildFileDataFromMailAttachments([
+      {
+        id: 'a1',
+        name: 'Fwd Q3 report.eml',
+        contentType: 'message/rfc822',
+        size: 1000,
+        content: { format: 'eml', content: emlBase64 }
+      }
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].displayType).toBe('Email');
+    expect(out[0].content).toContain('Subject: Re: Q3 numbers');
+    expect(out[0].content).toContain('Please see the attached figures for Q3.');
+  });
+
+  test('parses a meeting invite (format: icalendar) into a readable summary', async () => {
+    const icsBase64 =
+      'QkVHSU46VkNBTEVOREFSDQpWRVJTSU9OOjIuMA0KQkVHSU46VkVWRU5UDQpTVU1NQVJZOlF1YXJ0ZXJseSBQbGFubmluZw0KRFRTVEFSVDoyMDI2MDcxNVQwOTAwMDBaDQpEVEVORDoyMDI2MDcxNVQxMDAwMDBaDQpMT0NBVElPTjpDb25mZXJlbmNlIFJvb20gQQ0KT1JHQU5JWkVSO0NOPUphbmUgRG9lOm1haWx0bzpqYW5lQGV4YW1wbGUuY29tDQpFTkQ6VkVWRU5UDQpFTkQ6VkNBTEVOREFSDQo=';
+    const out = await buildFileDataFromMailAttachments([
+      {
+        id: 'a1',
+        name: 'invite.ics',
+        contentType: 'text/calendar',
+        size: 500,
+        content: { format: 'icalendar', content: icsBase64 }
+      }
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].displayType).toBe('Calendar invite');
+    expect(out[0].content).toContain('Meeting: Quarterly Planning');
+    expect(out[0].content).toContain('Location: Conference Room A');
+  });
+
+  test('skips attachments with an unrecognized, non-base64 content format', async () => {
+    const out = await buildFileDataFromMailAttachments([
+      {
+        id: 'a1',
+        name: 'mystery.dat',
+        contentType: 'application/octet-stream',
+        size: 100,
+        content: { format: 'some-future-format', content: 'whatever' }
       }
     ]);
     expect(out).toBeNull();

--- a/tests/unit/server/locale-override.test.js
+++ b/tests/unit/server/locale-override.test.js
@@ -1,12 +1,36 @@
-import { describe, it, expect, beforeAll, afterAll } from '@jest/globals';
+import { describe, it, expect, beforeAll, afterAll, jest } from '@jest/globals';
 import fs from 'fs/promises';
 import path from 'path';
-import { ConfigCache } from '../../../server/configCache.js';
+import configCacheSingleton from '../../../server/configCache.js';
+
+jest.mock('../../../server/pathUtils.js', () => ({
+  getRootDir: () => process.cwd()
+}));
+
+jest.mock('../../../server/utils/authorization.js', () => ({
+  resolveGroupInheritance: groups => groups,
+  filterResourcesByPermissions: resources => resources,
+  isAnonymousAccessAllowed: () => false
+}));
+
+jest.mock('../../../server/toolLoader.js', () => ({
+  loadTools: async () => []
+}));
+
+jest.mock('../../../server/utils/ApiKeyVerifier.js', () => {
+  return jest.fn().mockImplementation(() => ({
+    validateEnabledModelsApiKeys: async () => {}
+  }));
+});
 
 // Jest transpiles this file to CommonJS via Babel, which does not support
 // the raw `import.meta` syntax, so __dirname is used directly rather than
 // deriving it from import.meta.url.
 const rootDir = path.join(__dirname, '../../../');
+
+if (typeof global.setImmediate !== 'function') {
+  global.setImmediate = (fn, ...args) => setTimeout(fn, 0, ...args);
+}
 
 describe('Locale Override Feature', () => {
   let configCache;
@@ -30,8 +54,10 @@ describe('Locale Override Feature', () => {
     await fs.writeFile(testOverrideFile, JSON.stringify(overrideContent, null, 2));
 
     // Initialize config cache
-    configCache = new ConfigCache();
-    await configCache.initialize();
+    configCache = configCacheSingleton;
+    if (!configCache.isInitialized) {
+      await configCache.initialize();
+    }
   });
 
   afterAll(async () => {
@@ -51,7 +77,8 @@ describe('Locale Override Feature', () => {
   it('should merge override locale with builtin locale', async () => {
     // Load the locale with overrides
     await configCache.loadAndCacheLocale('en');
-    const translations = configCache.getLocalizations('en');
+    const localeEntry = configCache.getLocalizations('en');
+    const translations = localeEntry?.data;
 
     expect(translations).toBeDefined();
     expect(translations.app).toBeDefined();
@@ -61,7 +88,7 @@ describe('Locale Override Feature', () => {
   });
 
   it('should preserve non-overridden keys from builtin locale', async () => {
-    const translations = configCache.getLocalizations('en');
+    const translations = configCache.getLocalizations('en')?.data;
 
     expect(translations).toBeDefined();
     // These keys should exist from the base translation file
@@ -72,7 +99,7 @@ describe('Locale Override Feature', () => {
   it('should handle missing override file gracefully', async () => {
     // Load a locale without override file
     await configCache.loadAndCacheLocale('de');
-    const translations = configCache.getLocalizations('de');
+    const translations = configCache.getLocalizations('de')?.data;
 
     expect(translations).toBeDefined();
     expect(translations.app).toBeDefined();


### PR DESCRIPTION
## Summary

Fixes #1451.

Attachments to an Outlook email that Office.js returns as attached-email
(`format: 'eml'`), meeting-invite (`format: 'icalendar'`), or cloud-share-link
(`format: 'url'`) content fetch successfully — so they have no `.error` — but
were previously treated as unusable and silently dropped by
`buildFileDataFromMailAttachments` via `hasBase64Content`, with no log line
and no indication to the user that anything was missing, even though the
review banner showed them as "attached".

Rather than just detecting and flagging these as "unsupported" (this PR's
first iteration), `.eml` and `.icalendar` are plain-text formats — so they're
now actually parsed into real content instead.

## Changes

- **`client/src/features/office/utilities/emailAttachmentParsers.js`** (new):
  dependency-free parsers —
  - `parseEmlAttachment`: decodes an attached/forwarded email into a
    "Subject/From/To/Cc/Date + body" text block (handles multipart/alternative,
    quoted-printable and base64 `Content-Transfer-Encoding`, RFC 2047 encoded
    headers, and falls back to a regex-based HTML→text conversion for
    HTML-only bodies).
  - `parseIcsAttachment`: decodes a meeting invite into a short summary
    (subject, start/end time, location, organizer).
  - Pure (`atob`/`TextDecoder`/regex only, no DOM) so it's unit-testable under
    plain Node.
- **`buildChatApiMessages.js`**: `buildFileDataFromMailAttachments` now
  dispatches on the attachment's actual content format — `eml`/`icalendar` go
  through the new parsers, `url` (OneDrive/SharePoint share links, which have
  no fetchable file bytes) sends the link itself as a text reference instead
  of being dropped, and everything else goes through the existing
  binary-document pipeline (PDF/DOCX/XLSX/PPTX/MSG/...) unchanged.
- **`client/src/features/office/utilities/attachmentFormat.js`** (new in this
  PR): `sanitizeContentType`/`hasBase64Content` extracted to a dependency-free
  leaf module (previously inline in `buildChatApiMessages.js`, which pulls in
  the full document pipeline) so they're unit-testable under plain Node.
- **`OfficeMailContextBanner.jsx`**: since every fetched, non-error attachment
  now produces real content, the banner's original attached/failed/pending
  states are enough again — no new "unsupported" status needed. Two small
  banner improvements remain from this PR: attachments over 20 MB are skipped
  up front (in `outlookMailContext.js`) instead of risking a hung task pane,
  and old Outlook hosts (pre-Mailbox 1.8, which can't fetch attachment content
  at all) get one explanatory banner line instead of the same error repeated
  per attachment.
- Regression tests (plain-Node, matching the existing `tokenStats.test.js`
  convention — no test runner is configured for the client):
  `emailAttachmentParsers.test.js` (eml/ics parsing, including malformed
  input) and `attachmentFormat.test.js` (content-format classification).
- Added a changelog entry under `docs/releases/5.5.0/features.md`.

## Out of scope

- Per-attachment status still can't reflect a `processDocumentFile` failure
  that only happens at send time (e.g. an encrypted PDF) — the banner reflects
  what's known synchronously when the email is read. The failure is still
  logged and the attachment is dropped rather than sent as garbage.
- Cloud-hosted attachments (OneDrive/SharePoint `url` format) still can't have
  their actual file content retrieved client-side — that would need a Graph
  API integration with its own auth flow. They now send their share link as a
  reference instead of nothing.

## Test plan

- [x] `node client/src/features/office/utilities/emailAttachmentParsers.test.js` — all pass
- [x] `node client/src/features/office/utilities/attachmentFormat.test.js` — all pass
- [x] `node --check` on all modified/added plain-JS files
- [ ] Manual verification in Outlook (desktop/OWA) with an email containing a PDF, a Word doc, a forwarded `.eml`, and a meeting invite — not run in this environment (no Outlook host available); please verify before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
