### PR TITLE
fix: prevent admin lockout via group deletion/update

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -84,3 +84,15 @@ kept mislabeling upload-based answers.
 - Covers document uploads, image uploads, and email context in tool-enabled apps.
 - The detected source is also cleared when a turn instead pauses for a clarification question or
   ends in an error, so it can't carry over to the next message.
+
+## Group Management: Admin Lockout Prevention
+
+The admin Groups API's protected-group list previously checked for `admin`/`user`, but the
+built-in groups are shipped as `admins`/`users`. This meant the real administrator group could be
+deleted, or have its administrative access removed via an update, silently locking every admin out
+of the platform until `groups.json` was hand-edited.
+
+- Deleting or updating a group is now blocked whenever it would leave the platform with zero
+  groups granting administrative access, in addition to the built-in `admins`, `users`,
+  `anonymous`, and `authenticated` groups remaining non-deletable.
+- The group create/update endpoints now also accept the documented `inherits` field.

--- a/server/routes/admin/groups.js
+++ b/server/routes/admin/groups.js
@@ -17,6 +17,16 @@ import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
 
 /**
+ * Count groups that grant adminAccess. Used to prevent removing/demoting the
+ * last group that can administer the platform.
+ */
+function countAdminAccessGroups(groups, excludeGroupId = null) {
+  return Object.entries(groups || {}).filter(
+    ([groupId, group]) => groupId !== excludeGroupId && group?.permissions?.adminAccess === true
+  ).length;
+}
+
+/**
  * @swagger
  * components:
  *   schemas:
@@ -521,7 +531,7 @@ export default function registerAdminGroupRoutes(app) {
    */
   app.post(buildServerPath('/api/admin/groups'), adminAuth, async (req, res) => {
     try {
-      const { id, name, description, permissions, mappings = [] } = req.body;
+      const { id, name, description, permissions, mappings = [], inherits = [] } = req.body;
 
       if (!id || !name) {
         return sendBadRequest(res, 'Group ID and name are required');
@@ -574,7 +584,8 @@ export default function registerAdminGroupRoutes(app) {
           workflows: Array.isArray(permissions.workflows) ? permissions.workflows : [],
           adminAccess: Boolean(permissions.adminAccess)
         },
-        mappings: Array.isArray(mappings) ? mappings : []
+        mappings: Array.isArray(mappings) ? mappings : [],
+        inherits: Array.isArray(inherits) ? inherits : []
       };
 
       groupsData.groups[id] = newGroup;
@@ -674,7 +685,7 @@ export default function registerAdminGroupRoutes(app) {
         return;
       }
 
-      const { name, description, permissions, mappings } = req.body;
+      const { name, description, permissions, mappings, inherits } = req.body;
 
       const rootDir = getRootDir();
       const groupsFilePath = join(rootDir, 'contents', 'config', 'groups.json');
@@ -700,9 +711,27 @@ export default function registerAdminGroupRoutes(app) {
       if (name !== undefined) group.name = name;
       if (description !== undefined) group.description = description;
       if (mappings !== undefined) group.mappings = Array.isArray(mappings) ? mappings : [];
+      if (inherits !== undefined) group.inherits = Array.isArray(inherits) ? inherits : [];
 
       // Update permissions
       if (permissions !== undefined && typeof permissions === 'object') {
+        const newAdminAccess =
+          permissions.adminAccess !== undefined
+            ? Boolean(permissions.adminAccess)
+            : group.permissions.adminAccess || false;
+
+        // Prevent stripping adminAccess from the last group that grants it,
+        // which would lock every admin out of the platform.
+        if (group.permissions?.adminAccess === true && newAdminAccess !== true) {
+          const remainingAdminGroups = countAdminAccessGroups(groupsData.groups, groupId);
+          if (remainingAdminGroups === 0) {
+            return sendBadRequest(
+              res,
+              `Cannot remove administrative access from group '${groupId}': it is the only group with administrative access`
+            );
+          }
+        }
+
         group.permissions = {
           apps: Array.isArray(permissions.apps) ? permissions.apps : group.permissions.apps || [],
           prompts: Array.isArray(permissions.prompts)
@@ -714,10 +743,7 @@ export default function registerAdminGroupRoutes(app) {
           workflows: Array.isArray(permissions.workflows)
             ? permissions.workflows
             : group.permissions.workflows || [],
-          adminAccess:
-            permissions.adminAccess !== undefined
-              ? Boolean(permissions.adminAccess)
-              : group.permissions.adminAccess || false
+          adminAccess: newAdminAccess
         };
       }
 
@@ -758,13 +784,14 @@ export default function registerAdminGroupRoutes(app) {
    *     summary: Delete a user group
    *     description: |
    *       Permanently deletes a user group and its configuration.
-   *       Protected system groups (admin, user, anonymous, authenticated) cannot be deleted
-   *       to maintain system integrity.
+   *       Protected system groups (admins, users, anonymous, authenticated) cannot be deleted
+   *       to maintain system integrity. Additionally, the last remaining group that grants
+   *       adminAccess cannot be deleted, to prevent locking all admins out of the platform.
    *
    *       **Protected Groups:**
    *       The following system groups are protected and cannot be deleted:
-   *       - admin: Administrative access group
-   *       - user: Standard user group
+   *       - admins: Administrative access group
+   *       - users: Standard user group
    *       - anonymous: Anonymous access group
    *       - authenticated: Base authenticated user group
    *     tags:
@@ -802,7 +829,7 @@ export default function registerAdminGroupRoutes(app) {
    *                 error:
    *                   type: string
    *             example:
-   *               error: "Cannot delete protected system group: admin"
+   *               error: "Cannot delete protected system group: admins"
    *       404:
    *         description: Group not found
    *         content:
@@ -827,7 +854,7 @@ export default function registerAdminGroupRoutes(app) {
       }
 
       // Prevent deletion of core system groups
-      const protectedGroups = ['admin', 'user', 'anonymous', 'authenticated'];
+      const protectedGroups = ['admins', 'users', 'anonymous', 'authenticated'];
       if (protectedGroups.includes(groupId)) {
         return sendBadRequest(res, `Cannot delete protected system group: ${groupId}`);
       }
@@ -851,6 +878,18 @@ export default function registerAdminGroupRoutes(app) {
 
       const deletedGroup = groupsData.groups[groupId];
       const groupName = deletedGroup.name;
+
+      // Prevent deleting the last group that grants adminAccess, which would
+      // lock every admin out of the platform.
+      if (deletedGroup.permissions?.adminAccess === true) {
+        const remainingAdminGroups = countAdminAccessGroups(groupsData.groups, groupId);
+        if (remainingAdminGroups === 0) {
+          return sendBadRequest(
+            res,
+            `Cannot delete group '${groupId}': it is the only group with administrative access`
+          );
+        }
+      }
 
       // Save snapshot before deletion
       await saveSnapshot({

--- a/server/routes/admin/groups.js
+++ b/server/routes/admin/groups.js
@@ -567,8 +567,9 @@ export default function registerAdminGroupRoutes(app) {
         };
       }
 
-      // Check if group ID already exists
-      if (groupsData.groups[id]) {
+      // Check if group ID already exists (own-property check so names inherited
+      // from Object.prototype, e.g. "hasOwnProperty", can't be mistaken for a group)
+      if (Object.hasOwn(groupsData.groups, id)) {
         return sendErrorResponse(res, 409, 'Group ID already exists');
       }
 
@@ -699,8 +700,9 @@ export default function registerAdminGroupRoutes(app) {
         return sendNotFound(res, 'Groups file');
       }
 
-      // Check if group exists
-      if (!groupsData.groups[groupId]) {
+      // Check if group exists (own-property check so names inherited from
+      // Object.prototype, e.g. "hasOwnProperty", can't be mistaken for a group)
+      if (!Object.hasOwn(groupsData.groups, groupId)) {
         return sendNotFound(res, 'Group');
       }
 
@@ -871,8 +873,9 @@ export default function registerAdminGroupRoutes(app) {
         return sendNotFound(res, 'Groups file');
       }
 
-      // Check if group exists
-      if (!groupsData.groups[groupId]) {
+      // Check if group exists (own-property check so names inherited from
+      // Object.prototype, e.g. "hasOwnProperty", can't be mistaken for a group)
+      if (!Object.hasOwn(groupsData.groups, groupId)) {
         return sendNotFound(res, 'Group');
       }
 


### PR DESCRIPTION
## Summary

Fixes #1680.

The admin Groups API's protected-group list checked for group IDs `'admin'`/`'user'`, but the groups shipped in `server/defaults/config/groups.json` are `'admins'`/`'users'`. As a result:

- `DELETE /api/admin/groups/:groupId` would happily delete the real `admins` group (the only group with `adminAccess: true`), since `'admins'` was never in the protected list.
- `PUT /api/admin/groups/:groupId` had no protection at all, so `adminAccess` could be stripped from `admins` via a normal update.

Either action leaves no group granting `adminAccess`, permanently locking every admin out of the platform until someone hand-edits `groups.json` (the rescue fallback in `adminAuth.js` only triggers when `loadGroupsConfiguration` throws — it does not help here).

## Changes

- `server/routes/admin/groups.js`:
  - Fixed the protected-group ID list (`'admin'`/`'user'` → `'admins'`/`'users'`) so the built-in groups actually match what's shipped.
  - Added a `countAdminAccessGroups` guard used by both `DELETE` and `PUT` to refuse any operation that would leave zero groups with `adminAccess: true` — this protects custom admin groups too, not just the built-in ones.
  - `POST`/`PUT` now accept and persist the documented `inherits` field, which was previously silently dropped on create.
  - Updated the related Swagger doc comments/examples to match.
- `docs/releases/5.5.0/features.md`: added a changelog entry per repo convention.

## Test plan

- [x] `node --check server/routes/admin/groups.js` (no `node_modules` available in this sandbox to run the full lint/test suite)
- [ ] Manually verify in a running instance: `DELETE /api/admin/groups/admins` is rejected with 400, and `PUT /api/admin/groups/admins` with `adminAccess: false` is rejected with 400
- [ ] Manually verify a non-last admin-access group can still be deleted/demoted normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012npe46UgHdKwqKoE3Bob6F

---
_Generated by [Claude Code](https://claude.ai/code/session_012npe46UgHdKwqKoE3Bob6F)_