### PR TITLE
Fix cross-request tool-call state contamination in streaming converters

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -106,3 +106,15 @@ of the platform until `groups.json` was hand-edited.
   groups granting administrative access, in addition to the built-in `admins`, `users`,
   `anonymous`, and `authenticated` groups remaining non-deletable.
 - The group create/update endpoints now also accept the documented `inherits` field.
+
+## Fixed Cross-Chat Tool-Call Mixups Under Concurrent Load
+
+Streaming tool calls for OpenAI-, Anthropic-, and vLLM/local-backed apps are now tracked per
+conversation instead of in one shared bucket. Previously, two users streaming tool calls at the
+same time — or a user whose stream was cancelled mid-flight — could have their pending tool-call
+data overwritten or merged with another user's, occasionally causing a tool to run with the wrong
+or corrupted arguments.
+
+- Each conversation's in-flight tool-call data is now isolated by chat.
+- A cancelled or errored stream can no longer leave stale tool-call data behind to be picked up by
+  a later, unrelated conversation.

--- a/server/adapters/BaseAdapter.js
+++ b/server/adapters/BaseAdapter.js
@@ -1,7 +1,7 @@
 import logger from '../utils/logger.js';
 import { createParser } from 'eventsource-parser';
 import { getReadableStream } from '../utils/streamUtils.js';
-import { convertResponseToGeneric } from './toolCalling/index.js';
+import { convertResponseToGeneric, clearStreamingState } from './toolCalling/index.js';
 
 /**
  * Base adapter class for LLM providers to reduce duplication
@@ -169,7 +169,7 @@ export class BaseAdapter {
    * @yields {object} Normalized result chunks consumed by StreamingHandler
    */
   async *parseResponseStream(response, ctx) {
-    yield* this.parseSseStream(response, ctx.model.provider);
+    yield* this.parseSseStream(response, ctx.model.provider, ctx.chatId);
   }
 
   /**
@@ -179,9 +179,12 @@ export class BaseAdapter {
    *
    * @param {Response} response
    * @param {string} provider - Provider name passed to the converter registry
+   * @param {string} [streamId] - Per-chat identifier isolating tool-call accumulation
+   *   state between concurrent streams; falls back to a shared 'default' bucket
+   *   (previous behavior) when the caller doesn't provide one.
    * @yields {object} Normalized result chunks
    */
-  async *parseSseStream(response, provider) {
+  async *parseSseStream(response, provider, streamId = 'default') {
     const readable = getReadableStream(response);
     const reader = readable.getReader();
     const decoder = new TextDecoder();
@@ -231,7 +234,7 @@ export class BaseAdapter {
         while (queue.length > 0) {
           const evt = queue.shift();
           try {
-            const result = await convertResponseToGeneric(evt.data, provider);
+            const result = await convertResponseToGeneric(evt.data, provider, streamId);
             if (!result) continue;
             yield result;
             if (result.error || result.complete) return;
@@ -269,6 +272,10 @@ export class BaseAdapter {
       } catch {
         /* ignore */
       }
+      // Guard against a stale pending tool call surviving an aborted/errored
+      // stream and being finalized by a later, unrelated stream on the same
+      // provider's shared state map (only relevant when streamId was reused).
+      clearStreamingState(provider, streamId);
     }
   }
 

--- a/server/adapters/toolCalling/AnthropicConverter.js
+++ b/server/adapters/toolCalling/AnthropicConverter.js
@@ -328,6 +328,15 @@ export async function convertAnthropicResponseToGeneric(data, streamId = 'defaul
 }
 
 /**
+ * Discard accumulated streaming state for a stream that errored or was aborted,
+ * so a stale pending tool call can't leak into a later, unrelated stream.
+ * @param {string} streamId - Stream identifier to clear
+ */
+export function clearAnthropicStreamingState(streamId = 'default') {
+  streamingState.delete(streamId);
+}
+
+/**
  * Convert generic streaming response to Anthropic format
  * Note: This is primarily for testing/debugging as we typically don't need to convert back to Anthropic format
  * @param {import('./GenericToolCalling.js').GenericStreamingResponse} genericResponse - Generic response

--- a/server/adapters/toolCalling/OpenAIConverter.js
+++ b/server/adapters/toolCalling/OpenAIConverter.js
@@ -426,6 +426,15 @@ export async function convertOpenAIResponseToGeneric(data, streamId = 'default')
 }
 
 /**
+ * Discard accumulated streaming state for a stream that errored or was aborted,
+ * so stale pending tool calls can't leak into a later, unrelated stream.
+ * @param {string} streamId - Stream identifier to clear
+ */
+export function clearOpenAIStreamingState(streamId = 'default') {
+  streamingState.delete(streamId);
+}
+
+/**
  * Convert generic streaming response to OpenAI format
  * @param {import('./GenericToolCalling.js').GenericStreamingResponse} genericResponse - Generic response
  * @param {string} completionId - Completion ID for OpenAI format

--- a/server/adapters/toolCalling/ToolCallingConverter.js
+++ b/server/adapters/toolCalling/ToolCallingConverter.js
@@ -154,6 +154,24 @@ export async function convertResponseToGeneric(data, sourceProvider, streamId = 
 }
 
 /**
+ * Discard accumulated per-stream state (e.g. pending tool call accumulation) for a
+ * stream that errored, was aborted, or otherwise ended without reaching its natural
+ * completion event. Providers without stateful streaming (e.g. Google, Mistral) have
+ * no clear function and this is a no-op for them.
+ * @param {string} sourceProvider - Source provider name
+ * @param {string} streamId - Stream identifier to clear
+ */
+export function clearStreamingState(sourceProvider, streamId = 'default') {
+  const converter = CONVERTERS[sourceProvider];
+  if (!converter) return;
+
+  const clearFunction = converter[`clear${capitalize(sourceProvider)}StreamingState`];
+  if (clearFunction) {
+    clearFunction(streamId);
+  }
+}
+
+/**
  * Convert streaming response from generic format to any provider format
  * @param {import('./GenericToolCalling.js').GenericStreamingResponse} genericResponse - Generic response
  * @param {string} targetProvider - Target provider name

--- a/server/adapters/toolCalling/VLLMConverter.js
+++ b/server/adapters/toolCalling/VLLMConverter.js
@@ -418,6 +418,15 @@ export async function convertVLLMResponseToGeneric(data, streamId = 'default') {
 }
 
 /**
+ * Discard accumulated streaming state for a stream that errored or was aborted,
+ * so stale pending tool calls can't leak into a later, unrelated stream.
+ * @param {string} streamId - Stream identifier to clear
+ */
+export function clearVLLMStreamingState(streamId = 'default') {
+  streamingState.delete(streamId);
+}
+
+/**
  * Convert generic streaming response to vLLM format (same as OpenAI)
  * @param {import('./GenericToolCalling.js').GenericStreamingResponse} genericResponse - Generic response
  * @param {string} completionId - Completion ID for vLLM format

--- a/server/adapters/toolCalling/index.js
+++ b/server/adapters/toolCalling/index.js
@@ -30,6 +30,7 @@ export {
   convertResponseToGeneric,
   convertResponseFromGeneric,
   convertResponseBetweenProviders,
+  clearStreamingState,
   processMessageForProvider,
   getSupportedProviders,
   isProviderSupported,

--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -1,5 +1,5 @@
 import { createCompletionRequest } from '../../adapters/index.js';
-import { convertResponseToGeneric } from '../../adapters/toolCalling/index.js';
+import { convertResponseToGeneric, clearStreamingState } from '../../adapters/toolCalling/index.js';
 import { logInteraction, getErrorDetails } from '../../utils.js';
 import { runTool } from '../../toolLoader.js';
 import { normalizeToolName } from '../../adapters/toolCalling/index.js';
@@ -941,7 +941,7 @@ class ToolExecutor {
 
         while (events.length > 0) {
           const evt = events.shift();
-          const result = await convertResponseToGeneric(evt.data, model.provider);
+          const result = await convertResponseToGeneric(evt.data, model.provider, chatId);
 
           if (result.error) {
             throw Object.assign(new Error(result.errorMessage || 'Error processing response'), {
@@ -1038,6 +1038,12 @@ class ToolExecutor {
           }
         }
       }
+
+      // Whether the stream finished naturally, was superseded by a newer
+      // request on this chatId, or the reader was cancelled mid-flight,
+      // discard any leftover tool-call accumulation state so it can't be
+      // finalized by a future, unrelated stream reusing this chatId.
+      clearStreamingState(model.provider, chatId);
 
       if (finishReason !== 'tool_calls' && collectedToolCalls.length === 0) {
         logger.info('No tool calls to process', {
@@ -1249,6 +1255,10 @@ class ToolExecutor {
       // Clear source bookkeeping so a failed turn can't leak a detected
       // upload/email source into the next turn on this chatId.
       this.resetKnowledgeSources(chatId);
+      // A throw (e.g. result.error) can skip the post-loop cleanup below the
+      // streaming reader, so also clear here to avoid leaking pending tool
+      // calls into the next turn on this chatId.
+      clearStreamingState(model.provider, chatId);
     }
   }
 
@@ -1365,7 +1375,7 @@ class ToolExecutor {
 
           while (events.length > 0) {
             const evt = events.shift();
-            const result = await convertResponseToGeneric(evt.data, model.provider);
+            const result = await convertResponseToGeneric(evt.data, model.provider, chatId);
 
             if (result.error) {
               throw Object.assign(new Error(result.errorMessage || 'Error processing response'), {
@@ -1432,6 +1442,12 @@ class ToolExecutor {
             }
           }
         }
+
+        // Whether the stream finished naturally, was superseded by a newer
+        // request on this chatId, or the reader was cancelled mid-flight,
+        // discard any leftover tool-call accumulation state so it can't be
+        // finalized by a future, unrelated stream reusing this chatId.
+        clearStreamingState(model.provider, chatId);
 
         // If no tool calls, this is the final response - stream it back to client
         if (finishReason !== 'tool_calls' && collectedToolCalls.length === 0) {

--- a/tests/unit/server/tool-executor-answer-source-detection.test.js
+++ b/tests/unit/server/tool-executor-answer-source-detection.test.js
@@ -55,6 +55,7 @@ jest.mock('../../../server/adapters/toolCalling/index.js', () => ({
     complete: true,
     tool_calls: []
   })),
+  clearStreamingState: jest.fn(),
   normalizeToolName: x => x
 }));
 


### PR DESCRIPTION
## Summary

Fixes #1678.

The OpenAI, Anthropic, and vLLM tool-calling converters accumulate streaming tool-call state (`pendingToolCall(s)`) in a module-level `Map` keyed by `streamId`. However, the two call paths that invoke `convertResponseToGeneric` — `BaseAdapter.parseSseStream` and `ToolExecutor`'s two streaming loops — never passed a `streamId`, so every concurrent chat fell back to the same shared `'default'` bucket.

This meant:
- Two users streaming tool calls at the same time could overwrite/merge each other's pending `id`/`name`/`arguments` (Anthropic keeps a single `state.pendingToolCall`, so this was especially easy to hit).
- An aborted or errored stream left its `pendingToolCalls` in the shared state, since it's normally only cleared on a `finish_reason`/`message_stop` event. A later, unrelated request finalizing on that shared key could then execute a stale/"ghost" tool call.

### Fix

- Thread `ctx.chatId` through `BaseAdapter.parseResponseStream` → `parseSseStream` → `convertResponseToGeneric` as `streamId`, and do the same in `ToolExecutor`'s two streaming loops (`processChatWithTools`, `continueWithToolExecution`) — each chat's conversation ID now isolates its own tool-call accumulation state.
- Added `clear{OpenAI,Anthropic,VLLM}StreamingState(streamId)` to the three stateful converters, and a provider-agnostic `clearStreamingState(provider, streamId)` dispatcher in `ToolCallingConverter`/`toolCalling/index.js` (a no-op for stateless converters like Google/Mistral).
- Call `clearStreamingState` after every stream read loop ends (natural completion, abort, or superseded request) and in the outer error-handling `catch` blocks, so a thrown/aborted stream can never leave data behind for a future stream on the same chat.

### Affected files

- `server/adapters/BaseAdapter.js`
- `server/adapters/toolCalling/{OpenAIConverter,AnthropicConverter,VLLMConverter,ToolCallingConverter,index}.js`
- `server/services/chat/ToolExecutor.js`

## Test plan

- [x] `npx jest --config tests/config/jest.config.js tests/unit` — all runnable suites pass (152/152 tests); the 7 failing suites are pre-existing environment issues unrelated to this change (missing client deps / Node-version-only ESM parsing), verified unchanged on `main`.
- [x] Updated `tests/unit/server/tool-executor-answer-source-detection.test.js`'s mock of `adapters/toolCalling/index.js` to include the new `clearStreamingState` export.
- [x] `npx eslint` and `npx prettier --check` on all changed files — clean (pre-existing unrelated warnings only).
- [ ] Manual verification of two concurrent tool-calling chats not cross-contaminating (not exercised live in this sandbox; recommend a quick smoke test with two concurrent `local`/OpenAI-tool-calling sessions before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BCLQNBPWg6SdmFreSM9Ai2


---
_Generated by [Claude Code](https://claude.ai/code/session_01BCLQNBPWg6SdmFreSM9Ai2)_