### PR TITLE
refactor(server): dedupe usageTracker request/response and rating logic

### DIFF
--- a/server/tests/usageTracker.test.js
+++ b/server/tests/usageTracker.test.js
@@ -1,0 +1,113 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Unit tests for usageTracker.js — focused on the request/response collapse
+ * (recordChatMessage) and the shared rating helpers (computeAverageRating /
+ * applyRating) added to deduplicate what used to be three copies of the same
+ * rating math. Disk I/O and dynamic config imports are mocked so tests run
+ * against an in-memory usage object only.
+ */
+
+let fileContents = null;
+
+jest.unstable_mockModule('fs/promises', () => ({
+  default: {
+    readFile: jest.fn(async () => {
+      if (fileContents === null) {
+        const error = new Error('ENOENT');
+        error.code = 'ENOENT';
+        throw error;
+      }
+      return fileContents;
+    }),
+    writeFile: jest.fn(async (_file, data) => {
+      fileContents = data;
+    }),
+    mkdir: jest.fn(async () => {})
+  }
+}));
+
+jest.unstable_mockModule('../featureRegistry.js', () => ({
+  isFeatureEnabled: () => true
+}));
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: {
+    getFeatures: () => ({}),
+    getPlatform: () => ({ features: { usageTrackingMode: 'pseudonymous' } })
+  }
+}));
+
+jest.unstable_mockModule('../services/UserFingerprint.js', () => ({
+  resolveUserId: async userId => userId || 'anonymous'
+}));
+
+jest.unstable_mockModule('../services/UsageEventLog.js', () => ({
+  logUsageEvent: () => {}
+}));
+
+jest.unstable_mockModule('../telemetry.js', () => ({
+  recordTokenUsage: () => {}
+}));
+
+jest.unstable_mockModule('../telemetry/metrics.js', () => ({
+  recordMagicPromptUsage: () => {},
+  recordFeedbackEvent: () => {}
+}));
+
+jest.unstable_mockModule('../utils/logger.js', () => ({
+  default: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} }
+}));
+
+const { recordChatRequest, recordChatResponse, recordFeedback, getUsage, resetUsage } =
+  await import('../usageTracker.js');
+
+beforeEach(async () => {
+  fileContents = null;
+  await resetUsage();
+});
+
+describe('recordChatRequest / recordChatResponse', () => {
+  it('bump shared message/token counters and their own prompt/completion bucket independently', async () => {
+    await recordChatRequest({ userId: 'u1', appId: 'a1', modelId: 'm1', tokens: 10 });
+    await recordChatResponse({ userId: 'u1', appId: 'a1', modelId: 'm1', tokens: 25 });
+
+    const usage = await getUsage();
+    expect(usage.messages.total).toBe(2);
+    expect(usage.tokens.total).toBe(35);
+    expect(usage.tokens.prompt.total).toBe(10);
+    expect(usage.tokens.completion.total).toBe(25);
+    expect(usage.tokens.prompt.perUser.u1).toBe(10);
+    expect(usage.tokens.completion.perUser.u1).toBe(25);
+    expect(usage.tokens.perUser.u1).toBe(35);
+  });
+});
+
+describe('recordFeedback', () => {
+  it('numeric rating updates top-level ratings/total/averageRating and matching per-* buckets consistently', async () => {
+    await recordFeedback({ userId: 'u1', appId: 'a1', modelId: 'm1', rating: 5 });
+    await recordFeedback({ userId: 'u2', appId: 'a1', modelId: 'm1', rating: 1 });
+
+    const usage = await getUsage();
+    expect(usage.feedback.total).toBe(2);
+    expect(usage.feedback.ratings[5]).toBe(1);
+    expect(usage.feedback.ratings[1]).toBe(1);
+    expect(usage.feedback.averageRating).toBe(3);
+    expect(usage.feedback.good).toBe(1);
+    expect(usage.feedback.bad).toBe(1);
+
+    // Per-app bucket must agree with the top-level totals it feeds into.
+    expect(usage.feedback.perApp.a1.total).toBe(2);
+    expect(usage.feedback.perApp.a1.averageRating).toBe(3);
+  });
+
+  it('legacy string rating only bumps good/bad, not ratings/total', async () => {
+    await recordFeedback({ userId: 'u1', appId: 'a1', modelId: 'm1', rating: 'positive' });
+
+    const usage = await getUsage();
+    expect(usage.feedback.good).toBe(1);
+    expect(usage.feedback.bad).toBe(0);
+    expect(usage.feedback.total).toBe(0);
+    expect(usage.feedback.perUser.u1.good).toBe(1);
+  });
+});

--- a/server/usageTracker.js
+++ b/server/usageTracker.js
@@ -107,14 +107,7 @@ function migrateLegacyFeedback(feedbackObj) {
     feedbackObj.ratings[5] += good;
     feedbackObj.ratings[1] += bad;
     feedbackObj.total = legacyTotal;
-
-    // Calculate weighted average: (5*good + 1*bad) / total
-    if (feedbackObj.total > 0) {
-      const weightedSum = 5 * good + 1 * bad;
-      feedbackObj.averageRating = weightedSum / feedbackObj.total;
-    } else {
-      feedbackObj.averageRating = 0;
-    }
+    feedbackObj.averageRating = computeAverageRating(feedbackObj.ratings);
   }
 
   // Keep legacy fields for backward compatibility
@@ -169,7 +162,7 @@ function scheduleSave() {
     try {
       await saveUsage();
     } catch (error) {
-      logger.error('Failed to save usage data', { component: 'UsageTracker', error: e });
+      logger.error('Failed to save usage data', { component: 'UsageTracker', error });
     }
   }, SAVE_INTERVAL_MS);
 }
@@ -178,6 +171,41 @@ function inc(map, key, amount) {
   if (!key) return;
   if (key === '__proto__' || key === 'constructor' || key === 'prototype') return;
   map[key] = (map[key] || 0) + amount;
+}
+
+function computeAverageRating(ratings) {
+  const totalRatings = Object.values(ratings).reduce((sum, count) => sum + count, 0);
+  if (totalRatings === 0) return 0;
+  const weightedSum = Object.entries(ratings).reduce(
+    (sum, [rating, count]) => sum + parseInt(rating) * count,
+    0
+  );
+  return weightedSum / totalRatings;
+}
+
+function applyRating(bucket, rating) {
+  // Handle numeric ratings (1-5)
+  if (typeof rating === 'number') {
+    const roundedRating = Math.round(rating * 2) / 2; // Round to nearest 0.5
+    const ratingKey = Math.ceil(roundedRating); // Round up for indexing (1.5 -> 2)
+
+    if (ratingKey >= 1 && ratingKey <= 5) {
+      bucket.ratings[ratingKey] += 1;
+      bucket.total += 1;
+      bucket.averageRating = computeAverageRating(bucket.ratings);
+
+      // Update legacy format (ratings 4-5 = good, ratings 1-3 = bad)
+      if (ratingKey >= 4) {
+        bucket.good += 1;
+      } else {
+        bucket.bad += 1;
+      }
+    }
+  } else {
+    // Handle legacy string format for backward compatibility
+    const legacyRating = rating === 'positive' ? 'good' : 'bad';
+    bucket[legacyRating] = (bucket[legacyRating] || 0) + 1;
+  }
 }
 
 function incFeedback(map, key, rating) {
@@ -191,43 +219,15 @@ function incFeedback(map, key, rating) {
     good: 0,
     bad: 0
   };
-
-  // Handle numeric ratings (1-5)
-  if (typeof rating === 'number') {
-    const roundedRating = Math.round(rating * 2) / 2; // Round to nearest 0.5
-    const ratingKey = Math.ceil(roundedRating); // Round up for indexing (1.5 -> 2)
-
-    if (ratingKey >= 1 && ratingKey <= 5) {
-      map[key].ratings[ratingKey] += 1;
-      map[key].total += 1;
-
-      // Calculate new average rating
-      const totalRatings = Object.values(map[key].ratings).reduce((sum, count) => sum + count, 0);
-      const weightedSum = Object.entries(map[key].ratings).reduce(
-        (sum, [rating, count]) => sum + parseInt(rating) * count,
-        0
-      );
-      map[key].averageRating = totalRatings > 0 ? weightedSum / totalRatings : 0;
-
-      // Update legacy format (ratings 4-5 = good, ratings 1-3 = bad)
-      if (ratingKey >= 4) {
-        map[key].good += 1;
-      } else {
-        map[key].bad += 1;
-      }
-    }
-  } else {
-    // Handle legacy string format for backward compatibility
-    const legacyRating = rating === 'positive' ? 'good' : 'bad';
-    map[key][legacyRating] = (map[key][legacyRating] || 0) + 1;
-  }
+  applyRating(map[key], rating);
 }
 
 export function estimateTokens(text) {
   return estimateTokensShared(text);
 }
 
-export async function recordChatRequest({
+async function recordChatMessage({
+  direction,
   userId,
   appId,
   modelId,
@@ -249,64 +249,32 @@ export async function recordChatRequest({
   inc(data.tokens.perUser, resolvedUser, tokens);
   inc(data.tokens.perApp, appId, tokens);
   inc(data.tokens.perModel, modelId, tokens);
-  inc(data.tokens.prompt.perUser, resolvedUser, tokens);
-  inc(data.tokens.prompt.perApp, appId, tokens);
-  inc(data.tokens.prompt.perModel, modelId, tokens);
-  inc(data.tokens.prompt, 'total', tokens);
+  const directionBucket = data.tokens[direction];
+  inc(directionBucket.perUser, resolvedUser, tokens);
+  inc(directionBucket.perApp, appId, tokens);
+  inc(directionBucket.perModel, modelId, tokens);
+  inc(directionBucket, 'total', tokens);
   if (!data.tokenSources) data.tokenSources = { provider: 0, estimate: 0 };
   data.tokenSources[tokenSource] = (data.tokenSources[tokenSource] || 0) + 1;
   recordTokenUsage(tokens);
   logUsageEvent({
-    type: 'chat_request',
+    type: direction === 'prompt' ? 'chat_request' : 'chat_response',
     userId: resolvedUser,
     appId,
     modelId,
-    promptTokens: tokens,
+    ...(direction === 'prompt' ? { promptTokens: tokens } : { completionTokens: tokens }),
     tokenSource
   });
   dirty = true;
   scheduleSave();
 }
 
-export async function recordChatResponse({
-  userId,
-  appId,
-  modelId,
-  tokens = 0,
-  tokenSource = 'estimate',
-  user
-}) {
-  await loadConfig();
-  if (!trackingEnabled) return;
-  const resolvedUser =
-    trackingMode === 'identified' && user?.id ? user.id : await resolveUserId(userId, trackingMode);
-  const data = await loadUsage();
-  data.messages.total += 1;
-  inc(data.messages.perUser, resolvedUser, 1);
-  inc(data.messages.perApp, appId, 1);
-  inc(data.messages.perModel, modelId, 1);
+export async function recordChatRequest(args) {
+  return recordChatMessage({ ...args, direction: 'prompt' });
+}
 
-  data.tokens.total += tokens;
-  inc(data.tokens.perUser, resolvedUser, tokens);
-  inc(data.tokens.perApp, appId, tokens);
-  inc(data.tokens.perModel, modelId, tokens);
-  inc(data.tokens.completion.perUser, resolvedUser, tokens);
-  inc(data.tokens.completion.perApp, appId, tokens);
-  inc(data.tokens.completion.perModel, modelId, tokens);
-  inc(data.tokens.completion, 'total', tokens);
-  if (!data.tokenSources) data.tokenSources = { provider: 0, estimate: 0 };
-  data.tokenSources[tokenSource] = (data.tokenSources[tokenSource] || 0) + 1;
-  recordTokenUsage(tokens);
-  logUsageEvent({
-    type: 'chat_response',
-    userId: resolvedUser,
-    appId,
-    modelId,
-    completionTokens: tokens,
-    tokenSource
-  });
-  dirty = true;
-  scheduleSave();
+export async function recordChatResponse(args) {
+  return recordChatMessage({ ...args, direction: 'completion' });
 }
 
 export async function recordFeedback({ userId, appId, modelId, rating, user }) {
@@ -316,38 +284,7 @@ export async function recordFeedback({ userId, appId, modelId, rating, user }) {
     trackingMode === 'identified' && user?.id ? user.id : await resolveUserId(userId, trackingMode);
   const data = await loadUsage();
 
-  // Handle numeric ratings (1-5)
-  if (typeof rating === 'number') {
-    const roundedRating = Math.round(rating * 2) / 2; // Round to nearest 0.5
-    const ratingKey = Math.ceil(roundedRating); // Round up for indexing
-
-    if (ratingKey >= 1 && ratingKey <= 5) {
-      data.feedback.ratings[ratingKey] += 1;
-      data.feedback.total += 1;
-
-      // Calculate new average rating
-      const totalRatings = Object.values(data.feedback.ratings).reduce(
-        (sum, count) => sum + count,
-        0
-      );
-      const weightedSum = Object.entries(data.feedback.ratings).reduce(
-        (sum, [rating, count]) => sum + parseInt(rating) * count,
-        0
-      );
-      data.feedback.averageRating = totalRatings > 0 ? weightedSum / totalRatings : 0;
-
-      // Update legacy format (ratings 4-5 = good, ratings 1-3 = bad)
-      if (ratingKey >= 4) {
-        data.feedback.good += 1;
-      } else {
-        data.feedback.bad += 1;
-      }
-    }
-  } else {
-    // Handle legacy string format for backward compatibility
-    const r = rating === 'positive' ? 'good' : 'bad';
-    data.feedback[r] += 1;
-  }
+  applyRating(data.feedback, rating);
 
   incFeedback(data.feedback.perUser, resolvedUser, rating);
   incFeedback(data.feedback.perApp, appId, rating);


### PR DESCRIPTION
Fixes #1851

## Summary
- Collapse `recordChatRequest`/`recordChatResponse` in `server/usageTracker.js` into a single internal `recordChatMessage({ direction })` helper — the two exported functions were ~40-line duplicates differing only in which token bucket (`prompt` vs `completion`) and event type they wrote. Exported signatures/behavior are unchanged, so no call sites needed updates.
- Extract `computeAverageRating(ratings)` and `applyRating(bucket, rating)` helpers so the 1–5 star rating math (round-to-0.5, ceil-to-bucket, weighted average, legacy `good`/`bad` mapping) exists in one place instead of being copied across `incFeedback`, `recordFeedback`, and `migrateLegacyFeedback`.
- Fixed an incidental bug in `scheduleSave`'s catch block that referenced an undefined `e` instead of the caught `error`, which threw a `ReferenceError` and masked the real save-failure error whenever a save actually failed.
- This is a behavior-preserving refactor — no changes to `usage.json`'s on-disk shape, and no other files needed changes (verified all 8 importers only use the unchanged exported functions).

## Test plan
- [x] Added `server/tests/usageTracker.test.js` covering: `recordChatRequest`/`recordChatResponse` bump shared counters and independent prompt/completion buckets; `recordFeedback` with a numeric rating keeps top-level and per-app buckets consistent; legacy string ratings only bump `good`/`bad`.
- [x] `npx eslint server/usageTracker.js server/tests/usageTracker.test.js` — no errors
- [x] `npx prettier --check server/usageTracker.js server/tests/usageTracker.test.js` — passes
- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/usageTracker.test.js` (from `server/`) — 3/3 passing


---
_Generated by [Claude Code](https://claude.ai/code/session_011t3n6nnshvPhKBkvaA8qSt)_