### PR TITLE
fix(admin): honor adaptive polling in AgentRunsPage, dedupe StatusBadge

### DIFF
--- a/client/src/features/admin/pages/AdminWorkflowExecutionsPage.jsx
+++ b/client/src/features/admin/pages/AdminWorkflowExecutionsPage.jsx
@@ -15,6 +15,7 @@ import { getLocalizedContent } from '../../../utils/localizeContent';
 import Icon from '../../../shared/components/Icon';
 import { fetchAdminExecutions, cancelAdminExecution } from '../../../api/adminApi';
 import ConfirmDialog from '../../../shared/components/ConfirmDialog';
+import StatusBadge from '../../workflows/components/StatusBadge';
 
 /**
  * Auto-refresh polling interval in milliseconds (5 seconds)
@@ -514,7 +515,6 @@ function AdminWorkflowExecutionsPage() {
                   </thead>
                   <tbody className="bg-white dark:bg-gray-900 divide-y divide-gray-200 dark:divide-gray-700">
                     {executions.map(execution => {
-                      const badgeClasses = getStatusBadgeClasses(execution.status);
                       return (
                         <tr
                           key={execution.executionId}
@@ -546,17 +546,7 @@ function AdminWorkflowExecutionsPage() {
                             </div>
                           </td>
                           <td className="px-4 py-3 whitespace-nowrap">
-                            <span
-                              className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium capitalize ${badgeClasses.bg} ${badgeClasses.text}`}
-                            >
-                              {execution.status === 'running' && (
-                                <span className="mr-1.5 h-1.5 w-1.5 rounded-full bg-blue-500 animate-pulse" />
-                              )}
-                              {t(
-                                `admin.workflowExecutions.status.${execution.status}`,
-                                execution.status
-                              )}
-                            </span>
+                            <StatusBadge status={execution.status} />
                           </td>
                           <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
                             {formatDateTime(execution.startedAt)}

--- a/client/src/features/admin/pages/AgentRunsPage.jsx
+++ b/client/src/features/admin/pages/AgentRunsPage.jsx
@@ -3,23 +3,14 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { fetchAgentRuns } from '../../../api/agentsAdminApi';
 import AdminBreadcrumb from '../components/AdminBreadcrumb';
 import { DataTable } from '../components/data-table';
+import StatusBadge from '../../workflows/components/StatusBadge';
+
+const ACTIVE_POLL_MS = 5000;
+const IDLE_POLL_MS = 30000;
 
 function formatTimestamp(timestamp) {
   if (!timestamp) return '—';
   return new Date(timestamp).toLocaleString();
-}
-
-const STATUS_BADGE_CLASSES = {
-  completed: 'bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300',
-  failed: 'bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-300',
-  paused: 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-800 dark:text-yellow-300',
-  running: 'bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-300'
-};
-
-function StatusBadge({ status }) {
-  const cls =
-    STATUS_BADGE_CLASSES[status] || 'bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300';
-  return <span className={`px-2 py-0.5 text-xs rounded font-medium ${cls}`}>{status}</span>;
 }
 
 export default function AgentRunsPage() {
@@ -31,28 +22,30 @@ export default function AgentRunsPage() {
 
   useEffect(() => {
     let mounted = true;
-    let interval;
+    let timer;
 
     async function load() {
+      let hasActiveRun = true;
       try {
         const res = await fetchAgentRuns(profileId ? { profileId } : {});
         if (!mounted) return;
-        setRuns(res?.data || []);
+        const data = res?.data || [];
+        setRuns(data);
         setError(null);
+        hasActiveRun = data.some(r => r.status === 'running' || r.status === 'paused');
       } catch (err) {
         if (mounted) setError(err.message);
       } finally {
         if (mounted) setLoading(false);
       }
+      if (mounted) timer = setTimeout(load, hasActiveRun ? ACTIVE_POLL_MS : IDLE_POLL_MS);
     }
 
     load();
-    // Refresh while any run is in flight; otherwise drop to a slower cadence.
-    interval = setInterval(load, 5000);
 
     return () => {
       mounted = false;
-      if (interval) clearInterval(interval);
+      if (timer) clearTimeout(timer);
     };
   }, [profileId]);
 


### PR DESCRIPTION
## Summary

- `AgentRunsPage` polled `/admin/agents/runs` unconditionally every 5s for as long as the tab was open, despite an in-code comment claiming it dropped to a slower cadence once nothing was in flight. Replaced the `setInterval` with a self-rescheduling `setTimeout` that polls at 5s while any run is `running`/`paused`, and backs off to 30s once all visible runs are terminal.
- Removed `AgentRunsPage`'s local `StatusBadge`/`STATUS_BADGE_CLASSES` map and `AdminWorkflowExecutionsPage`'s hand-built per-row status pill, and switched both to the existing shared `StatusBadge` component (`client/src/features/workflows/components/StatusBadge.jsx`). The shared component already covers the full status vocabulary (including `cancelled`/`pending`, which the old `AgentRunsPage` map fell back to a generic gray badge for), renders i18n labels, and includes the running-state spin animation.
- Left `AdminWorkflowExecutionsPage`'s stats-summary tiles (`getStatusBadgeClasses`) untouched — those color a whole clickable tile (background + big count), which isn't the same shape as the `StatusBadge` pill, and is out of scope for this fix (kept as noted in the broader consolidation tracked separately in #1816).

Fixes #1849

## Test plan

- [x] `npx eslint` on both changed files — clean
- [x] `vite build` — succeeds
- [x] Ran the dev server, logged in as the local admin, and drove `/admin/agents/runs` and `/admin/workflows/executions` in a browser via Playwright
- [x] Confirmed via network-request timestamps that `AgentRunsPage` polls once immediately, then waits ~30s before the next request when no run is active (previously it would have re-polled at ~5s, ~10s, ...)
- [x] Confirmed the status column renders without errors through the shared `StatusBadge` component on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QbFLqHUef6qvMFTZSXe6sK

---
_Generated by [Claude Code](https://claude.ai/code/session_01QbFLqHUef6qvMFTZSXe6sK)_