### PR TITLE
refactor(chat): collapse ChatService pass-through facade, delete dead processChat()

### DIFF
--- a/server/services/chat/ChatService.js
+++ b/server/services/chat/ChatService.js
@@ -2,7 +2,6 @@ import RequestBuilder from './RequestBuilder.js';
 import NonStreamingHandler from './NonStreamingHandler.js';
 import StreamingHandler from './StreamingHandler.js';
 import ToolExecutor from './ToolExecutor.js';
-import ErrorHandler from '../../utils/ErrorHandler.js';
 import { processMessageTemplates } from '../../serverHelpers.js';
 import logger from '../../utils/logger.js';
 import { v4 as uuidv4 } from 'uuid';
@@ -15,219 +14,22 @@ class ChatService {
     this.nonStreamingHandler = options.nonStreamingHandler || new NonStreamingHandler();
     this.streamingHandler = options.streamingHandler || new StreamingHandler();
     this.toolExecutor = options.toolExecutor || new ToolExecutor();
-    this.errorHandler = options.errorHandler || new ErrorHandler();
   }
 
   async prepareChatRequest(params) {
-    const {
-      appId,
-      modelId,
-      messages,
-      temperature,
-      style,
-      outputFormat,
-      language,
-      bypassAppPrompts,
-      thinkingEnabled,
-      thinkingBudget,
-      thinkingThoughts,
-      enabledTools,
-      websearchEnabled,
-      imageAspectRatio,
-      imageQuality,
-      requestedSkill,
-      documentIds,
-      res,
-      clientRes,
-      user,
-      chatId
-    } = params;
-
-    return await this.requestBuilder.prepareChatRequest({
-      appId,
-      modelId,
-      messages,
-      temperature,
-      style,
-      outputFormat,
-      language,
-      bypassAppPrompts,
-      thinkingEnabled,
-      thinkingBudget,
-      thinkingThoughts,
-      enabledTools,
-      websearchEnabled,
-      imageAspectRatio,
-      imageQuality,
-      requestedSkill,
-      documentIds,
-      processMessageTemplates,
-      res,
-      clientRes,
-      user,
-      chatId
-    });
+    return await this.requestBuilder.prepareChatRequest({ ...params, processMessageTemplates });
   }
 
   async processNonStreamingChat(params) {
-    const {
-      request,
-      res,
-      buildLogData,
-      messageId,
-      model,
-      llmMessages,
-      DEFAULT_TIMEOUT,
-      getLocalizedError,
-      clientLanguage
-    } = params;
-
-    return await this.nonStreamingHandler.executeNonStreamingResponse({
-      request,
-      res,
-      buildLogData,
-      messageId,
-      model,
-      llmMessages,
-      DEFAULT_TIMEOUT,
-      getLocalizedError,
-      clientLanguage
-    });
+    return await this.nonStreamingHandler.executeNonStreamingResponse(params);
   }
 
   async processStreamingChat(params) {
-    const {
-      request,
-      chatId,
-      clientRes,
-      buildLogData,
-      model,
-      llmMessages,
-      DEFAULT_TIMEOUT,
-      getLocalizedError,
-      clientLanguage
-    } = params;
-
-    return await this.streamingHandler.executeStreamingResponse({
-      request,
-      chatId,
-      clientRes,
-      buildLogData,
-      model,
-      llmMessages,
-      DEFAULT_TIMEOUT,
-      getLocalizedError,
-      clientLanguage
-    });
+    return await this.streamingHandler.executeStreamingResponse(params);
   }
 
   async processChatWithTools(params) {
-    const { prep, chatId, buildLogData, DEFAULT_TIMEOUT, getLocalizedError, clientLanguage, user } =
-      params;
-
-    return await this.toolExecutor.processChatWithTools({
-      prep,
-      chatId,
-      buildLogData,
-      DEFAULT_TIMEOUT,
-      getLocalizedError,
-      clientLanguage,
-      user
-    });
-  }
-
-  async processChat(params) {
-    const {
-      appId,
-      modelId,
-      messages,
-      temperature,
-      style,
-      outputFormat,
-      language,
-      bypassAppPrompts,
-      res,
-      clientRes,
-      chatId,
-      buildLogData,
-      messageId,
-      DEFAULT_TIMEOUT,
-      getLocalizedError,
-      clientLanguage,
-      hasTools = false,
-      user
-    } = params;
-
-    try {
-      const prepResult = await this.prepareChatRequest({
-        appId,
-        modelId,
-        messages,
-        temperature,
-        style,
-        outputFormat,
-        language,
-        bypassAppPrompts,
-        res,
-        clientRes,
-        user,
-        chatId
-      });
-
-      if (!prepResult.success) {
-        if (res && !clientRes) {
-          return res.status(400).json(this.errorHandler.formatErrorResponse(prepResult.error));
-        }
-        return { success: false, error: prepResult.error };
-      }
-
-      const { model, llmMessages, request, tools } = prepResult.data;
-
-      if (!clientRes) {
-        return await this.processNonStreamingChat({
-          request,
-          res,
-          buildLogData,
-          messageId,
-          model,
-          llmMessages,
-          DEFAULT_TIMEOUT
-        });
-      }
-
-      if (hasTools && tools && tools.length > 0) {
-        return await this.processChatWithTools({
-          prep: prepResult.data,
-          chatId,
-          buildLogData,
-          DEFAULT_TIMEOUT,
-          getLocalizedError,
-          clientLanguage,
-          user
-        });
-      }
-
-      return await this.processStreamingChat({
-        request,
-        chatId,
-        clientRes,
-        buildLogData,
-        model,
-        llmMessages,
-        DEFAULT_TIMEOUT,
-        getLocalizedError,
-        clientLanguage
-      });
-    } catch (error) {
-      logger.error('Error in processChat', { component: 'ChatService', error });
-
-      const errorResponse = this.errorHandler.formatErrorResponse(error);
-      if (res && !clientRes) {
-        return res.status(500).json(errorResponse);
-      }
-
-      return { success: false, error: errorResponse };
-    }
+    return await this.toolExecutor.processChatWithTools(params);
   }
 
   /**


### PR DESCRIPTION
## Summary

Fixes #1848.

`ChatService`'s `prepareChatRequest`, `processNonStreamingChat`, `processStreamingChat`, and `processChatWithTools` each destructured ~10-20 named params only to re-pass the identical object to the underlying handler — pure boilerplate where every new parameter had to be threaded through 2-3 places. This is exactly how the error-localization bug happened: `ChatService.processChat()`'s non-streaming branch omitted `getLocalizedError`/`clientLanguage` when forwarding to `processNonStreamingChat`, so provider errors on that path were never localized.

Investigation (grep across `server/`, `client/`, `tests/`) confirmed `ChatService.processChat()` has **zero callers** — the real call sites (`server/routes/chat/sessionRoutes.js`, `ChatService.invokeAppInternal`) call the four handler-facade methods directly and already thread `getLocalizedError`/`clientLanguage` correctly on every branch. The reported bug is therefore unreachable in production, so the fix is to delete the dead orchestrator outright rather than patch it:

- Deleted `ChatService.processChat()` (dead code + latent bug, in one step).
- Removed the now-unused `ErrorHandler` import/field (only referenced from `processChat()`).
- Collapsed the four remaining facade methods to direct pass-throughs (`return await this.<handler>.<method>(params)`), verified the underlying handler signatures (`RequestBuilder.prepareChatRequest`, `NonStreamingHandler.executeNonStreamingResponse`, `StreamingHandler.executeStreamingResponse`, `ToolExecutor.processChatWithTools`) accept the same field names 1:1, so this is behavior-preserving. `prepareChatRequest` still explicitly injects `processMessageTemplates` via spread since callers don't provide it.

## Test plan

- [x] `node --check server/services/chat/ChatService.js` — syntax valid
- [x] Verified no callers of the deleted `processChat()` (`grep -rn '\.processChat\('` across `server/`, `client/`, `tests/`)
- [x] Verified `sessionRoutes.js` and `invokeAppInternal` (the real call sites) already call the four handler methods directly with matching param names — behavior unchanged
- [ ] Manual smoke test of streaming/non-streaming/tools chat flows against a local dev server (not run in this sandbox — no `node_modules` installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V6oVg1oDsqWaMnr65BLpyF


---
_Generated by [Claude Code](https://claude.ai/code/session_01V6oVg1oDsqWaMnr65BLpyF)_