### PR TITLE
Fix async-Promise-executor anti-pattern in WorkflowEngine._executeWithTimeout

### DIFF
--- a/server/services/workflow/WorkflowEngine.js
+++ b/server/services/workflow/WorkflowEngine.js
@@ -942,9 +942,10 @@ export class WorkflowEngine {
 
     try {
       result = await this._executeWithTimeout(
-        () => executor.execute(node, updatedState, context),
+        signal => executor.execute(node, updatedState, { ...context, abortSignal: signal }),
         timeout,
-        `Node ${nodeId} execution timed out after ${timeout}ms`
+        `Node ${nodeId} execution timed out after ${timeout}ms`,
+        context.abortSignal
       );
     } catch (error) {
       // Re-throw to be handled by caller
@@ -1545,29 +1546,47 @@ export class WorkflowEngine {
 
   /**
    * Executes a function with a timeout
-   * @param {Function} fn - The async function to execute
+   * @param {Function} fn - The async function to execute; receives an AbortSignal
+   *   that fires when the timeout elapses (or the outer signal aborts) so callers
+   *   that respect it can actually tear down their in-flight work
    * @param {number} timeout - Timeout in milliseconds
    * @param {string} timeoutMessage - Error message on timeout
+   * @param {AbortSignal} [outerSignal] - Signal (e.g. workflow-level cancellation)
+   *   that should also abort the signal passed to fn
    * @returns {Promise<*>} The function result
    * @private
    */
-  async _executeWithTimeout(fn, timeout, timeoutMessage) {
-    return new Promise(async (resolve, reject) => {
-      const timeoutId = setTimeout(() => {
+  async _executeWithTimeout(fn, timeout, timeoutMessage, outerSignal) {
+    const timeoutController = new AbortController();
+    const onOuterAbort = () => timeoutController.abort();
+
+    if (outerSignal) {
+      if (outerSignal.aborted) {
+        timeoutController.abort();
+      } else {
+        outerSignal.addEventListener('abort', onOuterAbort, { once: true });
+      }
+    }
+
+    let timeoutId;
+    const timeoutPromise = new Promise((_resolve, reject) => {
+      timeoutId = setTimeout(() => {
         const error = new Error(timeoutMessage);
         error.code = 'NODE_TIMEOUT';
+        // Settle the race with the NODE_TIMEOUT error first so callers keep
+        // seeing that contract even if fn() also rejects (e.g. because it
+        // observes the abort below) in the same tick.
         reject(error);
+        timeoutController.abort();
       }, timeout);
-
-      try {
-        const result = await fn();
-        clearTimeout(timeoutId);
-        resolve(result);
-      } catch (error) {
-        clearTimeout(timeoutId);
-        reject(error);
-      }
     });
+
+    try {
+      return await Promise.race([fn(timeoutController.signal), timeoutPromise]);
+    } finally {
+      clearTimeout(timeoutId);
+      outerSignal?.removeEventListener('abort', onOuterAbort);
+    }
   }
 
   /**

--- a/server/tests/services/workflow/WorkflowEngine.executeWithTimeout.test.js
+++ b/server/tests/services/workflow/WorkflowEngine.executeWithTimeout.test.js
@@ -1,0 +1,125 @@
+/**
+ * WorkflowEngine._executeWithTimeout tests.
+ *
+ * Covers the rewrite away from the `new Promise(async (resolve, reject) => ...)`
+ * anti-pattern: a synchronous throw before the first await must still reject,
+ * and the AbortSignal passed to `fn` must actually fire on timeout and on an
+ * outer (workflow-level cancellation) signal.
+ */
+
+import { jest } from '@jest/globals';
+import { WorkflowEngine } from '../../../services/workflow/WorkflowEngine.js';
+
+function createEngine() {
+  // Stub out the heavy collaborators — none of them are touched by
+  // _executeWithTimeout, which is a pure timing/abort helper.
+  return new WorkflowEngine({ stateManager: {}, scheduler: {} });
+}
+
+describe('WorkflowEngine._executeWithTimeout', () => {
+  test('resolves normally when fn completes before the timeout', async () => {
+    const engine = createEngine();
+    const result = await engine._executeWithTimeout(
+      () => Promise.resolve('done'),
+      1000,
+      'timed out'
+    );
+    expect(result).toBe('done');
+  });
+
+  test('rejects with NODE_TIMEOUT when fn exceeds the timeout, aborting the passed signal', async () => {
+    const engine = createEngine();
+    let receivedSignal;
+    const fn = signal =>
+      new Promise((resolve, reject) => {
+        receivedSignal = signal;
+        signal.addEventListener('abort', () => reject(new Error('aborted')));
+      });
+
+    await expect(engine._executeWithTimeout(fn, 20, 'timed out after 20ms')).rejects.toMatchObject({
+      code: 'NODE_TIMEOUT',
+      message: 'timed out after 20ms'
+    });
+    expect(receivedSignal.aborted).toBe(true);
+  });
+
+  test('a synchronous throw inside fn before its first await rejects correctly', async () => {
+    const engine = createEngine();
+    const fn = () => {
+      throw new Error('boom');
+    };
+
+    await expect(engine._executeWithTimeout(fn, 1000, 'timed out')).rejects.toThrow('boom');
+  });
+
+  test('a pre-aborted outer signal is propagated to fn immediately', async () => {
+    jest.useFakeTimers();
+    try {
+      const engine = createEngine();
+      const outerController = new AbortController();
+      outerController.abort();
+
+      let receivedSignal;
+      const fn = signal => {
+        receivedSignal = signal;
+        return new Promise(() => {});
+      };
+
+      // Fire-and-forget: fn never settles, so just assert on the signal
+      // state rather than awaiting the (intentionally never-resolving)
+      // call. The no-op catch avoids an unhandled rejection once
+      // clearAllTimers below fires the still-pending timeout.
+      engine._executeWithTimeout(fn, 1000, 'timed out', outerController.signal).catch(() => {});
+      await Promise.resolve();
+
+      expect(receivedSignal.aborted).toBe(true);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  test('an outer signal aborting mid-flight propagates to fn', async () => {
+    jest.useFakeTimers();
+    try {
+      const engine = createEngine();
+      const outerController = new AbortController();
+
+      let receivedSignal;
+      const fn = signal => {
+        receivedSignal = signal;
+        return new Promise(() => {});
+      };
+
+      // No-op catch: prevents the still-pending timeout (cleared below)
+      // from surfacing as an unhandled rejection.
+      engine._executeWithTimeout(fn, 1000, 'timed out', outerController.signal).catch(() => {});
+      await Promise.resolve();
+      expect(receivedSignal.aborted).toBe(false);
+
+      outerController.abort();
+      expect(receivedSignal.aborted).toBe(true);
+    } finally {
+      jest.clearAllTimers();
+      jest.useRealTimers();
+    }
+  });
+
+  test('clears the timeout timer once fn settles, leaving no dangling timer', async () => {
+    jest.useFakeTimers();
+    try {
+      const engine = createEngine();
+      let resolveFn;
+      const fn = () => new Promise(resolve => (resolveFn = resolve));
+
+      const promise = engine._executeWithTimeout(fn, 1000, 'timed out');
+      expect(jest.getTimerCount()).toBe(1);
+
+      resolveFn('ok');
+      await promise;
+      expect(jest.getTimerCount()).toBe(0);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `_executeWithTimeout` (`server/services/workflow/WorkflowEngine.js`) wrapped an `async (resolve, reject) => {...}` directly inside `new Promise(...)` — the async-Promise-executor anti-pattern, where a synchronous throw before the first `await` is swallowed instead of rejecting.
- On timeout it only ever called `reject()`, leaving the wrapped `fn()` (the node executor) running in the background with no way to signal it to stop.
- Rewrote it to race `fn(signal)` against a timer promise using a per-call `AbortController`. The `AbortSignal` is created on timeout (or when an outer signal — workflow-level `engine.cancel()` — aborts), cleared via `finally`, and the `NODE_TIMEOUT` error contract is preserved even if `fn()` also rejects in the same tick (the timeout rejection always settles the race first).
- At the call site, the combined signal now replaces `context.abortSignal` for the executor invocation, so executors that already check `context.abortSignal` (`LoopNodeExecutor`, `PlannerNodeExecutor`, `CorpusSearchNodeExecutor`) now actually stop on a per-node timeout, not just on an explicit `engine.cancel()`.

**Scope note:** the underlying LLM streaming call and the `executeLLMWithTools` tool loop still don't check any abort signal at all — that's the deeper gap tracked in #1683, which covers the same code path (`WorkflowLLMHelper.executeStreamingRequest`, `PromptNodeExecutor`'s tool loop) in more depth. Per the scope-overlap note left on #1847 by the implementation-planning pass, this PR intentionally limits itself to the anti-pattern fix and wiring the signal into executors that already consume it, leaving the LLM/tool-loop threading to #1683 to avoid two PRs racing on the same lines.

Fixes #1847

## Test plan

- [x] Added `server/tests/services/workflow/WorkflowEngine.executeWithTimeout.test.js` covering: normal resolution, `NODE_TIMEOUT` rejection with the passed signal aborted, a synchronous throw inside `fn` rejecting correctly (the actual anti-pattern regression test), a pre-aborted outer signal propagating immediately, an outer signal aborting mid-flight, and the timer being cleared once `fn` settles.
- [x] `npx eslint` clean on changed files.
- [x] `npx prettier --write` applied.
- [x] All 6 new tests pass (`node --experimental-vm-modules node_modules/jest/bin/jest.js tests/services/workflow/WorkflowEngine.executeWithTimeout.test.js --forceExit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01XGdYGRXC4Si77oFS64jM6h)_