### PR TITLE
fix(config): declare all consumed env vars in the envalid schema

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -22,17 +22,6 @@ const env = cleanEnv(
     CONTENTS_DIR: str({ default: 'contents', optional: true }),
     DATA_DIR: str({ default: 'data', optional: true }),
     APP_ROOT_DIR: str({ optional: true }),
-    BRAVE_SEARCH_API_KEY: str({ optional: true }),
-    BRAVE_SEARCH_ENDPOINT: str({
-      default: 'https://api.search.brave.com/res/v1/web/search',
-      optional: true
-    }),
-    OPENAI_API_KEY: str({ optional: true }),
-    ANTHROPIC_API_KEY: str({ optional: true }),
-    MISTRAL_API_KEY: str({ optional: true }),
-    GOOGLE_API_KEY: str({ optional: true }),
-    LOCAL_API_KEY: str({ optional: true }),
-    DEFAULT_API_KEY: str({ optional: true }),
     AUTH_MODE: str({ default: 'proxy', optional: true }),
     PROXY_AUTH_ENABLED: str({ optional: true }),
     PROXY_AUTH_USER_HEADER: str({ optional: true }),
@@ -42,17 +31,8 @@ const env = cleanEnv(
     HTTP_PROXY: str({ optional: true }),
     HTTPS_PROXY: str({ optional: true }),
     NO_PROXY: str({ optional: true }),
-    JWT_SECRET: str({ optional: true }),
     USE_HTTPS: str({ default: 'false', optional: true }),
-    NODE_ENV: str({ default: 'development', optional: true }),
-    IASSISTANT_TIMEOUT: num({ default: 60000 }),
-    IFINDER_API_URL: str({ optional: true }),
-    IFINDER_DOWNLOAD_DIR: str({ default: '/tmp/ifinder-downloads', optional: true }),
-    IFINDER_PRIVATE_KEY: str({ optional: true }),
-    IFINDER_TIMEOUT: num({ default: 30000 }),
-    MAGIC_PROMPT_MODEL: str({ optional: true }),
-    MAGIC_PROMPT_PROMPT: str({ optional: true }),
-    SEARCH_CACHE_TTL_MS: num({ optional: true })
+    NODE_ENV: str({ default: 'development', optional: true })
   },
   {
     reporter: () => {}, // Disable envalid's default reporter that shows missing variables
@@ -82,14 +62,6 @@ const config = Object.freeze({
   CONTENTS_DIR: env.CONTENTS_DIR,
   DATA_DIR: env.DATA_DIR,
   APP_ROOT_DIR: env.APP_ROOT_DIR,
-  BRAVE_SEARCH_API_KEY: env.BRAVE_SEARCH_API_KEY,
-  BRAVE_SEARCH_ENDPOINT: env.BRAVE_SEARCH_ENDPOINT,
-  OPENAI_API_KEY: env.OPENAI_API_KEY,
-  ANTHROPIC_API_KEY: env.ANTHROPIC_API_KEY,
-  MISTRAL_API_KEY: env.MISTRAL_API_KEY,
-  GOOGLE_API_KEY: env.GOOGLE_API_KEY,
-  LOCAL_API_KEY: env.LOCAL_API_KEY,
-  DEFAULT_API_KEY: env.DEFAULT_API_KEY,
   AUTH_MODE: env.AUTH_MODE,
   PROXY_AUTH_ENABLED: env.PROXY_AUTH_ENABLED,
   PROXY_AUTH_USER_HEADER: env.PROXY_AUTH_USER_HEADER,
@@ -99,17 +71,8 @@ const config = Object.freeze({
   HTTP_PROXY: env.HTTP_PROXY,
   HTTPS_PROXY: env.HTTPS_PROXY,
   NO_PROXY: env.NO_PROXY,
-  JWT_SECRET: env.JWT_SECRET,
   USE_HTTPS: env.USE_HTTPS,
-  NODE_ENV: env.NODE_ENV,
-  IASSISTANT_TIMEOUT: env.IASSISTANT_TIMEOUT,
-  IFINDER_API_URL: env.IFINDER_API_URL,
-  IFINDER_DOWNLOAD_DIR: env.IFINDER_DOWNLOAD_DIR,
-  IFINDER_PRIVATE_KEY: env.IFINDER_PRIVATE_KEY,
-  IFINDER_TIMEOUT: env.IFINDER_TIMEOUT,
-  MAGIC_PROMPT_MODEL: env.MAGIC_PROMPT_MODEL,
-  MAGIC_PROMPT_PROMPT: env.MAGIC_PROMPT_PROMPT,
-  SEARCH_CACHE_TTL_MS: env.SEARCH_CACHE_TTL_MS
+  NODE_ENV: env.NODE_ENV
 });
 
 export default config;

--- a/server/config.js
+++ b/server/config.js
@@ -41,7 +41,18 @@ const env = cleanEnv(
     PROXY_AUTH_JWT_HEADER: str({ optional: true }),
     HTTP_PROXY: str({ optional: true }),
     HTTPS_PROXY: str({ optional: true }),
-    NO_PROXY: str({ optional: true })
+    NO_PROXY: str({ optional: true }),
+    JWT_SECRET: str({ optional: true }),
+    USE_HTTPS: str({ default: 'false', optional: true }),
+    NODE_ENV: str({ default: 'development', optional: true }),
+    IASSISTANT_TIMEOUT: num({ default: 60000 }),
+    IFINDER_API_URL: str({ optional: true }),
+    IFINDER_DOWNLOAD_DIR: str({ default: '/tmp/ifinder-downloads', optional: true }),
+    IFINDER_PRIVATE_KEY: str({ optional: true }),
+    IFINDER_TIMEOUT: num({ default: 30000 }),
+    MAGIC_PROMPT_MODEL: str({ optional: true }),
+    MAGIC_PROMPT_PROMPT: str({ optional: true }),
+    SEARCH_CACHE_TTL_MS: num({ optional: true })
   },
   {
     reporter: () => {}, // Disable envalid's default reporter that shows missing variables
@@ -49,8 +60,18 @@ const env = cleanEnv(
   }
 );
 
+// Provider- and model-specific API keys (e.g. COHERE_API_KEY, GPT_4_AZURE1_API_KEY for
+// model id "gpt-4-azure1") are looked up dynamically by name in utils.js and can't be
+// enumerated in the schema above, since the set of providers/models is defined in JSON
+// config rather than known statically. Pass through only vars matching that one pattern
+// instead of the entire process environment, so undeclared/unrelated env vars stay out
+// of the exported config.
+const dynamicApiKeys = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => key.endsWith('_API_KEY'))
+);
+
 const config = Object.freeze({
-  ...process.env,
+  ...dynamicApiKeys,
   PORT: env.PORT,
   HOST: env.HOST,
   REQUEST_TIMEOUT: env.REQUEST_TIMEOUT,
@@ -77,7 +98,18 @@ const config = Object.freeze({
   PROXY_AUTH_JWT_HEADER: env.PROXY_AUTH_JWT_HEADER,
   HTTP_PROXY: env.HTTP_PROXY,
   HTTPS_PROXY: env.HTTPS_PROXY,
-  NO_PROXY: env.NO_PROXY
+  NO_PROXY: env.NO_PROXY,
+  JWT_SECRET: env.JWT_SECRET,
+  USE_HTTPS: env.USE_HTTPS,
+  NODE_ENV: env.NODE_ENV,
+  IASSISTANT_TIMEOUT: env.IASSISTANT_TIMEOUT,
+  IFINDER_API_URL: env.IFINDER_API_URL,
+  IFINDER_DOWNLOAD_DIR: env.IFINDER_DOWNLOAD_DIR,
+  IFINDER_PRIVATE_KEY: env.IFINDER_PRIVATE_KEY,
+  IFINDER_TIMEOUT: env.IFINDER_TIMEOUT,
+  MAGIC_PROMPT_MODEL: env.MAGIC_PROMPT_MODEL,
+  MAGIC_PROMPT_PROMPT: env.MAGIC_PROMPT_PROMPT,
+  SEARCH_CACHE_TTL_MS: env.SEARCH_CACHE_TTL_MS
 });
 
 export default config;

--- a/server/services/WebSearchService.js
+++ b/server/services/WebSearchService.js
@@ -202,9 +202,6 @@ class BraveSearchProvider extends SearchProvider {
     // Cache only successful responses (errors throw above and never reach here),
     // so a transient 429 is never cached. TTL is configurable; default 10 min —
     // long enough to dedupe within a multi-round run, short enough to stay fresh.
-    // `config.SEARCH_CACHE_TTL_MS` arrives via the `{...process.env}` spread and
-    // is a string when set, so coerce it (Number.isFinite would reject a string
-    // and silently pin the default, making the override dead config).
     const parsedTtl = Number(config.SEARCH_CACHE_TTL_MS);
     const ttlMs = Number.isFinite(parsedTtl) && parsedTtl > 0 ? parsedTtl : 600000;
     setCachedSearch(cacheKey, payload, ttlMs);


### PR DESCRIPTION
## Summary

`server/config.js` declares ~30 env vars with `envalid` but then spreads the entire `process.env` into the frozen `config` export, so any undeclared key resolves silently. Two security-relevant vars in particular — `JWT_SECRET` (session signing) and `USE_HTTPS` (cookie `secure` flag) — were consumed via `config.X` but never validated by the schema, and the exported object leaked every environment variable present on the process to any code importing `config.js`.

- Declared the previously-undeclared-but-consumed keys in the `cleanEnv` schema: `JWT_SECRET`, `USE_HTTPS`, `NODE_ENV`, `IASSISTANT_TIMEOUT`, `IFINDER_API_URL`, `IFINDER_DOWNLOAD_DIR`, `IFINDER_PRIVATE_KEY`, `IFINDER_TIMEOUT`, `MAGIC_PROMPT_MODEL`, `MAGIC_PROMPT_PROMPT`, `SEARCH_CACHE_TTL_MS`.
- Removed the `...process.env` spread and built the frozen `config` export entirely from validated `env.X` values plus the pre-existing explicit keys.
- Preserved the one legitimate dynamic-lookup use case: `utils.js` resolves per-provider/per-model API key overrides via computed names (`${PROVIDER}_API_KEY`, `${MODEL_ID}_API_KEY`, e.g. `GPT_4_AZURE1_API_KEY`) that can't be enumerated ahead of time since providers/models are defined in JSON config. A narrow pass-through of only env vars matching `*_API_KEY` keeps that working without reintroducing the full-environment leak.
- Removed a stale comment in `WebSearchService.js` that referenced the now-removed spread behavior.

## Verification

- Booted the server (`node server/server.js`) — starts cleanly, no new errors/warnings.
- Manually verified via a standalone script that:
  - `JWT_SECRET` / `USE_HTTPS` now flow through as validated config values.
  - An arbitrary `*_API_KEY` env var (simulating a model-specific override) still resolves.
  - An unrelated, undeclared env var no longer leaks onto the exported `config` object.
- `npx eslint server/config.js server/services/WebSearchService.js` — clean.
- `npx prettier --check` on both files — clean.
- `server/tests/jwt-user-validation.test.js` (the only existing test that touches `config.js`, via a full mock) fails identically on unmodified `main` in this sandbox due to a pre-existing Jest/ESM environment issue unrelated to this change — confirmed via `git stash`.

Fixes #1836

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DF5yzogf96SxTxsY3F9mHG)_