### PR TITLE
fix: track ActionTracker steps per chat, silence listener warning (#1843)

### DIFF
--- a/server/actionTracker.js
+++ b/server/actionTracker.js
@@ -5,17 +5,24 @@ import logger from './utils/logger.js';
 export class ActionTracker extends EventEmitter {
   constructor() {
     super();
-    this.steps = 0;
+    this.stepCounts = new Map();
+    // Every listener attached below (InMemorySink, agents/runs.js, workflowRoutes.js,
+    // workflowRunner.js) is request/connection-scoped and pairs its on() with an off()
+    // in a cleanup path, so concurrent chats/connections legitimately exceed the
+    // default 10-listener warning threshold without leaking.
+    this.setMaxListeners(0);
   }
 
   trackAction(chatId, action = {}) {
-    this.steps += 1;
-    this.emit('fire-sse', { event: 'action', steps: this.steps, chatId, ...action });
+    const steps = (this.stepCounts.get(chatId) || 0) + 1;
+    this.stepCounts.set(chatId, steps);
+    this.emit('fire-sse', { event: 'action', steps, chatId, ...action });
   }
 
   trackError(chatId, error = {}) {
     const stacktrace = new Error().stack;
     logger.error(`Error for chat ID ${chatId}:`, { ...error, stacktrace });
+    this.stepCounts.delete(chatId);
     this.emit('fire-sse', { event: 'error', chatId, ...error });
   }
 
@@ -24,10 +31,12 @@ export class ActionTracker extends EventEmitter {
   }
 
   trackDisconnected(chatId, reason = {}) {
+    this.stepCounts.delete(chatId);
     this.emit('fire-sse', { event: 'disconnected', chatId, ...reason });
   }
 
   trackDone(chatId, finishReason = {}) {
+    this.stepCounts.delete(chatId);
     this.emit('fire-sse', { event: UnifiedEvents.DONE, chatId, ...finishReason });
   }
 

--- a/server/tests/actionTracker.test.js
+++ b/server/tests/actionTracker.test.js
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for ActionTracker's per-chat step isolation.
+ *
+ * trackAction used to increment a single process-wide `steps` counter shared
+ * by every chat, so concurrent chats saw a contaminated, ever-growing step
+ * number. It's now tracked per chatId and cleared when a chat's turn ends.
+ */
+
+import { ActionTracker } from '../actionTracker.js';
+
+describe('ActionTracker per-chat step counter', () => {
+  test('tracks independent, correctly incrementing steps per chatId', () => {
+    const tracker = new ActionTracker();
+    const events = [];
+    tracker.on('fire-sse', event => events.push(event));
+
+    tracker.trackAction('chat-a', {});
+    tracker.trackAction('chat-b', {});
+    tracker.trackAction('chat-a', {});
+
+    const stepsFor = chatId => events.filter(e => e.chatId === chatId).map(e => e.steps);
+    expect(stepsFor('chat-a')).toEqual([1, 2]);
+    expect(stepsFor('chat-b')).toEqual([1]);
+  });
+
+  test.each(['trackDone', 'trackError', 'trackDisconnected'])(
+    '%s clears the step counter so the next turn restarts at 1',
+    method => {
+      const tracker = new ActionTracker();
+      const events = [];
+      tracker.on('fire-sse', event => events.push(event));
+
+      tracker.trackAction('chat-a', {});
+      tracker.trackAction('chat-a', {});
+      tracker[method]('chat-a');
+      tracker.trackAction('chat-a', {});
+
+      const steps = events.filter(e => e.event === 'action').map(e => e.steps);
+      expect(steps).toEqual([1, 2, 1]);
+    }
+  );
+
+  test('does not warn about exceeding the default max listener count', () => {
+    const tracker = new ActionTracker();
+    const warnings = [];
+    const onWarning = warning => warnings.push(warning);
+    process.on('warning', onWarning);
+
+    try {
+      for (let i = 0; i < 15; i += 1) {
+        tracker.on('fire-sse', () => {});
+      }
+    } finally {
+      process.off('warning', onWarning);
+    }
+
+    expect(warnings.some(w => w.name === 'MaxListenersExceededWarning')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1843.

- `ActionTracker.trackAction` incremented a single process-wide `steps` counter shared by every chat, so concurrent chats' `'action'` SSE events reported a contaminated, ever-growing step number instead of a count scoped to that chat, and it never reset. Replaced with a per-`chatId` `Map`, cleared on `trackDone`/`trackError`/`trackDisconnected` so each new turn restarts at 1.
- Added `this.setMaxListeners(0)` in the constructor with a comment explaining why: every `'fire-sse'` listener attach site (`InMemorySink`, `routes/agents/runs.js`, `routes/workflow/workflowRoutes.js`, `tools/workflowRunner.js`) is request/connection-scoped and reliably pairs its `.on()` with an `.off()` in a cleanup path — verified via grep — so concurrent chats/connections legitimately exceeding Node's default 10-listener threshold was a false-positive `MaxListenersExceededWarning`, not a real leak.
- I checked whether any client code reads the numeric `steps` value from the `'action'` SSE event — it doesn't appear to be consumed today, so this is a correctness/isolation fix with no visible behavior change.

## Test plan

- [x] Added `server/tests/actionTracker.test.js` (Jest): verifies independent per-chat step counters, that `trackDone`/`trackError`/`trackDisconnected` reset the counter, and that attaching many listeners no longer triggers `MaxListenersExceededWarning`.
- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/actionTracker.test.js` — 5/5 passing.
- [x] `node tests/inmemory-sink-overflow.test.js` (existing `actionTracker` consumer) — still passing.
- [x] `npx eslint server/actionTracker.js server/tests/actionTracker.test.js` — clean.
- [x] Confirmed the broader `server` test suite has the same pre-existing failures on `main` before this change (111 failing suites at baseline, unrelated to `actionTracker.js`) — no new failures introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AeC6S6KV9qVfF8g6zq7PPU

---
_Generated by [Claude Code](https://claude.ai/code/session_01AeC6S6KV9qVfF8g6zq7PPU)_