### PR TITLE
fix: remove client/src/api/api.js re-export shim (#1828)

### DIFF
--- a/client/src/api/api.js
+++ b/client/src/api/api.js
@@ -1,2 +1,0 @@
-// Re-export all API functions from the new modular structure
-export * from './index';

--- a/client/src/features/admin/components/McpToolsSelector.jsx
+++ b/client/src/features/admin/components/McpToolsSelector.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
-import { fetchMcpToolCatalog } from '../../../api/api';
+import { fetchMcpToolCatalog } from '../../../api';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 
 /**

--- a/client/src/features/admin/pages/AdminPromptEditPage.jsx
+++ b/client/src/features/admin/pages/AdminPromptEditPage.jsx
@@ -11,8 +11,7 @@ import {
   updatePrompt,
   fetchAdminApps
 } from '../../../api/adminApi';
-import { clearApiCache } from '../../../api/api';
-import { fetchUIConfig } from '../../../api';
+import { clearApiCache, fetchUIConfig } from '../../../api';
 import { fetchJsonSchema } from '../../../utils/schemaService';
 import DualModeEditor from '../../../shared/components/DualModeEditor';
 import PromptFormEditor from '../components/PromptFormEditor';

--- a/client/src/features/admin/pages/AdminToolEditPage.jsx
+++ b/client/src/features/admin/pages/AdminToolEditPage.jsx
@@ -16,7 +16,7 @@ import {
   fetchToolScript,
   updateToolScript
 } from '../../../api/adminApi';
-import { clearApiCache } from '../../../api/api';
+import { clearApiCache } from '../../../api';
 
 function AdminToolEditPage() {
   const { t } = useTranslation();

--- a/client/src/features/apps/components/AppRouterWrapper.jsx
+++ b/client/src/features/apps/components/AppRouterWrapper.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
-import { fetchAppDetails } from '../../../api/api';
+import { fetchAppDetails } from '../../../api';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import { useTranslation } from 'react-i18next';
 import AppChat from '../pages/AppChat';

--- a/client/src/features/apps/components/AppShareModal.jsx
+++ b/client/src/features/apps/components/AppShareModal.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
-import { createShortLink, getShortLink } from '../../../api/api';
+import { createShortLink, getShortLink } from '../../../api';
 
 function generateCode(length = 6) {
   const chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';

--- a/client/src/features/apps/pages/AppChat.jsx
+++ b/client/src/features/apps/pages/AppChat.jsx
@@ -7,7 +7,7 @@ import {
 } from '../../../utils/chatId';
 import { getConversationMessages } from '../../../api/endpoints/apps';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { fetchAppDetails } from '../../../api/api';
+import { fetchAppDetails } from '../../../api';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import { useTranslation } from 'react-i18next';
 import { getLocalizedContent } from '../../../utils/localizeContent';

--- a/client/src/features/apps/pages/AppsList.jsx
+++ b/client/src/features/apps/pages/AppsList.jsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { fetchApps } from '../../../api/api';
+import { fetchApps } from '../../../api';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import { useTranslation } from 'react-i18next';
 import { getLocalizedContent } from '../../../utils/localizeContent';

--- a/client/src/features/canvas/pages/AppCanvas.jsx
+++ b/client/src/features/canvas/pages/AppCanvas.jsx
@@ -18,7 +18,7 @@ import useAppChat from '../../chat/hooks/useAppChat';
 import useVoiceCommands from '../../voice/hooks/useVoiceCommands';
 import useAppSettings from '../../../shared/hooks/useAppSettings';
 import useCanvas from '../hooks/useCanvas';
-import { fetchAppDetails } from '../../../api/api';
+import { fetchAppDetails } from '../../../api';
 import { markdownToHtml, isMarkdown } from '../../../utils/markdownUtils';
 import { getOrCreateChatId, resetChatId } from '../../../utils/chatId';
 

--- a/client/src/features/chat/components/ChatInputActionsMenu.jsx
+++ b/client/src/features/chat/components/ChatInputActionsMenu.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
-import { fetchToolsBasic } from '../../../api/api';
+import { fetchToolsBasic } from '../../../api';
 import { VoiceInputComponent } from '../../voice/components';
 import MagicPromptLoader from '../../../shared/components/MagicPromptLoader';
 import ImageGenerationControls from './ImageGenerationControls';

--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { sendMessageFeedback } from '../../../api/api';
+import { sendMessageFeedback } from '../../../api';
 import { getConversationId } from '../../../utils/chatId';
 import StarRating from '../../../shared/components/StarRating';
 import MessageVariables from './MessageVariables';

--- a/client/src/features/chat/hooks/useAppChat.js
+++ b/client/src/features/chat/hooks/useAppChat.js
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { useTranslation } from 'react-i18next';
 import useChatMessages from './useChatMessages';
 import useEventSource from '../../../shared/hooks/useEventSource';
-import { sendAppChatMessage } from '../../../api/api';
+import { sendAppChatMessage } from '../../../api';
 import { buildApiUrl } from '../../../utils/runtimeBasePath';
 import { setConversationId } from '../../../utils/chatId';
 

--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -38,7 +38,7 @@ import {
 } from '../utilities/officeCapabilities';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import { officeLocale } from '../utilities/officeLocale';
-import { fetchApps } from '../../../api/api';
+import { fetchApps } from '../../../api';
 import { useOfficeConfig } from '../contexts/OfficeConfigContext';
 import { useEmbeddedHost } from '../contexts/EmbeddedHostContext';
 import './OfficeChatPanel.css';

--- a/client/src/features/prompts/components/PromptSearch.jsx
+++ b/client/src/features/prompts/components/PromptSearch.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import Fuse from 'fuse.js';
 import Icon from '../../../shared/components/Icon';
-import { fetchPrompts } from '../../../api/api';
+import { fetchPrompts } from '../../../api';
 import { fetchSkills } from '../../../api/endpoints/skills';
 import { createFavoriteItemHelpers } from '../../../utils/favoriteItems';
 import { getRecentPromptIds, recordPromptUsage } from '../../../utils/recentPrompts';

--- a/client/src/features/prompts/pages/PromptsList.jsx
+++ b/client/src/features/prompts/pages/PromptsList.jsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useSearchParams } from 'react-router-dom';
-import { fetchPrompts } from '../../../api/api';
+import { fetchPrompts } from '../../../api';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import Icon from '../../../shared/components/Icon';
 import PromptModal from '../components/PromptModal';

--- a/client/src/pages/UnifiedPage.jsx
+++ b/client/src/pages/UnifiedPage.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import LoadingSpinner from '../shared/components/LoadingSpinner';
-import { fetchPageContent } from '../api/api';
+import { fetchPageContent } from '../api';
 import { renderMarkdown } from '../config/marked.config';
 import ReactComponentRenderer from '../shared/components/ReactComponentRenderer';
 

--- a/client/src/services/i18nService.js
+++ b/client/src/services/i18nService.js
@@ -1,7 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
-import { fetchTranslations } from '../api/api';
+import { fetchTranslations } from '../api';
 import { apiClient } from '../api/client';
 // Import core translations statically to avoid Firefox dynamic import issues
 import enCoreTranslations from '../../../shared/i18n/en.json';

--- a/client/src/shared/components/AppListPanel.jsx
+++ b/client/src/shared/components/AppListPanel.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { fetchApps } from '../../api/api';
+import { fetchApps } from '../../api';
 import { getLocalizedContent } from '../../utils/localizeContent';
 import AppCard from './AppCard';
 import Icon from './Icon';

--- a/client/src/shared/components/DocumentTitle.jsx
+++ b/client/src/shared/components/DocumentTitle.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
 import { useUIConfig } from '../contexts/UIConfigContext';
 import { getLocalizedContent } from '../../utils/localizeContent';
-import { fetchAppDetails } from '../../api/api';
+import { fetchAppDetails } from '../../api';
 
 /**
  * DocumentTitle component manages the browser tab title dynamically

--- a/client/src/shared/components/SmartSearch.jsx
+++ b/client/src/shared/components/SmartSearch.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import Icon from './Icon';
-import { fetchApps } from '../../api/api';
+import { fetchApps } from '../../api';
 import { getLocalizedContent } from '../../utils/localizeContent';
 import { createFavoriteItemHelpers } from '../../utils/favoriteItems';
 import { getRecentAppIds } from '../../utils/recentApps';

--- a/client/src/shared/components/ToolsSelector.jsx
+++ b/client/src/shared/components/ToolsSelector.jsx
@@ -1,7 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import Icon from './Icon';
-import { fetchTools } from '../../api/api';
+import { fetchTools } from '../../api';
 import { getLocalizedContent } from '../../utils/localizeContent';
 
 function ToolsSelector({ selectedTools = [], onToolsChange, excludeToolIds = [] }) {

--- a/client/src/shared/contexts/PlatformConfigContext.jsx
+++ b/client/src/shared/contexts/PlatformConfigContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from 'react';
-import { fetchAuthStatus, fetchUIConfig, fetchPlatformConfig } from '../../api/api';
+import { fetchAuthStatus, fetchUIConfig, fetchPlatformConfig } from '../../api';
 
 const PlatformConfigContext = createContext({
   platformConfig: null,

--- a/client/src/shared/contexts/UIConfigContext.jsx
+++ b/client/src/shared/contexts/UIConfigContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useState, useContext, useEffect } from 'react';
-import { fetchUIConfig } from '../../api/api';
+import { fetchUIConfig } from '../../api';
 import { buildPath, buildAssetUrl } from '../../utils/runtimeBasePath';
 
 // Default header color as a fallback if config is not loaded

--- a/client/src/shared/hooks/useAppSettings.js
+++ b/client/src/shared/hooks/useAppSettings.js
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { saveAppSettings, loadAppSettings } from '../../utils/appSettings';
-import { fetchModels, fetchStyles } from '../../api/api';
+import { fetchModels, fetchStyles } from '../../api';
 import { filterModelsForApp, pickInitialModelForApp } from '../../utils/modelFiltering';
 import { useUIConfig } from '../contexts/UIConfigContext';
 

--- a/client/src/shared/hooks/useEventSource.js
+++ b/client/src/shared/hooks/useEventSource.js
@@ -1,5 +1,5 @@
 import { useRef, useCallback, useEffect } from 'react';
-import { checkAppChatStatus, stopAppChatStream } from '../../api/api';
+import { checkAppChatStatus, stopAppChatStream } from '../../api';
 import { parseSseStream } from '../utils/parseSseStream';
 import { getRefreshToken, refreshTokenOrExpireSession } from '../../features/office/api/officeAuth';
 

--- a/client/src/shared/hooks/useMagicPrompt.js
+++ b/client/src/shared/hooks/useMagicPrompt.js
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { generateMagicPrompt } from '../../api/api';
+import { generateMagicPrompt } from '../../api';
 import { FeatureFlags } from '../../../../shared/featureFlags.js';
 
 /**

--- a/client/src/shared/hooks/useSessionManagement.js
+++ b/client/src/shared/hooks/useSessionManagement.js
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { getSessionId, renewSession, getSessionInfo } from '../../utils/sessionManager.js';
-import { sendSessionStart } from '../../api/api';
+import { sendSessionStart } from '../../api';
 
 /**
  * Custom hook to handle session initialization and renewal

--- a/client/src/utils/forceRefresh.js
+++ b/client/src/utils/forceRefresh.js
@@ -17,7 +17,7 @@
  * salt matches.
  */
 
-import { fetchUIConfig } from '../api/api';
+import { fetchUIConfig } from '../api';
 
 const REFRESH_SALT_KEY = 'ihub-refresh-salt';
 const DISCLAIMER_KEY = 'ihub-disclaimer-acknowledged';


### PR DESCRIPTION
## Summary

- `client/src/api/api.js` was a 2-line `export * from './index'` shim that created a second import path for the same module (`client/src/api/index.js`), with `AdminPromptEditPage.jsx` even importing from both paths in the same file.
- Repointed all 27 files that imported from `.../api/api` to import from the canonical `.../api` index instead (path-only change, no renamed exports).
- Merged the duplicate import in `AdminPromptEditPage.jsx` into a single import from `../../../api`.
- Deleted `client/src/api/api.js`.

No functional/behavior change — pure import-path cleanup.

Fixes #1828

## Test plan

- [x] `grep -rn "api/api" client/src` returns no matches
- [x] `npm run lint:fix` — no new errors (pre-existing warnings elsewhere unrelated to this change)
- [x] `npm run format:fix` — no changes needed beyond the codemod
- [x] `cd client && npm run build` — builds successfully with no missing-module errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_012q6XCFP7NsS92ijZ7sUUJs)_