### PR TITLE
Remove dead getUserServices and fix false legacy-base64 docs

### DIFF
--- a/server/services/TokenStorageService.js
+++ b/server/services/TokenStorageService.js
@@ -502,34 +502,6 @@ class TokenStorageService {
   }
 
   /**
-   * List all services that have tokens for a user
-   */
-  async getUserServices(userId) {
-    try {
-      const services = [];
-      const integrationDir = await fs.readdir(this.storageBasePath);
-
-      for (const serviceName of integrationDir) {
-        const tokenFile = path.join(this.storageBasePath, serviceName, `${userId}.json`);
-        try {
-          await fs.access(tokenFile);
-          services.push(serviceName);
-        } catch (error) {
-          // File doesn't exist, skip
-        }
-      }
-
-      return services;
-    } catch (error) {
-      logger.error('Error listing user services', {
-        component: 'TokenStorage',
-        error
-      });
-      return [];
-    }
-  }
-
-  /**
    * Get token metadata without decrypting the actual tokens
    */
   async getTokenMetadata(userId, serviceName, providerId = null) {
@@ -602,8 +574,8 @@ class TokenStorageService {
 
   /**
    * Generic decryption for simple strings (e.g., API keys)
-   * Supports both new ENC[...] format and legacy base64 format
-   * @param {string} encryptedData - Encrypted data in ENC[...] format or legacy base64
+   * Supports the ENC[...] format only
+   * @param {string} encryptedData - Encrypted data in ENC[...] format
    * @returns {string} Decrypted plaintext
    */
   decryptString(encryptedData) {
@@ -671,7 +643,7 @@ class TokenStorageService {
 
   /**
    * Check if a string appears to be encrypted
-   * Supports both ENC[...] format and legacy base64 format
+   * Supports the ENC[...] format only
    * @param {string} value - The value to check
    * @returns {boolean} True if the value appears to be encrypted
    */


### PR DESCRIPTION
## Summary

- Removes `TokenStorageService.getUserServices()` — it had zero callers anywhere in the repo and was silently broken after the per-provider token migration (it only checked the legacy `${userId}.json` path, while `migrateLegacyTokenFiles` renames files to `${userId}__${providerId}.json`), so it would always return an empty array on any migrated install.
- Corrects the `decryptString` and `isEncrypted` docblocks, which falsely claimed support for a "legacy base64 format". Neither method ever implemented this — `isEncrypted` only recognizes the `ENC[...]` envelope, and `_decrypt` unconditionally parses it as `ENC[...]`.

Confirmed no test files or docs reference `getUserServices`.

Closes #1827

## Test plan

- [x] `node --check server/services/TokenStorageService.js` — syntax verified
- [x] Grepped `server/`, `client/`, `docs/`, `server/tests/` for `getUserServices` — only the (now removed) definition remained
- [ ] `npm run lint:fix` (dependencies not installed in this sandbox — please verify in CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0198YNavbUAWCBboan1TFm57

---
_Generated by [Claude Code](https://claude.ai/code/session_0198YNavbUAWCBboan1TFm57)_