### PR TITLE
refactor(settings): extract shared IntegrationCard and localize IntegrationsPage

### DIFF
--- a/client/src/features/settings/components/IntegrationCard.jsx
+++ b/client/src/features/settings/components/IntegrationCard.jsx
@@ -1,0 +1,114 @@
+import { useTranslation } from 'react-i18next';
+import Icon from '../../../shared/components/Icon';
+
+export default function IntegrationCard({
+  icon,
+  iconBgClassName = 'bg-blue-600',
+  connectButtonClassName = 'bg-blue-600 hover:bg-blue-700',
+  title,
+  description,
+  connected,
+  userInfo,
+  tokenExpiring,
+  features = [],
+  connectLabel,
+  onConnect,
+  onDisconnect,
+  extraActions
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6">
+      <div className="flex items-start space-x-4">
+        <div className="flex-shrink-0">
+          <div
+            className={`w-12 h-12 ${iconBgClassName} rounded-lg flex items-center justify-center`}
+          >
+            <Icon name={icon} className="w-7 h-7 text-white" />
+          </div>
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{title}</h3>
+              <p className="text-gray-600 dark:text-gray-400 text-sm">{description}</p>
+            </div>
+
+            <div className="flex items-center">
+              <span
+                className={`px-3 py-1 text-xs font-medium rounded-full ${
+                  connected
+                    ? 'bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-300'
+                    : 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300'
+                }`}
+              >
+                {connected
+                  ? t('integrations.page.card.connected')
+                  : t('integrations.page.card.notConnected')}
+              </span>
+            </div>
+          </div>
+
+          {connected && userInfo && (
+            <div className="mt-3 p-3 bg-gray-50 dark:bg-gray-900/50 rounded-md">
+              <div className="flex items-center text-sm text-gray-700 dark:text-gray-300">
+                <Icon name="user" className="w-4 h-4 mr-2" />
+                <span className="font-medium">{userInfo.displayName}</span>
+                {userInfo.email && (
+                  <span className="ml-2 text-gray-500 dark:text-gray-400">({userInfo.email})</span>
+                )}
+              </div>
+              {tokenExpiring && (
+                <div className="mt-2 flex items-center text-sm text-amber-600 dark:text-amber-400">
+                  <Icon name="exclamationTriangle" className="w-4 h-4 mr-2" />
+                  <span>{t('integrations.page.card.tokenExpiring')}</span>
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="mt-4 flex items-center space-x-3">
+            {connected ? (
+              <>
+                {extraActions}
+                <button
+                  onClick={onDisconnect}
+                  className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md font-medium transition-colors flex items-center"
+                >
+                  <Icon name="x-circle" className="w-4 h-4 mr-2" />
+                  {t('integrations.page.card.disconnect')}
+                </button>
+              </>
+            ) : (
+              <button
+                onClick={onConnect}
+                className={`${connectButtonClassName} text-white px-4 py-2 rounded-md font-medium transition-colors flex items-center`}
+              >
+                <Icon name="link" className="w-4 h-4 mr-2" />
+                {connectLabel}
+              </button>
+            )}
+          </div>
+
+          {connected && features.length > 0 && (
+            <div className="mt-3">
+              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
+                {t('integrations.page.card.availableFeatures')}
+              </h4>
+              <ul className="text-sm text-gray-700 dark:text-gray-300 space-y-1">
+                {features.map(feature => (
+                  <li key={feature} className="flex items-center">
+                    <Icon name="check" className="w-4 h-4 text-green-500 mr-2 flex-shrink-0" />
+                    {feature}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/features/settings/pages/IntegrationsPage.jsx
+++ b/client/src/features/settings/pages/IntegrationsPage.jsx
@@ -4,11 +4,12 @@ import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../auth/hooks/useAuth';
 import { usePlatformConfig } from '../../../shared/contexts/PlatformConfigContext';
 import Icon from '../../../shared/components/Icon';
+import IntegrationCard from '../components/IntegrationCard';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import { buildApiUrl } from '../../../utils/runtimeBasePath';
 
 export default function IntegrationsPage() {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const lang = i18n.language;
   const { user } = useAuth();
   const { platformConfig } = usePlatformConfig();
@@ -36,14 +37,16 @@ export default function IntegrationsPage() {
       // eslint-disable-next-line @eslint-react/set-state-in-effect
       setMessage({
         type: 'success',
-        text: 'JIRA account connected successfully! You can now use JIRA features in your apps.'
+        text: t('integrations.page.jira.connected')
       });
       navigate('/settings/integrations', { replace: true });
     } else if (jiraError) {
       // eslint-disable-next-line @eslint-react/set-state-in-effect
       setMessage({
         type: 'error',
-        text: `JIRA connection failed: ${decodeURIComponent(jiraError)}`
+        text: t('integrations.page.jira.connectionFailed', {
+          message: decodeURIComponent(jiraError)
+        })
       });
       navigate('/settings/integrations', { replace: true });
     }
@@ -56,18 +59,21 @@ export default function IntegrationsPage() {
       if (connected === 'true') {
         setMessage({
           type: 'success',
-          text: `${provider.displayName} account connected successfully! You can now select files from ${provider.displayName}.`
+          text: t('integrations.page.cloud.connected', { name: provider.displayName })
         });
         navigate('/settings/integrations', { replace: true });
       } else if (error) {
         setMessage({
           type: 'error',
-          text: `${provider.displayName} connection failed: ${decodeURIComponent(error)}`
+          text: t('integrations.page.cloud.connectionFailed', {
+            name: provider.displayName,
+            message: decodeURIComponent(error)
+          })
         });
         navigate('/settings/integrations', { replace: true });
       }
     });
-  }, [location.search, navigate, cloudProviders]);
+  }, [location.search, navigate, cloudProviders, t]);
 
   // Derive Jira enabled state from platform config
   const jiraEnabled = platformConfig?.jira?.enabled;
@@ -90,7 +96,7 @@ export default function IntegrationsPage() {
       try {
         // Check JIRA status only if configured on the server
         if (jiraEnabled) {
-          const jiraResponse = await fetch('/api/integrations/jira/status', {
+          const jiraResponse = await fetch(buildApiUrl('integrations/jira/status'), {
             credentials: 'include'
           });
           const jiraData = await jiraResponse.json();
@@ -104,7 +110,7 @@ export default function IntegrationsPage() {
         // Check cloud storage provider status dynamically
         for (const provider of cloudProviders) {
           try {
-            const response = await fetch(`/api/integrations/${provider.type}/status`, {
+            const response = await fetch(buildApiUrl(`integrations/${provider.type}/status`), {
               credentials: 'include'
             });
             const data = await response.json();
@@ -127,84 +133,53 @@ export default function IntegrationsPage() {
     loadIntegrations();
   }, [user?.id, cloudProviders, jiraEnabled]);
 
-  const handleConnect = async integration => {
-    if (integration === 'jira') {
-      // Use fetch to initiate the OAuth flow so credentials are included
-      try {
-        // Get current page path as return URL
-        const returnUrl = window.location.origin + window.location.pathname;
-        const response = await fetch(
-          `/api/integrations/jira/auth?returnUrl=${encodeURIComponent(returnUrl)}`,
-          {
-            credentials: 'include',
-            redirect: 'manual' // Don't automatically follow redirects
-          }
-        );
-
-        if (
-          response.type === 'opaqueredirect' ||
-          response.status === 302 ||
-          response.status === 301
-        ) {
-          // The server is redirecting to JIRA OAuth, follow the redirect manually
-          window.location.href = `/api/integrations/jira/auth?returnUrl=${encodeURIComponent(returnUrl)}`;
-        } else if (!response.ok) {
-          const errorData = await response.json().catch(() => ({ message: 'Unknown error' }));
-          setMessage({
-            type: 'error',
-            text: `Connection failed: ${errorData.message || 'Unknown error'}`
-          });
-        }
-      } catch (error) {
-        setMessage({
-          type: 'error',
-          text: `Connection failed: ${error.message}`
-        });
-      }
-    }
-  };
-
-  // Handle cloud provider connection
-  const handleCloudConnect = provider => {
-    // Get current page path as return URL
+  // Connect flow — JIRA pre-checks the auth response before redirecting so
+  // config errors surface inline instead of after a failed round trip.
+  const handleConnect = async ({ type, id }) => {
     const returnUrl = window.location.origin + window.location.pathname;
-    window.location.href = `/api/integrations/${provider.type}/auth?providerId=${encodeURIComponent(provider.id)}&returnUrl=${encodeURIComponent(returnUrl)}`;
-  };
+    const authUrl =
+      type === 'jira'
+        ? `${buildApiUrl('integrations/jira/auth')}?returnUrl=${encodeURIComponent(returnUrl)}`
+        : `${buildApiUrl(`integrations/${type}/auth`)}?providerId=${encodeURIComponent(id)}&returnUrl=${encodeURIComponent(returnUrl)}`;
 
-  const handleDisconnect = async integration => {
-    if (integration === 'jira') {
-      try {
-        const response = await fetch('/api/integrations/jira/disconnect', {
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json'
-          }
-        });
+    if (type !== 'jira') {
+      window.location.href = authUrl;
+      return;
+    }
 
-        if (response.ok) {
-          setIntegrations(prev => ({
-            ...prev,
-            jira: { connected: false, message: 'JIRA account disconnected' }
-          }));
-          setMessage({
-            type: 'success',
-            text: 'JIRA account disconnected successfully'
-          });
-        }
-      } catch (error) {
+    try {
+      const response = await fetch(authUrl, {
+        credentials: 'include',
+        redirect: 'manual' // Don't automatically follow redirects
+      });
+
+      if (
+        response.type === 'opaqueredirect' ||
+        response.status === 302 ||
+        response.status === 301
+      ) {
+        // The server is redirecting to JIRA OAuth, follow the redirect manually
+        window.location.href = authUrl;
+      } else if (!response.ok) {
+        const errorData = await response.json().catch(() => ({ message: 'Unknown error' }));
         setMessage({
           type: 'error',
-          text: `Failed to disconnect JIRA: ${error.message}`
+          text: t('integrations.page.jira.connectionFailed', {
+            message: errorData.message || 'Unknown error'
+          })
         });
       }
+    } catch (error) {
+      setMessage({
+        type: 'error',
+        text: t('integrations.page.jira.connectionFailed', { message: error.message })
+      });
     }
   };
 
-  // Handle cloud provider disconnection
-  const handleCloudDisconnect = async provider => {
+  const handleDisconnect = async ({ type, id, displayName }) => {
     try {
-      const response = await fetch(`/api/integrations/${provider.type}/disconnect`, {
+      const response = await fetch(buildApiUrl(`integrations/${type}/disconnect`), {
         method: 'POST',
         credentials: 'include',
         headers: {
@@ -215,49 +190,55 @@ export default function IntegrationsPage() {
       if (response.ok) {
         setIntegrations(prev => ({
           ...prev,
-          [provider.id]: {
-            connected: false,
-            message: `${provider.displayName} account disconnected`
-          }
+          [id]: { connected: false }
         }));
         setMessage({
           type: 'success',
-          text: `${provider.displayName} account disconnected successfully`
+          text:
+            type === 'jira'
+              ? t('integrations.page.jira.disconnected')
+              : t('integrations.page.cloud.disconnected', { name: displayName })
         });
       }
     } catch (error) {
       setMessage({
         type: 'error',
-        text: `Failed to disconnect ${provider.displayName}: ${error.message}`
+        text:
+          type === 'jira'
+            ? t('integrations.page.jira.disconnectFailed', { message: error.message })
+            : t('integrations.page.cloud.disconnectFailed', {
+                name: displayName,
+                message: error.message
+              })
       });
     }
   };
 
-  const handleTest = async integration => {
-    if (integration === 'jira') {
-      try {
-        const response = await fetch('/api/integrations/jira/test', {
-          credentials: 'include'
-        });
-        const data = await response.json();
+  const handleTest = async () => {
+    try {
+      const response = await fetch(buildApiUrl('integrations/jira/test'), {
+        credentials: 'include'
+      });
+      const data = await response.json();
 
-        if (data.success) {
-          setMessage({
-            type: 'success',
-            text: `JIRA connection test successful! Found ${data.testResults?.accessibleTickets || 0} accessible tickets.`
-          });
-        } else {
-          setMessage({
-            type: 'error',
-            text: `JIRA connection test failed: ${data.message}`
-          });
-        }
-      } catch (error) {
+      if (data.success) {
+        setMessage({
+          type: 'success',
+          text: t('integrations.page.jira.testSuccess', {
+            count: data.testResults?.accessibleTickets || 0
+          })
+        });
+      } else {
         setMessage({
           type: 'error',
-          text: `JIRA connection test failed: ${error.message}`
+          text: t('integrations.page.jira.testFailed', { message: data.message })
         });
       }
+    } catch (error) {
+      setMessage({
+        type: 'error',
+        text: t('integrations.page.jira.testFailed', { message: error.message })
+      });
     }
   };
 
@@ -271,10 +252,10 @@ export default function IntegrationsPage() {
         <div className="text-center">
           <Icon name="lock" className="w-12 h-12 text-gray-400 mx-auto mb-4" />
           <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">
-            Authentication Required
+            {t('integrations.page.authRequiredTitle')}
           </h2>
           <p className="text-gray-600 dark:text-gray-400">
-            Please log in to manage your integrations.
+            {t('integrations.page.authRequiredBody')}
           </p>
         </div>
       </div>
@@ -290,10 +271,10 @@ export default function IntegrationsPage() {
             <div className="flex items-center justify-between">
               <div>
                 <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
-                  Integrations
+                  {t('integrations.page.title')}
                 </h1>
                 <p className="text-gray-600 dark:text-gray-400 mt-1">
-                  Connect your external accounts to enhance your AI applications
+                  {t('integrations.page.subtitle')}
                 </p>
               </div>
               <Icon name="link" className="w-8 h-8 text-blue-600" />
@@ -341,248 +322,102 @@ export default function IntegrationsPage() {
               <div className="flex items-center justify-center py-8">
                 <Icon name="spinner" className="w-8 h-8 animate-spin text-blue-600" />
                 <span className="ml-3 text-gray-600 dark:text-gray-400">
-                  Loading integrations...
+                  {t('integrations.page.loading')}
                 </span>
               </div>
             ) : (
               <div className="space-y-6">
                 {/* JIRA Integration — only shown when Jira is configured server-side */}
                 {jiraEnabled && (
-                  <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-6">
-                    <div className="flex items-start space-x-4">
-                      <div className="flex-shrink-0">
-                        <div className="w-12 h-12 bg-blue-600 rounded-lg flex items-center justify-center">
-                          <Icon name="ticket" className="w-7 h-7 text-white" />
-                        </div>
-                      </div>
-
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center justify-between">
-                          <div>
-                            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                              JIRA
-                            </h3>
-                            <p className="text-gray-600 dark:text-gray-400 text-sm">
-                              Atlassian JIRA integration for ticket management and project insights
-                            </p>
-                          </div>
-
-                          <div className="flex items-center">
-                            <span
-                              className={`px-3 py-1 text-xs font-medium rounded-full ${
-                                integrations.jira?.connected
-                                  ? 'bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-300'
-                                  : 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300'
-                              }`}
-                            >
-                              {integrations.jira?.connected ? 'Connected' : 'Not Connected'}
-                            </span>
-                          </div>
-                        </div>
-
-                        {integrations.jira?.connected && integrations.jira.userInfo && (
-                          <div className="mt-3 p-3 bg-gray-50 dark:bg-gray-900/50 rounded-md">
-                            <div className="flex items-center text-sm text-gray-700 dark:text-gray-300">
-                              <Icon name="user" className="w-4 h-4 mr-2" />
-                              <span className="font-medium">
-                                {integrations.jira.userInfo.displayName}
-                              </span>
-                              <span className="ml-2 text-gray-500 dark:text-gray-400">
-                                ({integrations.jira.userInfo.emailAddress})
-                              </span>
-                            </div>
-                          </div>
-                        )}
-
-                        <div className="mt-4 flex items-center space-x-3">
-                          {integrations.jira?.connected ? (
-                            <>
-                              <button
-                                onClick={() => handleTest('jira')}
-                                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md font-medium transition-colors flex items-center"
-                              >
-                                <Icon name="check-circle" className="w-4 h-4 mr-2" />
-                                Test Connection
-                              </button>
-                              <button
-                                onClick={() => handleDisconnect('jira')}
-                                className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md font-medium transition-colors flex items-center"
-                              >
-                                <Icon name="x-circle" className="w-4 h-4 mr-2" />
-                                Disconnect
-                              </button>
-                            </>
-                          ) : (
-                            <button
-                              onClick={() => handleConnect('jira')}
-                              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md font-medium transition-colors flex items-center"
-                            >
-                              <Icon name="link" className="w-4 h-4 mr-2" />
-                              Connect JIRA Account
-                            </button>
-                          )}
-                        </div>
-
-                        {integrations.jira?.connected && (
-                          <div className="mt-3">
-                            <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
-                              Available Features:
-                            </h4>
-                            <ul className="text-sm text-gray-700 dark:text-gray-300 space-y-1">
-                              <li className="flex items-center">
-                                <Icon
-                                  name="check"
-                                  className="w-4 h-4 text-green-500 mr-2 flex-shrink-0"
-                                />
-                                Search and retrieve JIRA tickets
-                              </li>
-                              <li className="flex items-center">
-                                <Icon
-                                  name="check"
-                                  className="w-4 h-4 text-green-500 mr-2 flex-shrink-0"
-                                />
-                                Create new tickets and issues
-                              </li>
-                              <li className="flex items-center">
-                                <Icon
-                                  name="check"
-                                  className="w-4 h-4 text-green-500 mr-2 flex-shrink-0"
-                                />
-                                Update existing tickets
-                              </li>
-                              <li className="flex items-center">
-                                <Icon
-                                  name="check"
-                                  className="w-4 h-4 text-green-500 mr-2 flex-shrink-0"
-                                />
-                                Get project and user information
-                              </li>
-                            </ul>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
+                  <IntegrationCard
+                    icon="ticket"
+                    iconBgClassName="bg-blue-600"
+                    title={t('integrations.jira.title')}
+                    description={t('integrations.page.jira.description')}
+                    connected={!!integrations.jira?.connected}
+                    userInfo={
+                      integrations.jira?.userInfo
+                        ? {
+                            displayName: integrations.jira.userInfo.displayName,
+                            email: integrations.jira.userInfo.emailAddress
+                          }
+                        : null
+                    }
+                    features={[
+                      t('integrations.page.jira.features.search'),
+                      t('integrations.page.jira.features.create'),
+                      t('integrations.page.jira.features.update'),
+                      t('integrations.page.jira.features.info')
+                    ]}
+                    connectLabel={t('integrations.page.card.connectAccount', { name: 'JIRA' })}
+                    onConnect={() =>
+                      handleConnect({ type: 'jira', id: 'jira', displayName: 'JIRA' })
+                    }
+                    onDisconnect={() =>
+                      handleDisconnect({ type: 'jira', id: 'jira', displayName: 'JIRA' })
+                    }
+                    extraActions={
+                      <button
+                        onClick={handleTest}
+                        className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md font-medium transition-colors flex items-center"
+                      >
+                        <Icon name="check-circle" className="w-4 h-4 mr-2" />
+                        {t('integrations.jira.test')}
+                      </button>
+                    }
+                  />
                 )}
 
                 {/* Cloud Storage Integrations */}
                 {cloudProviders.map(provider => (
-                  <div
+                  <IntegrationCard
                     key={provider.id}
-                    className="border border-gray-200 dark:border-gray-700 rounded-lg p-6"
-                  >
-                    <div className="flex items-start space-x-4">
-                      <div className="flex-shrink-0">
-                        <div className="w-12 h-12 bg-gradient-to-br from-purple-600 to-teal-500 rounded-lg flex items-center justify-center">
-                          <Icon name="cloud" className="w-7 h-7 text-white" />
-                        </div>
-                      </div>
-
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center justify-between">
-                          <div>
-                            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-                              {provider.displayName}
-                            </h3>
-                            <p className="text-gray-600 dark:text-gray-400 text-sm">
-                              {provider.type === 'office365'
-                                ? 'Microsoft Office 365 integration for cloud file access'
-                                : 'Google Drive integration for cloud file access'}
-                            </p>
-                          </div>
-
-                          <div className="flex items-center">
-                            <span
-                              className={`px-3 py-1 text-xs font-medium rounded-full ${
-                                integrations[provider.id]?.connected
-                                  ? 'bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-300'
-                                  : 'bg-gray-100 dark:bg-gray-700 text-gray-800 dark:text-gray-300'
-                              }`}
-                            >
-                              {integrations[provider.id]?.connected ? 'Connected' : 'Not Connected'}
-                            </span>
-                          </div>
-                        </div>
-
-                        {integrations[provider.id]?.connected &&
-                          integrations[provider.id].userInfo && (
-                            <div className="mt-3 p-3 bg-gray-50 dark:bg-gray-900/50 rounded-md">
-                              <div className="flex items-center text-sm text-gray-700 dark:text-gray-300">
-                                <Icon name="user" className="w-4 h-4 mr-2" />
-                                <span className="font-medium">
-                                  {integrations[provider.id].userInfo.displayName}
-                                </span>
-                                <span className="ml-2 text-gray-500 dark:text-gray-400">
-                                  (
-                                  {integrations[provider.id].userInfo.mail ||
-                                    integrations[provider.id].userInfo.emailAddress}
-                                  )
-                                </span>
-                              </div>
-                              {integrations[provider.id].tokenInfo?.isExpiring && (
-                                <div className="mt-2 flex items-center text-sm text-amber-600 dark:text-amber-400">
-                                  <Icon name="exclamationTriangle" className="w-4 h-4 mr-2" />
-                                  <span>Token expires soon - consider reconnecting</span>
-                                </div>
-                              )}
-                            </div>
-                          )}
-
-                        <div className="mt-4 flex items-center space-x-3">
-                          {integrations[provider.id]?.connected ? (
-                            <button
-                              onClick={() => handleCloudDisconnect(provider)}
-                              className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-md font-medium transition-colors flex items-center"
-                            >
-                              <Icon name="x-circle" className="w-4 h-4 mr-2" />
-                              Disconnect
-                            </button>
-                          ) : (
-                            <button
-                              onClick={() => handleCloudConnect(provider)}
-                              className="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded-md font-medium transition-colors flex items-center"
-                            >
-                              <Icon name="link" className="w-4 h-4 mr-2" />
-                              Connect {provider.displayName} Account
-                            </button>
-                          )}
-                        </div>
-
-                        {integrations[provider.id]?.connected && (
-                          <div className="mt-3">
-                            <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
-                              Available Features:
-                            </h4>
-                            <ul className="text-sm text-gray-700 dark:text-gray-300 space-y-1">
-                              <li className="flex items-center">
-                                <Icon
-                                  name="check"
-                                  className="w-4 h-4 text-green-500 mr-2 flex-shrink-0"
-                                />
-                                {provider.type === 'office365'
-                                  ? 'Browse OneDrive and SharePoint files'
-                                  : 'Browse Google Drive files'}
-                              </li>
-                              <li className="flex items-center">
-                                <Icon
-                                  name="check"
-                                  className="w-4 h-4 text-green-500 mr-2 flex-shrink-0"
-                                />
-                                Upload cloud files to chats
-                              </li>
-                              <li className="flex items-center">
-                                <Icon
-                                  name="check"
-                                  className="w-4 h-4 text-green-500 mr-2 flex-shrink-0"
-                                />
-                                Secure OAuth 2.0 with PKCE
-                              </li>
-                            </ul>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
+                    icon="cloud"
+                    iconBgClassName="bg-gradient-to-br from-purple-600 to-teal-500"
+                    connectButtonClassName="bg-purple-600 hover:bg-purple-700"
+                    title={provider.displayName}
+                    description={
+                      provider.type === 'office365'
+                        ? t('integrations.page.cloud.description.office365')
+                        : t('integrations.page.cloud.description.googleDrive')
+                    }
+                    connected={!!integrations[provider.id]?.connected}
+                    userInfo={
+                      integrations[provider.id]?.userInfo
+                        ? {
+                            displayName: integrations[provider.id].userInfo.displayName,
+                            email:
+                              integrations[provider.id].userInfo.mail ||
+                              integrations[provider.id].userInfo.emailAddress
+                          }
+                        : null
+                    }
+                    tokenExpiring={!!integrations[provider.id]?.tokenInfo?.isExpiring}
+                    features={[
+                      provider.type === 'office365'
+                        ? t('integrations.page.cloud.features.browseOffice365')
+                        : t('integrations.page.cloud.features.browseGoogleDrive'),
+                      t('integrations.page.cloud.features.upload'),
+                      t('integrations.page.cloud.features.oauth')
+                    ]}
+                    connectLabel={t('integrations.page.card.connectAccount', {
+                      name: provider.displayName
+                    })}
+                    onConnect={() =>
+                      handleConnect({
+                        type: provider.type,
+                        id: provider.id,
+                        displayName: provider.displayName
+                      })
+                    }
+                    onDisconnect={() =>
+                      handleDisconnect({
+                        type: provider.type,
+                        id: provider.id,
+                        displayName: provider.displayName
+                      })
+                    }
+                  />
                 ))}
 
                 {/* Office Integration — shown when enabled by admin */}
@@ -606,14 +441,13 @@ export default function IntegrationsPage() {
                             </p>
                           </div>
                           <span className="px-3 py-1 text-xs font-medium rounded-full bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-300">
-                            Available
+                            {t('integrations.page.office.available')}
                           </span>
                         </div>
 
                         <div className="mt-4">
                           <p className="text-sm text-gray-600 dark:text-gray-400 mb-3">
-                            Deploy this manifest in Microsoft 365 Admin Center to make the add-in
-                            available to your organization.
+                            {t('integrations.page.office.deployHint')}
                           </p>
                           <div className="flex items-center gap-2">
                             <input
@@ -628,14 +462,14 @@ export default function IntegrationsPage() {
                               onClick={() => navigator.clipboard?.writeText(officeManifestUrl)}
                               className="shrink-0 rounded-md border border-gray-300 dark:border-gray-600 px-3 py-1.5 text-sm text-gray-600 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700"
                             >
-                              Copy
+                              {t('integrations.page.office.copy')}
                             </button>
                             <a
                               href={officeManifestUrl}
                               download="manifest.xml"
                               className="shrink-0 rounded-md bg-blue-600 text-white px-3 py-1.5 text-sm font-medium hover:bg-blue-700"
                             >
-                              Download
+                              {t('integrations.page.office.download')}
                             </a>
                           </div>
                         </div>
@@ -649,10 +483,10 @@ export default function IntegrationsPage() {
                   <div className="border border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-6 text-center">
                     <Icon name="link" className="w-8 h-8 text-gray-400 mx-auto mb-2" />
                     <h3 className="text-lg font-medium text-gray-500 dark:text-gray-400 mb-1">
-                      No Integrations Configured
+                      {t('integrations.page.empty.title')}
                     </h3>
                     <p className="text-gray-400 dark:text-gray-500 text-sm">
-                      Contact your administrator to enable external integrations.
+                      {t('integrations.page.empty.body')}
                     </p>
                   </div>
                 )}
@@ -662,10 +496,10 @@ export default function IntegrationsPage() {
                   <div className="border border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-6 text-center">
                     <Icon name="plus" className="w-8 h-8 text-gray-400 mx-auto mb-2" />
                     <h3 className="text-lg font-medium text-gray-500 dark:text-gray-400 mb-1">
-                      More Integrations Coming Soon
+                      {t('integrations.page.comingSoon.title')}
                     </h3>
                     <p className="text-gray-400 dark:text-gray-500 text-sm">
-                      We're working on adding more integrations to enhance your AI applications
+                      {t('integrations.page.comingSoon.body')}
                     </p>
                   </div>
                 )}

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -2035,6 +2035,66 @@
         "addComment": "Sind Sie sicher, dass Sie diesen Kommentar hinzufügen möchten?",
         "transitionTicket": "Sind Sie sicher, dass Sie den Ticket-Status ändern möchten?"
       }
+    },
+    "page": {
+      "title": "Integrationen",
+      "subtitle": "Verbinden Sie Ihre externen Konten, um Ihre KI-Anwendungen zu erweitern",
+      "loading": "Integrationen werden geladen...",
+      "authRequiredTitle": "Authentifizierung erforderlich",
+      "authRequiredBody": "Bitte melden Sie sich an, um Ihre Integrationen zu verwalten.",
+      "card": {
+        "connected": "Verbunden",
+        "notConnected": "Nicht verbunden",
+        "availableFeatures": "Verfügbare Funktionen:",
+        "connectAccount": "{{name}}-Konto verbinden",
+        "disconnect": "Trennen",
+        "tokenExpiring": "Token läuft bald ab - erneute Verbindung empfohlen"
+      },
+      "jira": {
+        "description": "Atlassian-JIRA-Integration für Ticketverwaltung und Projekteinblicke",
+        "features": {
+          "search": "JIRA-Tickets suchen und abrufen",
+          "create": "Neue Tickets und Vorgänge erstellen",
+          "update": "Bestehende Tickets aktualisieren",
+          "info": "Projekt- und Benutzerinformationen abrufen"
+        },
+        "connected": "JIRA-Konto erfolgreich verbunden! Sie können jetzt JIRA-Funktionen in Ihren Apps nutzen.",
+        "connectionFailed": "Verbindung fehlgeschlagen: {{message}}",
+        "disconnected": "JIRA-Konto erfolgreich getrennt",
+        "disconnectFailed": "Trennen von JIRA fehlgeschlagen: {{message}}",
+        "testSuccess": "JIRA-Verbindungstest erfolgreich! {{count}} zugängliche Tickets gefunden.",
+        "testFailed": "JIRA-Verbindungstest fehlgeschlagen: {{message}}"
+      },
+      "cloud": {
+        "description": {
+          "office365": "Microsoft-Office-365-Integration für Cloud-Dateizugriff",
+          "googleDrive": "Google-Drive-Integration für Cloud-Dateizugriff"
+        },
+        "features": {
+          "browseOffice365": "OneDrive- und SharePoint-Dateien durchsuchen",
+          "browseGoogleDrive": "Google-Drive-Dateien durchsuchen",
+          "upload": "Cloud-Dateien zu Chats hinzufügen",
+          "oauth": "Sicheres OAuth 2.0 mit PKCE"
+        },
+        "connected": "{{name}}-Konto erfolgreich verbunden! Sie können jetzt Dateien aus {{name}} auswählen.",
+        "connectionFailed": "{{name}}-Verbindung fehlgeschlagen: {{message}}",
+        "disconnected": "{{name}}-Konto erfolgreich getrennt",
+        "disconnectFailed": "Trennen von {{name}} fehlgeschlagen: {{message}}"
+      },
+      "office": {
+        "available": "Verfügbar",
+        "deployHint": "Stellen Sie dieses Manifest im Microsoft 365 Admin Center bereit, um das Add-in für Ihre Organisation verfügbar zu machen.",
+        "copy": "Kopieren",
+        "download": "Herunterladen"
+      },
+      "empty": {
+        "title": "Keine Integrationen konfiguriert",
+        "body": "Wenden Sie sich an Ihren Administrator, um externe Integrationen zu aktivieren."
+      },
+      "comingSoon": {
+        "title": "Weitere Integrationen folgen in Kürze",
+        "body": "Wir arbeiten daran, weitere Integrationen hinzuzufügen, um Ihre KI-Anwendungen zu erweitern"
+      }
     }
   },
   "workflow": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -2070,6 +2070,66 @@
         "addComment": "Are you sure you want to add this comment?",
         "transitionTicket": "Are you sure you want to change the ticket status?"
       }
+    },
+    "page": {
+      "title": "Integrations",
+      "subtitle": "Connect your external accounts to enhance your AI applications",
+      "loading": "Loading integrations...",
+      "authRequiredTitle": "Authentication Required",
+      "authRequiredBody": "Please log in to manage your integrations.",
+      "card": {
+        "connected": "Connected",
+        "notConnected": "Not Connected",
+        "availableFeatures": "Available Features:",
+        "connectAccount": "Connect {{name}} Account",
+        "disconnect": "Disconnect",
+        "tokenExpiring": "Token expires soon - consider reconnecting"
+      },
+      "jira": {
+        "description": "Atlassian JIRA integration for ticket management and project insights",
+        "features": {
+          "search": "Search and retrieve JIRA tickets",
+          "create": "Create new tickets and issues",
+          "update": "Update existing tickets",
+          "info": "Get project and user information"
+        },
+        "connected": "JIRA account connected successfully! You can now use JIRA features in your apps.",
+        "connectionFailed": "Connection failed: {{message}}",
+        "disconnected": "JIRA account disconnected successfully",
+        "disconnectFailed": "Failed to disconnect JIRA: {{message}}",
+        "testSuccess": "JIRA connection test successful! Found {{count}} accessible tickets.",
+        "testFailed": "JIRA connection test failed: {{message}}"
+      },
+      "cloud": {
+        "description": {
+          "office365": "Microsoft Office 365 integration for cloud file access",
+          "googleDrive": "Google Drive integration for cloud file access"
+        },
+        "features": {
+          "browseOffice365": "Browse OneDrive and SharePoint files",
+          "browseGoogleDrive": "Browse Google Drive files",
+          "upload": "Upload cloud files to chats",
+          "oauth": "Secure OAuth 2.0 with PKCE"
+        },
+        "connected": "{{name}} account connected successfully! You can now select files from {{name}}.",
+        "connectionFailed": "{{name}} connection failed: {{message}}",
+        "disconnected": "{{name}} account disconnected successfully",
+        "disconnectFailed": "Failed to disconnect {{name}}: {{message}}"
+      },
+      "office": {
+        "available": "Available",
+        "deployHint": "Deploy this manifest in Microsoft 365 Admin Center to make the add-in available to your organization.",
+        "copy": "Copy",
+        "download": "Download"
+      },
+      "empty": {
+        "title": "No Integrations Configured",
+        "body": "Contact your administrator to enable external integrations."
+      },
+      "comingSoon": {
+        "title": "More Integrations Coming Soon",
+        "body": "We're working on adding more integrations to enhance your AI applications"
+      }
     }
   },
   "workflow": {


### PR DESCRIPTION
## Summary

- Extracts a shared `IntegrationCard` component (`client/src/features/settings/components/IntegrationCard.jsx`) used by both the JIRA and cloud-provider (Office 365 / Google Drive) cards in `IntegrationsPage.jsx`, eliminating ~115 lines of duplicated JSX per card (icon tile, connected pill, user-info panel, expiring-token warning, connect/disconnect buttons, feature checklist).
- Unifies `handleDisconnect`/`handleCloudDisconnect` into a single `handleDisconnect({ type, id, displayName })` handler parameterized by integration type, matching the pattern `handleCloudConnect` already used.
- Localizes every hardcoded English string on the page ("Connected", "Not Connected", "Authentication Required", feature lists, status/error messages, etc.) via a new `integrations.page.*` i18n namespace added to both `shared/i18n/en.json` and `shared/i18n/de.json`.
- Switches the page's raw `fetch('/api/...')` calls to `buildApiUrl(...)` so status/connect/disconnect/test requests resolve correctly behind a sub-path deployment.

## Test plan

- [x] `npx eslint` on the changed files — no errors
- [x] `npx prettier --check` on the changed files — formatted correctly
- [x] `npm run build` (client) — builds successfully, no compile errors
- [x] Verified translation JSON files parse correctly (`en.json`, `de.json`)
- [ ] Manual click-through of `/settings/integrations` in a browser with JIRA/cloud providers configured (not performed in this environment — no `contents/` config available to boot a full dev server with these integrations enabled)

Closes #1854

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMXmSPC9V5ZzHq2FDMATcX

---
_Generated by [Claude Code](https://claude.ai/code/session_01XMXmSPC9V5ZzHq2FDMATcX)_