### PR TITLE
fix: remove dead per-request cache and unused SourceManager from SourceResolutionService

### DIFF
--- a/server/services/SourceResolutionService.js
+++ b/server/services/SourceResolutionService.js
@@ -1,5 +1,4 @@
 import configCache from '../configCache.js';
-import { createSourceManager } from '../sources/index.js';
 import logger from '../utils/logger.js';
 
 /**
@@ -11,14 +10,11 @@ import logger from '../utils/logger.js';
  * Key Features:
  * - Resolves source ID string references to configured sources
  * - Unifies admin and app source schemas
- * - Provides caching and error handling
+ * - Provides error handling
  */
 class SourceResolutionService {
   constructor() {
     this.configCache = configCache;
-    this.sourceManager = createSourceManager();
-    this.resolutionCache = new Map();
-    this.cacheTimeout = 5 * 60 * 1000; // 5 minutes cache TTL
   }
 
   /**
@@ -35,21 +31,6 @@ class SourceResolutionService {
         appId: app.id
       });
       return [];
-    }
-
-    // Generate cache key for resolution caching
-    const cacheKey = this.generateCacheKey(app.id, app.sources);
-
-    // Check cache first
-    if (this.resolutionCache.has(cacheKey)) {
-      const cached = this.resolutionCache.get(cacheKey);
-      if (Date.now() - cached.timestamp < this.cacheTimeout) {
-        logger.info('Using cached source resolution for app', {
-          component: 'SourceResolutionService',
-          appId: app.id
-        });
-        return cached.sources;
-      }
     }
 
     logger.info('Resolving source references for app', {
@@ -91,12 +72,6 @@ class SourceResolutionService {
         // Continue processing other sources
       }
     }
-
-    // Cache the resolved sources
-    this.resolutionCache.set(cacheKey, {
-      sources: resolvedSources,
-      timestamp: Date.now()
-    });
 
     logger.info('Resolved sources for app', {
       component: 'SourceResolutionService',
@@ -202,52 +177,6 @@ class SourceResolutionService {
       return value[language] || value['en'] || Object.values(value)[0] || null;
     }
     return null;
-  }
-
-  /**
-   * Generate cache key for source resolution
-   *
-   * @param {string} appId - Application ID
-   * @param {Array} sources - Source references array (all strings)
-   * @returns {string} Cache key
-   */
-  generateCacheKey(appId, sources) {
-    const sourceSignature = sources.filter(source => typeof source === 'string').join('|');
-    return `${appId}:${sourceSignature}`;
-  }
-
-  /**
-   * Clear resolution cache (useful for testing or config changes)
-   */
-  clearCache() {
-    this.resolutionCache.clear();
-    logger.info('Source resolution cache cleared', { component: 'SourceResolutionService' });
-  }
-
-  /**
-   * Get cache statistics for monitoring
-   *
-   * @returns {object} Cache statistics
-   */
-  getCacheStats() {
-    const now = Date.now();
-    let validEntries = 0;
-    let expiredEntries = 0;
-
-    for (const [_key, value] of this.resolutionCache.entries()) {
-      if (now - value.timestamp < this.cacheTimeout) {
-        validEntries++;
-      } else {
-        expiredEntries++;
-      }
-    }
-
-    return {
-      totalEntries: this.resolutionCache.size,
-      validEntries,
-      expiredEntries,
-      cacheTimeout: this.cacheTimeout
-    };
   }
 }
 

--- a/server/tests/SourceResolutionService.test.js
+++ b/server/tests/SourceResolutionService.test.js
@@ -1,0 +1,96 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Unit tests for SourceResolutionService. configCache is mocked so tests
+ * control which admin sources are "configured" without touching disk.
+ *
+ * The service is instantiated fresh per test (mirroring how PromptService
+ * and PromptNodeExecutor use it in production — see #1820), so these tests
+ * also guard against resolveAppSources depending on any cross-instance
+ * cache state.
+ */
+
+const store = { sources: [] };
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: {
+    getSources: () => ({ data: store.sources })
+  }
+}));
+
+jest.unstable_mockModule('../utils/logger.js', () => ({
+  default: {
+    error: () => {},
+    warn: () => {},
+    info: () => {},
+    debug: () => {}
+  }
+}));
+
+const { default: SourceResolutionService } = await import('../services/SourceResolutionService.js');
+
+function setSources(sources) {
+  store.sources = sources;
+}
+
+beforeEach(() => {
+  setSources([]);
+});
+
+describe('SourceResolutionService.resolveAppSources', () => {
+  it('returns an empty array when the app has no sources', async () => {
+    const service = new SourceResolutionService();
+
+    await expect(service.resolveAppSources({ id: 'app-1', sources: [] })).resolves.toEqual([]);
+  });
+
+  it('resolves a string source reference against admin sources', async () => {
+    setSources([
+      {
+        id: 'faq',
+        name: { en: 'FAQ' },
+        description: { en: 'Frequently asked questions' },
+        type: 'filesystem',
+        enabled: true,
+        exposeAs: 'prompt',
+        config: { path: 'sources/faq.md' }
+      }
+    ]);
+    const service = new SourceResolutionService();
+
+    const resolved = await service.resolveAppSources({ id: 'app-1', sources: ['faq'] });
+
+    expect(resolved).toHaveLength(1);
+    expect(resolved[0]).toMatchObject({ id: 'faq', type: 'filesystem', exposeAs: 'prompt' });
+  });
+
+  it('skips disabled or unknown source references without throwing', async () => {
+    setSources([{ id: 'disabled-source', enabled: false, config: {} }]);
+    const service = new SourceResolutionService();
+
+    const resolved = await service.resolveAppSources({
+      id: 'app-1',
+      sources: ['disabled-source', 'does-not-exist']
+    });
+
+    expect(resolved).toEqual([]);
+  });
+
+  it('does not reuse resolutions across separate instances (no dead cache)', async () => {
+    setSources([{ id: 'faq', enabled: true, config: {} }]);
+    const first = await new SourceResolutionService().resolveAppSources({
+      id: 'app-1',
+      sources: ['faq']
+    });
+    expect(first).toHaveLength(1);
+
+    // Even if the admin source disappears between requests, a fresh instance
+    // must reflect current config rather than any stale cached resolution.
+    setSources([]);
+    const second = await new SourceResolutionService().resolveAppSources({
+      id: 'app-1',
+      sources: ['faq']
+    });
+    expect(second).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1820.

`SourceResolutionService` is instantiated fresh on every chat request (`PromptService.js:283`, `PromptNodeExecutor.js:1343`), so its `resolutionCache` (5-minute TTL) could never produce a cache hit — the `Map` died with each request. The constructor also built an unused `this.sourceManager` via `createSourceManager()` that was never referenced again anywhere in the class. Per the issue's recommendation (and since `configCache` already caches `sources.json`), this deletes the dead machinery rather than turning it into a real singleton.

- Removed `this.sourceManager`/`createSourceManager` import, `resolutionCache`, and `cacheTimeout` from the constructor.
- Removed the cache-check and cache-write blocks in `resolveAppSources`.
- Deleted the now-unused `generateCacheKey()`, `clearCache()`, and `getCacheStats()` methods.
- Updated the class docblock to drop the caching claim.
- No behavior change: `resolveAppSources` still resolves string source refs the same way, and I verified (via grep) that `clearCache`/`getCacheStats` have no external callers anywhere in `server/`, `client/`, or tests.

## Test plan

- [x] `npx eslint` on changed files — 0 errors
- [x] `npx prettier --check` on changed files — passes
- [x] Added `server/tests/SourceResolutionService.test.js` covering: no-sources short-circuit, resolving a valid string source ref, skipping disabled/unknown refs, and that a fresh instance doesn't rely on any cross-instance cache state — all 4 pass
- [x] Manually instantiated the service and called `resolveAppSources` in a REPL to confirm no `clearCache`/`getCacheStats`/`sourceManager` remain and resolution still works
- [x] `timeout 10s node server/server.js` — server starts cleanly
- [x] Confirmed the pre-existing `server` Jest suite has the same 109 failing / 26 passing suites on `main` with and without this change (unrelated environment issue, not a regression)

No changelog entry per `CLAUDE.md` — pure dead-code removal, not visible to admins or end users.

https://claude.ai/code/session_01Kcgg4hvNB2S8MjTboqmxxd


---
_Generated by [Claude Code](https://claude.ai/code/session_01Kcgg4hvNB2S8MjTboqmxxd)_