### PR TITLE
refactor(tools): extract shared StatusBadge and ProgressBar components

### DIFF
--- a/client/src/features/tools/pages/JobListPage.jsx
+++ b/client/src/features/tools/pages/JobListPage.jsx
@@ -2,44 +2,12 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { Link } from 'react-router-dom';
 import { buildApiUrl } from '../../../utils/runtimeBasePath';
 import { apiClient } from '../../../api/client';
-
-function StatusBadge({ status }) {
-  const colors = {
-    queued: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
-    processing: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-    building: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-    completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-    error: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
-    cancelled: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
-  };
-
-  return (
-    <span
-      className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${colors[status] || colors.queued}`}
-    >
-      {status}
-    </span>
-  );
-}
+import StatusBadge from '../../../shared/components/StatusBadge';
+import ProgressBar from '../../../shared/components/ProgressBar';
 
 function formatDate(timestamp) {
   if (!timestamp) return '-';
   return new Date(timestamp).toLocaleString();
-}
-
-function ProgressBar({ value, max }) {
-  const pct = max > 0 ? Math.round((value / max) * 100) : 0;
-  return (
-    <div className="flex items-center gap-2">
-      <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-2 overflow-hidden">
-        <div
-          className="bg-blue-600 h-2 rounded-full transition-all duration-300"
-          style={{ width: `${pct}%` }}
-        />
-      </div>
-      <span className="text-xs text-gray-500 dark:text-gray-400 w-10 text-right">{pct}%</span>
-    </div>
-  );
 }
 
 export default function JobListPage() {
@@ -160,7 +128,11 @@ export default function JobListPage() {
                     </td>
                     <td className="py-3 px-2 w-32">
                       {job.progress?.total > 0 ? (
-                        <ProgressBar value={job.progress.current} max={job.progress.total} />
+                        <ProgressBar
+                          value={job.progress.current}
+                          max={job.progress.total}
+                          variant="inline"
+                        />
                       ) : isActive ? (
                         <span className="text-xs text-gray-400">Pending...</span>
                       ) : (

--- a/client/src/features/tools/pages/OcrPage.jsx
+++ b/client/src/features/tools/pages/OcrPage.jsx
@@ -3,6 +3,8 @@ import { Link } from 'react-router-dom';
 import { buildApiUrl } from '../../../utils/runtimeBasePath';
 import { apiClient } from '../../../api/client';
 import { useEstimatedTokenCount } from '../../../shared/hooks/useEstimatedTokenCount.js';
+import StatusBadge from '../../../shared/components/StatusBadge';
+import ProgressBar from '../../../shared/components/ProgressBar';
 
 const ACCEPTED_TYPES = ['application/pdf', 'image/jpeg', 'image/png', 'image/tiff', 'image/webp'];
 const ACCEPTED_EXTENSIONS = ['pdf', 'jpg', 'jpeg', 'png', 'tiff', 'tif', 'webp'];
@@ -30,43 +32,6 @@ function isAcceptedFile(file) {
   if (ACCEPTED_TYPES.includes(file.type)) return true;
   const ext = file.name.split('.').pop()?.toLowerCase();
   return ACCEPTED_EXTENSIONS.includes(ext);
-}
-
-function ProgressBar({ value, max, label }) {
-  const pct = max > 0 ? Math.round((value / max) * 100) : 0;
-  return (
-    <div className="w-full">
-      {label && <div className="text-sm text-gray-600 dark:text-gray-400 mb-1">{label}</div>}
-      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3 overflow-hidden">
-        <div
-          className="bg-blue-600 h-3 rounded-full transition-all duration-300"
-          style={{ width: `${pct}%` }}
-        />
-      </div>
-      <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 text-right">
-        {value} / {max} ({pct}%)
-      </div>
-    </div>
-  );
-}
-
-function StatusBadge({ status }) {
-  const colors = {
-    queued: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
-    processing: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-    building: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
-    completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
-    error: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
-    cancelled: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
-  };
-
-  return (
-    <span
-      className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${colors[status] || colors.queued}`}
-    >
-      {status}
-    </span>
-  );
 }
 
 function JobCard({ job, onCancel }) {

--- a/client/src/shared/components/ProgressBar.jsx
+++ b/client/src/shared/components/ProgressBar.jsx
@@ -1,0 +1,32 @@
+export default function ProgressBar({ value, max, label, variant = 'stacked' }) {
+  const pct = max > 0 ? Math.round((value / max) * 100) : 0;
+
+  if (variant === 'inline') {
+    return (
+      <div className="flex items-center gap-2">
+        <div className="flex-1 bg-gray-200 dark:bg-gray-700 rounded-full h-2 overflow-hidden">
+          <div
+            className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <span className="text-xs text-gray-500 dark:text-gray-400 w-10 text-right">{pct}%</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full">
+      {label && <div className="text-sm text-gray-600 dark:text-gray-400 mb-1">{label}</div>}
+      <div className="w-full bg-gray-200 dark:bg-gray-700 rounded-full h-3 overflow-hidden">
+        <div
+          className="bg-blue-600 h-3 rounded-full transition-all duration-300"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 text-right">
+        {value} / {max} ({pct}%)
+      </div>
+    </div>
+  );
+}

--- a/client/src/shared/components/StatusBadge.jsx
+++ b/client/src/shared/components/StatusBadge.jsx
@@ -1,0 +1,18 @@
+const STATUS_COLORS = {
+  queued: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300',
+  processing: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  building: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300',
+  completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+  error: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+  cancelled: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-300'
+};
+
+export default function StatusBadge({ status, className = '' }) {
+  return (
+    <span
+      className={`inline-flex px-2 py-0.5 text-xs font-medium rounded-full ${STATUS_COLORS[status] || STATUS_COLORS.queued} ${className}`}
+    >
+      {status}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- `OcrPage.jsx` and `JobListPage.jsx` each defined byte-identical local `StatusBadge` components (same `queued/processing/building/completed/error/cancelled` → Tailwind color map) and near-identical `ProgressBar` components.
- Extracted both into `client/src/shared/components/StatusBadge.jsx` and `client/src/shared/components/ProgressBar.jsx` and updated both pages to import them.
- `ProgressBar` takes an optional `variant` prop (`'stacked'` default, matching OcrPage's label+caption layout, or `'inline'`, matching JobListPage's compact bar) so both pages keep their exact prior visual output.
- Left `client/src/features/workflows/components/StatusBadge.jsx` / `ProgressBar.jsx` untouched — they use a different, larger status vocabulary (`pending/running/paused/approved/rejected/...`) plus icons and i18n, so forcing them into the same shared component would require threading unrelated config through every call site for no current benefit.
- Verified via `grep` that no other file in the codebase has a third copy of this status-color map.

This is a behavior-preserving refactor (no visual or functional change).

## Test plan

- [x] `npx eslint` on all changed/new files — no new errors (pre-existing a11y warnings in `OcrPage.jsx` unrelated to this change)
- [x] `npx prettier --write` on all changed/new files — no diffs
- [x] `client && npx vite build` — builds successfully
- [ ] Manual verification in browser: OCR tool and Jobs list page render identical badge colors / progress bars for each status (queued, processing, completed, error, cancelled)

Fixes #1816

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y8JfwtrHYxMfxguvTAiCRK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y8JfwtrHYxMfxguvTAiCRK)_