### PR TITLE
fix(chat): remove undefined state-setter calls that crashed message handling

### DIFF
--- a/client/src/features/chat/hooks/useAppChat.js
+++ b/client/src/features/chat/hooks/useAppChat.js
@@ -272,18 +272,19 @@ function useAppChat({
           }
           break;
         case 'response.message.id':
-          // Store the iFinder message ID for feedback submission
+          // Store the iFinder message ID for feedback submission. This event
+          // is emitted before 'done', so the message is still streaming —
+          // preserve its current content and loading state and only attach
+          // the id via the shared updater (there is no standalone setMessages).
           if (data?.messageId && lastMessageIdRef.current) {
-            const currentMessages = messagesRef.current;
-            const messageIndex = currentMessages.findIndex(m => m.id === lastMessageIdRef.current);
-            if (messageIndex !== -1) {
-              const updatedMessages = [...currentMessages];
-              updatedMessages[messageIndex] = {
-                ...updatedMessages[messageIndex],
-                ifinderMessageId: data.messageId
-              };
-              setMessages(updatedMessages);
-              messagesRef.current = updatedMessages;
+            const currentMessage = messagesRef.current.find(m => m.id === lastMessageIdRef.current);
+            if (currentMessage) {
+              updateAssistantMessage(
+                lastMessageIdRef.current,
+                currentMessage.content || '',
+                currentMessage.loading,
+                { ifinderMessageId: data.messageId }
+              );
             }
           }
           break;
@@ -326,7 +327,6 @@ function useAppChat({
             }
           }
           setProcessing(false);
-          setSearchStatus(null);
           // Reset clarification state when done normally
           setClarificationPending(false);
           activeClarificationRef.current = null;

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -175,3 +175,14 @@ the URL.
 - No configuration change is required — existing OpenAI-adapter models work as configured.
 - When a request URL genuinely cannot be resolved, the error now names the offending URL (with any
   embedded secrets redacted) so misconfiguration is easier to diagnose.
+
+## Chat No Longer Crashes When a Response Finishes
+
+Chat responses now complete cleanly instead of failing with an "Add-in Error" (`setSearchStatus is
+not defined`) the moment the model finished answering. The crash surfaced in the Outlook add-in but
+came from the shared chat used across the platform, so any app could be affected.
+
+- Fixes the error thrown at the end of every response, so answers now display and finalize normally.
+- Also fixes a related crash for iFinder-backed apps that emit a response message id (used for
+  answer feedback), which previously interrupted the reply the same way.
+- No configuration or admin action required.

--- a/tests/unit/client/use-app-chat-event-handlers.test.jsx
+++ b/tests/unit/client/use-app-chat-event-handlers.test.jsx
@@ -1,0 +1,157 @@
+/**
+ * Regression tests for client/src/features/chat/hooks/useAppChat.js
+ *
+ * The SSE `handleEvent` switch called two state setters that did not exist in
+ * scope, so the handlers threw "X is not defined" at runtime the moment the
+ * matching event arrived. Both slipped past ESLint (no `no-undef` error) and
+ * only surfaced in the browser — reported as an "Add-in Error" in the Outlook
+ * add-in, thrown from the ChatMessageList bundle:
+ *
+ *   - 'done'                 → `setSearchStatus(null)` — a dangling reference
+ *     left behind when PR #1860 removed the top-level `searchStatus` state
+ *     (declaration, `search.status` write and `resetConversationState` reset
+ *     were removed; this third call in the `done` handler was missed).
+ *   - 'response.message.id'  → `setMessages(...)` — `useChatMessages` never
+ *     exposed a `setMessages` setter (it is internal to that hook).
+ *
+ * These exercise the real hook end-to-end through the real `useChatMessages`,
+ * so the assertions fail (with a ReferenceError) against the pre-fix code and
+ * pass against the fix.
+ */
+
+import '@testing-library/jest-dom';
+import { renderHook, act } from '@testing-library/react';
+
+// The client's `uuid` build is ESM-only and jest does not transform
+// node_modules; stub it (used only for default id generation).
+jest.mock('uuid', () => ({
+  __esModule: true,
+  v4: () => '00000000-0000-0000-0000-000000000000'
+}));
+
+// Capture the SSE event handler that useAppChat wires into useEventSource and
+// stub the transport so no real EventSource / network connection is opened.
+let capturedOnEvent = null;
+jest.mock('../../../client/src/shared/hooks/useEventSource', () => ({
+  __esModule: true,
+  default: ({ onEvent }) => {
+    capturedOnEvent = onEvent;
+    return {
+      initEventSource: jest.fn(),
+      cleanupEventSource: jest.fn()
+    };
+  }
+}));
+
+// sendAppChatMessage is only reached from the 'connected' handler (not under
+// test); stub the api module so importing the hook does not pull in the client.
+jest.mock('../../../client/src/api', () => ({
+  __esModule: true,
+  sendAppChatMessage: jest.fn()
+}));
+
+// Minimal i18n: return the provided default string (or the key).
+jest.mock('react-i18next', () => ({
+  __esModule: true,
+  useTranslation: () => ({ t: (key, def) => def || key })
+}));
+
+// These two utils use `import.meta.env`, which the jest babel transform does
+// not handle; stub them with factories so the real files are never parsed.
+jest.mock('../../../client/src/utils/debugLog', () => ({
+  __esModule: true,
+  debugLog: () => {}
+}));
+jest.mock('../../../client/src/utils/runtimeBasePath', () => ({
+  __esModule: true,
+  buildApiUrl: path => `/api/${path}`
+}));
+
+const useAppChat = require('../../../client/src/features/chat/hooks/useAppChat').default;
+
+/**
+ * Drive sendMessage so an assistant placeholder exists in state and
+ * lastMessageIdRef points at it — the precondition every SSE handler assumes.
+ * Returns the assistant message.
+ */
+function startAssistantMessage(result) {
+  act(() => {
+    result.current.sendMessage({
+      displayMessage: 'hello',
+      apiMessage: { content: 'hello' },
+      params: {}
+    });
+  });
+  return result.current.messages.find(m => m.role === 'assistant');
+}
+
+beforeEach(() => {
+  capturedOnEvent = null;
+  sessionStorage.clear();
+});
+
+test("'response.message.id' attaches ifinderMessageId (no setMessages ReferenceError)", async () => {
+  const { result } = renderHook(() => useAppChat({ appId: 'app1', chatId: 'chat-resp' }));
+
+  const assistant = startAssistantMessage(result);
+  expect(assistant).toBeTruthy();
+  expect(assistant.loading).toBe(true);
+  expect(assistant.ifinderMessageId).toBeUndefined();
+
+  // Pre-fix: threw "setMessages is not defined".
+  await act(async () => {
+    await capturedOnEvent({ type: 'response.message.id', data: { messageId: 'resp-123' } });
+  });
+
+  const updated = result.current.messages.find(m => m.id === assistant.id);
+  expect(updated.ifinderMessageId).toBe('resp-123');
+  // Emitted before 'done', so the message keeps streaming: loading preserved.
+  expect(updated.loading).toBe(true);
+});
+
+test("'done' completes the message (no setSearchStatus ReferenceError)", async () => {
+  const onMessageComplete = jest.fn();
+  const { result } = renderHook(() =>
+    useAppChat({ appId: 'app1', chatId: 'chat-done', onMessageComplete })
+  );
+
+  const assistant = startAssistantMessage(result);
+  expect(result.current.processing).toBe(true);
+
+  // Pre-fix: threw "setSearchStatus is not defined".
+  await act(async () => {
+    await capturedOnEvent({
+      type: 'done',
+      fullContent: 'final answer',
+      data: { finishReason: 'stop' }
+    });
+  });
+
+  const done = result.current.messages.find(m => m.id === assistant.id);
+  expect(done.content).toBe('final answer');
+  expect(done.loading).toBe(false);
+  expect(result.current.processing).toBe(false);
+  expect(onMessageComplete).toHaveBeenCalledWith('final answer', 'hello');
+});
+
+test("a 'response.message.id' then 'done' sequence keeps both effects", async () => {
+  const { result } = renderHook(() => useAppChat({ appId: 'app1', chatId: 'chat-seq' }));
+
+  const assistant = startAssistantMessage(result);
+
+  await act(async () => {
+    await capturedOnEvent({ type: 'chunk', fullContent: 'partial' });
+    await capturedOnEvent({ type: 'response.message.id', data: { messageId: 'resp-999' } });
+    await capturedOnEvent({
+      type: 'done',
+      fullContent: 'partial done',
+      data: { finishReason: 'stop' }
+    });
+  });
+
+  const msg = result.current.messages.find(m => m.id === assistant.id);
+  expect(msg.ifinderMessageId).toBe('resp-999'); // survived the 'done' finalize
+  expect(msg.content).toBe('partial done');
+  expect(msg.loading).toBe(false);
+  expect(result.current.processing).toBe(false);
+});


### PR DESCRIPTION
## Summary

Fixes the runtime crash reported from the Outlook add-in:

> **Add-in Error** — `setSearchStatus is not defined`
> (thrown from the `ChatMessageList` bundle)

The SSE `handleEvent` switch in `client/src/features/chat/hooks/useAppChat.js` called two state setters that were **never in scope**, so each threw `ReferenceError: X is not defined` the moment its event arrived. Both slipped past ESLint (no `no-undef` error is emitted for these) and only failed in the browser.

## Root cause

| Event | Broken call | Why |
| --- | --- | --- |
| `done` | `setSearchStatus(null)` | PR #1860 removed the dead top-level `searchStatus` state (declaration, the `search.status` write, and the `resetConversationState` reset) but **missed this third call** in the `done` handler. Fires at the end of *every* response. |
| `response.message.id` | `setMessages(updatedMessages)` | `useChatMessages` never exposes a `setMessages` setter — it is internal to that hook. This has been broken since the handler was added in #1808. Fires for iFinder-backed apps (feedback message id). |

## Changes

- **`done` handler** — remove the orphaned `setSearchStatus(null)`. The per-message `searchStatus` written via `updateAssistantMessage` is what the UI actually reads, so nothing else is needed (completes the cleanup #1860 started).
- **`response.message.id` handler** — rewrite to use `updateAssistantMessage` (the real API from `useChatMessages`), preserving the message's current content and loading state while attaching `ifinderMessageId`. This event is emitted before `done` (server `StreamingHandler` order), so the message is still streaming and its loading state is kept `true`.
- **Regression test** — `tests/unit/client/use-app-chat-event-handlers.test.jsx` drives the **real** hook through the **real** `useChatMessages`. It fails with the exact `ReferenceError`s against the pre-fix code and passes with the fix.
- **Changelog** — entry added to `docs/releases/5.5.0/features.md`.

## Verification

- New regression test: **3/3 pass** with the fix; **3/3 fail** with the documented `ReferenceError`s when the source fix is reverted (test kept in place).
- Full client unit suite: **13 suites, 117 tests pass**.
- ESLint: 0 errors on the changed source (pre-existing `appendWorkflowStep` dependency warning is unrelated); Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm9xMyu8d2TpMEmpRBPNYL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rm9xMyu8d2TpMEmpRBPNYL)_