### PR TITLE
fix(security): use separator-aware boundary check for skill file installs

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -186,6 +186,15 @@ could make the read/update/delete script endpoints touch files outside `server/t
   `server/tools/`.
 - Creating or updating a tool now rejects a `script` value that isn't a bare `<name>.js` filename.
 
+## Marketplace Skill Installs Now Use a Stricter Directory Boundary Check
+
+Installing a multi-file skill package from the marketplace now uses the same separator-aware
+boundary check as other content installers, closing a gap where a companion filename could
+resolve into a sibling directory that merely shared the skill's directory name as a prefix
+(e.g. `foo-evil` next to `foo`).
+
+- No admin action required; existing skill packages install exactly as before.
+
 ## Chat No Longer Crashes When a Response Finishes
 
 Chat responses now complete cleanly instead of failing with an "Add-in Error" (`setSearchStatus is

--- a/server/services/marketplace/ContentInstaller.js
+++ b/server/services/marketplace/ContentInstaller.js
@@ -23,7 +23,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
-import { isValidId } from '../../utils/pathSecurity.js';
+import { isValidId, resolveAndValidatePath } from '../../utils/pathSecurity.js';
 import { getRootDir } from '../../pathUtils.js';
 import config from '../../config.js';
 import registryService from './RegistryService.js';
@@ -529,10 +529,9 @@ class ContentInstaller {
       if (typeof content === 'object' && content !== null && content.files) {
         // Multi-file skill package
         for (const [filename, fileContent] of Object.entries(content.files)) {
-          const filePath = path.join(skillDir, filename);
-          const resolvedPath = path.resolve(filePath);
           // Guard against path traversal within the skill's own file list
-          if (!resolvedPath.startsWith(path.resolve(skillDir))) {
+          const filePath = await resolveAndValidatePath(filename, skillDir);
+          if (!filePath) {
             throw new Error(`Path traversal detected in skill file: ${filename}`);
           }
           // Ensure parent directory exists (companion files may live in subdirs)

--- a/server/tests/ContentInstaller.skill-path-traversal.test.js
+++ b/server/tests/ContentInstaller.skill-path-traversal.test.js
@@ -1,0 +1,95 @@
+/**
+ * Regression tests for #1804: ContentInstaller's skill multi-file write path
+ * used a prefix check (`resolvedPath.startsWith(path.resolve(skillDir))`)
+ * with no trailing separator, so a companion filename resolving into a
+ * sibling directory that shares the skill directory's name as a prefix
+ * (e.g. skillDir `.../skills/foo`, filename `../foo-evil/x`) incorrectly
+ * passed the boundary check. The fix reuses `resolveAndValidatePath` from
+ * `utils/pathSecurity.js`, which performs a separator-aware boundary check.
+ *
+ * Note: The repo's source is native ESM (uses `import.meta.url`), so this
+ * file uses `jest.unstable_mockModule` + dynamic imports rather than the
+ * CommonJS-only `jest.mock` API. Run with
+ * `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+import { promises as fs } from 'fs';
+import { existsSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+// TokenStorageService (a transitive import via RegistryService) reads
+// getRootDir() synchronously at module-load time to build its singleton, so
+// this must resolve to a real directory before the dynamic import below runs.
+const state = { rootDir: os.tmpdir() };
+
+jest.unstable_mockModule('../pathUtils.js', () => ({
+  getRootDir: () => state.rootDir
+}));
+
+const { default: contentInstaller } = await import('../services/marketplace/ContentInstaller.js');
+
+describe('ContentInstaller skill multi-file path traversal protection (#1804)', () => {
+  let tmpRoot;
+  let skillDir;
+  let siblingEvilFile;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ihub-content-installer-test-'));
+    state.rootDir = tmpRoot;
+
+    skillDir = path.join(tmpRoot, 'contents', 'skills', 'foo');
+    await fs.mkdir(skillDir, { recursive: true });
+
+    // A sibling directory that shares the target skill directory's name as a
+    // prefix ("foo" vs "foo-evil") — the exact case the old prefix check missed.
+    const evilDir = path.join(tmpRoot, 'contents', 'skills', 'foo-evil');
+    await fs.mkdir(evilDir, { recursive: true });
+    siblingEvilFile = path.join(evilDir, 'x');
+    await fs.writeFile(siblingEvilFile, 'untouched');
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  test('writes a benign companion file in a subdirectory', async () => {
+    await contentInstaller._writeContent(
+      'skill',
+      'foo',
+      { files: { 'assets/logo.png': 'binarydata' } },
+      { dir: 'skills', ext: null }
+    );
+
+    const written = await fs.readFile(path.join(skillDir, 'assets', 'logo.png'), 'utf8');
+    expect(written).toBe('binarydata');
+  });
+
+  test('rejects a companion filename that traverses into a sibling directory sharing a name prefix', async () => {
+    await expect(
+      contentInstaller._writeContent(
+        'skill',
+        'foo',
+        { files: { '../foo-evil/x': 'pwned' } },
+        { dir: 'skills', ext: null }
+      )
+    ).rejects.toThrow('Path traversal detected in skill file');
+
+    const content = await fs.readFile(siblingEvilFile, 'utf8');
+    expect(content).toBe('untouched');
+  });
+
+  test('rejects a classic ../.. traversal attempt', async () => {
+    await expect(
+      contentInstaller._writeContent(
+        'skill',
+        'foo',
+        { files: { '../../../../etc/passwd': 'pwned' } },
+        { dir: 'skills', ext: null }
+      )
+    ).rejects.toThrow('Path traversal detected in skill file');
+
+    expect(existsSync(path.join(tmpRoot, 'etc', 'passwd'))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1804. `ContentInstaller._writeContent`'s path-traversal guard for multi-file skill packages used a bare prefix check:

```js
const resolvedPath = path.resolve(filePath);
if (!resolvedPath.startsWith(path.resolve(skillDir))) { ... }
```

Because `path.resolve(skillDir)` has no trailing separator, a companion filename that resolves into a *sibling* directory sharing the skill directory's name as a prefix (e.g. `skillDir` = `.../skills/foo`, filename `../foo-evil/x` → `.../skills/foo-evil/x`) incorrectly passed the boundary check. Current callers happen to constrain filenames enough that this isn't exploitable today, but the guard itself was wrong.

- Replaced the hand-rolled check with `resolveAndValidatePath(filename, skillDir)` from `server/utils/pathSecurity.js` — the same helper already used elsewhere (`skills.js`, `pages.js`, and the recently-fixed `#1806`/admin tools script paths) that does a separator-aware boundary check plus `fs.realpath` canonicalization.
- Added `server/tests/ContentInstaller.skill-path-traversal.test.js` covering: a benign companion file in a subdirectory still installs correctly, a sibling-directory-with-shared-prefix traversal is rejected, and a classic `../../` traversal is rejected.
- Added a changelog entry under `docs/releases/5.5.0/features.md` (no admin action required — behavior is unchanged for legitimate skill packages).

## Test plan

- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/ContentInstaller.skill-path-traversal.test.js` — 3/3 passing
- [x] `npx eslint server/services/marketplace/ContentInstaller.js server/tests/ContentInstaller.skill-path-traversal.test.js` — clean (only 3 pre-existing warnings in untouched lines)
- [x] `npx prettier --check` on both changed files — passes

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01E7BeR1YQLJTec6nJ91Nm1Y)_