### PR TITLE
Fix tool-argument repair corrupting valid JSON containing "}{" (#1802)

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -207,6 +207,18 @@ resolve into a sibling directory that merely shared the skill's directory name a
 
 - No admin action required; existing skill packages install exactly as before.
 
+## Tool Calls With Certain Text Arguments No Longer Get Corrupted
+
+Tool-call arguments containing the literal characters `}{` in a text value (for example a code
+snippet, regex, or JSON example) are no longer corrupted before being parsed. A parsing safeguard
+meant to repair concatenated streaming fragments was previously applied to every tool call
+unconditionally, silently mangling otherwise valid arguments or causing the tool to run with no
+arguments at all.
+
+- Tool arguments are now parsed as-is first; the streaming-fragment repair only runs as a fallback
+  when the original arguments aren't valid JSON.
+- No configuration or admin action required.
+
 ## Chat No Longer Crashes When a Response Finishes
 
 Chat responses now complete cleanly instead of failing with an "Add-in Error" (`setSearchStatus is

--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -382,6 +382,10 @@ class ToolExecutor {
     let args = {};
 
     try {
+      args = JSON.parse(toolCall.function.arguments);
+    } catch {
+      // Raw string wasn't valid JSON — attempt repairs for known streaming artifacts
+      // (concatenated fragments like `{...}{...}`, or a truncated leading/trailing brace).
       let finalArgs = toolCall.function.arguments.replace(/}{/g, ',');
       try {
         args = JSON.parse(finalArgs);
@@ -400,13 +404,6 @@ class ToolExecutor {
           args = {};
         }
       }
-    } catch (error) {
-      logger.error('Failed to parse tool arguments', {
-        component: 'ToolExecutor',
-        toolId,
-        arguments: toolCall.function.arguments,
-        error: error
-      });
     }
 
     logger.info('executeToolCall invoked', {

--- a/tests/unit/server/tool-executor-argument-parsing.test.js
+++ b/tests/unit/server/tool-executor-argument-parsing.test.js
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the tool-call argument parsing/repair logic in
+ * server/services/chat/ToolExecutor.js (executeToolCall).
+ *
+ * Regression coverage for issue #1802: the `}{` -> `,` repair heuristic used
+ * to run unconditionally, BEFORE the first JSON.parse attempt. That corrupted
+ * perfectly valid JSON whose string values legitimately contain the literal
+ * substring `}{` (e.g. a code snippet or regex passed as a tool argument).
+ * The fix tries JSON.parse on the raw, untouched string first and only falls
+ * back to the repair heuristics when that fails.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+
+// pathUtils resolves the app root via import.meta.url, which babel-jest's CJS
+// transform cannot express — stub it with an equivalent that works under jest.
+jest.mock('../../../server/pathUtils.js', () => ({
+  getRootDir: () => require('path').join(__dirname, '../../../')
+}));
+
+// configCache drags in the whole config/auth loading stack (more import.meta
+// modules). Argument parsing never touches configuration.
+jest.mock('../../../server/configCache.js', () => ({
+  default: {
+    getPlatform: () => ({}),
+    getApps: () => ({ data: [] }),
+    getModels: () => ({ data: [] })
+  }
+}));
+
+// requestThrottler / httpConfig pull in ESM-only node-fetch, which jest's CJS
+// transform can't load from node_modules. Never called here.
+jest.mock('../../../server/requestThrottler.js', () => ({
+  throttledFetch: jest.fn()
+}));
+jest.mock('../../../server/utils/httpConfig.js', () => ({
+  getSSLConfig: jest.fn(() => ({})),
+  getProxyConfig: jest.fn(() => ({})),
+  createAgent: jest.fn(),
+  enhanceFetchOptions: jest.fn(options => options),
+  httpFetch: jest.fn()
+}));
+
+// toolLoader reaches the MCP SDK (ESM-only in node_modules). runTool is
+// mocked so we can inspect exactly what arguments executeToolCall parsed.
+const mockRunTool = jest.fn(async () => ({ result: 'ok' }));
+jest.mock('../../../server/toolLoader.js', () => ({
+  runTool: (...args) => mockRunTool(...args),
+  getToolsForApp: jest.fn(async () => []),
+  loadTools: jest.fn(async () => [])
+}));
+
+// usageTracker imports the shared tokenEstimator, which uses import.meta to
+// lazily resolve its tokenizer. Token accounting is irrelevant here.
+jest.mock('../../../server/usageTracker.js', () => ({
+  estimateTokens: jest.fn(() => 0),
+  recordChatRequest: jest.fn(),
+  recordChatResponse: jest.fn()
+}));
+
+// Avoid writing real interaction logs to disk during the test run.
+jest.mock('../../../server/utils.js', () => ({
+  logInteraction: jest.fn(async () => {}),
+  getErrorDetails: jest.fn(error => ({ message: error?.message || String(error) }))
+}));
+
+// The real logger writes through winston's Console transport, which relies on
+// setImmediate — unavailable in jest's jsdom test environment. Argument
+// parsing doesn't need real logging.
+jest.mock('../../../server/utils/logger.js', () => ({
+  __esModule: true,
+  default: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    http: jest.fn(),
+    verbose: jest.fn(),
+    debug: jest.fn(),
+    silly: jest.fn()
+  }
+}));
+
+import ToolExecutor from '../../../server/services/chat/ToolExecutor.js';
+
+const TOOLS = [{ id: 'my_tool', parameters: { properties: {} } }];
+
+function makeToolCall(args) {
+  return {
+    id: 'call-1',
+    function: {
+      name: 'my_tool',
+      arguments: args
+    }
+  };
+}
+
+describe('ToolExecutor.executeToolCall argument parsing', () => {
+  beforeEach(() => {
+    mockRunTool.mockClear();
+  });
+
+  it('parses valid JSON containing a literal "}{" inside a string value without corrupting it', async () => {
+    const executor = new ToolExecutor();
+    const toolCall = makeToolCall('{"text":"}{"}');
+
+    await executor.executeToolCall(toolCall, TOOLS, 'chat-1', () => ({}));
+
+    expect(mockRunTool).toHaveBeenCalledTimes(1);
+    const [, calledArgs] = mockRunTool.mock.calls[0];
+    expect(calledArgs.text).toBe('}{');
+  });
+
+  it('still repairs concatenated streaming fragments like {"a":1}{"b":2}', async () => {
+    const executor = new ToolExecutor();
+    const toolCall = makeToolCall('{"a":1}{"b":2}');
+
+    await executor.executeToolCall(toolCall, TOOLS, 'chat-1', () => ({}));
+
+    const [, calledArgs] = mockRunTool.mock.calls[0];
+    expect(calledArgs.a).toBe(1);
+    expect(calledArgs.b).toBe(2);
+  });
+
+  it('falls back to empty args when arguments are unparseable even after repair', async () => {
+    const executor = new ToolExecutor();
+    const toolCall = makeToolCall('not json at all {{{');
+
+    await executor.executeToolCall(toolCall, TOOLS, 'chat-1', () => ({}));
+
+    const [, calledArgs] = mockRunTool.mock.calls[0];
+    expect(calledArgs.chatId).toBe('chat-1');
+    // No parsed properties beyond the ones executeToolCall injects itself.
+    expect(Object.keys(calledArgs).sort()).toEqual(['appConfig', 'chatId', 'user']);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1802.

`ToolExecutor.executeToolCall` applied the `}{` → `,` streaming-fragment repair heuristic
**unconditionally, before ever attempting to parse the raw tool-call arguments string**. Any
perfectly valid JSON whose string values happened to contain the literal substring `}{` (e.g. a
code snippet, regex, or text argument) was silently corrupted, or the corrupted string failed to
parse and the tool ran with empty arguments — with no error surfaced to the model.

- `JSON.parse` is now attempted on the raw, untouched arguments string first.
- Only when that fails do we fall back to the existing repair heuristics, in order: the `}{` → `,`
  merge (for genuinely concatenated streaming fragments like `{...}{...}`), then the
  bracket-wrapping repair, then giving up to `args = {}` with an error logged (unchanged final
  fallback behavior).
- Added `tests/unit/server/tool-executor-argument-parsing.test.js` covering: valid JSON containing
  a literal `}{` in a string value, concatenated streaming fragments still repairing correctly, and
  unparseable input still falling back to empty args.
- Added a changelog entry under `docs/releases/5.5.0/features.md`.

## Test plan

- [x] `npm run test:unit -- tests/unit/server/tool-executor-argument-parsing.test.js` — new tests
      pass (185/185 server+client suites that could run in this sandbox passed; the 5 unrelated
      failing suites are pre-existing missing client `node_modules` in this environment, not
      caused by this change).
- [x] `npx eslint` / `npx prettier --check` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2Zzny3dtdhepabFM7vsbG

---
_Generated by [Claude Code](https://claude.ai/code/session_01L2Zzny3dtdhepabFM7vsbG)_