### PR TITLE
fix(workflow): honor chat/workflow model in query-plan and quote-validator nodes

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -217,3 +217,19 @@ came from the shared chat used across the platform, so any app could be affected
 - Also fixes a related crash for iFinder-backed apps that emit a response message id (used for
   answer feedback), which previously interrupted the reply the same way.
 - No configuration or admin action required.
+
+## Workflow Search and Quote-Validation Steps Now Use the Configured Model
+
+The query-planning ("seed plan") and quote-validation steps in workflows now honor the same model
+selection as every other step. Previously these steps silently ran on the platform's global default
+model, ignoring both the model chosen in the chat/app and the workflow's own default — so a workflow
+pinned to one model could still run parts of a run on a different one.
+
+- Affects the corpus-search planning step (used by the Stellungnahmen / law-consultation review
+  workflows) and the quote-validation step.
+- Model precedence is now consistent across workflow steps: a per-step model wins, then the model
+  selected in the chat/app, then the workflow's default model, then the global default.
+- To pin a workflow step to a specific model regardless of the chat selection, set that step's model
+  in the workflow editor; this now takes effect for the planning and quote-validation steps too.
+- No configuration or admin action required; existing workflows pick up the corrected behavior
+  automatically.

--- a/server/services/workflow/executors/BaseNodeExecutor.js
+++ b/server/services/workflow/executors/BaseNodeExecutor.js
@@ -357,6 +357,69 @@ export class BaseNodeExecutor {
   }
 
   /**
+   * Resolve which model an LLM node should run on, using the SAME precedence as
+   * `prompt` nodes (`PromptNodeExecutor`). This is the shared default for every
+   * executor that calls an LLM; it is what makes `query-plan`, `quote-validator`
+   * and `prompt` nodes agree on model selection instead of each rolling its own
+   * (which previously left `query-plan`/`quote-validator` ignoring both the
+   * chat-selected model and the workflow-level default).
+   *
+   * Precedence (first match wins):
+   *   1. Node-level model — explicit `config.modelId`, else the DURABLE per-node
+   *      agent model (`_agentModelConfig.nodeModels[nodeId]`). A non-empty
+   *      `config.modelId` short-circuits before the durable lookup, matching the
+   *      prompt node exactly.
+   *   2. `_modelOverride` — the chat/app-selected model, injected into initial
+   *      data by `workflowRunner`. This is why the app's model overrides the
+   *      workflow's `defaultModelId` on chat-triggered runs.
+   *   3. Workflow-level `config.defaultModelId`, else the durable RUN-WIDE agent
+   *      default (`_agentModelConfig.defaultModelId`).
+   *   4. Execution-context model (`context.modelId`).
+   *   5. Global default (`models.find(m => m.default)`), else the first model.
+   *
+   * Pure w.r.t. config I/O — `models` is passed in, so this is unit-testable
+   * without mocking `configCache`. Returns null only when no models exist.
+   *
+   * NOTE: `VerifierNodeExecutor` intentionally overrides this with a different
+   * order (workflow default ahead of the durable per-node override); do not
+   * assume every node shares this exact precedence.
+   *
+   * @param {Array<Object>} models - Enabled model list (from configCache.getModels())
+   * @param {Object} [config] - Node config (may carry `modelId`)
+   * @param {Object} [context] - Execution context (carries `workflow.config`, `modelId`)
+   * @param {Object} [state] - Workflow state (reads `_modelOverride`, `_agentModelConfig`)
+   * @param {string} [nodeId] - Node id, for the per-node durable override lookup
+   * @returns {Object|null} Resolved model object, or null if no models are available
+   */
+  resolveModel(models, config = {}, context = {}, state = null, nodeId = undefined) {
+    if (!Array.isArray(models) || models.length === 0) return null;
+    const byId = id => (id ? models.find(m => m.id === id) : undefined);
+
+    // 1. Node-level model: explicit config.modelId, else the durable per-node
+    //    agent model. `config.modelId || …` matches the prompt node — a set-but-
+    //    invalid config.modelId falls through to _modelOverride, NOT to durable.
+    const nodeModel = byId(config?.modelId || this.resolveConfiguredModelId(state, nodeId));
+    if (nodeModel) return nodeModel;
+
+    // 2. Chat/app-selected model, injected as _modelOverride by workflowRunner.
+    const overrideModel = byId(state?.data?._modelOverride);
+    if (overrideModel) return overrideModel;
+
+    // 3. Workflow-level default, else the durable run-wide agent default.
+    const workflowModel = byId(
+      context?.workflow?.config?.defaultModelId || this.resolveConfiguredModelId(state)
+    );
+    if (workflowModel) return workflowModel;
+
+    // 4. Execution-context model.
+    const contextModel = byId(context?.modelId);
+    if (contextModel) return contextModel;
+
+    // 5. Global default.
+    return models.find(m => m.default) || models[0] || null;
+  }
+
+  /**
    * Build the state updates that record a node's step transcript for auditing,
    * preserving EVERY iteration instead of overwriting.
    *

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -253,10 +253,12 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
       // config.modelId may have been wiped by a config-cache TTL refresh (it's
       // applied at runtime by mutating the shared cached workflow). Fall back to
       // the durable per-run agent model config so we don't drop to local-vllm.
-      const resolvedModelId = config.modelId || this.resolveConfiguredModelId(state, node.id);
-      const model = await this.getModel(resolvedModelId, context, state);
+      const { data: models } = configCache.getModels();
+      const model = this.resolveModel(models, config, context, state, node.id);
       if (!model) {
-        return this.createErrorResult(`Model not found: ${resolvedModelId || 'default'}`, {
+        const requestedModelId =
+          config.modelId || this.resolveConfiguredModelId(state, node.id) || 'default';
+        return this.createErrorResult(`Model not found: ${requestedModelId}`, {
           nodeId: node.id
         });
       }
@@ -1215,66 +1217,6 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
     }
 
     return result;
-  }
-
-  /**
-   * Get model configuration by ID or use default.
-   *
-   * Priority order:
-   * 1. Model specified in node config (config.modelId)
-   * 2. Model override from initial data (_modelOverride)
-   * 3. Workflow-level defaultModelId from workflow config
-   * 4. Model from execution context
-   * 5. Default model
-   *
-   * @param {string} modelId - Model ID from node config or null
-   * @param {Object} context - Execution context
-   * @param {Object} state - Current workflow state
-   * @returns {Promise<Object|null>} Model configuration or null
-   * @private
-   */
-  async getModel(modelId, context, state) {
-    const { data: models } = configCache.getModels();
-    if (!models) {
-      return null;
-    }
-
-    // 1. Use model from node config if specified. If the configured model
-    //    isn't in the enabled set (e.g. its id was wiped/changed), fall
-    //    through to the durable fallbacks below rather than failing the node.
-    if (modelId) {
-      const configured = models.find(m => m.id === modelId);
-      if (configured) return configured;
-    }
-
-    // 2. Check for model override from initial data (user selection at start)
-    const modelOverride = state?.data?._modelOverride;
-    if (modelOverride) {
-      const overrideModel = models.find(m => m.id === modelOverride);
-      if (overrideModel) {
-        return overrideModel;
-      }
-    }
-
-    // 3. Check workflow-level defaultModelId, then the DURABLE per-run agent
-    //    model config (state survives the config-cache TTL refresh that wipes
-    //    the runtime-applied workflow.config.defaultModelId).
-    const workflowDefaultModelId =
-      context.workflow?.config?.defaultModelId || this.resolveConfiguredModelId(state);
-    if (workflowDefaultModelId) {
-      const workflowModel = models.find(m => m.id === workflowDefaultModelId);
-      if (workflowModel) {
-        return workflowModel;
-      }
-    }
-
-    // 4. Use context model if available
-    if (context.modelId) {
-      return models.find(m => m.id === context.modelId);
-    }
-
-    // 5. Fall back to default model
-    return models.find(m => m.default) || models[0];
   }
 
   /**

--- a/server/services/workflow/executors/QueryPlanNodeExecutor.js
+++ b/server/services/workflow/executors/QueryPlanNodeExecutor.js
@@ -35,7 +35,6 @@ export class QueryPlanNodeExecutor extends BaseNodeExecutor {
       questionPath = '$.data.userQuestion',
       seedsPath,
       outputVar = '_queryPlan',
-      modelId,
       maxTopics = 8,
       maxSynonymsPerTopic = 5,
       queryLanguage: configQueryLanguage,
@@ -71,8 +70,11 @@ export class QueryPlanNodeExecutor extends BaseNodeExecutor {
     const seeds = seedsPath ? this.resolveVariable(seedsPath, state) : null;
 
     const { data: models } = configCache.getModels();
-    const model =
-      models?.find(m => m.id === modelId) || models?.find(m => m.default) || models?.[0];
+    // Use the shared prompt-node precedence (config.modelId → _modelOverride →
+    // workflow defaultModelId → context → global default) so the seed-plan step
+    // honors the chat-selected model and the workflow default instead of
+    // silently dropping to the global default model.
+    const model = this.resolveModel(models, config, context, state, node.id);
     if (!model) {
       return this.createErrorResult('No model available for query planning', { nodeId: node.id });
     }

--- a/server/services/workflow/executors/QuoteValidatorNodeExecutor.js
+++ b/server/services/workflow/executors/QuoteValidatorNodeExecutor.js
@@ -46,7 +46,6 @@ export class QuoteValidatorNodeExecutor extends BaseNodeExecutor {
       recordsVar = '_records',
       coverageVar = '_coverage',
       corpusVar = '_corpus',
-      modelId,
       maxSourceChars = 30000
     } = config;
     const language = context?.language || 'en';
@@ -124,7 +123,13 @@ export class QuoteValidatorNodeExecutor extends BaseNodeExecutor {
 
         // Lazily resolve model + key on first LLM need.
         if (!model) {
-          const resolved = await this.resolveModelAndKey(modelId, language);
+          const resolved = await this.resolveModelAndKey({
+            config,
+            context,
+            state,
+            nodeId: node.id,
+            language
+          });
           if (!resolved.ok) {
             // Mark remaining quotes unvalidated and stop trying further LLM calls
             // for this run — the lack of a valid model is a run-level problem.
@@ -224,10 +229,12 @@ export class QuoteValidatorNodeExecutor extends BaseNodeExecutor {
     );
   }
 
-  async resolveModelAndKey(modelId, language) {
+  async resolveModelAndKey({ config, context, state, nodeId, language }) {
     const { data: models } = configCache.getModels();
-    const model =
-      models?.find(m => m.id === modelId) || models?.find(m => m.default) || models?.[0];
+    // Shared prompt-node precedence (config.modelId → _modelOverride → workflow
+    // defaultModelId → context → global default) so quote validation runs on the
+    // same model the rest of the workflow uses, not the global default.
+    const model = this.resolveModel(models, config, context, state, nodeId);
     if (!model) {
       return { ok: false, error: 'No model available for quote validation' };
     }

--- a/server/services/workflow/executors/VerifierNodeExecutor.js
+++ b/server/services/workflow/executors/VerifierNodeExecutor.js
@@ -454,15 +454,24 @@ export class VerifierNodeExecutor extends BaseNodeExecutor {
    * @returns {{ passed: boolean, score: number, feedback: string, verdict: string, failures: string[] }}
    */
   /**
-   * Resolve the verification model with the same precedence the prompt node
-   * uses: explicit per-node `config.modelId` → the run's workflow-level
-   * `defaultModelId` (published from the agent profile's preferredModel) →
-   * the global default → the first available model. Pure, so it's unit-tested
+   * Resolve the verification model. This intentionally OVERRIDES
+   * `BaseNodeExecutor.resolveModel` with a precedence tuned for agent runs:
+   * explicit per-node `config.modelId` → the run's workflow-level
+   * `defaultModelId` (published from the agent profile's preferredModel) → the
+   * DURABLE per-run agent model config → the global default → the first
+   * available model.
+   *
+   * Two deliberate differences from the base (prompt-node) precedence: the
+   * workflow/profile default is preferred OVER the durable per-node override so
+   * a verifier follows the operator-configured run model, and `_modelOverride`
+   * (the chat-selected model) is not consulted. Pure, so it's unit-tested
    * directly without configCache. Returns null when no models are available.
    *
    * @param {Array} models
    * @param {Object} config - node config (may carry modelId)
    * @param {Object} context - execution context (carries workflow.config)
+   * @param {Object} [state] - workflow state (durable agent model config)
+   * @param {string} [nodeId] - node id for the per-node durable lookup
    * @returns {Object|null}
    */
   resolveModel(models, config = {}, context = {}, state = null, nodeId = undefined) {

--- a/server/tests/workflow-model-resolution.test.js
+++ b/server/tests/workflow-model-resolution.test.js
@@ -1,0 +1,113 @@
+// Plain-node test (node server/tests/workflow-model-resolution.test.js).
+// Covers the shared BaseNodeExecutor.resolveModel precedence and the fact that
+// query-plan / quote-validator nodes now inherit it (previously they resolved
+// only config.modelId → global default, ignoring the chat-selected model and
+// the workflow-level default). Verifier intentionally keeps its own override.
+import { BaseNodeExecutor } from '../services/workflow/executors/BaseNodeExecutor.js';
+import { QueryPlanNodeExecutor } from '../services/workflow/executors/QueryPlanNodeExecutor.js';
+import { QuoteValidatorNodeExecutor } from '../services/workflow/executors/QuoteValidatorNodeExecutor.js';
+import { VerifierNodeExecutor } from '../services/workflow/executors/VerifierNodeExecutor.js';
+
+let failures = 0;
+function check(label, cond, detail) {
+  if (!cond) failures++;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && detail) console.log('   ' + detail);
+}
+
+function run() {
+  const base = new BaseNodeExecutor();
+  const models = [
+    { id: 'global-default', default: true },
+    { id: 'node-model' },
+    { id: 'app-model' },
+    { id: 'workflow-model' },
+    { id: 'context-model' },
+    { id: 'durable-node-model' },
+    { id: 'durable-run-model' }
+  ];
+
+  const wfCtx = { workflow: { config: { defaultModelId: 'workflow-model' } } };
+
+  // 1. Explicit node config.modelId wins over everything else.
+  check(
+    'config.modelId wins over override/workflow/context',
+    base.resolveModel(
+      models,
+      { modelId: 'node-model' },
+      { ...wfCtx, modelId: 'context-model' },
+      { data: { _modelOverride: 'app-model' } },
+      'n1'
+    )?.id === 'node-model'
+  );
+
+  // 2. THE FIX: the chat/app-selected model (_modelOverride) beats the
+  //    workflow-level defaultModelId, the context model, and the global default.
+  const m2 = base.resolveModel(
+    models,
+    {},
+    { ...wfCtx, modelId: 'context-model' },
+    { data: { _modelOverride: 'app-model' } },
+    'n1'
+  );
+  check('_modelOverride beats workflow defaultModelId', m2?.id === 'app-model', m2?.id);
+
+  // 3. Workflow defaultModelId is used when no node model / override is present.
+  check(
+    'workflow defaultModelId used when no override',
+    base.resolveModel(models, {}, wfCtx, { data: {} }, 'n1')?.id === 'workflow-model'
+  );
+
+  // 4. context.modelId used when nothing higher-priority is set.
+  check(
+    'context.modelId used as a later fallback',
+    base.resolveModel(models, {}, { modelId: 'context-model' }, { data: {} }, 'n1')?.id ===
+      'context-model'
+  );
+
+  // 5. Global default is the final fallback.
+  check(
+    'global default is the final fallback',
+    base.resolveModel(models, {}, {}, { data: {} }, 'n1')?.id === 'global-default'
+  );
+
+  // 6. Durable per-node agent model (step 1) wins even over _modelOverride,
+  //    matching prompt-node behavior for agent runs.
+  const stateNode = {
+    data: {
+      _modelOverride: 'app-model',
+      _agentModelConfig: {
+        defaultModelId: 'durable-run-model',
+        nodeModels: { n1: 'durable-node-model' }
+      }
+    }
+  };
+  check(
+    'durable per-node model wins over _modelOverride',
+    base.resolveModel(models, {}, {}, stateNode, 'n1')?.id === 'durable-node-model'
+  );
+
+  // 7. No models → null (both empty and non-array).
+  check('empty models → null', base.resolveModel([], {}, {}) === null);
+  check('non-array models → null', base.resolveModel(null, {}, {}) === null);
+
+  // 8. Design intent: query-plan and quote-validator INHERIT the base resolver
+  //    (no per-executor override), while verifier intentionally overrides it.
+  check(
+    'QueryPlan inherits BaseNodeExecutor.resolveModel',
+    QueryPlanNodeExecutor.prototype.resolveModel === BaseNodeExecutor.prototype.resolveModel
+  );
+  check(
+    'QuoteValidator inherits BaseNodeExecutor.resolveModel',
+    QuoteValidatorNodeExecutor.prototype.resolveModel === BaseNodeExecutor.prototype.resolveModel
+  );
+  check(
+    'Verifier intentionally overrides resolveModel',
+    VerifierNodeExecutor.prototype.resolveModel !== BaseNodeExecutor.prototype.resolveModel
+  );
+
+  console.log(`\n${failures === 0 ? '✅ all passed' : `❌ ${failures} failed`}`);
+  process.exit(failures ? 1 : 0);
+}
+
+run();


### PR DESCRIPTION
## Problem

In workflows, the `query-plan` (the **seed-plan** in the Stellungnahmen / law-consultation review workflows) and `quote-validator` nodes resolved their model as **`config.modelId` → global default only**. They ignored both:

- the **chat/app-selected model** (`_modelOverride`, injected by `workflowRunner`), and
- the **workflow-level `defaultModelId`**.

So even when a workflow was pinned to a model — or a user picked one in chat — those steps silently ran on the platform's global default model. This is what made the seed-plan behave inconsistently with the rest of a run.

Meanwhile `prompt` nodes already implemented the full precedence, and `VerifierNodeExecutor` had its own (yet different) copy — three divergent implementations.

## Fix

Hoist the prompt-node precedence into a single shared method:

```
BaseNodeExecutor.resolveModel(models, config, context, state, nodeId)
```

- `QueryPlanNodeExecutor` and `QuoteValidatorNodeExecutor` now use it (the actual fix).
- `PromptNodeExecutor` delegates to it too, so there is **one source of truth** for the prompt precedence (its now-dead `getModel` is removed — behavior preserved, with a slightly more graceful fallback on an invalid configured id).
- `VerifierNodeExecutor` is intentionally **left as-is**: its tests require the workflow/profile default to win over the durable per-node override — the opposite of prompt ordering — so it keeps its own resolver. Its misleading "same as the prompt node" comment is corrected to document the intentional divergence.

### Resolved precedence (first match wins)

1. Node `config.modelId` (else the durable per-node agent model)
2. `_modelOverride` — the chat/app-selected model
3. Workflow `config.defaultModelId` (else the durable run-wide agent default)
4. `context.modelId`
5. Global default model

## Impact

- To **pin** a workflow step to a model regardless of the chat selection, set that step's `modelId` — this now takes effect for the planning and quote-validation steps too.
- No config or migration needed; existing workflows pick up the corrected behavior automatically.

## Testing

- New `server/tests/workflow-model-resolution.test.js` — 11 checks covering the full precedence, the `_modelOverride`-beats-workflow-default fix, durable-config handling, empty-models, and the inherit-vs-override design intent. **All pass.**
- Existing `agent-durable-model-config.test.js` and `agent-adversarial-verifier.test.js` (Verifier resolver) — **still pass**, confirming Verifier behavior is unchanged.
- `eslint` (no new errors) and `prettier` clean on all changed files.

_Note: a pre-existing circular-import issue in `executors/index.js` makes `CorpusSearchNodeExecutor.pagination.test.js` fail to load depending on entry order; verified identical on `main` with these changes stashed — out of scope here._

## Changelog

Added an entry to `docs/releases/5.5.0/features.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Snvefw5uPURufvLC75iTkj)_