### PR TITLE
fix(tools): parse raw tool-call arguments before applying }{ repair heuristic

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -217,3 +217,15 @@ came from the shared chat used across the platform, so any app could be affected
 - Also fixes a related crash for iFinder-backed apps that emit a response message id (used for
   answer feedback), which previously interrupted the reply the same way.
 - No configuration or admin action required.
+
+## Tool Arguments Are No Longer Corrupted by a Stray Repair Step
+
+Tool calls whose arguments legitimately contained the text `}{` — for example a code snippet or a
+regular expression passed as a string value — could be silently corrupted before being handed to
+the tool, or fail to parse entirely and run with empty arguments. A repair step meant to patch
+concatenated streaming fragments was applied to every tool call before the arguments were even
+checked for validity.
+
+- Valid tool arguments are now parsed as-is; the fragment-repair heuristic only kicks in as a
+  fallback when the arguments aren't valid JSON on their own.
+- No configuration or admin action required.

--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -382,6 +382,11 @@ class ToolExecutor {
     let args = {};
 
     try {
+      args = JSON.parse(toolCall.function.arguments);
+    } catch {
+      // Raw string wasn't valid JSON — likely concatenated streaming fragments
+      // (e.g. "{...}{...}"). Only apply the merge heuristic as a fallback so
+      // valid JSON whose string values legitimately contain "}{" isn't corrupted.
       let finalArgs = toolCall.function.arguments.replace(/}{/g, ',');
       try {
         args = JSON.parse(finalArgs);
@@ -400,13 +405,6 @@ class ToolExecutor {
           args = {};
         }
       }
-    } catch (error) {
-      logger.error('Failed to parse tool arguments', {
-        component: 'ToolExecutor',
-        toolId,
-        arguments: toolCall.function.arguments,
-        error: error
-      });
     }
 
     logger.info('executeToolCall invoked', {

--- a/tests/unit/server/tool-executor-argument-parsing.test.js
+++ b/tests/unit/server/tool-executor-argument-parsing.test.js
@@ -1,0 +1,125 @@
+/**
+ * @jest-environment node
+ *
+ * Regression coverage for issue #1802: executeToolCall used to run
+ * `arguments.replace(/}{/g, ',')` unconditionally, BEFORE the first JSON.parse
+ * attempt. That corrupted otherwise-valid JSON whose string values legitimately
+ * contain the literal substring "}{" (e.g. a code snippet or regex argument).
+ *
+ * The fix tries JSON.parse on the raw string first, and only falls back to the
+ * "}{ -> ," merge heuristic (then bracket-wrapping) when the raw parse fails.
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('../../../server/pathUtils.js', () => ({
+  getRootDir: () => require('path').join(__dirname, '../../../')
+}));
+
+jest.mock('../../../server/configCache.js', () => ({
+  default: {
+    getPlatform: () => ({}),
+    getApps: () => ({ data: [] }),
+    getModels: () => ({ data: [] })
+  }
+}));
+
+jest.mock('../../../server/requestThrottler.js', () => ({
+  throttledFetch: jest.fn()
+}));
+jest.mock('../../../server/utils/httpConfig.js', () => ({
+  getSSLConfig: jest.fn(() => ({})),
+  getProxyConfig: jest.fn(() => ({})),
+  createAgent: jest.fn(),
+  enhanceFetchOptions: jest.fn(options => options),
+  httpFetch: jest.fn()
+}));
+
+const mockRunTool = jest.fn(async () => ({ result: 'ok' }));
+jest.mock('../../../server/toolLoader.js', () => ({
+  runTool: (...args) => mockRunTool(...args),
+  getToolsForApp: jest.fn(async () => []),
+  loadTools: jest.fn(async () => [])
+}));
+
+jest.mock('../../../server/usageTracker.js', () => ({
+  estimateTokens: jest.fn(() => 0),
+  recordChatRequest: jest.fn(),
+  recordChatResponse: jest.fn()
+}));
+
+jest.mock('../../../server/utils.js', () => ({
+  logInteraction: jest.fn(async () => {}),
+  getErrorDetails: jest.fn(() => ({ message: 'err', code: 'ERR' }))
+}));
+
+import ToolExecutor from '../../../server/services/chat/ToolExecutor.js';
+
+const TOOLS = [{ id: 'echo', parameters: { properties: {} } }];
+
+function makeToolCall(argsString) {
+  return {
+    id: 'call-1',
+    function: { name: 'echo', arguments: argsString }
+  };
+}
+
+describe('ToolExecutor.executeToolCall argument parsing', () => {
+  beforeEach(() => {
+    mockRunTool.mockClear();
+  });
+
+  it('parses plain valid JSON arguments unchanged', async () => {
+    await new ToolExecutor().executeToolCall(
+      makeToolCall('{"query":"hello"}'),
+      TOOLS,
+      'chat-1',
+      () => ({}),
+      { id: 'u' },
+      { id: 'app' }
+    );
+
+    expect(mockRunTool).toHaveBeenCalledWith('echo', expect.objectContaining({ query: 'hello' }));
+  });
+
+  it('does not corrupt valid JSON whose string value contains the literal "}{"', async () => {
+    await new ToolExecutor().executeToolCall(
+      makeToolCall('{"text":"}{"}'),
+      TOOLS,
+      'chat-1',
+      () => ({}),
+      { id: 'u' },
+      { id: 'app' }
+    );
+
+    expect(mockRunTool).toHaveBeenCalledWith('echo', expect.objectContaining({ text: '}{' }));
+  });
+
+  it('still repairs concatenated streaming fragments like {"a":1}{"b":2}', async () => {
+    await new ToolExecutor().executeToolCall(
+      makeToolCall('{"a":1}{"b":2}'),
+      TOOLS,
+      'chat-1',
+      () => ({}),
+      { id: 'u' },
+      { id: 'app' }
+    );
+
+    expect(mockRunTool).toHaveBeenCalledWith('echo', expect.objectContaining({ a: 1, b: 2 }));
+  });
+
+  it('falls back to empty args when arguments are unparseable even after repair', async () => {
+    await new ToolExecutor().executeToolCall(
+      makeToolCall('not json at all'),
+      TOOLS,
+      'chat-1',
+      () => ({}),
+      { id: 'u' },
+      { id: 'app' }
+    );
+
+    const callArgs = mockRunTool.mock.calls[0][1];
+    expect(callArgs.query).toBeUndefined();
+    expect(callArgs.chatId).toBe('chat-1');
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1802.

`ToolExecutor.executeToolCall` unconditionally ran `arguments.replace(/}{/g, ',')` on the raw tool-call arguments string **before** attempting `JSON.parse`. That regex was meant to repair concatenated streaming fragments (e.g. `{"a":1}{"b":2}`), but it ran even on perfectly valid JSON — so any argument whose string value legitimately contained the literal substring `}{` (a code snippet, a regex, etc.) got corrupted, either producing silently wrong values or failing to parse and falling back to `args = {}` with no error surfaced to the model.

- `JSON.parse` is now tried on the raw arguments string first.
- The `}{` → `,` merge heuristic, and the existing bracket-wrapping repair, only run as fallbacks when the raw parse fails.
- Final failure still falls back to `args = {}` with an error logged (unchanged behavior).

## Changes

- `server/services/chat/ToolExecutor.js`: reordered the parse/repair logic in `executeToolCall`.
- `tests/unit/server/tool-executor-argument-parsing.test.js`: new regression tests covering (1) plain valid JSON, (2) valid JSON containing a literal `}{` in a string value, (3) concatenated streaming fragments still repairing correctly, and (4) unparseable arguments still falling back to `{}`.
- `docs/releases/5.5.0/features.md`: changelog entry.

## Test plan

- [x] `npx jest --config tests/config/jest.config.js tests/unit/server/tool-executor-argument-parsing.test.js` — 4/4 passing
- [x] `npx jest --config tests/config/jest.config.js tests/unit/server` — 104/104 passing (no regressions)
- [x] `npx eslint` / `npx prettier --check` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UoW89Ct6Ts5HC3uRJxGqHk

---
_Generated by [Claude Code](https://claude.ai/code/session_01UoW89Ct6Ts5HC3uRJxGqHk)_