### PR TITLE
fix(anthropic): stop sending a stray Authorization: undefined header

### DIFF
--- a/server/adapters/anthropic.js
+++ b/server/adapters/anthropic.js
@@ -211,9 +211,8 @@ class AnthropicAdapterClass extends BaseAdapter {
       url: model.url,
       method: 'POST',
       headers: {
-        ...this.createRequestHeaders(apiKey),
+        'Content-Type': 'application/json',
         'x-api-key': apiKey || '', // Anthropic uses x-api-key instead of Authorization
-        Authorization: undefined, // Remove Authorization header for Anthropic
         'anthropic-version': '2023-06-01' // TODO check if still accurate
       },
       body: requestBody

--- a/server/tests/anthropic-headers.test.js
+++ b/server/tests/anthropic-headers.test.js
@@ -1,0 +1,30 @@
+import AnthropicAdapter from '../adapters/anthropic.js';
+
+describe('AnthropicAdapter request headers', () => {
+  const model = {
+    modelId: 'claude-4-sonnet',
+    url: 'https://api.anthropic.com/v1/messages',
+    provider: 'anthropic'
+  };
+  const messages = [{ role: 'user', content: 'test' }];
+
+  test('does not send an Authorization header', async () => {
+    const req = await AnthropicAdapter.createCompletionRequest(model, messages, 'test-key');
+
+    expect(req.headers).not.toHaveProperty('Authorization');
+
+    // A plain object key check isn't sufficient — { Authorization: undefined }
+    // passes the check above but still serializes to a real wire header via
+    // fetch's Headers class, which is how this bug slipped through originally.
+    const headers = new Headers(req.headers);
+    expect(headers.has('authorization')).toBe(false);
+  });
+
+  test('sends x-api-key and anthropic-version headers', async () => {
+    const req = await AnthropicAdapter.createCompletionRequest(model, messages, 'test-key');
+
+    expect(req.headers['x-api-key']).toBe('test-key');
+    expect(req.headers['anthropic-version']).toBe('2023-06-01');
+    expect(req.headers['Content-Type']).toBe('application/json');
+  });
+});


### PR DESCRIPTION
## Summary

- The Anthropic adapter built its request headers by spreading `createRequestHeaders(apiKey)` (which sets `Authorization: Bearer <key>`) and then tried to remove it via `Authorization: undefined`. Object spread keeps the key, so `fetch`/`Headers` serialized every Anthropic request with a literal `authorization: undefined` header instead of omitting it — the stated intent ("Remove Authorization header for Anthropic") never actually happened.
- Replaced the spread with an explicit headers object (`Content-Type`, `x-api-key`, `anthropic-version`) for the Anthropic request builder, so `Authorization` is never introduced in the first place.
- Added a regression test that checks both the plain object (`toHaveProperty`) and a real `Headers` instance, since the plain-object check alone is what let this bug slip through originally.

Anthropic currently authenticates via `x-api-key` and ignores `Authorization`, so this was harmless in practice, but is a latent risk for any proxy/WAF or a future Anthropic API version that validates `Authorization` headers.

Fixes #1801

## Test plan

- [x] Added `server/tests/anthropic-headers.test.js`, verified it fails against the old code (`Authorization: undefined`) and passes with the fix
- [x] `npx eslint server/adapters/anthropic.js server/tests/anthropic-headers.test.js` — clean
- [x] `npx prettier --write` on changed files — no changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T4J91JHVdPb3W2NGBC4BJc

---
_Generated by [Claude Code](https://claude.ai/code/session_01T4J91JHVdPb3W2NGBC4BJc)_