### PR TITLE
fix(cli): stop catch(error) from shadowing error() logger in update CLI

### DIFF
--- a/server/cli/update.js
+++ b/server/cli/update.js
@@ -228,8 +228,8 @@ export async function runUpdateCLI(subcommand, force = false) {
         process.exit(0);
       }
     }
-  } catch (error) {
-    error(error.message);
+  } catch (err) {
+    error(err.message);
     process.exit(1);
   }
 }

--- a/server/tests/update-cli-error-handling.test.js
+++ b/server/tests/update-cli-error-handling.test.js
@@ -1,0 +1,50 @@
+/**
+ * Regression test for #1799: runUpdateCLI's catch block used `catch (error)`,
+ * which shadowed the module-scoped `error(msg)` logger, so any real failure
+ * crashed with "TypeError: error is not a function" instead of printing the
+ * actual failure message.
+ *
+ * Note: The repo's source is native ESM (uses `import.meta.url`), so this
+ * file uses `jest.unstable_mockModule` + dynamic imports rather than the
+ * CommonJS-only `jest.mock` API. Run with
+ * `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+
+const failure = new Error('network error contacting GitHub');
+
+jest.unstable_mockModule('../services/updateService.js', () => ({
+  checkForUpdate: jest.fn(async () => {
+    throw failure;
+  }),
+  downloadUpdate: jest.fn(),
+  applyUpdate: jest.fn(),
+  rollback: jest.fn(),
+  getUpdateStatus: jest.fn(),
+  isBinaryInstallation: () => true,
+  isContainerInstallation: () => false,
+  checkDiskSpace: jest.fn(),
+  checkWritePermissions: jest.fn()
+}));
+
+const { runUpdateCLI } = await import('../cli/update.js');
+
+describe('runUpdateCLI error handling', () => {
+  it('logs the real failure message instead of crashing on a shadowed error() helper', async () => {
+    const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => {});
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+
+    await runUpdateCLI('check');
+
+    const loggedMessages = errorSpy.mock.calls.map(call => call.join(' '));
+    expect(loggedMessages.some(msg => msg.includes(failure.message))).toBe(true);
+    expect(loggedMessages.some(msg => msg.includes('is not a function'))).toBe(false);
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+    errorSpy.mockRestore();
+    logSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- `runUpdateCLI`'s top-level `catch (error)` shadowed the module-scoped `error(msg)` logging helper (`server/cli/update.js:44`), so any real failure in the self-update CLI (network error, checksum mismatch, download/apply/rollback failure) crashed with `TypeError: error is not a function` instead of printing the actual failure message.
- Renamed the catch binding to `err` so `error(err.message)` correctly invokes the logger.
- Added a regression test (`server/tests/update-cli-error-handling.test.js`) that mocks `updateService.checkForUpdate` to reject and asserts `runUpdateCLI('check')` logs the real error message (not "is not a function") and exits with code 1. Verified the test fails against the old code and passes against the fix.

## Test plan
- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/update-cli-error-handling.test.js` passes
- [x] Confirmed the new test reproduces the original `TypeError: error is not a function` when the fix is reverted
- [x] `npx eslint server/cli/update.js server/tests/update-cli-error-handling.test.js` — no errors
- [x] `npx prettier --check` — no formatting issues

Fixes #1799

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Chsx6Q2YwZG6wpGutLLTFe

---
_Generated by [Claude Code](https://claude.ai/code/session_01Chsx6Q2YwZG6wpGutLLTFe)_