### PR TITLE
fix: add missing CACHE_KEYS entries so cache keys never resolve to undefined

### DIFF
--- a/client/src/utils/cache.js
+++ b/client/src/utils/cache.js
@@ -220,7 +220,11 @@ export const CACHE_KEYS = {
   UI_CONFIG: 'ui-config',
   PLATFORM_CONFIG: 'platform-config',
   AUTH_STATUS: 'auth-status',
-  MIMETYPES_CONFIG: 'mimetypes-config'
+  MIMETYPES_CONFIG: 'mimetypes-config',
+  TRANSLATIONS: 'translations',
+  PAGE_CONTENT: 'page-content',
+  TOOLS: 'tools-list',
+  MODEL_DETAILS: 'model-details'
 };
 
 /**


### PR DESCRIPTION
## Summary

`CACHE_KEYS` in `client/src/utils/cache.js` only defined 9 members, but `client/src/api/endpoints/misc.js` and `models.js` already referenced 4 more that didn't exist: `TRANSLATIONS`, `PAGE_CONTENT`, `TOOLS`, `MODEL_DETAILS`.

- `fetchToolsBasic` passed the bare `CACHE_KEYS.TOOLS` (`undefined`) directly as the cache key into `handleApiResponse`, whose cache/dedup gates are plain truthiness checks — so tool lists were fetched fresh on every call with zero caching or deduplication, despite the explicit `DEFAULT_CACHE_TTL.MEDIUM` argument.
- The other three (`TRANSLATIONS`, `PAGE_CONTENT`, `MODEL_DETAILS`) went through `buildCacheKey(undefined, params)`, which "worked" only by accident by stringifying into a literal `"undefined?..."` key prefix — functional today but fragile and one bad refactor away from key collisions.

This adds the 4 missing constants so every reference resolves to a real, distinct string, matching the existing kebab-case convention.

## Changes

- `client/src/utils/cache.js`: added `TRANSLATIONS`, `PAGE_CONTENT`, `TOOLS`, `MODEL_DETAILS` to `CACHE_KEYS`. No call-site changes needed — `misc.js` and `models.js` already reference these constants correctly.

## Test plan

- [x] `npx eslint client/src/utils/cache.js` — clean
- [ ] Manual smoke check: load a page that calls `fetchToolsBasic` twice within 5 minutes and confirm the second call hits the in-memory cache instead of firing a new `/tools` request

Note: I attempted to add a regression test under `tests/unit/client/`, but importing `cache.js` directly fails under the current Jest config — the file uses `import.meta.env.DEV` (Vite-only syntax) which the project's Babel preset doesn't transform for CommonJS, so no existing test imports this module. Fixing that is a test-infra change out of scope for this small fix.

Fixes #1796

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01EuPJWdcHzZb4G8SLBkq5VN)_