### PR TITLE
Fix createSourceManager silently ignoring per-call config

### DIFF
--- a/server/services/PromptService.js
+++ b/server/services/PromptService.js
@@ -2,9 +2,6 @@ import { getLocalizedContent } from '../../shared/localize.js';
 import configCache from '../configCache.js';
 import { createSourceManager } from '../sources/index.js';
 import SourceResolutionService from './SourceResolutionService.js';
-import config from '../config.js';
-import { getRootDir } from '../pathUtils.js';
-import path from 'path';
 import { isFeatureEnabled } from '../featureRegistry.js';
 import logger from '../utils/logger.js';
 
@@ -293,12 +290,10 @@ class PromptService {
           const resolvedSources = await sourceResolutionService.resolveAppSources(app, context);
 
           if (resolvedSources.length > 0) {
-            // Create source manager for content loading
-            const sourceManager = createSourceManager({
-              filesystem: {
-                basePath: path.resolve(getRootDir(), config.CONTENTS_DIR)
-              }
-            });
+            // createSourceManager() is a process-wide singleton; config is only
+            // honored on the very first call, so we rely on FileSystemHandler's
+            // own default basePath here instead of passing a redundant override.
+            const sourceManager = createSourceManager();
 
             // Load content from resolved sources
             const result = await sourceManager.loadSources(resolvedSources, context);

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -27,9 +27,6 @@ import { dedupeCitations } from '../citationUtils.js';
 import { estimateTokens } from '../../../usageTracker.js';
 import SourceResolutionService from '../../SourceResolutionService.js';
 import { createSourceManager } from '../../../sources/index.js';
-import config from '../../../config.js';
-import { getRootDir } from '../../../pathUtils.js';
-import path from 'path';
 import logger from '../../../utils/logger.js';
 import { getAgentToolIds } from '../../../agents/runtime/agentToolRegistrar.js';
 import { readMemoryBodyForPrompt } from '../../../agents/memory/memoryFile.js';
@@ -1365,12 +1362,11 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
         };
       }
 
-      // Load content from resolved sources
-      const sourceManager = createSourceManager({
-        filesystem: {
-          basePath: path.resolve(getRootDir(), config.CONTENTS_DIR)
-        }
-      });
+      // Load content from resolved sources.
+      // createSourceManager() is a process-wide singleton; config is only
+      // honored on the very first call, so we rely on FileSystemHandler's
+      // own default basePath here instead of passing a redundant override.
+      const sourceManager = createSourceManager();
 
       const result = await sourceManager.loadSources(resolvedSources, sourceContext);
 

--- a/server/sources/index.js
+++ b/server/sources/index.js
@@ -16,7 +16,12 @@ import SourceManager from './SourceManager.js';
 // Singleton instance of SourceManager
 let singletonSourceManager = null;
 
-// Factory function to create source manager with default configuration
+// Factory function to create source manager with default configuration.
+// NOTE: this is a process-wide singleton — `config` is only honored on the
+// very first call. Later calls, regardless of what they pass, receive the
+// already-constructed instance unchanged. Callers that need a custom
+// filesystem basePath etc. must ensure that config is supplied by whichever
+// call happens to run first, or rely on the handler defaults instead.
 export const createSourceManager = (config = {}) => {
   if (!singletonSourceManager) {
     singletonSourceManager = new SourceManager(config);

--- a/server/tests/source-manager-singleton.test.js
+++ b/server/tests/source-manager-singleton.test.js
@@ -1,0 +1,30 @@
+/**
+ * Regression test for createSourceManager()'s singleton behavior.
+ *
+ * createSourceManager() caches a single SourceManager instance in module
+ * scope and only honors the `config` argument on the very first call —
+ * every later call, regardless of what it passes, receives the
+ * already-constructed instance unchanged. This test locks in that
+ * documented behavior so a future refactor can't silently start
+ * reconfiguring (or silently keep dropping) per-call config without the
+ * test suite noticing either way.
+ *
+ * See issue #1794.
+ */
+
+import { createSourceManager } from '../sources/index.js';
+
+describe('createSourceManager singleton', () => {
+  it('ignores config passed on calls after the first and always returns the same instance', () => {
+    const first = createSourceManager();
+    const defaultBasePath = first.getHandler('filesystem').basePath;
+
+    const second = createSourceManager({
+      filesystem: { basePath: '/tmp/should-be-ignored' }
+    });
+
+    expect(second).toBe(first);
+    expect(second.getHandler('filesystem').basePath).toBe(defaultBasePath);
+    expect(second.getHandler('filesystem').basePath).not.toBe('/tmp/should-be-ignored');
+  });
+});


### PR DESCRIPTION
## Summary
- `createSourceManager()` caches a single `SourceManager` in module scope and only honors the `config` argument on the very first call — every later call gets the already-constructed instance, silently discarding whatever `config` it was passed.
- `PromptService.js` and `PromptNodeExecutor.js` both called it with a `filesystem.basePath` override that only ever took effect if one of them happened to run first; this "worked" only because the override is provably equal to `FileSystemHandler`'s own default. Dropped the now-redundant override at both call sites and call `createSourceManager()` with no args.
- Added a documenting comment on `createSourceManager` in `server/sources/index.js` explaining the singleton's first-call-wins behavior, so it isn't mistaken for a per-call config API in the future.
- Added a regression test (`server/tests/source-manager-singleton.test.js`) asserting that a second call with a different `filesystem.basePath` does not affect the already-constructed instance.

## Test plan
- [x] `npm run lint:fix` / `npm run format:fix` on changed files — no new warnings/errors introduced
- [x] `server/tests/source-manager-singleton.test.js` (new) passes
- [x] `server/tests/SourceResolutionService.test.js` and `server/tests/admin-sources-user-context.test.js` still pass

Closes #1794

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKw7MBebmGMsF6SpBh6aLB

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKw7MBebmGMsF6SpBh6aLB)_