### PR TITLE
feat(voice): realtime speech-to-text via iHub-proxied vLLM (Voxtral)

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -104,6 +104,9 @@ const AdminUICustomization = lazyWithRetry(
   () => import('./features/admin/pages/AdminUICustomization')
 );
 const AdminLoggingPage = lazyWithRetry(() => import('./features/admin/pages/AdminLoggingPage'));
+const AdminVoiceInputPage = lazyWithRetry(
+  () => import('./features/admin/pages/AdminVoiceInputPage')
+);
 const AdminTelemetryPage = lazyWithRetry(() => import('./features/admin/pages/AdminTelemetryPage'));
 const AdminFeaturesPage = lazyWithRetry(() => import('./features/admin/pages/AdminFeaturesPage'));
 const AdminAuditLogPage = lazyWithRetry(() => import('./features/admin/pages/AdminAuditLogPage'));
@@ -648,6 +651,12 @@ function App() {
             )}
             {showAdminPage('telemetry') && (
               <Route path="telemetry" element={<LazyAdminRoute component={AdminTelemetryPage} />} />
+            )}
+            {showAdminPage('system') && (
+              <Route
+                path="voice-input"
+                element={<LazyAdminRoute component={AdminVoiceInputPage} />}
+              />
             )}
 
             {/* Observability - Audit Log */}

--- a/client/src/features/admin/components/AdminCommandPalette.jsx
+++ b/client/src/features/admin/components/AdminCommandPalette.jsx
@@ -26,6 +26,7 @@ const ADMIN_PAGES = [
   { label: 'Usage Reports', href: '/admin/usage' },
   { label: 'Logging', href: '/admin/logging' },
   { label: 'Telemetry', href: '/admin/telemetry' },
+  { label: 'Voice Input', href: '/admin/voice-input' },
   { label: 'Features', href: '/admin/features' },
   { label: 'Security', href: '/admin/security' },
   { label: 'Backup & Restore', href: '/admin/backup' },

--- a/client/src/features/admin/components/AdminSidebarNavData.js
+++ b/client/src/features/admin/components/AdminSidebarNavData.js
@@ -23,7 +23,8 @@ import {
   ArrowPathIcon,
   ExclamationTriangleIcon,
   ClipboardDocumentCheckIcon,
-  NewspaperIcon
+  NewspaperIcon,
+  MicrophoneIcon
 } from '@heroicons/react/24/outline';
 
 /**
@@ -287,6 +288,13 @@ export function getAdminNavSections({ t, showAdminPage, featureFlags }) {
           href: '/admin/features',
           icon: FlagIcon,
           visible: showAdminPage('features')
+        },
+        {
+          key: 'voice-input',
+          label: t('admin.nav.voiceInput', 'Voice Input'),
+          href: '/admin/voice-input',
+          icon: MicrophoneIcon,
+          visible: showAdminPage('system')
         },
         {
           key: 'security',

--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -2350,13 +2350,31 @@ function AppFormEditor({
                         <option value="default">
                           {t('admin.apps.edit.defaultService', 'Default (Browser)')}
                         </option>
+                        <option value="azure">
+                          {t('admin.apps.edit.azureService', 'Azure Speech')}
+                        </option>
+                        <option value="vllm-realtime">
+                          {t(
+                            'admin.apps.edit.vllmRealtimeService',
+                            'vLLM Realtime (server-proxied)'
+                          )}
+                        </option>
                         <option value="custom">
                           {t('admin.apps.edit.customService', 'Custom Service')}
                         </option>
                       </select>
+                      {app.settings?.speechRecognition?.service === 'vllm-realtime' && (
+                        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                          {t(
+                            'admin.apps.edit.vllmRealtimeHint',
+                            'Streams microphone audio to the iHub server, which proxies it to the vLLM realtime endpoint configured in platform.json (speech.realtime).'
+                          )}
+                        </p>
+                      )}
                     </div>
 
-                    {app.settings?.speechRecognition?.service === 'custom' && (
+                    {(app.settings?.speechRecognition?.service === 'custom' ||
+                      app.settings?.speechRecognition?.service === 'azure') && (
                       <div className="pl-6">
                         <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                           {t('admin.apps.edit.customServiceHost', 'Custom Service Host')}

--- a/client/src/features/admin/pages/AdminVoiceInputPage.jsx
+++ b/client/src/features/admin/pages/AdminVoiceInputPage.jsx
@@ -1,0 +1,335 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import Icon from '../../../shared/components/Icon';
+import { makeAdminApiCall } from '../../../api/adminApi';
+
+const DEFAULT_SPEECH = {
+  realtime: { enabled: false, url: 'ws://localhost:8080/v1/realtime', model: '', apiKey: '' },
+  azure: { enabled: false, host: '', region: '' }
+};
+
+/**
+ * Admin page for configuring voice-input / speech-to-text backends stored in
+ * platform.json under `speech`:
+ *   - vLLM Realtime (server-proxied, e.g. Voxtral) — fully managed here.
+ *   - Azure Speech — platform-level host/region defaults. The subscription KEY
+ *     is provided via the VITE_AZURE_SUBSCRIPTION_ID env var, not stored here.
+ */
+function AdminVoiceInputPage() {
+  const { t } = useTranslation();
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState('');
+  const [config, setConfig] = useState(DEFAULT_SPEECH);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState(null);
+
+  useEffect(() => {
+    loadConfig();
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+  }, []);
+
+  const loadConfig = async () => {
+    try {
+      setLoading(true);
+      const response = await makeAdminApiCall('/admin/configs/platform', { method: 'GET' });
+      const platform = response.data || {};
+      const speech = platform.speech || {};
+      setConfig({
+        realtime: { ...DEFAULT_SPEECH.realtime, ...(speech.realtime || {}) },
+        azure: { ...DEFAULT_SPEECH.azure, ...(speech.azure || {}) }
+      });
+      setMessage('');
+    } catch (error) {
+      setMessage({
+        type: 'error',
+        text:
+          error.message || t('admin.voiceInput.loadError', 'Failed to load voice input settings')
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSave = async () => {
+    try {
+      setSaving(true);
+      setMessage('');
+      const response = await makeAdminApiCall('/admin/configs/platform', { method: 'GET' });
+      const platform = response.data || {};
+      platform.speech = {
+        ...(platform.speech || {}),
+        realtime: config.realtime,
+        azure: config.azure
+      };
+      await makeAdminApiCall('/admin/configs/platform', { method: 'POST', body: platform });
+      setMessage({
+        type: 'success',
+        text: t('admin.voiceInput.saveSuccess', 'Voice input settings saved.')
+      });
+      // Reload so the API key shows its redacted state again.
+      await loadConfig();
+    } catch (error) {
+      setMessage({
+        type: 'error',
+        text:
+          error.message || t('admin.voiceInput.saveError', 'Failed to save voice input settings')
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTestRealtime = async () => {
+    try {
+      setTesting(true);
+      setTestResult(null);
+      const response = await makeAdminApiCall('/admin/voice/realtime/test', {
+        method: 'POST',
+        body: {
+          url: config.realtime.url,
+          model: config.realtime.model,
+          apiKey: config.realtime.apiKey
+        }
+      });
+      setTestResult(response.data || { ok: false, message: 'No response' });
+    } catch (error) {
+      setTestResult({ ok: false, message: error.message || 'Test request failed' });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  const setRealtime = (field, value) => {
+    setTestResult(null);
+    setConfig(prev => ({ ...prev, realtime: { ...prev.realtime, [field]: value } }));
+  };
+  const setAzure = (field, value) =>
+    setConfig(prev => ({ ...prev, azure: { ...prev.azure, [field]: value } }));
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-6">
+        <div className="max-w-4xl mx-auto">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+            <p className="text-gray-600 dark:text-gray-400">{t('common.loading', 'Loading...')}</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const inputClass =
+    'mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm';
+  const labelClass = 'block text-sm font-medium text-gray-700 dark:text-gray-300';
+
+  return (
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 p-6">
+      <div className="max-w-4xl mx-auto space-y-6">
+        {/* Header */}
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+          <div className="flex items-start mb-2">
+            <Icon name="microphone" className="w-8 h-8 mr-3 text-blue-500 flex-shrink-0" />
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+                {t('admin.voiceInput.title', 'Voice Input (Speech-to-Text)')}
+              </h1>
+              <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+                {t(
+                  'admin.voiceInput.description',
+                  'Configure the speech-to-text backends available to apps. Enable a backend here, then select it per app under the app editor’s Speech Recognition Service.'
+                )}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {message && (
+          <div
+            className={`p-4 rounded-lg ${
+              message.type === 'success'
+                ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-300'
+                : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300'
+            }`}
+          >
+            {message.text}
+          </div>
+        )}
+
+        {/* vLLM Realtime */}
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 space-y-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {t('admin.voiceInput.realtime.title', 'vLLM Realtime (server-proxied)')}
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+              {t(
+                'admin.voiceInput.realtime.description',
+                'Streams microphone audio through the iHub server to a vLLM realtime endpoint (e.g. Voxtral). The URL and API key stay on the server. Select "vLLM Realtime" as an app’s Speech Recognition Service to use it.'
+              )}
+            </p>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+            <input
+              type="checkbox"
+              checked={!!config.realtime.enabled}
+              onChange={e => setRealtime('enabled', e.target.checked)}
+              className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            {t('admin.voiceInput.realtime.enabled', 'Enable vLLM realtime transcription')}
+          </label>
+
+          <div>
+            <label className={labelClass} htmlFor="realtime-url">
+              {t('admin.voiceInput.realtime.url', 'Realtime WebSocket URL')}
+            </label>
+            <input
+              id="realtime-url"
+              type="text"
+              value={config.realtime.url || ''}
+              onChange={e => setRealtime('url', e.target.value)}
+              placeholder="ws://localhost:8080/v1/realtime"
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className={labelClass} htmlFor="realtime-model">
+              {t('admin.voiceInput.realtime.model', 'Model')}
+            </label>
+            <input
+              id="realtime-model"
+              type="text"
+              value={config.realtime.model || ''}
+              onChange={e => setRealtime('model', e.target.value)}
+              placeholder="mistralai/Voxtral-Mini-4B-Realtime-2602"
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className={labelClass} htmlFor="realtime-apikey">
+              {t('admin.voiceInput.realtime.apiKey', 'API Key (optional)')}
+            </label>
+            <input
+              id="realtime-apikey"
+              type="password"
+              value={config.realtime.apiKey || ''}
+              onChange={e => setRealtime('apiKey', e.target.value)}
+              autoComplete="new-password"
+              placeholder={t('admin.voiceInput.realtime.apiKeyPlaceholder', 'Leave blank if none')}
+              className={inputClass}
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {t(
+                'admin.voiceInput.realtime.apiKeyHint',
+                'Stored encrypted at rest. Local vLLM usually needs no key. A shown value of ***REDACTED*** means a key is already set — leave it to keep it.'
+              )}
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3 pt-2 border-t border-gray-100 dark:border-gray-700">
+            <button
+              type="button"
+              onClick={handleTestRealtime}
+              disabled={testing || !config.realtime.url}
+              className="inline-flex items-center px-3 py-2 rounded-md border border-indigo-600 text-indigo-600 dark:text-indigo-400 dark:border-indigo-400 text-sm font-medium hover:bg-indigo-50 dark:hover:bg-indigo-900/20 disabled:opacity-50"
+            >
+              {testing
+                ? t('admin.voiceInput.realtime.testing', 'Testing…')
+                : t('admin.voiceInput.realtime.test', 'Test connection')}
+            </button>
+            {testResult && (
+              <span
+                className={`text-sm flex items-center gap-1 ${
+                  testResult.ok
+                    ? 'text-green-600 dark:text-green-400'
+                    : 'text-red-600 dark:text-red-400'
+                }`}
+              >
+                <Icon
+                  name={testResult.ok ? 'check-circle' : 'clearCircle'}
+                  className="w-4 h-4 flex-shrink-0"
+                />
+                {testResult.message}
+              </span>
+            )}
+          </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.voiceInput.realtime.testHint',
+              'Tests connectivity from the iHub server to the vLLM realtime endpoint using the values above (the saved key is used when the field shows ***REDACTED***).'
+            )}
+          </p>
+        </div>
+
+        {/* Azure */}
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6 space-y-4">
+          <div>
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+              {t('admin.voiceInput.azure.title', 'Azure Speech')}
+            </h2>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
+              {t(
+                'admin.voiceInput.azure.description',
+                'Azure Cognitive Services Speech runs in the browser. These platform-level defaults are used when an app does not set its own host. The subscription key is provided via the VITE_AZURE_SUBSCRIPTION_ID environment variable and is not stored here.'
+              )}
+            </p>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+            <input
+              type="checkbox"
+              checked={!!config.azure.enabled}
+              onChange={e => setAzure('enabled', e.target.checked)}
+              className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+            />
+            {t('admin.voiceInput.azure.enabled', 'Enable Azure Speech')}
+          </label>
+
+          <div>
+            <label className={labelClass} htmlFor="azure-host">
+              {t('admin.voiceInput.azure.host', 'Default host / endpoint')}
+            </label>
+            <input
+              id="azure-host"
+              type="url"
+              value={config.azure.host || ''}
+              onChange={e => setAzure('host', e.target.value)}
+              placeholder="https://westeurope.stt.speech.microsoft.com"
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className={labelClass} htmlFor="azure-region">
+              {t('admin.voiceInput.azure.region', 'Region (optional)')}
+            </label>
+            <input
+              id="azure-region"
+              type="text"
+              value={config.azure.region || ''}
+              onChange={e => setAzure('region', e.target.value)}
+              placeholder="westeurope"
+              className={inputClass}
+            />
+          </div>
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="inline-flex items-center px-4 py-2 rounded-md bg-indigo-600 text-white text-sm font-medium hover:bg-indigo-700 disabled:opacity-50"
+          >
+            {saving ? t('common.saving', 'Saving...') : t('common.save', 'Save')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AdminVoiceInputPage;

--- a/client/src/features/admin/pages/AdminVoiceInputPage.jsx
+++ b/client/src/features/admin/pages/AdminVoiceInputPage.jsx
@@ -5,15 +5,15 @@ import { makeAdminApiCall } from '../../../api/adminApi';
 
 const DEFAULT_SPEECH = {
   realtime: { enabled: false, url: 'ws://localhost:8080/v1/realtime', model: '', apiKey: '' },
-  azure: { enabled: false, host: '', region: '' }
+  azure: { enabled: false, host: '', region: '', subscriptionKey: '' }
 };
 
 /**
  * Admin page for configuring voice-input / speech-to-text backends stored in
  * platform.json under `speech`:
  *   - vLLM Realtime (server-proxied, e.g. Voxtral) — fully managed here.
- *   - Azure Speech — platform-level host/region defaults. The subscription KEY
- *     is provided via the VITE_AZURE_SUBSCRIPTION_ID env var, not stored here.
+ *   - Azure Speech — host/region plus the subscription key, which is stored
+ *     encrypted server-side and brokered to the browser as a short-lived token.
  */
 function AdminVoiceInputPage() {
   const { t } = useTranslation();
@@ -273,7 +273,7 @@ function AdminVoiceInputPage() {
             <p className="text-sm text-gray-600 dark:text-gray-400 mt-1">
               {t(
                 'admin.voiceInput.azure.description',
-                'Azure Cognitive Services Speech runs in the browser. These platform-level defaults are used when an app does not set its own host. The subscription key is provided via the VITE_AZURE_SUBSCRIPTION_ID environment variable and is not stored here.'
+                'Azure Cognitive Services Speech runs in the browser via a short-lived token. The subscription key is stored encrypted on the server and exchanged for a token per session, so it never reaches the browser. Host/region are the defaults used when an app does not set its own host.'
               )}
             </p>
           </div>
@@ -304,7 +304,7 @@ function AdminVoiceInputPage() {
 
           <div>
             <label className={labelClass} htmlFor="azure-region">
-              {t('admin.voiceInput.azure.region', 'Region (optional)')}
+              {t('admin.voiceInput.azure.region', 'Region')}
             </label>
             <input
               id="azure-region"
@@ -314,6 +314,30 @@ function AdminVoiceInputPage() {
               placeholder="westeurope"
               className={inputClass}
             />
+          </div>
+
+          <div>
+            <label className={labelClass} htmlFor="azure-key">
+              {t('admin.voiceInput.azure.subscriptionKey', 'Subscription Key')}
+            </label>
+            <input
+              id="azure-key"
+              type="password"
+              value={config.azure.subscriptionKey || ''}
+              onChange={e => setAzure('subscriptionKey', e.target.value)}
+              autoComplete="new-password"
+              placeholder={t(
+                'admin.voiceInput.azure.subscriptionKeyPlaceholder',
+                'Azure Speech key'
+              )}
+              className={inputClass}
+            />
+            <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+              {t(
+                'admin.voiceInput.azure.subscriptionKeyHint',
+                'Stored encrypted at rest and never sent to the browser. A shown value of ***REDACTED*** means a key is already set — leave it to keep it.'
+              )}
+            </p>
           </div>
         </div>
 

--- a/client/src/features/voice/components/VoiceFeedback.jsx
+++ b/client/src/features/voice/components/VoiceFeedback.jsx
@@ -3,31 +3,50 @@ import { useTranslation } from 'react-i18next';
 const wavesCount = 3;
 
 const VoiceFeedback = props => {
-  const { isActive, setIsActive, transcript = '', mode = 'automatic' } = props;
+  const { isActive, setIsActive, transcript = '', mode = 'automatic', errorMessage = '' } = props;
   const { t } = useTranslation();
 
   const onClose = () => {
     setIsActive(false);
   };
 
+  const hasError = !!errorMessage;
+
   return (
-    <div id="voice-feedback" className={`voice-feedback ${isActive ? 'active' : ''}`}>
+    <div
+      id="voice-feedback"
+      className={`voice-feedback ${isActive ? 'active' : ''} ${hasError ? 'error' : ''}`}
+    >
       <div className="voice-feedback-content">
-        <div className="voice-waves">
-          {Array.from(Array(wavesCount).keys()).map((_, index) => (
-            <div key={`wave-${index}`} className="wave" />
-          ))}
-        </div>
-        <h3 className="voice-text">{t('voiceInput.listening', 'Listening...')}</h3>
-        <span className="voice-mode">
-          {mode === 'manual'
-            ? t('voiceInput.modeManual', 'Manual mode - click close when finished')
-            : t('voiceInput.modeAutomatic', 'Automatic mode - stops when you stop speaking')}
-        </span>
-        <span className="voice-instructions">
-          {t('voiceInput.instructions', 'Speak clearly and naturally')}
-        </span>
-        {transcript && <div className="voice-transcript">{transcript}</div>}
+        {hasError ? (
+          <>
+            <div className="voice-error-icon" aria-hidden="true">
+              !
+            </div>
+            <h3 className="voice-text">{t('voiceInput.errorTitle', 'Voice input error')}</h3>
+            <span className="voice-error-message" role="alert">
+              {errorMessage}
+            </span>
+          </>
+        ) : (
+          <>
+            <div className="voice-waves">
+              {Array.from(Array(wavesCount).keys()).map((_, index) => (
+                <div key={`wave-${index}`} className="wave" />
+              ))}
+            </div>
+            <h3 className="voice-text">{t('voiceInput.listening', 'Listening...')}</h3>
+            <span className="voice-mode">
+              {mode === 'manual'
+                ? t('voiceInput.modeManual', 'Manual mode - click close when finished')
+                : t('voiceInput.modeAutomatic', 'Automatic mode - stops when you stop speaking')}
+            </span>
+            <span className="voice-instructions">
+              {t('voiceInput.instructions', 'Speak clearly and naturally')}
+            </span>
+            {transcript && <div className="voice-transcript">{transcript}</div>}
+          </>
+        )}
         <button className="voice-close" onClick={onClose} type="button">
           &times;
         </button>

--- a/client/src/features/voice/components/VoiceInput.css
+++ b/client/src/features/voice/components/VoiceInput.css
@@ -174,3 +174,34 @@
 [data-theme='dark'] .voice-transcript {
   color: #fff;
 }
+
+/* Error state */
+.voice-error-icon {
+  width: 40px;
+  height: 40px;
+  margin: 0 auto 16px;
+  border-radius: 50%;
+  background-color: #dc2626;
+  color: #fff;
+  font-size: 1.5em;
+  font-weight: 700;
+  line-height: 40px;
+  text-align: center;
+}
+
+.voice-feedback.error .voice-text {
+  color: #dc2626;
+}
+
+.voice-error-message {
+  display: block;
+  font-size: 0.95em;
+  color: #dc2626;
+  max-width: 20rem;
+  margin: 0 auto;
+}
+
+[data-theme='dark'] .voice-error-message,
+[data-theme='dark'] .voice-feedback.error .voice-text {
+  color: #f87171;
+}

--- a/client/src/features/voice/components/VoiceInputComponent.jsx
+++ b/client/src/features/voice/components/VoiceInputComponent.jsx
@@ -10,8 +10,15 @@ const VoiceInputComponent = ({
   disabled = false,
   onCommand = null
 }) => {
-  const { isListening, transcript, toggleListening, stopListening, microphoneMode } =
-    useVoiceRecognition({ app, inputRef, onSpeechResult, onCommand, disabled });
+  const {
+    isListening,
+    transcript,
+    errorMessage,
+    clearError,
+    toggleListening,
+    stopListening,
+    microphoneMode
+  } = useVoiceRecognition({ app, inputRef, onSpeechResult, onCommand, disabled });
 
   useEffect(() => {
     const handleKeyDown = e => {
@@ -28,12 +35,13 @@ const VoiceInputComponent = ({
 
   const handleOnFeedbackOverlayClose = () => {
     stopListening();
+    clearError();
   };
 
   return (
     <>
       <VoiceFeedback
-        isActive={isListening}
+        isActive={isListening || !!errorMessage}
         setIsActive={handleOnFeedbackOverlayClose}
         transcript={
           app?.inputMode?.microphone?.showTranscript || app?.microphone?.showTranscript
@@ -41,6 +49,7 @@ const VoiceInputComponent = ({
             : ''
         }
         mode={microphoneMode}
+        errorMessage={errorMessage}
       />
       <VoiceInputButton
         isListening={isListening}

--- a/client/src/features/voice/hooks/useVoiceRecognition.js
+++ b/client/src/features/voice/hooks/useVoiceRecognition.js
@@ -1,15 +1,19 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import AzureSpeechRecognition from '../../../utils/azureRecognitionService';
+import VllmRealtimeRecognition from '../../../utils/vllmRealtimeRecognitionService';
+import { usePlatformConfig } from '../../../shared/contexts/PlatformConfigContext';
 
 const useVoiceRecognition = ({ app, inputRef, onSpeechResult, onCommand, disabled = false }) => {
   const { t, i18n } = useTranslation();
+  const { platformConfig } = usePlatformConfig();
   const [isListening, setIsListening] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
   const [transcript, setTranscript] = useState('');
   const recognitionRef = useRef(null);
   const originalInputValue = useRef('');
   const originalPlaceholder = useRef('');
+  const errorTimeoutRef = useRef(null);
 
   const microphoneMode = app?.inputMode?.microphone?.mode || app?.microphone?.mode || 'automatic';
 
@@ -32,6 +36,10 @@ const useVoiceRecognition = ({ app, inputRef, onSpeechResult, onCommand, disable
   useEffect(() => {
     return () => {
       stopListening();
+      if (errorTimeoutRef.current) {
+        clearTimeout(errorTimeoutRef.current);
+        errorTimeoutRef.current = null;
+      }
     };
   }, [stopListening]);
 
@@ -94,23 +102,49 @@ const useVoiceRecognition = ({ app, inputRef, onSpeechResult, onCommand, disable
     return { text: originalText, command: null };
   };
 
+  const clearError = useCallback(() => {
+    if (errorTimeoutRef.current) {
+      clearTimeout(errorTimeoutRef.current);
+      errorTimeoutRef.current = null;
+    }
+    setErrorMessage('');
+  }, []);
+
   const showError = message => {
+    if (errorTimeoutRef.current) {
+      clearTimeout(errorTimeoutRef.current);
+    }
     setErrorMessage(message);
     if (inputRef?.current) {
       inputRef.current.placeholder = message;
-      setTimeout(() => {
-        if (inputRef?.current) {
-          inputRef.current.placeholder = originalPlaceholder.current;
-        }
-      }, 3000);
     }
+    // Auto-dismiss the error (both the overlay error state and the placeholder)
+    // after a few seconds so it does not linger indefinitely.
+    errorTimeoutRef.current = setTimeout(() => {
+      errorTimeoutRef.current = null;
+      setErrorMessage('');
+      if (inputRef?.current) {
+        inputRef.current.placeholder = originalPlaceholder.current;
+      }
+    }, 5000);
   };
 
   const startListening = async () => {
     if (disabled) return;
 
+    clearError();
+
     try {
-      if (!('webkitSpeechRecognition' in window) && !('SpeechRecognition' in window)) {
+      const service = app?.settings?.speechRecognition?.service || 'default';
+
+      // The browser Web Speech API is only required for the 'default' service.
+      // Azure and the iHub-proxied vLLM realtime service capture audio directly
+      // and don't depend on window.SpeechRecognition.
+      if (
+        service === 'default' &&
+        !('webkitSpeechRecognition' in window) &&
+        !('SpeechRecognition' in window)
+      ) {
         showError(
           t('voiceInput.error.notSupported', 'Speech recognition not supported in this browser')
         );
@@ -135,10 +169,18 @@ const useVoiceRecognition = ({ app, inputRef, onSpeechResult, onCommand, disable
       const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
       let recognition;
 
-      switch (app?.settings?.speechRecognition?.service) {
+      switch (service) {
         case 'azure':
           recognition = new AzureSpeechRecognition();
-          recognition.host = app?.settings?.speechRecognition?.host;
+          // Prefer the per-app host; fall back to the platform-level Azure host
+          // configured in Admin → Voice Input (platform.speech.azure.host).
+          recognition.host =
+            app?.settings?.speechRecognition?.host || platformConfig?.speech?.azure?.host || '';
+          break;
+        case 'vllm-realtime':
+          // Streams mic audio to iHub, which proxies to a vLLM realtime endpoint.
+          // The endpoint is configured server-side, so no host is needed here.
+          recognition = new VllmRealtimeRecognition();
           break;
         case 'default':
         default:
@@ -169,9 +211,12 @@ const useVoiceRecognition = ({ app, inputRef, onSpeechResult, onCommand, disable
         recognitionLang = langMap[recognitionLang.toLowerCase()] || 'en-US';
       }
       recognition.lang = recognitionLang;
-      const isAzure = recognition instanceof AzureSpeechRecognition;
+      // Both the Azure service and the vLLM realtime service emit results as
+      // { text, isFinal } objects rather than the browser SpeechRecognition
+      // event shape. They mark themselves with `usesTextEventShape`.
+      const usesTextEventShape = recognition.usesTextEventShape === true;
 
-      if (isAzure) {
+      if (recognition instanceof AzureSpeechRecognition) {
         recognition.initRecognizer();
       }
 
@@ -187,7 +232,7 @@ const useVoiceRecognition = ({ app, inputRef, onSpeechResult, onCommand, disable
         let interimTranscript = '';
         let finalTranscript = '';
 
-        if (!isAzure) {
+        if (!usesTextEventShape) {
           // Browser SpeechRecognition API
           for (let i = event.resultIndex; i < event.results.length; i++) {
             const transcript = event.results[i][0].transcript;
@@ -199,7 +244,7 @@ const useVoiceRecognition = ({ app, inputRef, onSpeechResult, onCommand, disable
             }
           }
         } else {
-          // Azure Speech Recognition API
+          // Azure / vLLM realtime services emit { text, isFinal }
           if ('text' in event) {
             // Check if this is a final or interim result
             if (event.isFinal === false) {
@@ -280,6 +325,13 @@ const useVoiceRecognition = ({ app, inputRef, onSpeechResult, onCommand, disable
               'Network error. Please check your connection.'
             );
             break;
+          case 'service':
+            // Error surfaced by a proxied backend (e.g. the vLLM realtime
+            // endpoint). Prefer the server-supplied message when available.
+            errorMsg =
+              event.message ||
+              t('voiceInput.error.service', 'Transcription service unavailable. Please try again.');
+            break;
           default:
             errorMsg = t('voiceInput.error.general', 'Voice input error. Please try again.');
         }
@@ -315,6 +367,8 @@ const useVoiceRecognition = ({ app, inputRef, onSpeechResult, onCommand, disable
   return {
     isListening,
     transcript,
+    errorMessage,
+    clearError,
     toggleListening,
     stopListening,
     microphoneMode

--- a/client/src/features/voice/hooks/useVoiceRecognition.js
+++ b/client/src/features/voice/hooks/useVoiceRecognition.js
@@ -217,7 +217,9 @@ const useVoiceRecognition = ({ app, inputRef, onSpeechResult, onCommand, disable
       const usesTextEventShape = recognition.usesTextEventShape === true;
 
       if (recognition instanceof AzureSpeechRecognition) {
-        recognition.initRecognizer();
+        // Async: fetches a short-lived Azure token from the server before
+        // building the recognizer (the subscription key stays server-side).
+        await recognition.initRecognizer();
       }
 
       recognition.onstart = () => {

--- a/client/src/utils/azureRecognitionService.js
+++ b/client/src/utils/azureRecognitionService.js
@@ -1,8 +1,8 @@
 import * as speechSdk from 'microsoft-cognitiveservices-speech-sdk';
+import { buildApiUrl } from './runtimeBasePath';
 
 // const postfix = '?language=de-DE';
 const postfix = '';
-const subscriptionId = import.meta.env.VITE_AZURE_SUBSCRIPTION_ID;
 
 class AzureSpeechRecognition {
   recognition;
@@ -131,25 +131,47 @@ class AzureSpeechRecognition {
     );
   }
 
-  initRecognizer() {
-    try {
-      const hostURL = new URL(
-        `${this.host}/speech/recognition/interactive/cognitiveservices/v1${postfix}`
-      );
-      const speechConfig = speechSdk.SpeechConfig.fromHost(hostURL, subscriptionId);
-      const audioConfig = speechSdk.AudioConfig.fromDefaultMicrophoneInput();
+  // Fetch a short-lived Azure authorization token from the iHub server. The
+  // subscription key stays server-side; the browser only ever sees the token.
+  async #fetchAuthToken() {
+    const res = await fetch(buildApiUrl('/voice/azure/token'), { credentials: 'include' });
+    if (!res.ok) {
+      let message = `Azure token request failed (${res.status})`;
+      try {
+        const body = await res.json();
+        if (body?.error) message = body.error;
+      } catch {
+        /* non-JSON error body */
+      }
+      throw new Error(message);
+    }
+    return res.json(); // { token, region }
+  }
 
-      // No German recognition like this
-      speechConfig.speechRecognitionLanguage = this.lang ?? 'de-DE';
-      const recognizer = new speechSdk.SpeechRecognizer(speechConfig, audioConfig);
-      this.recognition = recognizer;
-    } catch (e) {
-      if (!host) {
-        console.error("Failed to construct URL since 'host' is not defined");
-        return;
+  async initRecognizer() {
+    try {
+      const { token, region } = await this.#fetchAuthToken();
+
+      // Prefer a custom host when configured (private/regional endpoint),
+      // otherwise use the region from the token response. Either way the
+      // recognizer authenticates with the short-lived token, never a key.
+      let speechConfig;
+      if (this.host) {
+        const hostURL = new URL(
+          `${this.host}/speech/recognition/interactive/cognitiveservices/v1${postfix}`
+        );
+        speechConfig = speechSdk.SpeechConfig.fromHost(hostURL);
+        speechConfig.authorizationToken = token;
+      } else {
+        speechConfig = speechSdk.SpeechConfig.fromAuthorizationToken(token, region);
       }
 
-      console.error(e);
+      const audioConfig = speechSdk.AudioConfig.fromDefaultMicrophoneInput();
+      speechConfig.speechRecognitionLanguage = this.lang ?? 'de-DE';
+      this.recognition = new speechSdk.SpeechRecognizer(speechConfig, audioConfig);
+    } catch (e) {
+      console.error('Failed to initialize Azure recognizer:', e);
+      this.#triggerOnError({ error: 'service', message: e.message });
     }
   }
 

--- a/client/src/utils/runtimeBasePath.js
+++ b/client/src/utils/runtimeBasePath.js
@@ -217,6 +217,27 @@ export const buildApiUrl = endpoint => {
 };
 
 /**
+ * Build an absolute WebSocket URL for an API endpoint.
+ * Uses ws:// or wss:// to match the current page protocol and respects the
+ * runtime base path (and any absolute API base override).
+ * @param {string} endpoint - API endpoint (e.g., "/voice/realtime")
+ * @returns {string} Complete ws(s):// URL
+ */
+export const buildWsUrl = endpoint => {
+  const apiPath = buildApiUrl(endpoint); // handles base path + override
+
+  // Already absolute (http/https override) → just swap the scheme.
+  if (/^https?:\/\//i.test(apiPath)) {
+    return apiPath.replace(/^http/i, 'ws');
+  }
+
+  const { protocol, host } = window.location;
+  const wsProtocol = protocol === 'https:' ? 'wss:' : 'ws:';
+  const path = apiPath.startsWith('/') ? apiPath : `/${apiPath}`;
+  return `${wsProtocol}//${host}${path}`;
+};
+
+/**
  * Build an asset URL (images, fonts, etc.)
  * @param {string} asset - Asset path
  * @returns {string} Complete asset URL

--- a/client/src/utils/vllmRealtimeRecognitionService.js
+++ b/client/src/utils/vllmRealtimeRecognitionService.js
@@ -1,0 +1,389 @@
+import { buildWsUrl } from './runtimeBasePath';
+
+/**
+ * Realtime speech recognition that streams microphone audio to the iHub server
+ * over a WebSocket. iHub proxies the audio to a vLLM realtime endpoint (Voxtral)
+ * and streams transcription text back. The browser never talks to vLLM directly.
+ *
+ * Mirrors the duck-typed interface `useVoiceRecognition` expects: the caller sets
+ * `continuous`, `interimResults`, `lang`, then assigns `onstart/onresult/onerror/
+ * onend` and calls `start()` / `stop()`. Results are emitted as `{ text, isFinal }`
+ * (same shape as the Azure service), so `usesTextEventShape` is set to true.
+ *
+ * Audio is captured as mono, downsampled to 16 kHz, and converted to PCM16 — the
+ * format the vLLM realtime API expects.
+ */
+
+const TARGET_SAMPLE_RATE = 16000;
+const FRAME_SIZE = 2048; // samples per worklet post (~128ms @16k)
+
+// Automatic-mode voice-activity detection thresholds.
+const SPEECH_RMS_THRESHOLD = 0.015; // above this = speech present
+const SILENCE_RMS_THRESHOLD = 0.01; // below this = silence
+const SILENCE_HANG_MS = 1200; // stop after this much trailing silence
+
+// Inline AudioWorklet: accumulates FRAME_SIZE samples then posts a copy to the
+// main thread. Loaded via a Blob URL so no separate asset/bundling is needed.
+const WORKLET_SOURCE = `
+class PCMCaptureProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+    this._size = ${FRAME_SIZE};
+    this._buf = new Float32Array(this._size);
+    this._i = 0;
+  }
+  process(inputs) {
+    const input = inputs[0];
+    if (input && input[0]) {
+      const ch = input[0];
+      for (let n = 0; n < ch.length; n++) {
+        this._buf[this._i++] = ch[n];
+        if (this._i >= this._size) {
+          this.port.postMessage(this._buf.slice(0, this._size));
+          this._i = 0;
+        }
+      }
+    }
+    return true;
+  }
+}
+registerProcessor('pcm-capture-processor', PCMCaptureProcessor);
+`;
+
+class VllmRealtimeRecognition {
+  constructor() {
+    this.continuous = false;
+    this.interimResults = true;
+    this.lang = 'en-US';
+    this.host = '';
+    // Tell useVoiceRecognition to use the {text, isFinal} result branch.
+    this.usesTextEventShape = true;
+
+    this._ws = null;
+    this._audioContext = null;
+    this._mediaStream = null;
+    this._sourceNode = null;
+    this._workletNode = null;
+    this._scriptNode = null;
+    this._stopped = false;
+    // `_committed` holds text from completed utterances (transcription.done),
+    // `_partial` accumulates the current utterance's streaming deltas. We emit
+    // these as interim results during the session and commit ONE final result
+    // at the end, so useVoiceRecognition (which appends finals to the input)
+    // never double-counts.
+    this._committed = '';
+    this._partial = '';
+    this._finalEmitted = false;
+    this._speechStarted = false;
+    this._silenceTimer = null;
+  }
+
+  async start() {
+    this._stopped = false;
+    this._committed = '';
+    this._partial = '';
+    this._finalEmitted = false;
+    this._speechStarted = false;
+
+    try {
+      this._mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch {
+      this.#emitError('not-allowed');
+      return;
+    }
+
+    try {
+      await this.#openSocket();
+    } catch {
+      this.#emitError('network');
+      this.#cleanup();
+      return;
+    }
+
+    try {
+      await this.#startCapture();
+    } catch (err) {
+      console.error('Realtime STT capture error:', err);
+      this.#emitError('audio-capture');
+      this.#cleanup();
+      return;
+    }
+
+    if (typeof this.onstart === 'function') this.onstart();
+  }
+
+  stop() {
+    if (this._stopped) return;
+    this._stopped = true;
+    // Tell the server we're done so it can flush the final transcription.
+    if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+      try {
+        this._ws.send(JSON.stringify({ type: 'stop' }));
+      } catch {
+        /* ignore */
+      }
+    }
+    this.#stopCaptureNodes();
+    // Give the server a brief window to deliver the final result before we tear
+    // the socket down; onend fires once the socket closes or the timeout hits.
+    setTimeout(() => this.#cleanup(), 1500);
+  }
+
+  // --- WebSocket ---
+  #openSocket() {
+    return new Promise((resolve, reject) => {
+      const url = buildWsUrl('/voice/realtime');
+      let ws;
+      try {
+        ws = new WebSocket(url);
+      } catch (err) {
+        reject(err);
+        return;
+      }
+      ws.binaryType = 'arraybuffer';
+      this._ws = ws;
+
+      let opened = false;
+
+      ws.onopen = () => {
+        opened = true;
+        ws.send(JSON.stringify({ type: 'start', lang: this.lang }));
+        resolve();
+      };
+
+      ws.onmessage = evt => {
+        let msg;
+        try {
+          msg = JSON.parse(evt.data);
+        } catch {
+          return;
+        }
+        this.#handleServerMessage(msg);
+      };
+
+      ws.onerror = () => {
+        if (!opened) reject(new Error('WebSocket connection failed'));
+      };
+
+      ws.onclose = () => {
+        if (!opened) {
+          reject(new Error('WebSocket closed before opening'));
+          return;
+        }
+        this.#finish();
+        this.#emitEnd();
+      };
+    });
+  }
+
+  #currentText() {
+    return `${this._committed} ${this._partial}`.replace(/\s+/g, ' ').trim();
+  }
+
+  #emitInterim() {
+    if (this.interimResults && typeof this.onresult === 'function') {
+      this.onresult({ text: this.#currentText(), isFinal: false });
+    }
+  }
+
+  #handleServerMessage(msg) {
+    switch (msg.type) {
+      case 'ready':
+        // Upstream connected; audio already flowing is fine.
+        break;
+      case 'delta':
+        // Incremental token(s) for the current utterance.
+        this._partial = `${this._partial}${msg.text || ''}`;
+        this.#emitInterim();
+        break;
+      case 'final':
+        // A completed utterance. Fold it into committed text; keep streaming.
+        this._committed = `${this._committed} ${msg.text || this._partial}`.trim();
+        this._partial = '';
+        this.#emitInterim();
+        // In automatic (single-utterance) mode, the first completed utterance
+        // ends the session.
+        if (!this.continuous) {
+          this.stop();
+        }
+        break;
+      case 'error':
+        // Surface the backend's message and end the session so the UI leaves
+        // its "listening" state instead of appearing to keep recording.
+        this.#emitError('service', msg.message);
+        this.#cleanup();
+        break;
+      default:
+        break;
+    }
+  }
+
+  // Commit the accumulated transcription as a single final result. Guarded so it
+  // only fires once (on stop, session end, or socket close).
+  #finish() {
+    if (this._finalEmitted) return;
+    this._finalEmitted = true;
+    const text = this.#currentText();
+    if (text && typeof this.onresult === 'function') {
+      this.onresult({ text, isFinal: true });
+    }
+  }
+
+  // --- Audio capture ---
+  async #startCapture() {
+    const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+    // Request 16 kHz directly; browsers that honor it save us a resample step.
+    this._audioContext = new AudioContextCtor({ sampleRate: TARGET_SAMPLE_RATE });
+    if (this._audioContext.state === 'suspended') {
+      await this._audioContext.resume();
+    }
+    this._sourceNode = this._audioContext.createMediaStreamSource(this._mediaStream);
+
+    const inputRate = this._audioContext.sampleRate;
+
+    // Prefer AudioWorklet; fall back to ScriptProcessorNode if unavailable.
+    let usedWorklet = false;
+    if (this._audioContext.audioWorklet) {
+      try {
+        const blob = new Blob([WORKLET_SOURCE], { type: 'application/javascript' });
+        const moduleUrl = URL.createObjectURL(blob);
+        await this._audioContext.audioWorklet.addModule(moduleUrl);
+        URL.revokeObjectURL(moduleUrl);
+        this._workletNode = new AudioWorkletNode(this._audioContext, 'pcm-capture-processor');
+        this._workletNode.port.onmessage = evt => this.#onAudioFrame(evt.data, inputRate);
+        this._sourceNode.connect(this._workletNode);
+        // Worklet needs a sink to keep the graph pulling audio.
+        this._workletNode.connect(this._audioContext.destination);
+        usedWorklet = true;
+      } catch (err) {
+        console.warn('AudioWorklet unavailable, falling back to ScriptProcessor:', err);
+      }
+    }
+
+    if (!usedWorklet) {
+      const node = this._audioContext.createScriptProcessor(4096, 1, 1);
+      node.onaudioprocess = e => {
+        const input = e.inputBuffer.getChannelData(0);
+        this.#onAudioFrame(new Float32Array(input), inputRate);
+      };
+      this._sourceNode.connect(node);
+      node.connect(this._audioContext.destination);
+      this._scriptNode = node;
+    }
+  }
+
+  #onAudioFrame(float32, inputRate) {
+    if (this._stopped) return;
+
+    // Voice-activity detection (used to auto-stop in automatic mode).
+    const rms = computeRms(float32);
+    this.#updateVad(rms);
+
+    const downsampled = inputRate === TARGET_SAMPLE_RATE ? float32 : downsample(float32, inputRate);
+    const pcm16 = floatTo16BitPCM(downsampled);
+    if (this._ws && this._ws.readyState === WebSocket.OPEN) {
+      this._ws.send(pcm16.buffer);
+    }
+  }
+
+  #updateVad(rms) {
+    if (this.continuous) return; // manual mode: user controls stop
+
+    if (rms >= SPEECH_RMS_THRESHOLD) {
+      this._speechStarted = true;
+      if (this._silenceTimer) {
+        clearTimeout(this._silenceTimer);
+        this._silenceTimer = null;
+      }
+    } else if (this._speechStarted && rms < SILENCE_RMS_THRESHOLD && !this._silenceTimer) {
+      this._silenceTimer = setTimeout(() => {
+        this.stop();
+      }, SILENCE_HANG_MS);
+    }
+  }
+
+  #stopCaptureNodes() {
+    try {
+      if (this._workletNode) {
+        this._workletNode.port.onmessage = null;
+        this._workletNode.disconnect();
+      }
+      if (this._scriptNode) {
+        this._scriptNode.onaudioprocess = null;
+        this._scriptNode.disconnect();
+      }
+      if (this._sourceNode) this._sourceNode.disconnect();
+    } catch {
+      /* ignore */
+    }
+    if (this._mediaStream) {
+      this._mediaStream.getTracks().forEach(track => track.stop());
+    }
+  }
+
+  #cleanup() {
+    if (this._silenceTimer) {
+      clearTimeout(this._silenceTimer);
+      this._silenceTimer = null;
+    }
+    this.#stopCaptureNodes();
+    if (this._audioContext && this._audioContext.state !== 'closed') {
+      this._audioContext.close().catch(() => {});
+    }
+    this._audioContext = null;
+    if (this._ws && this._ws.readyState <= WebSocket.OPEN) {
+      try {
+        this._ws.close();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  #emitError(code, message) {
+    if (typeof this.onerror === 'function') this.onerror({ error: code, message });
+  }
+
+  #emitEnd() {
+    if (typeof this.onend === 'function') this.onend();
+  }
+}
+
+// --- Audio helpers ---
+
+function computeRms(samples) {
+  let sum = 0;
+  for (let i = 0; i < samples.length; i++) sum += samples[i] * samples[i];
+  return Math.sqrt(sum / samples.length);
+}
+
+/**
+ * Linear-interpolation downsample from `inputRate` to 16 kHz.
+ * Per-chunk resampling; boundary artifacts are negligible for speech recognition.
+ */
+function downsample(samples, inputRate) {
+  if (inputRate === TARGET_SAMPLE_RATE) return samples;
+  const ratio = inputRate / TARGET_SAMPLE_RATE;
+  const outLength = Math.floor(samples.length / ratio);
+  const out = new Float32Array(outLength);
+  for (let i = 0; i < outLength; i++) {
+    const srcPos = i * ratio;
+    const idx = Math.floor(srcPos);
+    const frac = srcPos - idx;
+    const a = samples[idx] || 0;
+    const b = samples[idx + 1] !== undefined ? samples[idx + 1] : a;
+    out[i] = a + (b - a) * frac;
+  }
+  return out;
+}
+
+function floatTo16BitPCM(input) {
+  const out = new Int16Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    const s = Math.max(-1, Math.min(1, input[i]));
+    out[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+  }
+  return out;
+}
+
+export default VllmRealtimeRecognition;

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -139,11 +139,24 @@ export default defineConfig({
             target: 'http://localhost:3000',
             changeOrigin: true,
             xfwd: true,
+            // Proxy WebSocket upgrades for the API (e.g. the realtime
+            // speech-to-text endpoint at /api/voice/realtime). Scoped to /api
+            // so Vite's own HMR socket is untouched.
+            ws: path === '/api/',
             configure: proxy => {
               // xfwd adds X-Forwarded-For/Port/Proto but NOT X-Forwarded-Host.
               // changeOrigin replaces Host with the target, so Express can't see
               // the original browser-facing host without this header.
               proxy.on('proxyReq', (proxyReq, req) => {
+                if (req.headers.host) {
+                  proxyReq.setHeader('X-Forwarded-Host', req.headers.host);
+                }
+              });
+              // The proxyReq handler above fires for HTTP only. WebSocket
+              // upgrades (e.g. /api/voice/realtime) need the same header set via
+              // proxyReqWs, otherwise the server sees the rewritten target host
+              // and can't verify the browser-facing origin.
+              proxy.on('proxyReqWs', (proxyReq, req) => {
                 if (req.headers.host) {
                   proxyReq.setHeader('X-Forwarded-Host', req.headers.host);
                 }

--- a/docs/microphone-feature.md
+++ b/docs/microphone-feature.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The microphone feature allows users to dictate messages instead of typing. It supports two operation modes, an optional transcript overlay, and two speech recognition backends (browser-native and Azure Cognitive Services).
+The microphone feature allows users to dictate messages instead of typing. It supports two operation modes, an optional transcript overlay, and multiple speech recognition backends (browser-native, Azure Cognitive Services, and an iHub-proxied vLLM realtime endpoint such as Voxtral).
 
 ## Modes
 
@@ -19,7 +19,72 @@ Configure which backend to use with `settings.speechRecognition.service`:
 | ----- | -------- |
 | `default` (or omitted) | Uses the browser's built-in `SpeechRecognition` / `webkitSpeechRecognition` API. No additional credentials are required. |
 | `azure` | Uses Azure Cognitive Services Speech SDK. Set `settings.speechRecognition.host` to your Azure Speech endpoint. |
+| `vllm-realtime` | Streams microphone audio to the iHub server over a WebSocket; iHub proxies it to a vLLM realtime endpoint (e.g. Voxtral on `/v1/realtime`) and streams transcription back. The endpoint is configured **server-side** in `platform.json` (see below) — no per-app `host` is needed and the vLLM URL/key never reach the browser. |
 | `custom` | Falls through to the browser default. Reserved for future custom providers. |
+
+### vLLM Realtime (server-proxied)
+
+This mode is for self-hosted realtime speech models served by vLLM's realtime API
+(for example `mistralai/Voxtral-Mini-4B-Realtime-2602`). The data flow is:
+
+```
+browser mic ──(PCM16 16kHz over WebSocket)──▶ iHub /api/voice/realtime
+   iHub ──(vLLM realtime JSON protocol)──▶ vLLM /v1/realtime ──transcription──▶ iHub ──▶ browser
+```
+
+**Platform configuration** (`contents/config/platform.json`):
+
+```json
+{
+  "speech": {
+    "realtime": {
+      "enabled": true,
+      "url": "ws://localhost:8080/v1/realtime",
+      "model": "mistralai/Voxtral-Mini-4B-Realtime-2602",
+      "apiKey": ""
+    }
+  }
+}
+```
+
+- `enabled` — master switch for the server-side proxy. When `false` (default), the endpoint returns 503.
+- `url` — the vLLM realtime WebSocket URL (`ws://` or `wss://`).
+- `model` — the model id sent in the `session.update` handshake.
+- `apiKey` — optional. Local vLLM usually needs none. Supports plaintext, a `${ENV_VAR}` placeholder, or an encrypted `ENC[...]` value (decrypted on load).
+
+**App configuration** — an app simply opts in:
+
+```json
+{
+  "settings": {
+    "speechRecognition": {
+      "service": "vllm-realtime"
+    }
+  }
+}
+```
+
+Both `manual` (continuous) and `automatic` (silence-detected auto-stop via client-side
+voice-activity detection) microphone modes are supported. Because the browser captures
+raw audio via `getUserMedia` + `AudioContext`/`AudioWorklet`, this mode requires a secure
+context (HTTPS, or `localhost`) and does not depend on the browser's Web Speech API — so
+it also works in Firefox.
+
+### Configuring backends in the Admin UI
+
+Admins can configure the platform-level speech backends under **Admin → Voice Input**
+(`/admin/voice-input`) instead of editing `platform.json` by hand:
+
+- **vLLM Realtime** — enable/disable, WebSocket URL, model, and an optional API key
+  (stored encrypted at rest; a localhost vLLM usually needs none).
+- **Azure Speech** — enable/disable, default host/endpoint, and region. The Azure
+  subscription **key** is provided via the `VITE_AZURE_SUBSCRIPTION_ID` environment
+  variable (baked into the client at build time) and is intentionally **not** stored in
+  platform config. When an app selects the Azure service without its own
+  `settings.speechRecognition.host`, it falls back to the platform host configured here.
+
+Per-app selection of which backend to use still happens in the app editor's
+**Speech Recognition Service** dropdown.
 
 ## Supported Languages
 

--- a/docs/microphone-feature.md
+++ b/docs/microphone-feature.md
@@ -76,12 +76,20 @@ Admins can configure the platform-level speech backends under **Admin → Voice 
 (`/admin/voice-input`) instead of editing `platform.json` by hand:
 
 - **vLLM Realtime** — enable/disable, WebSocket URL, model, and an optional API key
-  (stored encrypted at rest; a localhost vLLM usually needs none).
-- **Azure Speech** — enable/disable, default host/endpoint, and region. The Azure
-  subscription **key** is provided via the `VITE_AZURE_SUBSCRIPTION_ID` environment
-  variable (baked into the client at build time) and is intentionally **not** stored in
-  platform config. When an app selects the Azure service without its own
+  (stored encrypted at rest; a localhost vLLM usually needs none). Optional resource
+  guards live alongside these under `speech.realtime`: `maxConnections` (global cap,
+  default 50), `maxConnectionsPerUser` (default 3), and `maxFrameBytes` (max inbound
+  audio frame, default 256 KB). The proxy also opens the upstream vLLM socket only on
+  the first audio frame and closes idle / no-audio connections automatically.
+- **Azure Speech** — enable/disable, default host/endpoint, region, and the subscription
+  **key**. The key is stored **encrypted at rest** on the server and exchanged for a
+  short-lived authorization token per session via `/api/voice/azure/token`, so it never
+  reaches the browser. When an app selects the Azure service without its own
   `settings.speechRecognition.host`, it falls back to the platform host configured here.
+
+  > **Migrating from `VITE_AZURE_SUBSCRIPTION_ID`:** earlier builds baked the Azure key
+  > into the client bundle via this env var. It is no longer used — set the key under
+  > **Admin → Voice Input** (`speech.azure.subscriptionKey`) instead.
 
 Per-app selection of which backend to use still happens in the app editor's
 **Speech Recognition Service** dropdown.

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -217,3 +217,31 @@ came from the shared chat used across the platform, so any app could be affected
 - Also fixes a related crash for iFinder-backed apps that emit a response message id (used for
   answer feedback), which previously interrupted the reply the same way.
 - No configuration or admin action required.
+
+## Realtime Voice Input via Self-Hosted vLLM (Voxtral)
+
+Apps can now use a new speech-to-text backend that streams microphone audio to the iHub
+server, which proxies it to a self-hosted vLLM realtime endpoint (for example Voxtral) and
+streams the transcription back live. Unlike the browser and Azure backends, the model URL
+and any API key stay on the server and never reach the browser.
+
+- Configure the endpoint under **Admin → Voice Input** (or `platform.json` → `speech.realtime`):
+  `enabled`, `url`, `model`, optional `apiKey`; disabled by default.
+- Enable it per app by setting the app's Speech Recognition Service to **vLLM Realtime**
+  (`settings.speechRecognition.service: "vllm-realtime"`) — no per-app host needed.
+- Supports both manual (push-to-talk) and automatic (stops when you pause) microphone modes,
+  and works in browsers without the Web Speech API (including Firefox). Requires HTTPS or
+  localhost for microphone access.
+
+## Admin Page for Voice Input (Speech-to-Text)
+
+A new **Admin → Voice Input** page centralizes speech-to-text backend configuration, so
+admins no longer need to edit `platform.json` by hand.
+
+- **vLLM Realtime**: toggle, WebSocket URL, model, and an optional API key (stored encrypted
+  at rest).
+- **Azure Speech**: toggle, default host/endpoint, and region. Apps that select Azure without
+  their own host fall back to this platform default. (The Azure subscription key remains the
+  `VITE_AZURE_SUBSCRIPTION_ID` environment variable and is not stored in config.)
+- The app editor's **Speech Recognition Service** dropdown now also lists Azure alongside the
+  browser default, vLLM Realtime, and custom options.

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -232,6 +232,12 @@ and any API key stay on the server and never reach the browser.
 - Supports both manual (push-to-talk) and automatic (stops when you pause) microphone modes,
   and works in browsers without the Web Speech API (including Firefox). Requires HTTPS or
   localhost for microphone access.
+- **Resource guards** protect the GPU-backed upstream: the vLLM socket opens only once the
+  browser sends its first audio frame (an abandoned connection never pins a session), idle and
+  no-audio connections are closed automatically, and per-user / global concurrent-connection
+  caps bound how many sessions can run at once. Tune them under `speech.realtime`:
+  `maxConnections` (default 50), `maxConnectionsPerUser` (default 3), `maxFrameBytes`
+  (default 256 KB).
 
 ## Admin Page for Voice Input (Speech-to-Text)
 
@@ -240,8 +246,15 @@ admins no longer need to edit `platform.json` by hand.
 
 - **vLLM Realtime**: toggle, WebSocket URL, model, and an optional API key (stored encrypted
   at rest).
-- **Azure Speech**: toggle, default host/endpoint, and region. Apps that select Azure without
-  their own host fall back to this platform default. (The Azure subscription key remains the
-  `VITE_AZURE_SUBSCRIPTION_ID` environment variable and is not stored in config.)
+- **Azure Speech**: toggle, default host/endpoint, region, and the subscription key. The key is
+  stored **encrypted at rest** on the server and exchanged for a short-lived authorization token
+  per session (`/api/voice/azure/token`), so it never reaches the browser. Apps that select
+  Azure without their own host fall back to the platform default host.
 - The app editor's **Speech Recognition Service** dropdown now also lists Azure alongside the
   browser default, vLLM Realtime, and custom options.
+
+> **Breaking change:** The Azure subscription key is no longer read from the
+> `VITE_AZURE_SUBSCRIPTION_ID` build-time client env var (which baked the key into the browser
+> bundle). Move the key into **Admin → Voice Input** (`platform.json` → `speech.azure.subscriptionKey`).
+> Existing deployments that relied on the env var must set the key server-side for Azure to keep
+> working.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8027,18 +8027,6 @@
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
-    "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "jiti": "lib/jiti-cli.mjs"
-      }
-    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/server/configCache.js
+++ b/server/configCache.js
@@ -440,6 +440,13 @@ class ConfigCache {
         if (configPath === 'config/platform.json') {
           const platformData = await loadJson(configPath);
           if (platformData !== null) {
+            // Decrypt the realtime speech API key so the WS proxy receives
+            // plaintext. Env-var placeholders are resolved later in setCacheEntry.
+            if (platformData.speech?.realtime?.apiKey) {
+              platformData.speech.realtime.apiKey = decryptIfEncrypted(
+                platformData.speech.realtime.apiKey
+              );
+            }
             this.setCacheEntry(configPath, platformData);
             logger.info('Cached platform config', { component: 'ConfigCache', configPath });
           } else {

--- a/server/configCache.js
+++ b/server/configCache.js
@@ -447,6 +447,13 @@ class ConfigCache {
                 platformData.speech.realtime.apiKey
               );
             }
+            // Decrypt the Azure Speech subscription key so the token broker
+            // (/api/voice/azure/token) can exchange it for a short-lived token.
+            if (platformData.speech?.azure?.subscriptionKey) {
+              platformData.speech.azure.subscriptionKey = decryptIfEncrypted(
+                platformData.speech.azure.subscriptionKey
+              );
+            }
             this.setCacheEntry(configPath, platformData);
             logger.info('Cached platform config', { component: 'ConfigCache', configPath });
           } else {

--- a/server/defaults/config/platform.json
+++ b/server/defaults/config/platform.json
@@ -9,7 +9,8 @@
     "azure": {
       "enabled": false,
       "host": "",
-      "region": ""
+      "region": "",
+      "subscriptionKey": ""
     }
   },
   "skills": {

--- a/server/defaults/config/platform.json
+++ b/server/defaults/config/platform.json
@@ -1,4 +1,17 @@
 {
+  "speech": {
+    "realtime": {
+      "enabled": false,
+      "url": "ws://localhost:8080/v1/realtime",
+      "model": "mistralai/Voxtral-Mini-4B-Realtime-2602",
+      "apiKey": ""
+    },
+    "azure": {
+      "enabled": false,
+      "host": "",
+      "region": ""
+    }
+  },
   "skills": {
     "skillsDirectory": "contents/skills",
     "maxSkillBodyTokens": 5000

--- a/server/migrations/V070__add_speech_realtime.js
+++ b/server/migrations/V070__add_speech_realtime.js
@@ -1,0 +1,21 @@
+export const version = '070';
+export const description = 'add_speech_realtime';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  // Realtime speech-to-text via an iHub-proxied vLLM realtime endpoint (Voxtral).
+  // Disabled by default; admins point `url`/`model` at their vLLM instance and
+  // flip `enabled` to true. Apps opt in via settings.speechRecognition.service.
+  ctx.setDefault(platform, 'speech.realtime.enabled', false);
+  ctx.setDefault(platform, 'speech.realtime.url', 'ws://localhost:8080/v1/realtime');
+  ctx.setDefault(platform, 'speech.realtime.model', 'mistralai/Voxtral-Mini-4B-Realtime-2602');
+  ctx.setDefault(platform, 'speech.realtime.apiKey', '');
+
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Added speech.realtime defaults to platform.json');
+}

--- a/server/migrations/V071__add_speech_azure.js
+++ b/server/migrations/V071__add_speech_azure.js
@@ -1,0 +1,20 @@
+export const version = '071';
+export const description = 'add_speech_azure';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  // Platform-level defaults for the Azure Speech backend. The subscription key
+  // is provided via the VITE_AZURE_SUBSCRIPTION_ID env var (client build) and is
+  // intentionally NOT stored here. Apps may still override the host per-app.
+  ctx.setDefault(platform, 'speech.azure.enabled', false);
+  ctx.setDefault(platform, 'speech.azure.host', '');
+  ctx.setDefault(platform, 'speech.azure.region', '');
+
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Added speech.azure defaults to platform.json');
+}

--- a/server/migrations/V072__add_speech_azure_subscription_key.js
+++ b/server/migrations/V072__add_speech_azure_subscription_key.js
@@ -1,0 +1,19 @@
+export const version = '072';
+export const description = 'add_speech_azure_subscription_key';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  // The Azure subscription key is now a server-side secret (encrypted at rest)
+  // brokered into a short-lived token via /api/voice/azure/token, replacing the
+  // former VITE_AZURE_SUBSCRIPTION_ID build-time client env var. Default empty;
+  // admins set it under Admin → Voice Input.
+  ctx.setDefault(platform, 'speech.azure.subscriptionKey', '');
+
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Added speech.azure.subscriptionKey default to platform.json');
+}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -59,6 +59,7 @@
         "swagger-ui-express": "^5.0.1",
         "uuid": "^14.0.1",
         "winston": "^3.19.0",
+        "ws": "^8.21.0",
         "yauzl": "^3.2.1",
         "zod": "^3.25.74",
         "zod-to-json-schema": "^3.24.6"

--- a/server/package.json
+++ b/server/package.json
@@ -65,6 +65,7 @@
     "swagger-ui-express": "^5.0.1",
     "uuid": "^14.0.1",
     "winston": "^3.19.0",
+    "ws": "^8.21.0",
     "yauzl": "^3.2.1",
     "zod": "^3.25.74",
     "zod-to-json-schema": "^3.24.6"

--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -5,6 +5,8 @@ import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { reconfigureOidcProviders } from '../../middleware/oidcAuth.js';
+import tokenStorageService from '../../services/TokenStorageService.js';
+import { testRealtimeConnection } from '../../websocket/realtimeTranscription.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
@@ -51,6 +53,19 @@ function restoreSecretIfRedacted(newValue, existingValue) {
   }
   // Otherwise use the new value (could be a new secret or env var placeholder)
   return newValue;
+}
+
+/**
+ * Encrypt a secret string for storage, unless it is an env var placeholder or
+ * already encrypted. Mirrors the guard pattern used for model API keys.
+ * @param {string} value
+ * @returns {string}
+ */
+function encryptSecretIfNeeded(value) {
+  if (!value || typeof value !== 'string') return value;
+  if (isEnvVarPlaceholder(value)) return value;
+  if (tokenStorageService.isEncrypted(value)) return value;
+  return tokenStorageService.encryptString(value);
 }
 
 /**
@@ -217,6 +232,17 @@ export default function registerAdminConfigRoutes(app) {
         };
       }
 
+      // Sanitize the realtime speech API key (server-side secret).
+      if (sanitizedConfig.speech?.realtime?.apiKey) {
+        sanitizedConfig.speech = {
+          ...sanitizedConfig.speech,
+          realtime: {
+            ...sanitizedConfig.speech.realtime,
+            apiKey: sanitizeSecret(sanitizedConfig.speech.realtime.apiKey)
+          }
+        };
+      }
+
       // Sanitize proxy auth JWT provider secrets
       if (sanitizedConfig.proxyAuth?.jwtProviders) {
         sanitizedConfig.proxyAuth = {
@@ -278,7 +304,8 @@ export default function registerAdminConfigRoutes(app) {
         iFinder: newConfig.iFinder || existingConfig.iFinder,
         iAssistant: newConfig.iAssistant || existingConfig.iAssistant,
         telemetry:
-          newConfig.telemetry !== undefined ? newConfig.telemetry : existingConfig.telemetry
+          newConfig.telemetry !== undefined ? newConfig.telemetry : existingConfig.telemetry,
+        speech: newConfig.speech !== undefined ? newConfig.speech : existingConfig.speech
       };
 
       // Restore secrets that were redacted in the client
@@ -305,6 +332,18 @@ export default function registerAdminConfigRoutes(app) {
       // the central credential store and are referenced by *Ref ids that are
       // plain config values — they pass through the merge above unchanged and
       // require no encrypt/restore handling here.
+
+      // Realtime speech API key: restore if the client sent the redacted
+      // placeholder, otherwise encrypt the newly provided secret at rest.
+      if (newConfig.speech?.realtime && Object.hasOwn(newConfig.speech.realtime, 'apiKey')) {
+        if (!mergedConfig.speech) mergedConfig.speech = {};
+        if (!mergedConfig.speech.realtime) mergedConfig.speech.realtime = {};
+        const restored = restoreSecretIfRedacted(
+          newConfig.speech.realtime.apiKey,
+          existingConfig.speech?.realtime?.apiKey
+        );
+        mergedConfig.speech.realtime.apiKey = encryptSecretIfNeeded(restored);
+      }
 
       // Save to file
       await atomicWriteJSON(platformConfigPath, mergedConfig);
@@ -410,6 +449,38 @@ export default function registerAdminConfigRoutes(app) {
       });
     } catch (error) {
       return sendInternalError(res, error, 'update platform configuration');
+    }
+  });
+
+  /**
+   * Test connectivity to the vLLM realtime speech endpoint.
+   * Accepts optional { url, model, apiKey } to test unsaved form values. When
+   * the apiKey is omitted, blank, or the redacted placeholder, the saved
+   * (decrypted) key from the platform cache is used so the secret is never sent
+   * to the browser.
+   */
+  app.post(buildServerPath('/api/admin/voice/realtime/test'), adminAuth, async (req, res) => {
+    try {
+      const body = req.body || {};
+      const saved = (configCache.getPlatform() || {}).speech?.realtime || {};
+
+      const url = (body.url ?? saved.url ?? '').trim();
+      const model = body.model ?? saved.model ?? '';
+
+      // Resolve the API key without leaking the stored secret.
+      let apiKey = body.apiKey;
+      if (!apiKey || apiKey === '***REDACTED***' || isEnvVarPlaceholder(apiKey)) {
+        apiKey = saved.apiKey || ''; // already decrypted by configCache
+      }
+
+      if (!url) {
+        return res.json({ ok: false, message: 'No realtime URL configured' });
+      }
+
+      const result = await testRealtimeConnection({ url, model, apiKey });
+      return res.json(result);
+    } catch (error) {
+      return sendInternalError(res, error, 'test realtime speech connection');
     }
   });
 }

--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -243,6 +243,17 @@ export default function registerAdminConfigRoutes(app) {
         };
       }
 
+      // Sanitize the Azure Speech subscription key (server-side secret).
+      if (sanitizedConfig.speech?.azure?.subscriptionKey) {
+        sanitizedConfig.speech = {
+          ...sanitizedConfig.speech,
+          azure: {
+            ...sanitizedConfig.speech.azure,
+            subscriptionKey: sanitizeSecret(sanitizedConfig.speech.azure.subscriptionKey)
+          }
+        };
+      }
+
       // Sanitize proxy auth JWT provider secrets
       if (sanitizedConfig.proxyAuth?.jwtProviders) {
         sanitizedConfig.proxyAuth = {
@@ -343,6 +354,17 @@ export default function registerAdminConfigRoutes(app) {
           existingConfig.speech?.realtime?.apiKey
         );
         mergedConfig.speech.realtime.apiKey = encryptSecretIfNeeded(restored);
+      }
+
+      // Azure Speech subscription key: same restore-or-encrypt handling.
+      if (newConfig.speech?.azure && Object.hasOwn(newConfig.speech.azure, 'subscriptionKey')) {
+        if (!mergedConfig.speech) mergedConfig.speech = {};
+        if (!mergedConfig.speech.azure) mergedConfig.speech.azure = {};
+        const restored = restoreSecretIfRedacted(
+          newConfig.speech.azure.subscriptionKey,
+          existingConfig.speech?.azure?.subscriptionKey
+        );
+        mergedConfig.speech.azure.subscriptionKey = encryptSecretIfNeeded(restored);
       }
 
       // Save to file

--- a/server/routes/chat/dataRoutes.js
+++ b/server/routes/chat/dataRoutes.js
@@ -974,6 +974,24 @@ export default function registerDataRoutes(app) {
               credentials: platform.cors.credentials
               // Note: origin is intentionally excluded as it may contain internal URLs
             }
+          : undefined,
+        // Speech-to-text: expose only non-secret fields the client needs.
+        // The vLLM realtime URL/apiKey stay server-side (the browser connects to
+        // iHub, not vLLM); only whether it's enabled is surfaced. Azure host is
+        // not a secret and lets the client fall back to a platform default.
+        speech: platform.speech
+          ? {
+              realtime: platform.speech.realtime
+                ? { enabled: platform.speech.realtime.enabled }
+                : undefined,
+              azure: platform.speech.azure
+                ? {
+                    enabled: platform.speech.azure.enabled,
+                    host: platform.speech.azure.host,
+                    region: platform.speech.azure.region
+                  }
+                : undefined
+            }
           : undefined
       };
 

--- a/server/routes/voiceRoutes.js
+++ b/server/routes/voiceRoutes.js
@@ -1,0 +1,37 @@
+import configCache from '../configCache.js';
+import { authRequired } from '../middleware/authRequired.js';
+import { getAzureSpeechToken } from '../services/azureSpeechToken.js';
+import { buildServerPath } from '../utils/basePath.js';
+import logger from '../utils/logger.js';
+
+/**
+ * User-facing voice / speech-to-text routes.
+ *
+ * `/api/voice/azure/token` brokers a short-lived Azure Speech authorization
+ * token so the browser SDK never receives the subscription key. Requires
+ * authentication; the key is read (decrypted) from platform.speech.azure.
+ */
+export default function registerVoiceRoutes(app) {
+  app.get(buildServerPath('/api/voice/azure/token'), authRequired, async (req, res) => {
+    try {
+      const azure = (configCache.getPlatform() || {}).speech?.azure || {};
+      if (!azure.enabled) {
+        return res.status(503).json({ error: 'Azure Speech is not enabled' });
+      }
+      const result = await getAzureSpeechToken({
+        subscriptionKey: azure.subscriptionKey, // decrypted by configCache on load
+        region: azure.region
+      });
+      if (!result.ok) {
+        return res.status(502).json({ error: result.error });
+      }
+      return res.json({ token: result.token, region: result.region });
+    } catch (error) {
+      logger.error('Failed to issue Azure Speech token', {
+        component: 'VoiceRoutes',
+        error: error.message
+      });
+      return res.status(500).json({ error: 'Failed to issue Azure Speech token' });
+    }
+  });
+}

--- a/server/server.js
+++ b/server/server.js
@@ -36,6 +36,7 @@ import { registerTriggerRoutes } from './routes/workflow/triggerRoutes.js';
 import { authRequired } from './middleware/authRequired.js';
 import { adminAuth } from './middleware/adminAuth.js';
 import { attachRealtimeTranscription } from './websocket/realtimeTranscription.js';
+import registerVoiceRoutes from './routes/voiceRoutes.js';
 import registerSetupRoutes from './routes/setup.js';
 import registerPwaRoutes from './routes/pwaRoutes.js';
 import registerThemeRoutes from './routes/themeRoutes.js';
@@ -473,6 +474,7 @@ if (cluster.isPrimary && workerCount > 1) {
   registerWorkflowRoutes(app, { getLocalizedError });
   registerTriggerRoutes(app, { authRequired, adminAuth });
   registerAgentRoutes(app);
+  registerVoiceRoutes(app);
   registerSetupRoutes(app);
 
   // --- Integration Routes ---

--- a/server/server.js
+++ b/server/server.js
@@ -35,6 +35,7 @@ import registerAgentRoutes from './routes/agents/index.js';
 import { registerTriggerRoutes } from './routes/workflow/triggerRoutes.js';
 import { authRequired } from './middleware/authRequired.js';
 import { adminAuth } from './middleware/adminAuth.js';
+import { attachRealtimeTranscription } from './websocket/realtimeTranscription.js';
 import registerSetupRoutes from './routes/setup.js';
 import registerPwaRoutes from './routes/pwaRoutes.js';
 import registerThemeRoutes from './routes/themeRoutes.js';
@@ -555,6 +556,12 @@ if (cluster.isPrimary && workerCount > 1) {
       message: 'Starting HTTP server (no SSL configuration provided)'
     });
   }
+
+  // Attach the realtime speech-to-text WebSocket handler. Works in both
+  // single-process and sticky-cluster worker modes — WS upgrades ride the same
+  // TCP connection the primary hands to the worker, so no extra coordination is
+  // needed.
+  attachRealtimeTranscription(server);
 
   if (cluster.isWorker) {
     // Inside a sticky cluster the primary owns the public port; this worker

--- a/server/services/azureSpeechToken.js
+++ b/server/services/azureSpeechToken.js
@@ -1,0 +1,92 @@
+/**
+ * Azure Speech token broker.
+ *
+ * The Azure subscription key is a server-side secret (stored encrypted in
+ * platform.speech.azure). The browser Speech SDK authenticates with a
+ * short-lived authorization token instead of the key, so the key never leaves
+ * the server. This module exchanges the subscription key for such a token via
+ * the Azure STS `issueToken` endpoint, with a small in-memory cache (tokens are
+ * valid ~10 minutes; Microsoft recommends refreshing before that).
+ *
+ * https://learn.microsoft.com/azure/ai-services/speech-service/rest-speech-to-text-short#authentication
+ */
+import logger from '../utils/logger.js';
+
+// Azure regions are lowercase alphanumerics (optionally hyphenated), e.g.
+// `westeurope`, `eastus2`. Rejecting anything else prevents an
+// attacker-influenced region from redirecting the token request (SSRF).
+const REGION_RE = /^[a-z0-9-]+$/;
+
+// Refresh a little before the ~10-minute Azure token lifetime.
+const TOKEN_TTL_MS = 9 * 60 * 1000;
+
+const cache = new Map(); // key -> { token, region, expiresAt }
+
+/**
+ * Exchange an Azure subscription key for a short-lived authorization token.
+ *
+ * @param {{subscriptionKey?: string, region?: string}} cfg
+ * @param {typeof fetch} [fetchImpl] Injectable for testing.
+ * @returns {Promise<{ok: true, token: string, region: string} | {ok: false, error: string}>}
+ */
+export async function issueAzureSpeechToken(cfg = {}, fetchImpl = fetch) {
+  const subscriptionKey = cfg.subscriptionKey;
+  const region = (cfg.region || '').trim();
+
+  if (!subscriptionKey) {
+    return { ok: false, error: 'Azure subscription key is not configured' };
+  }
+  if (!region) {
+    return { ok: false, error: 'Azure region is not configured' };
+  }
+  if (!REGION_RE.test(region)) {
+    return { ok: false, error: `Invalid Azure region "${region}"` };
+  }
+
+  const url = `https://${region}.api.cognitive.microsoft.com/sts/v1.0/issueToken`;
+  try {
+    const res = await fetchImpl(url, {
+      method: 'POST',
+      headers: {
+        'Ocp-Apim-Subscription-Key': subscriptionKey,
+        'Content-Length': '0'
+      }
+    });
+    if (!res.ok) {
+      return { ok: false, error: `Azure token request failed (HTTP ${res.status})` };
+    }
+    const token = await res.text();
+    return { ok: true, token, region };
+  } catch (err) {
+    return { ok: false, error: `Azure token request failed: ${err.message}` };
+  }
+}
+
+/**
+ * Cached variant of {@link issueAzureSpeechToken}. Returns a still-valid cached
+ * token when available, otherwise issues (and caches) a fresh one.
+ */
+export async function getAzureSpeechToken(cfg = {}, fetchImpl = fetch, now = Date.now()) {
+  const region = (cfg.region || '').trim();
+  const key = `${region}:${cfg.subscriptionKey || ''}`;
+  const cached = cache.get(key);
+  if (cached && cached.expiresAt > now) {
+    return { ok: true, token: cached.token, region: cached.region };
+  }
+
+  const result = await issueAzureSpeechToken(cfg, fetchImpl);
+  if (result.ok) {
+    cache.set(key, { token: result.token, region: result.region, expiresAt: now + TOKEN_TTL_MS });
+  } else {
+    logger.warn('Azure Speech token issuance failed', {
+      component: 'AzureSpeechToken',
+      error: result.error
+    });
+  }
+  return result;
+}
+
+/** Clear the token cache (used in tests). */
+export function _clearAzureTokenCache() {
+  cache.clear();
+}

--- a/server/tests/azureSpeechToken.test.js
+++ b/server/tests/azureSpeechToken.test.js
@@ -1,0 +1,79 @@
+/**
+ * Azure Speech token broker — unit tests.
+ *
+ * The server holds the Azure subscription key and exchanges it for a short-lived
+ * authorization token the browser SDK uses, so the key never reaches the client.
+ * These tests lock in the STS request shape and the input guards (including the
+ * region-format guard that prevents an attacker-influenced region from
+ * redirecting the token request — SSRF).
+ */
+import { issueAzureSpeechToken } from '../services/azureSpeechToken.js';
+
+const okFetch = token => async (url, opts) => ({
+  ok: true,
+  status: 200,
+  text: async () => token,
+  _url: url,
+  _opts: opts
+});
+
+describe('issueAzureSpeechToken', () => {
+  test('rejects when the subscription key is missing', async () => {
+    const result = await issueAzureSpeechToken({ region: 'westeurope' }, okFetch('t'));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/key/i);
+  });
+
+  test('rejects when the region is missing', async () => {
+    const result = await issueAzureSpeechToken({ subscriptionKey: 'sk' }, okFetch('t'));
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/region/i);
+  });
+
+  test('rejects a malformed region (SSRF guard)', async () => {
+    const result = await issueAzureSpeechToken(
+      { subscriptionKey: 'sk', region: 'evil.example.com/redirect' },
+      okFetch('t')
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/region/i);
+  });
+
+  test('POSTs to the regional STS endpoint with the subscription-key header', async () => {
+    let captured;
+    const fetchImpl = async (url, opts) => {
+      captured = { url, opts };
+      return { ok: true, status: 200, text: async () => 'the-token' };
+    };
+    const result = await issueAzureSpeechToken(
+      { subscriptionKey: 'sk-123', region: 'westeurope' },
+      fetchImpl
+    );
+    expect(result).toEqual({ ok: true, token: 'the-token', region: 'westeurope' });
+    expect(captured.url).toBe('https://westeurope.api.cognitive.microsoft.com/sts/v1.0/issueToken');
+    expect(captured.opts.method).toBe('POST');
+    expect(captured.opts.headers['Ocp-Apim-Subscription-Key']).toBe('sk-123');
+  });
+
+  test('reports a non-OK STS response with its status', async () => {
+    const fetchImpl = async () => ({ ok: false, status: 401, text: async () => 'Unauthorized' });
+    const result = await issueAzureSpeechToken(
+      { subscriptionKey: 'sk', region: 'westeurope' },
+      fetchImpl
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/401/);
+  });
+
+  test('reports a network failure without throwing', async () => {
+    const fetchImpl = async () => {
+      throw new Error('ECONNREFUSED');
+    };
+    const result = await issueAzureSpeechToken(
+      { subscriptionKey: 'sk', region: 'westeurope' },
+      fetchImpl
+    );
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/ECONNREFUSED/);
+  });
+});

--- a/server/tests/realtimeTranscription.test.js
+++ b/server/tests/realtimeTranscription.test.js
@@ -1,0 +1,208 @@
+/**
+ * Realtime speech-to-text WebSocket proxy — unit tests.
+ *
+ * Locks in the security-critical behavior of the upgrade path (Cross-Site
+ * WebSocket Hijacking origin guard, JWT/anonymous auth), the resource-exhaustion
+ * guard (per-user + global connection caps), and the upstream error-diagnostic
+ * mapping. These previously lived only in throwaway verification scripts.
+ */
+import {
+  normalizeOrigin,
+  isAllowedOrigin,
+  extractToken,
+  authenticateUpgrade,
+  ConnectionLimiter,
+  diagnoseSocketError,
+  diagnoseUnexpectedResponse,
+  diagnoseUpstreamClose
+} from '../websocket/realtimeTranscription.js';
+import { generateJwt } from '../utils/tokenService.js';
+import configCache from '../configCache.js';
+
+// verifyJwt (called inside authenticateUpgrade) resolves its algorithm and
+// signing key from the platform cache. Seed a symmetric HS256 secret so tokens
+// generated here validate, without depending on RSA key material.
+beforeAll(() => {
+  configCache.setCacheEntry('config/platform.json', {
+    jwt: { algorithm: 'HS256' },
+    auth: { jwtSecret: 'realtime-stt-test-secret' }
+  });
+});
+
+afterAll(() => {
+  // setCacheEntry schedules a TTL refresh timer that dynamically imports the
+  // telemetry module; cancel it so it can't fire after Jest tears the env down.
+  const timer = configCache.refreshTimers?.get('config/platform.json');
+  if (timer) clearTimeout(timer);
+  configCache.refreshTimers?.delete('config/platform.json');
+});
+
+const anonAllowed = {
+  anonymousAuth: { enabled: true, defaultGroups: ['anonymous'] }
+};
+const anonDenied = {
+  anonymousAuth: { enabled: false, defaultGroups: ['anonymous'] }
+};
+
+describe('normalizeOrigin', () => {
+  test('strips trailing path and slashes to scheme+host(+port)', () => {
+    expect(normalizeOrigin('https://app.example.com/')).toBe('https://app.example.com');
+    expect(normalizeOrigin('https://app.example.com/some/path')).toBe('https://app.example.com');
+    expect(normalizeOrigin('http://localhost:3000')).toBe('http://localhost:3000');
+  });
+});
+
+describe('isAllowedOrigin (CSWSH guard)', () => {
+  const platform = { cors: { origin: ['https://trusted.example.com'] } };
+
+  test('allows a missing Origin (non-browser caller cannot be a CSWSH victim)', () => {
+    expect(isAllowedOrigin({ headers: { host: 'ihub.local' } }, platform)).toBe(true);
+  });
+
+  test('allows same-origin via Host header', () => {
+    const req = { headers: { host: 'ihub.local', origin: 'https://ihub.local' } };
+    expect(isAllowedOrigin(req, platform)).toBe(true);
+  });
+
+  test('allows same-origin via X-Forwarded-Host (behind a reverse proxy)', () => {
+    const req = {
+      headers: {
+        host: 'internal:3000',
+        'x-forwarded-host': 'ihub.public.com',
+        origin: 'https://ihub.public.com'
+      }
+    };
+    expect(isAllowedOrigin(req, platform)).toBe(true);
+  });
+
+  test('allows an origin in the configured CORS allowlist', () => {
+    const req = { headers: { host: 'internal', origin: 'https://trusted.example.com' } };
+    expect(isAllowedOrigin(req, platform)).toBe(true);
+  });
+
+  test('rejects a cross-origin browser handshake', () => {
+    const req = { headers: { host: 'ihub.local', origin: 'https://evil.example.com' } };
+    expect(isAllowedOrigin(req, platform)).toBe(false);
+  });
+
+  test('honors a wildcard CORS origin', () => {
+    const req = { headers: { host: 'ihub.local', origin: 'https://anything.com' } };
+    expect(isAllowedOrigin(req, { cors: { origin: ['*'] } })).toBe(true);
+  });
+});
+
+describe('extractToken', () => {
+  test('reads a Bearer token from the Authorization header', () => {
+    expect(extractToken({ headers: { authorization: 'Bearer abc.def.ghi' } })).toBe('abc.def.ghi');
+  });
+
+  test('reads the authToken cookie and url-decodes it', () => {
+    const req = { headers: { cookie: 'other=1; authToken=a%2Bb.c; foo=2' } };
+    expect(extractToken(req)).toBe('a+b.c');
+  });
+
+  test('returns null when no token is present', () => {
+    expect(extractToken({ headers: {} })).toBeNull();
+  });
+});
+
+describe('authenticateUpgrade', () => {
+  test('accepts a valid JWT and returns the user identity', () => {
+    const { token } = generateJwt({ id: 'u1', name: 'Alice', groups: ['users'] });
+    const req = { headers: { cookie: `authToken=${token}` } };
+    const user = authenticateUpgrade(req, anonDenied);
+    expect(user).toBeTruthy();
+    expect(user.id).toBe('u1');
+  });
+
+  test('falls back to anonymous when anonymous access is enabled and no token', () => {
+    const user = authenticateUpgrade({ headers: {} }, anonAllowed);
+    expect(user).toEqual({ id: 'anonymous', name: 'anonymous' });
+  });
+
+  test('rejects (null) when no token and anonymous access is disabled', () => {
+    expect(authenticateUpgrade({ headers: {} }, anonDenied)).toBeNull();
+  });
+
+  test('rejects an invalid token when anonymous access is disabled', () => {
+    const req = { headers: { cookie: 'authToken=not-a-real-jwt' } };
+    expect(authenticateUpgrade(req, anonDenied)).toBeNull();
+  });
+});
+
+describe('ConnectionLimiter', () => {
+  test('enforces the per-user cap', () => {
+    const limiter = new ConnectionLimiter({ maxTotal: 10, maxPerUser: 2 });
+    expect(limiter.tryAcquire('a')).toBe(true);
+    expect(limiter.tryAcquire('a')).toBe(true);
+    expect(limiter.tryAcquire('a')).toBe(false); // third for 'a' exceeds per-user
+    expect(limiter.tryAcquire('b')).toBe(true); // other user unaffected
+  });
+
+  test('enforces the global cap across users', () => {
+    const limiter = new ConnectionLimiter({ maxTotal: 2, maxPerUser: 5 });
+    expect(limiter.tryAcquire('a')).toBe(true);
+    expect(limiter.tryAcquire('b')).toBe(true);
+    expect(limiter.tryAcquire('c')).toBe(false); // global cap reached
+  });
+
+  test('release frees a slot for the same user', () => {
+    const limiter = new ConnectionLimiter({ maxTotal: 1, maxPerUser: 1 });
+    expect(limiter.tryAcquire('a')).toBe(true);
+    expect(limiter.tryAcquire('a')).toBe(false);
+    limiter.release('a');
+    expect(limiter.tryAcquire('a')).toBe(true);
+  });
+
+  test('release never drives a counter negative', () => {
+    const limiter = new ConnectionLimiter({ maxTotal: 2, maxPerUser: 2 });
+    limiter.release('a'); // release without acquire is a no-op
+    expect(limiter.tryAcquire('a')).toBe(true);
+    expect(limiter.tryAcquire('a')).toBe(true);
+    expect(limiter.tryAcquire('a')).toBe(false);
+  });
+});
+
+describe('upstream error diagnostics', () => {
+  test('diagnoseSocketError includes the error code when the message is empty', () => {
+    expect(diagnoseSocketError({ code: 'ECONNREFUSED', message: '' })).toBe(
+      'Transcription service unreachable: ECONNREFUSED'
+    );
+  });
+
+  test('diagnoseSocketError falls back to a generic message when nothing is set', () => {
+    expect(diagnoseSocketError({})).toBe('Transcription service unreachable: connection error');
+  });
+
+  test('diagnoseUnexpectedResponse reports the HTTP status', () => {
+    expect(diagnoseUnexpectedResponse({ statusCode: 404, statusMessage: 'Not Found' })).toBe(
+      'Transcription service rejected the connection (HTTP 404 Not Found)'
+    );
+  });
+
+  test('diagnoseUpstreamClose reports an abnormal close before the handshake', () => {
+    const msg = diagnoseUpstreamClose({
+      gotTranscription: false,
+      upstreamReady: false,
+      code: 1006
+    });
+    expect(msg).toMatch(/closed the connection \(code 1006/);
+  });
+
+  test('diagnoseUpstreamClose is silent on a clean close after transcription', () => {
+    expect(
+      diagnoseUpstreamClose({ gotTranscription: true, upstreamReady: true, code: 1000 })
+    ).toBeNull();
+  });
+
+  test('diagnoseUpstreamClose is silent on a clean close with nothing transcribed', () => {
+    expect(
+      diagnoseUpstreamClose({ gotTranscription: false, upstreamReady: true, code: 1000 })
+    ).toBeNull();
+  });
+
+  test('diagnoseUpstreamClose reports an abnormal close code even after handshake', () => {
+    const msg = diagnoseUpstreamClose({ gotTranscription: false, upstreamReady: true, code: 1011 });
+    expect(msg).toMatch(/code 1011/);
+  });
+});

--- a/server/validators/appConfigSchema.js
+++ b/server/validators/appConfigSchema.js
@@ -105,7 +105,10 @@ const settingsSchema = z
       .optional(),
     speechRecognition: z
       .object({
-        service: z.enum(['default', 'custom']).optional().default('default'),
+        service: z
+          .enum(['default', 'azure', 'custom', 'vllm-realtime'])
+          .optional()
+          .default('default'),
         host: z.string().url().optional()
       })
       .optional()

--- a/server/validators/platformConfigSchema.js
+++ b/server/validators/platformConfigSchema.js
@@ -226,20 +226,28 @@ export const platformConfigSchema = z
             model: z.string().default(''),
             // Optional. Supports plaintext, ${ENV_VAR} placeholders, and
             // ENC[...] encrypted values (decrypted by configCache on load).
-            apiKey: z.string().default('')
+            apiKey: z.string().default(''),
+            // Resource guards for the WS proxy (each session pins a GPU-backed
+            // upstream socket). Optional; sane defaults applied in code.
+            maxConnections: z.number().int().positive().optional(),
+            maxConnectionsPerUser: z.number().int().positive().optional(),
+            maxFrameBytes: z.number().int().positive().optional()
           })
           .passthrough()
           .default({}),
-        // Azure Speech runs in the browser via the Speech SDK. The subscription
-        // KEY is provided via the VITE_AZURE_SUBSCRIPTION_ID env var (baked into
-        // the client) and is intentionally NOT stored here. These are the
-        // platform-level defaults the client falls back to when an app does not
-        // set its own settings.speechRecognition.host.
+        // Azure Speech runs in the browser via the Speech SDK, but the
+        // subscription KEY is a server-side secret: the server exchanges it for
+        // a short-lived authorization token (see /api/voice/azure/token) so the
+        // key never reaches the browser. host/region are the platform-level
+        // defaults the client uses when an app sets no host of its own.
         azure: z
           .object({
             enabled: z.boolean().default(false),
             host: z.string().default(''),
-            region: z.string().default('')
+            region: z.string().default(''),
+            // Server-side secret. Supports plaintext, ${ENV_VAR} placeholders,
+            // and ENC[...] encrypted values (decrypted by configCache on load).
+            subscriptionKey: z.string().default('')
           })
           .passthrough()
           .default({})

--- a/server/validators/platformConfigSchema.js
+++ b/server/validators/platformConfigSchema.js
@@ -212,7 +212,40 @@ export const platformConfigSchema = z
       })
       .passthrough()
       .default({}),
-    usageTracking: usageTrackingRetentionSchema.default({})
+    usageTracking: usageTrackingRetentionSchema.default({}),
+    // Realtime speech-to-text: the browser streams mic audio to iHub over a
+    // WebSocket and iHub proxies it to a vLLM realtime endpoint (e.g. Voxtral
+    // on /v1/realtime). The url/apiKey stay server-side. Apps opt in with
+    // settings.speechRecognition.service = 'vllm-realtime'.
+    speech: z
+      .object({
+        realtime: z
+          .object({
+            enabled: z.boolean().default(false),
+            url: z.string().default(''),
+            model: z.string().default(''),
+            // Optional. Supports plaintext, ${ENV_VAR} placeholders, and
+            // ENC[...] encrypted values (decrypted by configCache on load).
+            apiKey: z.string().default('')
+          })
+          .passthrough()
+          .default({}),
+        // Azure Speech runs in the browser via the Speech SDK. The subscription
+        // KEY is provided via the VITE_AZURE_SUBSCRIPTION_ID env var (baked into
+        // the client) and is intentionally NOT stored here. These are the
+        // platform-level defaults the client falls back to when an app does not
+        // set its own settings.speechRecognition.host.
+        azure: z
+          .object({
+            enabled: z.boolean().default(false),
+            host: z.string().default(''),
+            region: z.string().default('')
+          })
+          .passthrough()
+          .default({})
+      })
+      .passthrough()
+      .default({})
   })
   .passthrough();
 

--- a/server/websocket/realtimeTranscription.js
+++ b/server/websocket/realtimeTranscription.js
@@ -9,6 +9,15 @@
  * stay server-side (`platform.speech.realtime`); the browser never talks to vLLM
  * directly.
  *
+ * Resource guards (a transcription session pins a GPU-backed upstream socket):
+ *   - The upstream socket opens LAZILY on the first audio frame, not on connect,
+ *     so an idle/abandoned browser socket never pins an upstream session.
+ *   - A short no-audio grace timeout closes sockets that connect but never speak.
+ *   - Per-user and global concurrent-connection caps (ConnectionLimiter) bound
+ *     the number of simultaneous upstream sessions one user (or the whole
+ *     instance) can hold.
+ *   - `maxPayload` caps the size of a single inbound audio frame.
+ *
  * Browser <-> iHub protocol (iHub-defined, we own both ends):
  *   client -> server: JSON `{type:'start', lang?}`, then binary PCM16 frames,
  *                     then JSON `{type:'stop'}`
@@ -30,12 +39,62 @@ import { buildApiPath } from '../utils/basePath.js';
 // Close cleanly if the browser stops sending audio and no transcription is
 // flowing. Keeps orphaned upstream sockets from lingering.
 const IDLE_TIMEOUT_MS = 60_000;
+// A connection that opens but never sends an audio frame is closed after this,
+// so abandoned sockets don't sit holding a limiter slot.
+const NO_AUDIO_GRACE_MS = 15_000;
+
+// Defaults for the concurrent-connection caps. Overridable via
+// platform.speech.realtime.{maxConnections,maxConnectionsPerUser}.
+const DEFAULT_MAX_TOTAL_CONNECTIONS = 50;
+const DEFAULT_MAX_CONNECTIONS_PER_USER = 3;
+// Largest single inbound audio frame we accept. The browser sends ~4 KB PCM16
+// frames; 256 KB is generous headroom while bounding per-frame memory.
+const DEFAULT_MAX_FRAME_BYTES = 256 * 1024;
+// Cap on audio frames buffered while the upstream socket is still connecting,
+// so a fast talker can't grow memory unbounded during the (brief) handshake.
+const MAX_PENDING_FRAMES = 250;
+
+/**
+ * Tracks concurrent bridge connections and enforces a per-user and a global cap
+ * so no single user (and no single instance) can pin an unbounded number of
+ * GPU-backed upstream transcription sessions.
+ */
+export class ConnectionLimiter {
+  constructor({
+    maxTotal = DEFAULT_MAX_TOTAL_CONNECTIONS,
+    maxPerUser = DEFAULT_MAX_CONNECTIONS_PER_USER
+  } = {}) {
+    this.maxTotal = maxTotal;
+    this.maxPerUser = maxPerUser;
+    this.total = 0;
+    this.perUser = new Map();
+  }
+
+  /** Reserve a slot for `userId`. Returns false (and reserves nothing) if a cap is hit. */
+  tryAcquire(userId) {
+    const used = this.perUser.get(userId) || 0;
+    if (this.total >= this.maxTotal) return false;
+    if (used >= this.maxPerUser) return false;
+    this.total += 1;
+    this.perUser.set(userId, used + 1);
+    return true;
+  }
+
+  /** Free a previously-acquired slot. A release without a matching acquire is a no-op. */
+  release(userId) {
+    const used = this.perUser.get(userId) || 0;
+    if (used <= 0) return;
+    if (used === 1) this.perUser.delete(userId);
+    else this.perUser.set(userId, used - 1);
+    this.total = Math.max(0, this.total - 1);
+  }
+}
 
 /**
  * Strip a trailing slash / path from an origin so comparison is scheme+host(+port),
  * the form a browser sends in the Origin header.
  */
-function normalizeOrigin(origin) {
+export function normalizeOrigin(origin) {
   if (typeof origin !== 'string') return origin;
   const trimmed = origin.trim();
   const schemeEnd = trimmed.indexOf('://');
@@ -78,7 +137,7 @@ function resolveConfiguredOrigins(platform) {
  * victim (same-origin policy is a browser concept), so a missing Origin is
  * allowed.
  */
-function isAllowedOrigin(req) {
+export function isAllowedOrigin(req, platform = configCache.getPlatform() || {}) {
   const origin = req.headers.origin;
   if (!origin) return true; // non-browser caller — not a CSWSH vector
 
@@ -95,7 +154,7 @@ function isAllowedOrigin(req) {
     }
   }
 
-  const configured = resolveConfiguredOrigins(configCache.getPlatform() || {}).map(normalizeOrigin);
+  const configured = resolveConfiguredOrigins(platform).map(normalizeOrigin);
   if (configured.includes('*')) return true;
   return configured.includes(normalized);
 }
@@ -104,7 +163,7 @@ function isAllowedOrigin(req) {
  * Extract the authToken from a raw upgrade request (Bearer header or cookie).
  * The upgrade request never went through Express, so cookies aren't parsed.
  */
-function extractToken(req) {
+export function extractToken(req) {
   const authHeader = req.headers.authorization;
   if (authHeader && authHeader.startsWith('Bearer ')) {
     return authHeader.substring(7);
@@ -130,8 +189,7 @@ function extractToken(req) {
  * Authenticate an upgrade request. Returns a minimal user object, or null when
  * authentication is required but missing/invalid.
  */
-function authenticateUpgrade(req) {
-  const platform = configCache.getPlatform() || {};
+export function authenticateUpgrade(req, platform = configCache.getPlatform() || {}) {
   const token = extractToken(req);
 
   if (token) {
@@ -161,43 +219,73 @@ function getRealtimeConfig() {
   return cfg;
 }
 
+// --- Upstream error diagnostics (pure, unit-tested) ---
+
+/**
+ * Client-facing message for a socket-level upstream failure (ECONNREFUSED,
+ * ETIMEDOUT, ENOTFOUND, TLS errors…). `err.message` is often empty, so `err.code`
+ * usually carries the actionable detail.
+ */
+export function diagnoseSocketError(err = {}) {
+  const detail = [err.code, err.message].filter(Boolean).join(': ') || 'connection error';
+  return `Transcription service unreachable: ${detail}`;
+}
+
+/**
+ * Client-facing message when the upstream rejected the WS upgrade with an HTTP
+ * response (404 wrong path, 401/403 auth, 502 bad gateway…).
+ */
+export function diagnoseUnexpectedResponse(res = {}) {
+  return `Transcription service rejected the connection (HTTP ${res.statusCode} ${res.statusMessage || ''})`.trim();
+}
+
+/**
+ * Client-facing message for an upstream close, or null when the close is
+ * expected. A clean close (code 1000) is expected; so is a clean close after we
+ * already delivered transcription. Report only genuinely-abnormal closes:
+ * before the handshake completed, or a non-normal code with nothing transcribed.
+ */
+export function diagnoseUpstreamClose({ gotTranscription, upstreamReady, code, reason } = {}) {
+  if (!gotTranscription && (!upstreamReady || code !== 1000)) {
+    return `Transcription service closed the connection (code ${code}${reason ? `: ${reason}` : ''})`;
+  }
+  return null;
+}
+
 function sendJson(ws, obj) {
-  if (ws.readyState === WebSocket.OPEN) {
+  if (ws && ws.readyState === WebSocket.OPEN) {
     ws.send(JSON.stringify(obj));
   }
 }
 
 /**
- * Bridge a single accepted browser connection to a fresh upstream vLLM socket.
+ * Bridge a single accepted browser connection to a vLLM upstream socket. The
+ * limiter slot has already been acquired by the caller; this function owns
+ * releasing it exactly once on teardown.
  */
-function bridgeConnection(clientWs, user) {
+function bridgeConnection(clientWs, user, limiter) {
   const cfg = getRealtimeConfig();
   if (!cfg) {
     sendJson(clientWs, { type: 'error', message: 'Realtime transcription is not configured' });
     clientWs.close();
+    limiter.release(user.id);
     return;
   }
 
-  const headers = {};
-  if (cfg.apiKey) headers.Authorization = `Bearer ${cfg.apiKey}`;
-
-  let upstream;
-  try {
-    upstream = new WebSocket(cfg.url, { headers });
-  } catch (err) {
-    logger.error('Realtime STT: failed to open upstream socket', {
-      component: 'RealtimeSTT',
-      error: err.message
-    });
-    sendJson(clientWs, { type: 'error', message: 'Failed to reach transcription service' });
-    clientWs.close();
-    return;
-  }
-
+  let upstream = null; // opened lazily on the first audio frame
   let upstreamReady = false; // handshake complete, audio may flow
   let gotTranscription = false; // at least one delta/final was received
   let errorSent = false; // guard so we report a failure at most once
+  let released = false; // guard so we release the limiter slot at most once
   let idleTimer = null;
+  let graceTimer = null;
+  const pending = []; // base64 audio frames buffered until upstream opens
+
+  const releaseSlot = () => {
+    if (released) return;
+    released = true;
+    limiter.release(user.id);
+  };
 
   const resetIdle = () => {
     if (idleTimer) clearTimeout(idleTimer);
@@ -210,6 +298,8 @@ function bridgeConnection(clientWs, user) {
   const cleanup = () => {
     if (idleTimer) clearTimeout(idleTimer);
     idleTimer = null;
+    if (graceTimer) clearTimeout(graceTimer);
+    graceTimer = null;
     if (upstream && upstream.readyState <= WebSocket.OPEN) {
       try {
         upstream.close();
@@ -224,6 +314,7 @@ function bridgeConnection(clientWs, user) {
         /* ignore */
       }
     }
+    releaseSlot();
   };
 
   // Report an upstream failure to the browser (once) with a diagnostic message
@@ -242,88 +333,123 @@ function bridgeConnection(clientWs, user) {
     cleanup();
   };
 
-  // --- Upstream (vLLM) -> iHub ---
-  upstream.on('open', () => {
-    // Handshake: identify the model, then open the audio buffer.
-    sendJson(upstream, { type: 'session.update', model: cfg.model });
-    sendJson(upstream, { type: 'input_audio_buffer.commit' });
-    upstreamReady = true;
-    sendJson(clientWs, { type: 'ready' });
-    resetIdle();
-  });
+  // Open the upstream vLLM socket on demand (first audio frame). Everything the
+  // bridge does upstream lives here so no upstream session exists until the
+  // browser actually starts speaking.
+  const openUpstream = () => {
+    if (upstream) return;
+    if (graceTimer) {
+      clearTimeout(graceTimer);
+      graceTimer = null;
+    }
 
-  upstream.on('message', data => {
-    resetIdle();
-    let msg;
+    const headers = {};
+    if (cfg.apiKey) headers.Authorization = `Bearer ${cfg.apiKey}`;
+
     try {
-      msg = JSON.parse(data.toString());
-    } catch {
-      return; // vLLM realtime frames are JSON; ignore anything else
-    }
-    switch (msg.type) {
-      case 'transcription.delta':
-        gotTranscription = true;
-        sendJson(clientWs, { type: 'delta', text: msg.delta || '' });
-        break;
-      case 'transcription.done':
-        gotTranscription = true;
-        sendJson(clientWs, { type: 'final', text: msg.text || '' });
-        break;
-      case 'error':
-        notifyUpstreamError(`Transcription error: ${msg.error || 'unknown'}`, {
-          reason: 'upstream error frame',
-          upstreamError: msg.error
-        });
-        break;
-      // session.created and other control frames need no client action
-      default:
-        break;
-    }
-  });
-
-  // The vLLM server rejected the WebSocket upgrade with an HTTP response
-  // (e.g. 404 wrong path, 401/403 auth, 502 bad gateway) — very actionable.
-  upstream.on('unexpected-response', (_req, res) => {
-    notifyUpstreamError(
-      `Transcription service rejected the connection (HTTP ${res.statusCode} ${res.statusMessage || ''})`.trim(),
-      { reason: 'unexpected-response', statusCode: res.statusCode }
-    );
-  });
-
-  upstream.on('error', err => {
-    // Socket-level failures (ECONNREFUSED, ETIMEDOUT, ENOTFOUND, TLS errors…).
-    // err.message is often empty, so include err.code which usually is not.
-    const detail = [err.code, err.message].filter(Boolean).join(': ') || 'connection error';
-    notifyUpstreamError(`Transcription service unreachable: ${detail}`, {
-      reason: 'socket error',
-      error: err.message,
-      code: err.code
-    });
-  });
-
-  upstream.on('close', (code, reasonBuf) => {
-    const reason = reasonBuf ? reasonBuf.toString() : '';
-    // A clean close (code 1000) after we delivered transcription is expected.
-    // Report only genuinely-abnormal closes: before the handshake completed, or
-    // a non-normal code with nothing transcribed.
-    if (!errorSent && !gotTranscription && (!upstreamReady || code !== 1000)) {
-      notifyUpstreamError(
-        `Transcription service closed the connection (code ${code}${reason ? `: ${reason}` : ''})`,
-        { reason: 'abnormal close', code, closeReason: reason, upstreamReady }
-      );
+      upstream = new WebSocket(cfg.url, { headers });
+    } catch (err) {
+      notifyUpstreamError('Failed to reach transcription service', {
+        reason: 'construct error',
+        error: err.message
+      });
       return;
     }
-    cleanup();
-  });
+
+    // Arm the idle timer for the connecting phase too, so a handshake that hangs
+    // in CONNECTING (no 'open', no 'error') can't leave the bridge timer-less.
+    // It is reset on 'open' and on every subsequent frame.
+    resetIdle();
+
+    upstream.on('open', () => {
+      // Handshake: identify the model, then open the audio buffer.
+      sendJson(upstream, { type: 'session.update', model: cfg.model });
+      sendJson(upstream, { type: 'input_audio_buffer.commit' });
+      upstreamReady = true;
+      sendJson(clientWs, { type: 'ready' });
+      // Flush any audio captured during the handshake.
+      for (const audio of pending) {
+        sendJson(upstream, { type: 'input_audio_buffer.append', audio });
+      }
+      pending.length = 0;
+      resetIdle();
+    });
+
+    upstream.on('message', data => {
+      resetIdle();
+      let msg;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        return; // vLLM realtime frames are JSON; ignore anything else
+      }
+      switch (msg.type) {
+        case 'transcription.delta':
+          gotTranscription = true;
+          sendJson(clientWs, { type: 'delta', text: msg.delta || '' });
+          break;
+        case 'transcription.done':
+          gotTranscription = true;
+          sendJson(clientWs, { type: 'final', text: msg.text || '' });
+          break;
+        case 'error':
+          notifyUpstreamError(`Transcription error: ${msg.error || 'unknown'}`, {
+            reason: 'upstream error frame',
+            upstreamError: msg.error
+          });
+          break;
+        // session.created and other control frames need no client action
+        default:
+          break;
+      }
+    });
+
+    // The vLLM server rejected the WebSocket upgrade with an HTTP response
+    // (e.g. 404 wrong path, 401/403 auth, 502 bad gateway) — very actionable.
+    upstream.on('unexpected-response', (_req, res) => {
+      notifyUpstreamError(diagnoseUnexpectedResponse(res), {
+        reason: 'unexpected-response',
+        statusCode: res.statusCode
+      });
+    });
+
+    upstream.on('error', err => {
+      notifyUpstreamError(diagnoseSocketError(err), {
+        reason: 'socket error',
+        error: err.message,
+        code: err.code
+      });
+    });
+
+    upstream.on('close', (code, reasonBuf) => {
+      const reason = reasonBuf ? reasonBuf.toString() : '';
+      const message = errorSent
+        ? null
+        : diagnoseUpstreamClose({ gotTranscription, upstreamReady, code, reason });
+      if (message) {
+        notifyUpstreamError(message, {
+          reason: 'abnormal close',
+          code,
+          closeReason: reason,
+          upstreamReady
+        });
+        return;
+      }
+      cleanup();
+    });
+  };
 
   // --- iHub <- browser ---
   clientWs.on('message', (data, isBinary) => {
-    resetIdle();
     if (isBinary) {
-      // Raw PCM16 frame — base64-wrap into the vLLM realtime protocol.
+      // Raw PCM16 frame. Open the upstream on the first frame, then forward.
+      if (!upstream) openUpstream();
+      if (upstreamReady) resetIdle();
+      const audio = Buffer.from(data).toString('base64');
       if (upstreamReady && upstream.readyState === WebSocket.OPEN) {
-        const audio = Buffer.from(data).toString('base64');
         sendJson(upstream, { type: 'input_audio_buffer.append', audio });
+      } else if (pending.length < MAX_PENDING_FRAMES) {
+        pending.push(audio);
       }
       return;
     }
@@ -352,11 +478,33 @@ function bridgeConnection(clientWs, user) {
     cleanup();
   });
 
-  resetIdle();
+  // Wait for the first audio frame; close the connection if none arrives.
+  graceTimer = setTimeout(() => {
+    logger.info('Realtime STT: no audio received within grace window, closing', {
+      component: 'RealtimeSTT',
+      userId: user.id
+    });
+    cleanup();
+  }, NO_AUDIO_GRACE_MS);
+
   logger.info('Realtime STT: bridge established', {
     component: 'RealtimeSTT',
     userId: user.id
   });
+}
+
+/**
+ * Read the connection-cap / frame-size settings from platform config, falling
+ * back to sane defaults.
+ */
+function getConnectionLimits() {
+  const cfg = (configCache.getPlatform() || {}).speech?.realtime || {};
+  const toPositiveInt = (val, fallback) => (Number.isInteger(val) && val > 0 ? val : fallback);
+  return {
+    maxTotal: toPositiveInt(cfg.maxConnections, DEFAULT_MAX_TOTAL_CONNECTIONS),
+    maxPerUser: toPositiveInt(cfg.maxConnectionsPerUser, DEFAULT_MAX_CONNECTIONS_PER_USER),
+    maxFrameBytes: toPositiveInt(cfg.maxFrameBytes, DEFAULT_MAX_FRAME_BYTES)
+  };
 }
 
 /**
@@ -368,7 +516,12 @@ function bridgeConnection(clientWs, user) {
  * @param {import('http').Server|import('https').Server} httpServer
  */
 export function attachRealtimeTranscription(httpServer) {
-  const wss = new WebSocketServer({ noServer: true });
+  const limits = getConnectionLimits();
+  const limiter = new ConnectionLimiter({
+    maxTotal: limits.maxTotal,
+    maxPerUser: limits.maxPerUser
+  });
+  const wss = new WebSocketServer({ noServer: true, maxPayload: limits.maxFrameBytes });
 
   httpServer.on('upgrade', (req, socket, head) => {
     let pathname;
@@ -408,14 +561,29 @@ export function attachRealtimeTranscription(httpServer) {
       return;
     }
 
+    // Enforce the concurrent-connection caps before completing the handshake, so
+    // a flood of upgrades can't pin unbounded upstream sessions.
+    if (!limiter.tryAcquire(user.id)) {
+      logger.warn('Realtime STT: connection cap reached, rejecting upgrade', {
+        component: 'RealtimeSTT',
+        userId: user.id,
+        activeTotal: limiter.total
+      });
+      socket.write('HTTP/1.1 429 Too Many Requests\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
     wss.handleUpgrade(req, socket, head, ws => {
-      bridgeConnection(ws, user);
+      bridgeConnection(ws, user, limiter);
     });
   });
 
   logger.info('Realtime transcription WebSocket handler attached', {
     component: 'RealtimeSTT',
-    path: buildApiPath('/voice/realtime')
+    path: buildApiPath('/voice/realtime'),
+    maxConnections: limits.maxTotal,
+    maxConnectionsPerUser: limits.maxPerUser
   });
 }
 

--- a/server/websocket/realtimeTranscription.js
+++ b/server/websocket/realtimeTranscription.js
@@ -1,0 +1,459 @@
+/**
+ * Realtime speech-to-text WebSocket proxy.
+ *
+ * The browser opens a same-origin WebSocket to `/api/voice/realtime` and streams
+ * raw PCM16 (16 kHz, mono) audio frames. This module authenticates the upgrade
+ * (JWT `authToken` cookie, same logic as `authRequired`), then opens an upstream
+ * WebSocket to a vLLM realtime endpoint (e.g. Voxtral on `/v1/realtime`) and
+ * relays audio up / transcription text down. The vLLM URL and optional API key
+ * stay server-side (`platform.speech.realtime`); the browser never talks to vLLM
+ * directly.
+ *
+ * Browser <-> iHub protocol (iHub-defined, we own both ends):
+ *   client -> server: JSON `{type:'start', lang?}`, then binary PCM16 frames,
+ *                     then JSON `{type:'stop'}`
+ *   server -> client: JSON `{type:'ready'}` once upstream is connected,
+ *                     `{type:'delta', text}` (streaming), `{type:'final', text}`,
+ *                     `{type:'error', message}`
+ *
+ * iHub <-> vLLM protocol (vLLM realtime API):
+ *   see https://docs.vllm.ai/ — session.created / session.update /
+ *   input_audio_buffer.append|commit / transcription.delta|done / error
+ */
+import { WebSocketServer, WebSocket } from 'ws';
+import configCache from '../configCache.js';
+import logger from '../utils/logger.js';
+import { verifyJwt } from '../utils/tokenService.js';
+import { isAnonymousAccessAllowed } from '../utils/authorization.js';
+import { buildApiPath } from '../utils/basePath.js';
+
+// Close cleanly if the browser stops sending audio and no transcription is
+// flowing. Keeps orphaned upstream sockets from lingering.
+const IDLE_TIMEOUT_MS = 60_000;
+
+/**
+ * Strip a trailing slash / path from an origin so comparison is scheme+host(+port),
+ * the form a browser sends in the Origin header.
+ */
+function normalizeOrigin(origin) {
+  if (typeof origin !== 'string') return origin;
+  const trimmed = origin.trim();
+  const schemeEnd = trimmed.indexOf('://');
+  if (schemeEnd === -1) return trimmed.replace(/\/+$/, '');
+  const pathStart = trimmed.indexOf('/', schemeEnd + 3);
+  return pathStart === -1 ? trimmed : trimmed.slice(0, pathStart);
+}
+
+/**
+ * Resolve the configured CORS origins from platform config, expanding
+ * ${ENV_VAR} placeholders and comma-separated lists (same rules as the HTTP
+ * CORS middleware).
+ */
+function resolveConfiguredOrigins(platform) {
+  const raw = platform?.cors?.origin;
+  const out = [];
+  const pushResolved = val => {
+    if (typeof val !== 'string') return;
+    if (val.includes('${')) {
+      const replaced = val.replace(/\$\{([^}]+)\}/g, (_m, envVar) => process.env[envVar] || '');
+      replaced
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean)
+        .forEach(o => out.push(o));
+    } else if (val) {
+      out.push(val);
+    }
+  };
+  if (Array.isArray(raw)) raw.forEach(pushResolved);
+  else pushResolved(raw);
+  return out;
+}
+
+/**
+ * Guard against Cross-Site WebSocket Hijacking. The upgrade is authenticated via
+ * the `authToken` cookie, which browsers attach on cross-origin WS handshakes
+ * too — so we must reject browser connections whose Origin isn't same-origin or
+ * in the CORS allowlist. Non-browser clients omit Origin; they can't be a CSWSH
+ * victim (same-origin policy is a browser concept), so a missing Origin is
+ * allowed.
+ */
+function isAllowedOrigin(req) {
+  const origin = req.headers.origin;
+  if (!origin) return true; // non-browser caller — not a CSWSH vector
+
+  const normalized = normalizeOrigin(origin);
+  // Same-origin: the browser tab was served by this iHub instance. Check both
+  // the direct Host and the forwarded host, so this works behind a reverse
+  // proxy (production nginx) and the Vite dev proxy, where `Host` is the
+  // internal target but `X-Forwarded-Host` carries the browser-facing host.
+  const forwardedHost = (req.headers['x-forwarded-host'] || '').split(',')[0].trim();
+  const hosts = [req.headers.host, forwardedHost].filter(Boolean);
+  for (const host of hosts) {
+    if (normalized === `http://${host}` || normalized === `https://${host}`) {
+      return true;
+    }
+  }
+
+  const configured = resolveConfiguredOrigins(configCache.getPlatform() || {}).map(normalizeOrigin);
+  if (configured.includes('*')) return true;
+  return configured.includes(normalized);
+}
+
+/**
+ * Extract the authToken from a raw upgrade request (Bearer header or cookie).
+ * The upgrade request never went through Express, so cookies aren't parsed.
+ */
+function extractToken(req) {
+  const authHeader = req.headers.authorization;
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    return authHeader.substring(7);
+  }
+  const cookieHeader = req.headers.cookie;
+  if (cookieHeader) {
+    const entry = cookieHeader
+      .split(';')
+      .map(c => c.trim())
+      .find(c => c.startsWith('authToken='));
+    if (entry) {
+      try {
+        return decodeURIComponent(entry.substring('authToken='.length));
+      } catch {
+        return entry.substring('authToken='.length);
+      }
+    }
+  }
+  return null;
+}
+
+/**
+ * Authenticate an upgrade request. Returns a minimal user object, or null when
+ * authentication is required but missing/invalid.
+ */
+function authenticateUpgrade(req) {
+  const platform = configCache.getPlatform() || {};
+  const token = extractToken(req);
+
+  if (token) {
+    const decoded = verifyJwt(token);
+    if (decoded) {
+      return {
+        id: decoded.sub || decoded.username || decoded.id || 'user',
+        name: decoded.name || decoded.username || 'user'
+      };
+    }
+  }
+
+  // No valid token — allow only if anonymous access is enabled platform-wide.
+  if (isAnonymousAccessAllowed(platform)) {
+    return { id: 'anonymous', name: 'anonymous' };
+  }
+  return null;
+}
+
+/**
+ * Get the realtime speech config from the platform config, or null if disabled.
+ */
+function getRealtimeConfig() {
+  const platform = configCache.getPlatform() || {};
+  const cfg = platform.speech?.realtime;
+  if (!cfg || cfg.enabled === false || !cfg.url) return null;
+  return cfg;
+}
+
+function sendJson(ws, obj) {
+  if (ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(obj));
+  }
+}
+
+/**
+ * Bridge a single accepted browser connection to a fresh upstream vLLM socket.
+ */
+function bridgeConnection(clientWs, user) {
+  const cfg = getRealtimeConfig();
+  if (!cfg) {
+    sendJson(clientWs, { type: 'error', message: 'Realtime transcription is not configured' });
+    clientWs.close();
+    return;
+  }
+
+  const headers = {};
+  if (cfg.apiKey) headers.Authorization = `Bearer ${cfg.apiKey}`;
+
+  let upstream;
+  try {
+    upstream = new WebSocket(cfg.url, { headers });
+  } catch (err) {
+    logger.error('Realtime STT: failed to open upstream socket', {
+      component: 'RealtimeSTT',
+      error: err.message
+    });
+    sendJson(clientWs, { type: 'error', message: 'Failed to reach transcription service' });
+    clientWs.close();
+    return;
+  }
+
+  let upstreamReady = false; // handshake complete, audio may flow
+  let idleTimer = null;
+
+  const resetIdle = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = setTimeout(() => {
+      logger.info('Realtime STT: idle timeout, closing', { component: 'RealtimeSTT' });
+      cleanup();
+    }, IDLE_TIMEOUT_MS);
+  };
+
+  const cleanup = () => {
+    if (idleTimer) clearTimeout(idleTimer);
+    idleTimer = null;
+    if (upstream && upstream.readyState <= WebSocket.OPEN) {
+      try {
+        upstream.close();
+      } catch {
+        /* ignore */
+      }
+    }
+    if (clientWs.readyState <= WebSocket.OPEN) {
+      try {
+        clientWs.close();
+      } catch {
+        /* ignore */
+      }
+    }
+  };
+
+  // --- Upstream (vLLM) -> iHub ---
+  upstream.on('open', () => {
+    // Handshake: identify the model, then open the audio buffer.
+    sendJson(upstream, { type: 'session.update', model: cfg.model });
+    sendJson(upstream, { type: 'input_audio_buffer.commit' });
+    upstreamReady = true;
+    sendJson(clientWs, { type: 'ready' });
+    resetIdle();
+  });
+
+  upstream.on('message', data => {
+    resetIdle();
+    let msg;
+    try {
+      msg = JSON.parse(data.toString());
+    } catch {
+      return; // vLLM realtime frames are JSON; ignore anything else
+    }
+    switch (msg.type) {
+      case 'transcription.delta':
+        sendJson(clientWs, { type: 'delta', text: msg.delta || '' });
+        break;
+      case 'transcription.done':
+        sendJson(clientWs, { type: 'final', text: msg.text || '' });
+        break;
+      case 'error':
+        sendJson(clientWs, { type: 'error', message: msg.error || 'Transcription error' });
+        break;
+      // session.created and other control frames need no client action
+      default:
+        break;
+    }
+  });
+
+  upstream.on('error', err => {
+    logger.warn('Realtime STT: upstream error', { component: 'RealtimeSTT', error: err.message });
+    sendJson(clientWs, { type: 'error', message: 'Transcription service error' });
+    cleanup();
+  });
+
+  upstream.on('close', () => {
+    cleanup();
+  });
+
+  // --- iHub <- browser ---
+  clientWs.on('message', (data, isBinary) => {
+    resetIdle();
+    if (isBinary) {
+      // Raw PCM16 frame — base64-wrap into the vLLM realtime protocol.
+      if (upstreamReady && upstream.readyState === WebSocket.OPEN) {
+        const audio = Buffer.from(data).toString('base64');
+        sendJson(upstream, { type: 'input_audio_buffer.append', audio });
+      }
+      return;
+    }
+    // Text control frame from the browser.
+    let msg;
+    try {
+      msg = JSON.parse(data.toString());
+    } catch {
+      return;
+    }
+    if (msg.type === 'stop') {
+      if (upstreamReady && upstream.readyState === WebSocket.OPEN) {
+        sendJson(upstream, { type: 'input_audio_buffer.commit', final: true });
+      }
+    }
+    // {type:'start'} carries optional lang; the model auto-detects language, so
+    // no upstream action is needed today. Reserved for future use.
+  });
+
+  clientWs.on('error', err => {
+    logger.warn('Realtime STT: client error', { component: 'RealtimeSTT', error: err.message });
+    cleanup();
+  });
+
+  clientWs.on('close', () => {
+    cleanup();
+  });
+
+  resetIdle();
+  logger.info('Realtime STT: bridge established', {
+    component: 'RealtimeSTT',
+    userId: user.id
+  });
+}
+
+/**
+ * Attach the realtime transcription WebSocket handler to an HTTP(S) server.
+ * Safe to call in both single-process and sticky-cluster worker modes — WS
+ * upgrades ride the same TCP connection the primary hands to the worker, so no
+ * extra clustering coordination is required.
+ *
+ * @param {import('http').Server|import('https').Server} httpServer
+ */
+export function attachRealtimeTranscription(httpServer) {
+  const wss = new WebSocketServer({ noServer: true });
+
+  httpServer.on('upgrade', (req, socket, head) => {
+    let pathname;
+    try {
+      pathname = new URL(req.url, 'http://localhost').pathname;
+    } catch {
+      return; // malformed URL — let other handlers/ default behavior deal with it
+    }
+
+    // Only handle our endpoint; ignore everything else so other upgrade
+    // listeners (if any) keep working.
+    if (pathname !== buildApiPath('/voice/realtime')) {
+      return;
+    }
+
+    // Reject cross-origin browser handshakes (Cross-Site WebSocket Hijacking).
+    if (!isAllowedOrigin(req)) {
+      logger.warn('Realtime STT: rejected upgrade from disallowed origin', {
+        component: 'RealtimeSTT',
+        origin: req.headers.origin
+      });
+      socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    const user = authenticateUpgrade(req);
+    if (!user) {
+      socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    if (!getRealtimeConfig()) {
+      socket.write('HTTP/1.1 503 Service Unavailable\r\n\r\n');
+      socket.destroy();
+      return;
+    }
+
+    wss.handleUpgrade(req, socket, head, ws => {
+      bridgeConnection(ws, user);
+    });
+  });
+
+  logger.info('Realtime transcription WebSocket handler attached', {
+    component: 'RealtimeSTT',
+    path: buildApiPath('/voice/realtime')
+  });
+}
+
+/**
+ * Test connectivity to a vLLM realtime endpoint without streaming audio.
+ * Opens a WebSocket, performs the session handshake, and reports whether the
+ * endpoint is reachable and speaks the realtime protocol. Used by the admin
+ * "Test connection" button.
+ *
+ * @param {{url?: string, model?: string, apiKey?: string}} cfg
+ * @param {number} [timeoutMs=8000]
+ * @returns {Promise<{ok: boolean, message: string}>}
+ */
+export function testRealtimeConnection(cfg = {}, timeoutMs = 8000) {
+  return new Promise(resolve => {
+    const url = (cfg.url || '').trim();
+    if (!/^wss?:\/\//i.test(url)) {
+      resolve({ ok: false, message: 'URL must start with ws:// or wss://' });
+      return;
+    }
+
+    let settled = false;
+    let opened = false;
+    let ws;
+
+    const finish = result => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      if (ws && ws.readyState <= WebSocket.OPEN) {
+        try {
+          ws.close();
+        } catch {
+          /* ignore */
+        }
+      }
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      finish(
+        opened
+          ? { ok: true, message: 'Connected (handshake sent; no session frame received in time)' }
+          : { ok: false, message: `Connection timed out after ${timeoutMs}ms` }
+      );
+    }, timeoutMs);
+
+    try {
+      const headers = {};
+      if (cfg.apiKey) headers.Authorization = `Bearer ${cfg.apiKey}`;
+      ws = new WebSocket(url, { headers });
+    } catch (err) {
+      finish({ ok: false, message: `Failed to open socket: ${err.message}` });
+      return;
+    }
+
+    ws.on('open', () => {
+      opened = true;
+      sendJson(ws, { type: 'session.update', model: cfg.model });
+    });
+
+    ws.on('message', data => {
+      let msg;
+      try {
+        msg = JSON.parse(data.toString());
+      } catch {
+        // Any parseable-or-not frame means the endpoint responded.
+        finish({ ok: true, message: 'Connected — endpoint responded' });
+        return;
+      }
+      if (msg.type === 'error') {
+        finish({ ok: false, message: `Endpoint error: ${msg.error || 'unknown'}` });
+      } else {
+        // session.created / transcription.* / any control frame = healthy.
+        finish({ ok: true, message: `Connected — received "${msg.type}"` });
+      }
+    });
+
+    ws.on('error', err => {
+      finish({ ok: false, message: `Connection failed: ${err.message}` });
+    });
+
+    ws.on('close', () => {
+      if (!opened) finish({ ok: false, message: 'Connection closed before handshake' });
+    });
+  });
+}
+
+export default attachRealtimeTranscription;

--- a/server/websocket/realtimeTranscription.js
+++ b/server/websocket/realtimeTranscription.js
@@ -195,6 +195,8 @@ function bridgeConnection(clientWs, user) {
   }
 
   let upstreamReady = false; // handshake complete, audio may flow
+  let gotTranscription = false; // at least one delta/final was received
+  let errorSent = false; // guard so we report a failure at most once
   let idleTimer = null;
 
   const resetIdle = () => {
@@ -224,6 +226,22 @@ function bridgeConnection(clientWs, user) {
     }
   };
 
+  // Report an upstream failure to the browser (once) with a diagnostic message
+  // and a structured server log, then tear the bridge down.
+  const notifyUpstreamError = (clientMessage, logMeta = {}) => {
+    logger.warn('Realtime STT: upstream failure', {
+      component: 'RealtimeSTT',
+      userId: user.id,
+      url: cfg.url,
+      ...logMeta
+    });
+    if (!errorSent) {
+      errorSent = true;
+      sendJson(clientWs, { type: 'error', message: clientMessage });
+    }
+    cleanup();
+  };
+
   // --- Upstream (vLLM) -> iHub ---
   upstream.on('open', () => {
     // Handshake: identify the model, then open the audio buffer.
@@ -244,13 +262,18 @@ function bridgeConnection(clientWs, user) {
     }
     switch (msg.type) {
       case 'transcription.delta':
+        gotTranscription = true;
         sendJson(clientWs, { type: 'delta', text: msg.delta || '' });
         break;
       case 'transcription.done':
+        gotTranscription = true;
         sendJson(clientWs, { type: 'final', text: msg.text || '' });
         break;
       case 'error':
-        sendJson(clientWs, { type: 'error', message: msg.error || 'Transcription error' });
+        notifyUpstreamError(`Transcription error: ${msg.error || 'unknown'}`, {
+          reason: 'upstream error frame',
+          upstreamError: msg.error
+        });
         break;
       // session.created and other control frames need no client action
       default:
@@ -258,13 +281,38 @@ function bridgeConnection(clientWs, user) {
     }
   });
 
-  upstream.on('error', err => {
-    logger.warn('Realtime STT: upstream error', { component: 'RealtimeSTT', error: err.message });
-    sendJson(clientWs, { type: 'error', message: 'Transcription service error' });
-    cleanup();
+  // The vLLM server rejected the WebSocket upgrade with an HTTP response
+  // (e.g. 404 wrong path, 401/403 auth, 502 bad gateway) — very actionable.
+  upstream.on('unexpected-response', (_req, res) => {
+    notifyUpstreamError(
+      `Transcription service rejected the connection (HTTP ${res.statusCode} ${res.statusMessage || ''})`.trim(),
+      { reason: 'unexpected-response', statusCode: res.statusCode }
+    );
   });
 
-  upstream.on('close', () => {
+  upstream.on('error', err => {
+    // Socket-level failures (ECONNREFUSED, ETIMEDOUT, ENOTFOUND, TLS errors…).
+    // err.message is often empty, so include err.code which usually is not.
+    const detail = [err.code, err.message].filter(Boolean).join(': ') || 'connection error';
+    notifyUpstreamError(`Transcription service unreachable: ${detail}`, {
+      reason: 'socket error',
+      error: err.message,
+      code: err.code
+    });
+  });
+
+  upstream.on('close', (code, reasonBuf) => {
+    const reason = reasonBuf ? reasonBuf.toString() : '';
+    // A clean close (code 1000) after we delivered transcription is expected.
+    // Report only genuinely-abnormal closes: before the handshake completed, or
+    // a non-normal code with nothing transcribed.
+    if (!errorSent && !gotTranscription && (!upstreamReady || code !== 1000)) {
+      notifyUpstreamError(
+        `Transcription service closed the connection (code ${code}${reason ? `: ${reason}` : ''})`,
+        { reason: 'abnormal close', code, closeReason: reason, upstreamReady }
+      );
+      return;
+    }
     cleanup();
   });
 

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1508,7 +1508,8 @@
       "marketplace": "Marktplatz",
       "mcpGateway": "MCP-Gateway",
       "mcpServers": "MCP-Server",
-      "telemetry": "Telemetrie"
+      "telemetry": "Telemetrie",
+      "voiceInput": "Spracheingabe"
     },
     "mcp": {
       "common": {
@@ -2402,12 +2403,14 @@
     "tooltipManual": "Spracheingabe (Strg+M) - manuell",
     "tooltipAutomatic": "Spracheingabe (Strg+M) - automatisch",
     "ariaLabel": "Spracheingabe umschalten",
+    "errorTitle": "Fehler bei der Spracheingabe",
     "error": {
       "notSupported": "Spracherkennung wird in diesem Browser nicht unterstützt",
       "permissionDenied": "Bitte erlauben Sie den Mikrofonzugriff und versuchen Sie es erneut.",
       "noSpeech": "Keine Sprache erkannt. Bitte versuchen Sie es erneut.",
       "noMicrophone": "Kein Mikrofon gefunden. Bitte überprüfen Sie Ihre Geräteeinstellungen.",
       "network": "Netzwerkfehler. Bitte überprüfen Sie Ihre Verbindung.",
+      "service": "Transkriptionsdienst nicht verfügbar. Bitte versuchen Sie es erneut.",
       "general": "Fehler bei der Spracheingabe. Bitte versuchen Sie es erneut.",
       "startError": "Fehler beim Starten der Spracheingabe. Bitte versuchen Sie es erneut."
     }

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -634,6 +634,36 @@
     }
   },
   "admin": {
+    "voiceInput": {
+      "title": "Spracheingabe (Speech-to-Text)",
+      "description": "Konfigurieren Sie die für Apps verfügbaren Speech-to-Text-Backends. Aktivieren Sie hier ein Backend und wählen Sie es dann pro App im App-Editor unter „Spracherkennungsdienst“ aus.",
+      "loadError": "Spracheingabe-Einstellungen konnten nicht geladen werden",
+      "saveSuccess": "Spracheingabe-Einstellungen gespeichert.",
+      "saveError": "Spracheingabe-Einstellungen konnten nicht gespeichert werden",
+      "realtime": {
+        "title": "vLLM Realtime (serverseitig)",
+        "description": "Streamt Mikrofon-Audio über den iHub-Server an einen vLLM-Realtime-Endpunkt (z. B. Voxtral). URL und API-Schlüssel verbleiben auf dem Server. Wählen Sie „vLLM Realtime“ als Spracherkennungsdienst einer App, um ihn zu nutzen.",
+        "enabled": "vLLM-Realtime-Transkription aktivieren",
+        "url": "Realtime-WebSocket-URL",
+        "model": "Modell",
+        "apiKey": "API-Schlüssel (optional)",
+        "apiKeyPlaceholder": "Leer lassen, falls keiner",
+        "apiKeyHint": "Verschlüsselt gespeichert. Lokales vLLM benötigt meist keinen Schlüssel. Ein angezeigter Wert ***REDACTED*** bedeutet, dass bereits ein Schlüssel gesetzt ist — belassen Sie ihn, um ihn beizubehalten.",
+        "test": "Verbindung testen",
+        "testing": "Teste…",
+        "testHint": "Testet die Verbindung vom iHub-Server zum vLLM-Realtime-Endpunkt mit den obigen Werten (der gespeicherte Schlüssel wird verwendet, wenn das Feld ***REDACTED*** anzeigt)."
+      },
+      "azure": {
+        "title": "Azure Speech",
+        "description": "Azure Cognitive Services Speech läuft im Browser über ein kurzlebiges Token. Der Abonnementschlüssel wird verschlüsselt auf dem Server gespeichert und pro Sitzung gegen ein Token getauscht, sodass er den Browser nie erreicht. Host/Region sind die Standardwerte, wenn eine App keinen eigenen Host festlegt.",
+        "enabled": "Azure Speech aktivieren",
+        "host": "Standard-Host / -Endpunkt",
+        "region": "Region",
+        "subscriptionKey": "Abonnementschlüssel",
+        "subscriptionKeyPlaceholder": "Azure-Speech-Schlüssel",
+        "subscriptionKeyHint": "Verschlüsselt gespeichert und nie an den Browser gesendet. Ein angezeigter Wert ***REDACTED*** bedeutet, dass bereits ein Schlüssel gesetzt ist — belassen Sie ihn, um ihn beizubehalten."
+      }
+    },
     "agents": {
       "memory": {
         "builder": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1258,7 +1258,8 @@
       "marketplace": "Marketplace",
       "mcpGateway": "MCP gateway",
       "mcpServers": "MCP servers",
-      "telemetry": "Telemetry"
+      "telemetry": "Telemetry",
+      "voiceInput": "Voice Input"
     },
     "mcp": {
       "common": {
@@ -2437,12 +2438,14 @@
     "tooltipManual": "Voice input (Ctrl+M) - manual",
     "tooltipAutomatic": "Voice input (Ctrl+M) - automatic",
     "ariaLabel": "Toggle voice input",
+    "errorTitle": "Voice input error",
     "error": {
       "notSupported": "Speech recognition not supported in this browser",
       "permissionDenied": "Please allow microphone access and try again.",
       "noSpeech": "No speech detected. Please try again.",
       "noMicrophone": "No microphone found. Please check your device settings.",
       "network": "Network error. Please check your connection.",
+      "service": "Transcription service unavailable. Please try again.",
       "general": "Voice input error. Please try again.",
       "startError": "Error starting voice input. Please try again."
     }

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -410,6 +410,36 @@
     }
   },
   "admin": {
+    "voiceInput": {
+      "title": "Voice Input (Speech-to-Text)",
+      "description": "Configure the speech-to-text backends available to apps. Enable a backend here, then select it per app under the app editor’s Speech Recognition Service.",
+      "loadError": "Failed to load voice input settings",
+      "saveSuccess": "Voice input settings saved.",
+      "saveError": "Failed to save voice input settings",
+      "realtime": {
+        "title": "vLLM Realtime (server-proxied)",
+        "description": "Streams microphone audio through the iHub server to a vLLM realtime endpoint (e.g. Voxtral). The URL and API key stay on the server. Select \"vLLM Realtime\" as an app’s Speech Recognition Service to use it.",
+        "enabled": "Enable vLLM realtime transcription",
+        "url": "Realtime WebSocket URL",
+        "model": "Model",
+        "apiKey": "API Key (optional)",
+        "apiKeyPlaceholder": "Leave blank if none",
+        "apiKeyHint": "Stored encrypted at rest. Local vLLM usually needs no key. A shown value of ***REDACTED*** means a key is already set — leave it to keep it.",
+        "test": "Test connection",
+        "testing": "Testing…",
+        "testHint": "Tests connectivity from the iHub server to the vLLM realtime endpoint using the values above (the saved key is used when the field shows ***REDACTED***)."
+      },
+      "azure": {
+        "title": "Azure Speech",
+        "description": "Azure Cognitive Services Speech runs in the browser via a short-lived token. The subscription key is stored encrypted on the server and exchanged for a token per session, so it never reaches the browser. Host/region are the defaults used when an app does not set its own host.",
+        "enabled": "Enable Azure Speech",
+        "host": "Default host / endpoint",
+        "region": "Region",
+        "subscriptionKey": "Subscription Key",
+        "subscriptionKeyPlaceholder": "Azure Speech key",
+        "subscriptionKeyHint": "Stored encrypted at rest and never sent to the browser. A shown value of ***REDACTED*** means a key is already set — leave it to keep it."
+      }
+    },
     "agents": {
       "memory": {
         "builder": {


### PR DESCRIPTION
Closes #1913

## What & why

Adds a third voice-input backend, **`vllm-realtime`**: the browser streams microphone audio to the iHub server over a WebSocket, and iHub proxies it to a self-hosted **vLLM realtime endpoint** (e.g. Voxtral on `/v1/realtime`), streaming transcription back live. Unlike the browser and Azure backends, the model URL and any API key stay server-side and never reach the browser — enabling private/on-prem STT.

## Data flow

```
browser mic ──(PCM16 16kHz over WS)──▶ iHub /api/voice/realtime
   iHub ──(vLLM realtime JSON)──▶ vLLM /v1/realtime ──delta/done──▶ iHub ──▶ browser
```

## Highlights

**Server**
- WebSocket proxy `server/websocket/realtimeTranscription.js` on `/api/voice/realtime`, attached for both single-process and sticky-cluster modes.
- Upgrade authenticated via the `authToken` cookie; **CSWSH guard** via an `Origin` allowlist (same-origin + platform CORS origins, honoring `X-Forwarded-Host` behind reverse proxies).
- Connection self-test helper + `POST /api/admin/voice/realtime/test`.
- Platform `speech` config (`realtime` + `azure`) with schema, defaults, and migrations **V070/V071**. Realtime `apiKey` encrypted at rest, decrypted in `configCache`; only non-secret fields exposed via the public `/api/configs/platform`.

**Client**
- `vllmRealtimeRecognitionService.js`: `getUserMedia` + `AudioContext`/`AudioWorklet` capture, 16 kHz PCM16, **manual + automatic (VAD)** modes; works without the Web Speech API (incl. Firefox).
- `useVoiceRecognition`: new `vllm-realtime` case, shared text-event handling with Azure, platform Azure-host fallback, and **visible error surfacing** (the overlay now shows backend errors instead of a phantom "recording" state).
- New **Admin → Voice Input** page to configure both backends, with a **Test connection** button for vLLM.
- App editor's Speech Recognition Service dropdown adds **Azure** and **vLLM Realtime**.
- Vite dev proxy forwards WebSocket upgrades (and `X-Forwarded-Host`) for `/api`.

**Docs / i18n**: `docs/microphone-feature.md`, `docs/releases/5.5.0/features.md`, and en/de translations updated.

## Security notes

- vLLM URL/key are never sent to the browser; the WS endpoint only surfaces `enabled` to clients.
- Azure's subscription key remains the `VITE_AZURE_SUBSCRIPTION_ID` env var (its SDK runs in the browser) — deliberately not managed via the config API.
- Reverse proxies in front of iHub must forward `X-Forwarded-Host` (or `Host`) on WS upgrades, or the Origin check rejects them (documented in code).

## Testing

- Server proxy verified end-to-end against a mock vLLM upstream (`ready → delta → final`), plus Origin allow/deny cases (same-origin & forwarded-host allowed; cross-origin 403).
- Connection-test helper verified (reachable → ok, dead port → fail, bad scheme → rejected).
- Secret encrypt→decrypt round-trip verified; schema/config validated; client build + ESLint clean.
- Manually verified working end-to-end against a live vLLM Voxtral instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxYemXddGpFq81X4EDvezk