### PR TITLE
Fix UsageEventLog cleanup race that could silently drop usage events

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -217,3 +217,15 @@ came from the shared chat used across the platform, so any app could be affected
 - Also fixes a related crash for iFinder-backed apps that emit a response message id (used for
   answer feedback), which previously interrupted the reply the same way.
 - No configuration or admin action required.
+
+## Usage Statistics No Longer Lose Events During Cleanup
+
+The hourly usage-data retention cleanup could silently drop token-usage events that were flushed
+to disk at the same moment cleanup ran, causing usage/billing numbers in the admin dashboard to
+undercount without any error being logged.
+
+- Cleanup and the periodic flush of pending usage events are now serialized so an in-flight flush
+  can never be overwritten by a concurrent cleanup pass.
+- Flush and cleanup failures are now actually logged instead of throwing an unrelated internal
+  error that masked the real cause.
+- No configuration or admin action required.

--- a/server/services/UsageEventLog.js
+++ b/server/services/UsageEventLog.js
@@ -12,14 +12,39 @@ const FLUSH_INTERVAL_MS = 10000;
 let queue = [];
 let flushTimer = null;
 
-export async function flushQueue() {
+// Single-flight serialization for any operation that touches `usage-events.jsonl`.
+// `flushQueue` (appendFile) and `cleanupEvents` (read + writeFile) must not
+// interleave, otherwise a flush that lands between the cleanup's read and its
+// rewrite would be overwritten — silently losing the just-appended entries.
+let writeLock = Promise.resolve();
+function withWriteLock(fn) {
+  const prev = writeLock;
+  let release;
+  writeLock = new Promise(r => {
+    release = r;
+  });
+  return prev.then(fn).finally(release);
+}
+
+async function appendQueueToDisk() {
   if (queue.length === 0) return 0;
   await fs.mkdir(path.dirname(eventFile), { recursive: true });
-  const count = queue.length;
-  const lines = queue.map(entry => JSON.stringify(entry)).join('\n') + '\n';
+  const pending = queue;
   queue = [];
-  await fs.appendFile(eventFile, lines, 'utf8');
+  const count = pending.length;
+  const lines = pending.map(entry => JSON.stringify(entry)).join('\n') + '\n';
+  try {
+    await fs.appendFile(eventFile, lines, 'utf8');
+  } catch (err) {
+    // Re-buffer on failure so the next flush retries instead of dropping events.
+    queue = pending.concat(queue);
+    throw err;
+  }
   return count;
+}
+
+export async function flushQueue() {
+  return withWriteLock(appendQueueToDisk);
 }
 
 function scheduleFlush() {
@@ -29,7 +54,7 @@ function scheduleFlush() {
     try {
       await flushQueue();
     } catch (error) {
-      logger.error('Failed to flush usage events', { component: 'UsageEventLog', error: e });
+      logger.error('Failed to flush usage events', { component: 'UsageEventLog', error });
     }
   }, FLUSH_INTERVAL_MS);
 }
@@ -126,21 +151,33 @@ export function getMonthlyDir() {
 export async function cleanupEvents(retentionDays = 90) {
   if (retentionDays < 0) return; // -1 means keep forever
   try {
-    const events = await readEvents();
-    const cutoff = new Date();
-    cutoff.setDate(cutoff.getDate() - retentionDays);
-    const cutoffStr = cutoff.toISOString();
-    const retained = events.filter(e => e.ts >= cutoffStr);
-    if (retained.length < events.length) {
-      const lines = retained.map(e => JSON.stringify(e)).join('\n') + (retained.length ? '\n' : '');
-      await fs.writeFile(eventFile, lines, 'utf8');
-      logger.info('Usage event cleanup completed', {
-        component: 'UsageEventLog',
-        removed: events.length - retained.length
-      });
-    }
+    await withWriteLock(async () => {
+      // Drain any queued events into the on-disk file first so they're
+      // included in the read-filter pass below. Done under the lock so a
+      // new scheduleFlush() can't slip in between drain and rewrite.
+      try {
+        await appendQueueToDisk();
+      } catch {
+        // A drain failure is logged elsewhere; continue with what's on disk.
+      }
+
+      const events = await readEvents();
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - retentionDays);
+      const cutoffStr = cutoff.toISOString();
+      const retained = events.filter(e => e.ts >= cutoffStr);
+      if (retained.length < events.length) {
+        const lines =
+          retained.map(e => JSON.stringify(e)).join('\n') + (retained.length ? '\n' : '');
+        await fs.writeFile(eventFile, lines, 'utf8');
+        logger.info('Usage event cleanup completed', {
+          component: 'UsageEventLog',
+          removed: events.length - retained.length
+        });
+      }
+    });
   } catch (error) {
-    logger.error('Failed to cleanup usage events', { component: 'UsageEventLog', error: e });
+    logger.error('Failed to cleanup usage events', { component: 'UsageEventLog', error });
   }
 }
 
@@ -148,7 +185,7 @@ export async function cleanupEvents(retentionDays = 90) {
 setInterval(() => {
   if (queue.length > 0) {
     flushQueue().catch(error =>
-      logger.error('Usage event flush error', { component: 'UsageEventLog', error: e })
+      logger.error('Usage event flush error', { component: 'UsageEventLog', error })
     );
   }
 }, FLUSH_INTERVAL_MS);

--- a/server/tests/usageEventLog.test.js
+++ b/server/tests/usageEventLog.test.js
@@ -1,0 +1,134 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Unit tests for UsageEventLog.js — focused on the write-lock added to
+ * serialize flushQueue (append) against cleanupEvents (read-filter-rewrite)
+ * so a queued-but-unflushed event can never be silently dropped by a
+ * concurrent cleanup pass.
+ */
+
+let fileContents = null;
+let appendCallCount = 0;
+let failNextAppend = false;
+
+jest.unstable_mockModule('fs/promises', () => ({
+  default: {
+    readFile: jest.fn(async () => {
+      if (fileContents === null) {
+        const error = new Error('ENOENT');
+        error.code = 'ENOENT';
+        throw error;
+      }
+      return fileContents;
+    }),
+    writeFile: jest.fn(async (_file, data) => {
+      fileContents = data;
+    }),
+    appendFile: jest.fn(async (_file, data) => {
+      appendCallCount += 1;
+      if (failNextAppend) {
+        failNextAppend = false;
+        throw new Error('disk full');
+      }
+      fileContents = (fileContents ?? '') + data;
+    }),
+    mkdir: jest.fn(async () => {})
+  }
+}));
+
+jest.unstable_mockModule('../utils/logger.js', () => ({
+  default: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} }
+}));
+
+// The module registers a real periodic setInterval on import; fake timers
+// keep that handle from holding the process (and the Jest worker) open once
+// the test file finishes, since tests below drive flushing/cleanup directly.
+jest.useFakeTimers();
+
+const { logUsageEvent, flushQueue, cleanupEvents, readEvents } =
+  await import('../services/UsageEventLog.js');
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
+function entry(overrides = {}) {
+  return {
+    type: 'chat',
+    userId: 'u1',
+    appId: 'a1',
+    modelId: 'm1',
+    promptTokens: 1,
+    completionTokens: 1,
+    ...overrides
+  };
+}
+
+beforeEach(() => {
+  fileContents = null;
+  appendCallCount = 0;
+  failNextAppend = false;
+});
+
+describe('cleanupEvents', () => {
+  it('retains events within retention and drops events older than the cutoff', async () => {
+    const now = new Date().toISOString();
+    const old = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+    fileContents =
+      [JSON.stringify({ ts: now, type: 'chat' }), JSON.stringify({ ts: old, type: 'chat' })].join(
+        '\n'
+      ) + '\n';
+
+    await cleanupEvents(90);
+
+    const events = await readEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].ts).toBe(now);
+  });
+
+  it('does not touch the file when nothing is expired', async () => {
+    const now = new Date().toISOString();
+    fileContents = JSON.stringify({ ts: now, type: 'chat' }) + '\n';
+    const before = fileContents;
+
+    await cleanupEvents(90);
+
+    expect(fileContents).toBe(before);
+  });
+});
+
+describe('flushQueue / cleanupEvents race', () => {
+  it('a queued event survives a concurrent cleanup instead of being overwritten', async () => {
+    const old = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000).toISOString();
+    fileContents = JSON.stringify({ ts: old, type: 'chat' }) + '\n';
+
+    logUsageEvent(entry());
+
+    // Fire both without awaiting the first — the in-process write lock must
+    // serialize them so the queued event is drained to disk before (or after,
+    // but never lost during) the cleanup rewrite.
+    await Promise.all([flushQueue(), cleanupEvents(90)]);
+
+    const events = await readEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].type).toBe('chat');
+    expect(events[0].uid).toBe('u1');
+  });
+});
+
+describe('flushQueue append failure', () => {
+  it('re-buffers the queue instead of dropping events when appendFile fails', async () => {
+    logUsageEvent(entry({ userId: 'u2' }));
+    failNextAppend = true;
+
+    await expect(flushQueue()).rejects.toThrow('disk full');
+    expect(fileContents).toBeNull();
+
+    await flushQueue();
+
+    const events = await readEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0].uid).toBe('u2');
+    expect(appendCallCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1793.

`cleanupEvents` (run hourly from `UsageAggregator.runRollups`) read the whole `usage-events.jsonl`, filtered by retention, and rewrote the file with `fs.writeFile` — with no synchronization against the 10-second flush timer that appends new events to the same file via `fs.appendFile`. An append landing between the read and the rewrite was silently overwritten and lost. `feedbackStorage.js` already documents and fixes this exact race for `feedback.jsonl` with an in-process write lock, but the fix had never been ported to `UsageEventLog`.

- Added a `withWriteLock` single-flight lock (ported from `feedbackStorage.js`) so `flushQueue` (append) and `cleanupEvents` (read-filter-rewrite) can never interleave.
- `cleanupEvents` now drains any queued-but-unflushed events to disk *before* the read-filter pass, under the same lock, so nothing sitting in memory at cleanup time is lost.
- `flushQueue` now re-buffers the queue if `appendFile` fails, instead of silently dropping the batch.
- Fixed catch-block variable shadowing (`catch (error) { ... error: e }`) in three places that caused a `ReferenceError` instead of logging flush/cleanup failures — meaning those failures were previously invisible.
- Added `server/tests/usageEventLog.test.js` covering retention filtering, the flush/cleanup race (regression test), and append-failure re-buffering.
- Added a changelog entry under `docs/releases/5.5.0/features.md`.

Note: this fixes the single-process race. Cross-worker races under `WORKERS>1` (multiple processes appending to the same file) are a separate, wider issue called out in the original report and are out of scope here.

## Test plan

- [x] `server/tests/usageEventLog.test.js` — new suite, 4 tests, all passing
- [x] Full server jest suite run before/after — no new failures introduced (pre-existing failures in the suite are from non-jest scripts picked up by the test runner, unrelated to this change)
- [x] `npx eslint` / `npx prettier --check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LhUzki26dWXqPQemmK6bBw)_