### PR TITLE
Fix: honor platform defaultLanguage in GET /api/apps/:appId

### DIFF
--- a/server/routes/generalRoutes.js
+++ b/server/routes/generalRoutes.js
@@ -327,7 +327,7 @@ export default function registerGeneralRoutes(app, { getLocalizedError }) {
     async (req, res) => {
       try {
         const { appId } = req.params;
-        const { data: platform } = configCache.getPlatform() || {};
+        const platform = configCache.getPlatform() || {};
         const defaultLang = platform?.defaultLanguage || 'en';
         const language = req.headers['accept-language']?.split(',')[0] || defaultLang;
 

--- a/server/tests/generalRoutes-appLanguage.test.js
+++ b/server/tests/generalRoutes-appLanguage.test.js
@@ -1,0 +1,59 @@
+/**
+ * Regression test for GET /api/apps/:appId honoring the platform's
+ * configured defaultLanguage when no Accept-Language header is sent.
+ *
+ * Prior to the fix, the route destructured `configCache.getPlatform()` as
+ * `{ data: platform }`, but `getPlatform()` already returns the unwrapped
+ * platform object, so `platform` was always `undefined` and the localized
+ * `appNotFound` error always fell back to English regardless of the
+ * configured `defaultLanguage`. See issue #1800.
+ */
+
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: {
+    getPlatform: () => ({ defaultLanguage: 'de' }),
+    getApps: () => ({ data: [] })
+  }
+}));
+
+jest.unstable_mockModule('../middleware/authRequired.js', () => ({
+  authRequired: (req, res, next) => next(),
+  appAccessRequired: (req, res, next) => next()
+}));
+
+const { default: registerGeneralRoutes } = await import('../routes/generalRoutes.js');
+
+function createTestApp({ getLocalizedError }) {
+  const app = express();
+  app.use(express.json());
+  registerGeneralRoutes(app, { getLocalizedError });
+  return app;
+}
+
+describe('GET /api/apps/:appId - platform defaultLanguage (regression for #1800)', () => {
+  test('uses the configured defaultLanguage when no Accept-Language header is sent', async () => {
+    const getLocalizedError = jest.fn().mockResolvedValue('App nicht gefunden');
+    const app = createTestApp({ getLocalizedError });
+
+    const response = await request(app).get('/api/apps/does-not-exist');
+
+    expect(response.status).toBe(404);
+    expect(getLocalizedError).toHaveBeenCalledWith('appNotFound', {}, 'de');
+  });
+
+  test('Accept-Language header still takes precedence over defaultLanguage', async () => {
+    const getLocalizedError = jest.fn().mockResolvedValue('App not found');
+    const app = createTestApp({ getLocalizedError });
+
+    const response = await request(app)
+      .get('/api/apps/does-not-exist')
+      .set('Accept-Language', 'fr');
+
+    expect(response.status).toBe(404);
+    expect(getLocalizedError).toHaveBeenCalledWith('appNotFound', {}, 'fr');
+  });
+});


### PR DESCRIPTION
## Summary
- `configCache.getPlatform()` already returns the unwrapped platform object (`this.get('config/platform.json').data`), but `GET /api/apps/:appId` in `server/routes/generalRoutes.js` destructured it as `const { data: platform } = configCache.getPlatform() || {};`, reading a nonexistent nested `.data` — so `platform` was always `undefined` and `defaultLang` always fell back to the hardcoded `'en'`.
- Fixed by reading the platform object directly: `const platform = configCache.getPlatform() || {};`, matching every other call site in the codebase (`modelRoutes.js`, `chat/sessionRoutes.js`, etc.).
- Effect: when a client sends no `Accept-Language` header, the localized `appNotFound` error now correctly uses the platform's configured `defaultLanguage` instead of always being English.

## Test plan
- Added `server/tests/generalRoutes-appLanguage.test.js`, a Jest regression test that:
  - Mocks `configCache` with a `defaultLanguage: 'de'` platform config and verifies `getLocalizedError` is called with `'de'` when no `Accept-Language` header is sent.
  - Verifies an explicit `Accept-Language` header still takes precedence over the configured default.
- Confirmed the first test fails against the pre-fix code (`git stash` the fix) with `expected 'de', received 'en'`, and passes after the fix — proving it actually catches the regression.
- Ran `npx eslint` and `npx prettier --write` on both changed files — no issues.

Fixes #1800

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HizzJyzb5xH94USeg1NCsJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01HizzJyzb5xH94USeg1NCsJ)_