### PR TITLE
fix(outlook): restore manifest download broken by undefined displayName

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -258,3 +258,12 @@ admins no longer need to edit `platform.json` by hand.
 > bundle). Move the key into **Admin → Voice Input** (`platform.json` → `speech.azure.subscriptionKey`).
 > Existing deployments that relied on the env var must set the key server-side for Azure to keep
 > working.
+
+## Outlook Add-in: Manifest Download Restored
+
+Downloading the Outlook add-in manifest works again. The manifest endpoint had started returning a
+server error, which blocked installing or sideloading the add-in.
+
+- The generated manifest now uses the correct localized add-in name, task-pane button label, and
+  description, with English defaults and German (`de-DE`) overrides.
+- No admin action is required — the fix takes effect automatically on upgrade.

--- a/server/routes/integrations/officeAddin.js
+++ b/server/routes/integrations/officeAddin.js
@@ -450,11 +450,17 @@ function generateManifest({
           <bt:Url id="Taskpane.Url" DefaultValue="${baseUrl}/office/taskpane.html"/>
         </bt:Urls>
         <bt:ShortStrings>
-          <bt:String id="GroupLabel" DefaultValue="${escapeXml(displayName)} Add-in"/>
-          <bt:String id="TaskpaneButton.Label" DefaultValue="Show Task Pane"/>
+          <bt:String id="GroupLabel" DefaultValue="${escapeXml(displayNameEn)} Add-in">
+            <bt:Override Locale="de-DE" Value="${escapeXml(displayNameDe)} Add-in"/>
+          </bt:String>
+          <bt:String id="TaskpaneButton.Label" DefaultValue="${escapeXml(showTaskPaneLabelEn)}">
+            <bt:Override Locale="de-DE" Value="${escapeXml(showTaskPaneLabelDe)}"/>
+          </bt:String>
         </bt:ShortStrings>
         <bt:LongStrings>
-          <bt:String id="TaskpaneButton.Tooltip" DefaultValue="${escapeXml(description)}"/>
+          <bt:String id="TaskpaneButton.Tooltip" DefaultValue="${escapeXml(descriptionEn)}">
+            <bt:Override Locale="de-DE" Value="${escapeXml(descriptionDe)}"/>
+          </bt:String>
         </bt:LongStrings>
       </Resources>
     </VersionOverrides>


### PR DESCRIPTION
## Summary

Fixes #1918 — `GET /api/integrations/office-addin/manifest.xml` threw `ReferenceError: displayName is not defined` and returned 500, so the Outlook add-in manifest could no longer be downloaded (blocking install/sideload).

## Root cause

`generateManifest()` was refactored in #1550 (`82b6ec3c`) to take localized `displayNameEn`/`displayNameDe`/`descriptionEn`/`descriptionDe`/`showTaskPaneLabelEn`/`showTaskPaneLabelDe` params instead of a single `displayName`/`description`.

A concurrently-developed PR, #1481 (`401ca9eb`, branched before #1550 merged), rewrote the manifest template and restored the old `displayName`/`description` references in the **V1_1** Resources `<bt:ShortStrings>` / `<bt:LongStrings>` block. The function signature, the top-level `<DisplayName>`/`<Description>`, and the V1_0 Resources block were later reconciled to the En/De params — but this V1_1 block was missed, so it referenced the now-undefined `displayName`/`description` at render time and hardcoded the untranslated `"Show Task Pane"` label.

## Change

Point the V1_1 Resources block at the localized params (matching the already-correct V1_0 block and top-level `<DisplayName>`/`<Description>`):

- `GroupLabel` → `displayNameEn` + `de-DE` override
- `TaskpaneButton.Label` → localized `showTaskPaneLabelEn` + `de-DE` override (was hardcoded `"Show Task Pane"`)
- `TaskpaneButton.Tooltip` → `descriptionEn` + `de-DE` override

## Verification

- `npx eslint server/routes/integrations/officeAddin.js` → clean
- Booted the server and requested `GET /api/integrations/office-addin/manifest.xml`:
  - **200 OK** (was 500)
  - No `ReferenceError` in server logs
  - Rendered strings correct, e.g. `TaskpaneButton.Label` = `"Show Task Pane"` with `de-DE` override `"Aufgabenbereich anzeigen"`; `GroupLabel` = `"iHub Add-in"`; tooltip localized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)