### PR TITLE
Fix AdminAgentEditPage mutating shared BLANK_PROFILE/profile state on save

### DIFF
--- a/client/src/features/admin/pages/AdminAgentEditPage.jsx
+++ b/client/src/features/admin/pages/AdminAgentEditPage.jsx
@@ -109,8 +109,10 @@ export default function AdminAgentEditPage() {
   const { profileId } = useParams();
   const isNew = !profileId || profileId === 'new';
 
-  const [profile, setProfile] = useState(BLANK_PROFILE);
-  const [initialData, setInitialData] = useState(isNew ? BLANK_PROFILE : null);
+  const [profile, setProfile] = useState(() => structuredClone(BLANK_PROFILE));
+  const [initialData, setInitialData] = useState(() =>
+    isNew ? structuredClone(BLANK_PROFILE) : null
+  );
   const [models, setModels] = useState([]);
   const [apps, setApps] = useState([]);
   const [loading, setLoading] = useState(!isNew);
@@ -144,7 +146,7 @@ export default function AdminAgentEditPage() {
         // editing an older profile.
         const mergedProfile = { ...BLANK_PROFILE, ...loaded };
         setProfile(mergedProfile);
-        setInitialData(mergedProfile);
+        setInitialData(structuredClone(mergedProfile));
       } catch (err) {
         setError(err.message);
       } finally {
@@ -231,7 +233,7 @@ export default function AdminAgentEditPage() {
     setError(null);
     setSaving(true);
     try {
-      const payload = { ...profile };
+      const payload = structuredClone(profile);
       const name = cleanLocalized(payload.name);
       if (!name || Object.keys(name).length === 0) {
         setError(t('admin.agents.edit.nameRequired', 'Name is required (at least one language).'));

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,5 +1,15 @@
 # Features — 5.5.0
 
+## Agent Profile Editor No Longer Corrupts Shared State on Save
+
+Fixed a bug in the Agent Profile admin editor where saving could corrupt data shared across the
+page.
+
+- Creating a new agent no longer strips fields (like planner/synthesizer system prompts) from the
+  blank template used for subsequent "New Agent" sessions.
+- If a save fails, the editor no longer mistakenly reports the form as "no unsaved changes,"
+  preventing accidental loss of edits when navigating away.
+
 ## iHub Support Bot Can Now Answer Questions About the Platform
 
 The bundled **iHub Support Bot** app now references the built-in iHub Documentation source, so it


### PR DESCRIPTION
## Summary

Fixes #1791.

`handleSave` in `AdminAgentEditPage.jsx` shallow-copied `profile` (`{ ...profile }`) and then mutated nested objects in place (`delete payload.planner.system`, `payload.synthesizer.system = ...`, etc.). Those nested objects were the same references held in React state — and for new agents, the same references as the module-level `BLANK_PROFILE` constant — so saving a new agent permanently stripped fields from `BLANK_PROFILE` for the rest of the session. Loaded profiles also shared one object between `profile` and `initialData`, so in-place cleaning could make `useUnsavedChanges` report "not dirty" even after a failed save, letting users navigate away and silently lose edits.

## Changes

- `handleSave` now builds the payload with `structuredClone(profile)` before cleaning, so it never mutates React state or `BLANK_PROFILE`.
- The profile-load effect now sets `initialData` to an independent `structuredClone` of the merged profile instead of sharing the same object reference as `profile`.
- Initial `profile`/`initialData` state is now seeded from `structuredClone(BLANK_PROFILE)` so no code path can mutate the shared module-level constant.
- Added a changelog entry under `docs/releases/5.5.0/features.md`.

## Test plan

- [ ] Create a new agent, save it, then start another "New Agent" and confirm planner/synthesizer/memory fields are still present (not stripped from `BLANK_PROFILE`).
- [ ] Edit an existing agent, trigger a failing save (e.g. temporarily break the network/API), and confirm the unsaved-changes guard still blocks navigation away.
- [ ] Normal create/edit/save flow for an agent profile still works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WURycvsZPnb8bcgqzCVDZG

---
_Generated by [Claude Code](https://claude.ai/code/session_01WURycvsZPnb8bcgqzCVDZG)_