### PR TITLE
feat(admin): searchable group picker for user & mapping assignment

### DIFF
--- a/client/src/features/admin/components/GroupFormEditor.jsx
+++ b/client/src/features/admin/components/GroupFormEditor.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
 import ResourceSelector from './ResourceSelector';
+import GroupMultiSelect from './GroupMultiSelect';
 import {
   validateWithSchema,
   errorsToFieldErrors,
@@ -93,12 +94,7 @@ function GroupFormEditor({
     onChange(updatedGroup);
   };
 
-  const handleMappingChange = mappings => {
-    const mappingArray = mappings
-      .split(',')
-      .map(m => m.trim())
-      .filter(m => m.length > 0);
-
+  const handleMappingChange = mappingArray => {
     handleInputChange('mappings', mappingArray);
   };
 
@@ -274,29 +270,32 @@ function GroupFormEditor({
           <div className="md:grid md:grid-cols-3 md:gap-6">
             <div className="md:col-span-1">
               <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                External Group Mappings
+                {t('admin.groups.externalMappings', 'External Group Mappings')}
               </h3>
               <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                Map external groups from OIDC, LDAP, or other providers to this internal group
+                {t(
+                  'admin.groups.externalMappingsDescription',
+                  'Map external groups from OIDC, LDAP, or other providers to this internal group'
+                )}
               </p>
             </div>
             <div className="mt-5 md:col-span-2 md:mt-0">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                  External Group Names (comma-separated)
-                </label>
-                <input
-                  type="text"
-                  value={(group.mappings || []).join(', ')}
-                  onChange={e => handleMappingChange(e.target.value)}
-                  className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                  placeholder="IT-Admin, Platform-Admins, HR-Team"
-                />
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  Enter external group names that should be mapped to this group. Users with these
-                  external groups will automatically be assigned to this internal group.
-                </p>
-              </div>
+              <GroupMultiSelect
+                id="group-external-mappings"
+                label={t('admin.groups.externalGroupNames', 'External Group Names')}
+                value={group.mappings || []}
+                onChange={handleMappingChange}
+                warnOnCustom={false}
+                placeholder={t(
+                  'admin.groups.externalMappingsPlaceholder',
+                  'Type a group name and press Enter…'
+                )}
+                emptyMessage={t('admin.groups.externalMappingsEmpty', 'No external mappings yet')}
+                helpText={t(
+                  'admin.groups.externalMappingsHelp',
+                  'Enter external group names that should be mapped to this group. Users with these external groups will automatically be assigned to this internal group.'
+                )}
+              />
             </div>
           </div>
         </div>

--- a/client/src/features/admin/components/GroupMultiSelect.jsx
+++ b/client/src/features/admin/components/GroupMultiSelect.jsx
@@ -1,0 +1,387 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Icon from '../../../shared/components/Icon';
+
+/**
+ * GroupMultiSelect - Searchable multi-select for group names.
+ *
+ * Lets admins search and pick from known groups (so they choose the right ones)
+ * while still allowing free-form entry of names for non-existing groups. The
+ * latter is required because the same control is used to add external group
+ * mappings (e.g. OIDC/LDAP group names) that are not defined as internal groups.
+ *
+ * Selected values are stored as plain strings (group id for known groups, the
+ * raw name for custom/external entries). Known and custom entries are rendered
+ * differently so it is obvious which values resolve to a defined group.
+ *
+ * @param {object} props
+ * @param {string} [props.label] - Field label
+ * @param {string} [props.id] - Base id used for accessibility wiring
+ * @param {string[]} props.value - Currently selected group names/ids
+ * @param {(next: string[]) => void} props.onChange - Selection change handler
+ * @param {Array<{id: string, name?: string, description?: string}>} [props.availableGroups] - Known groups to suggest
+ * @param {string} [props.placeholder] - Search input placeholder
+ * @param {string} [props.helpText] - Helper text rendered below the control
+ * @param {string} [props.emptyMessage] - Message shown when nothing is selected
+ * @param {boolean} [props.allowCustom=true] - Allow adding names that are not known groups
+ * @param {boolean} [props.warnOnCustom=true] - Visually flag entries that are not defined groups
+ * @param {boolean} [props.disabled=false] - Disable the control
+ */
+function GroupMultiSelect({
+  label,
+  id = 'group-multi-select',
+  value = [],
+  onChange,
+  availableGroups = [],
+  placeholder,
+  helpText,
+  emptyMessage,
+  allowCustom = true,
+  warnOnCustom = true,
+  disabled = false
+}) {
+  const { t } = useTranslation();
+  const inputRef = useRef(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [showDropdown, setShowDropdown] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const selected = useMemo(() => (Array.isArray(value) ? value : []), [value]);
+
+  // Normalize known groups to a consistent option shape.
+  const options = useMemo(
+    () =>
+      (availableGroups || [])
+        .filter(g => g && (g.id || g.name))
+        .map(g => ({
+          id: String(g.id ?? g.name),
+          name: g.name ? String(g.name) : String(g.id),
+          description: g.description ? String(g.description) : ''
+        })),
+    [availableGroups]
+  );
+
+  // Lower-cased lookup set for case-insensitive de-duplication.
+  const selectedKeys = useMemo(
+    () => new Set(selected.map(v => String(v).toLowerCase())),
+    [selected]
+  );
+  const isSelected = useCallback(
+    candidate => selectedKeys.has(String(candidate).toLowerCase()),
+    [selectedKeys]
+  );
+
+  // Resolve chips: match each selected value to a known group when possible.
+  const selectedChips = useMemo(
+    () =>
+      selected.map(v => {
+        const match = options.find(o => o.id.toLowerCase() === String(v).toLowerCase());
+        return match
+          ? { value: v, label: match.name, description: match.description, known: true }
+          : { value: v, label: String(v), description: '', known: false };
+      }),
+    [selected, options]
+  );
+
+  // Filter known groups by search term, excluding already-selected ones.
+  const filteredOptions = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    return options.filter(o => {
+      if (isSelected(o.id)) return false;
+      if (!term) return true;
+      return o.id.toLowerCase().includes(term) || o.name.toLowerCase().includes(term);
+    });
+  }, [options, searchTerm, isSelected]);
+
+  const trimmedTerm = searchTerm.trim();
+  const hasExactMatch = options.some(
+    o =>
+      o.id.toLowerCase() === trimmedTerm.toLowerCase() ||
+      o.name.toLowerCase() === trimmedTerm.toLowerCase()
+  );
+  const showCustomOption =
+    allowCustom && trimmedTerm.length > 0 && !hasExactMatch && !isSelected(trimmedTerm);
+
+  // Combined, index-addressable list for keyboard navigation.
+  const navItems = useMemo(() => {
+    const items = filteredOptions.map(o => ({ type: 'group', option: o }));
+    if (showCustomOption) items.push({ type: 'custom', term: trimmedTerm });
+    return items;
+  }, [filteredOptions, showCustomOption, trimmedTerm]);
+
+  const commit = next => {
+    onChange?.(next);
+    setSearchTerm('');
+    setActiveIndex(-1);
+  };
+
+  const addValue = candidate => {
+    const val = String(candidate).trim();
+    if (!val || isSelected(val)) {
+      setSearchTerm('');
+      setActiveIndex(-1);
+      return;
+    }
+    commit([...selected, val]);
+  };
+
+  // Add by raw term: prefer the canonical id of a matching known group.
+  const addTerm = term => {
+    const val = String(term).trim();
+    if (!val) return;
+    const match = options.find(
+      o => o.id.toLowerCase() === val.toLowerCase() || o.name.toLowerCase() === val.toLowerCase()
+    );
+    addValue(match ? match.id : val);
+  };
+
+  const removeValue = candidate => {
+    commit(selected.filter(v => String(v) !== String(candidate)));
+  };
+
+  const openDropdown = () => {
+    if (!disabled) setShowDropdown(true);
+  };
+
+  const handleSelectNavItem = item => {
+    if (!item) return;
+    if (item.type === 'group') {
+      addValue(item.option.id);
+    } else if (item.type === 'custom') {
+      addTerm(item.term);
+    }
+    inputRef.current?.focus();
+  };
+
+  const handleKeyDown = e => {
+    if (disabled) return;
+
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setShowDropdown(true);
+      setActiveIndex(prev => (navItems.length === 0 ? -1 : (prev + 1) % navItems.length));
+      return;
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex(prev =>
+        navItems.length === 0 ? -1 : (prev - 1 + navItems.length) % navItems.length
+      );
+      return;
+    }
+    if (e.key === 'Enter' || e.key === ',') {
+      // Comma and Enter both commit the current entry.
+      if (e.key === 'Enter' && activeIndex >= 0 && navItems[activeIndex]) {
+        e.preventDefault();
+        handleSelectNavItem(navItems[activeIndex]);
+        return;
+      }
+      if (trimmedTerm) {
+        e.preventDefault();
+        addTerm(trimmedTerm);
+      } else if (e.key === ',') {
+        e.preventDefault();
+      }
+      return;
+    }
+    if (e.key === 'Escape') {
+      setShowDropdown(false);
+      setActiveIndex(-1);
+      return;
+    }
+    if (e.key === 'Backspace' && searchTerm.length === 0 && selected.length > 0) {
+      removeValue(selected[selected.length - 1]);
+    }
+  };
+
+  const resolvedPlaceholder =
+    placeholder ?? t('admin.groupSelect.placeholder', 'Search groups or type a name…');
+  const resolvedEmpty = emptyMessage ?? t('admin.groupSelect.empty', 'No groups selected yet');
+  const listboxId = `${id}-listbox`;
+
+  return (
+    <div className="space-y-2">
+      {label && (
+        <label htmlFor={id} className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+          {label}
+        </label>
+      )}
+
+      {/* Selected chips */}
+      <div className="min-h-[2rem]">
+        {selectedChips.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {selectedChips.map(chip => {
+              const flagged = !chip.known && warnOnCustom;
+              return (
+                <span
+                  key={chip.value}
+                  title={
+                    chip.known
+                      ? chip.description || t('admin.groupSelect.knownGroup', 'Defined group')
+                      : flagged
+                        ? t(
+                            'admin.groupSelect.customGroup',
+                            'Not a defined group — treated as an external group mapping'
+                          )
+                        : undefined
+                  }
+                  className={`inline-flex items-center px-3 py-1 rounded-full text-sm font-medium ${
+                    flagged
+                      ? 'bg-amber-100 dark:bg-amber-900/50 text-amber-800 dark:text-amber-300'
+                      : 'bg-blue-100 dark:bg-blue-900/50 text-blue-800 dark:text-blue-300'
+                  }`}
+                >
+                  <Icon
+                    name={flagged ? 'exclamation-triangle' : 'users'}
+                    size="xs"
+                    className="mr-1"
+                  />
+                  {chip.label}
+                  {!disabled && (
+                    <button
+                      type="button"
+                      onClick={() => removeValue(chip.value)}
+                      className="ml-2 text-current hover:text-red-600 dark:hover:text-red-400 focus:outline-none"
+                      aria-label={t('admin.groupSelect.remove', 'Remove {{name}}', {
+                        name: chip.label
+                      })}
+                    >
+                      <Icon name="x" size="sm" />
+                    </button>
+                  )}
+                </span>
+              );
+            })}
+          </div>
+        ) : (
+          <p className="text-sm text-gray-500 dark:text-gray-400 italic">{resolvedEmpty}</p>
+        )}
+      </div>
+
+      {/* Search / add input */}
+      <div className="relative">
+        <div className="relative">
+          <input
+            ref={inputRef}
+            id={id}
+            type="text"
+            role="combobox"
+            aria-expanded={showDropdown}
+            aria-controls={listboxId}
+            aria-activedescendant={activeIndex >= 0 ? `${id}-opt-${activeIndex}` : undefined}
+            aria-autocomplete="list"
+            autoComplete="off"
+            disabled={disabled}
+            value={searchTerm}
+            onChange={e => {
+              setSearchTerm(e.target.value);
+              setShowDropdown(true);
+              setActiveIndex(-1);
+            }}
+            onFocus={openDropdown}
+            onBlur={() => setShowDropdown(false)}
+            onKeyDown={handleKeyDown}
+            placeholder={resolvedPlaceholder}
+            className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm placeholder-gray-400 dark:placeholder-gray-500 disabled:bg-gray-100 dark:disabled:bg-gray-700"
+          />
+          <Icon
+            name="search"
+            size="sm"
+            className="absolute right-3 top-2.5 text-gray-400 dark:text-gray-500 pointer-events-none"
+          />
+        </div>
+
+        {showDropdown && (
+          <div
+            id={listboxId}
+            role="listbox"
+            className="absolute z-10 mt-1 w-full bg-white dark:bg-gray-800 shadow-lg max-h-60 rounded-md py-1 text-base ring-1 ring-black ring-opacity-5 dark:ring-gray-700 overflow-auto focus:outline-none sm:text-sm"
+          >
+            {navItems.length > 0 ? (
+              navItems.map((item, index) => {
+                const active = index === activeIndex;
+                const optionId = `${id}-opt-${index}`;
+                if (item.type === 'group') {
+                  const { option } = item;
+                  return (
+                    <button
+                      key={`group-${option.id}`}
+                      id={optionId}
+                      type="button"
+                      role="option"
+                      aria-selected={active}
+                      onMouseDown={e => e.preventDefault()}
+                      onMouseEnter={() => setActiveIndex(index)}
+                      onClick={() => handleSelectNavItem(item)}
+                      className={`w-full text-left px-4 py-2 focus:outline-none ${
+                        active ? 'bg-gray-100 dark:bg-gray-700' : ''
+                      }`}
+                    >
+                      <div className="flex items-center">
+                        <Icon
+                          name="plus"
+                          size="sm"
+                          className="mr-2 text-green-600 dark:text-green-400 flex-shrink-0"
+                        />
+                        <span className="text-gray-900 dark:text-gray-100">{option.name}</span>
+                        {option.name.toLowerCase() !== option.id.toLowerCase() && (
+                          <span className="ml-2 text-xs text-gray-400 dark:text-gray-500">
+                            {option.id}
+                          </span>
+                        )}
+                      </div>
+                      {option.description && (
+                        <p className="mt-0.5 ml-6 text-xs text-gray-500 dark:text-gray-400 truncate">
+                          {option.description}
+                        </p>
+                      )}
+                    </button>
+                  );
+                }
+                return (
+                  <button
+                    key="custom-option"
+                    id={optionId}
+                    type="button"
+                    role="option"
+                    aria-selected={active}
+                    onMouseDown={e => e.preventDefault()}
+                    onMouseEnter={() => setActiveIndex(index)}
+                    onClick={() => handleSelectNavItem(item)}
+                    className={`w-full text-left px-4 py-2 border-t border-gray-100 dark:border-gray-700 focus:outline-none ${
+                      active ? 'bg-gray-100 dark:bg-gray-700' : ''
+                    }`}
+                  >
+                    <div className="flex items-center">
+                      <Icon
+                        name="plus"
+                        size="sm"
+                        className="mr-2 text-amber-600 dark:text-amber-400 flex-shrink-0"
+                      />
+                      <span className="text-gray-900 dark:text-gray-100">
+                        {t('admin.groupSelect.addCustom', 'Add "{{name}}"', {
+                          name: item.term
+                        })}
+                      </span>
+                    </div>
+                  </button>
+                );
+              })
+            ) : (
+              <div className="px-4 py-2 text-sm text-gray-500 dark:text-gray-400">
+                {trimmedTerm
+                  ? t('admin.groupSelect.noMatches', 'No matching groups')
+                  : t('admin.groupSelect.startTyping', 'Start typing to search groups…')}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {helpText && <p className="text-xs text-gray-500 dark:text-gray-400">{helpText}</p>}
+    </div>
+  );
+}
+
+export default GroupMultiSelect;

--- a/client/src/features/admin/components/GroupMultiSelect.jsx
+++ b/client/src/features/admin/components/GroupMultiSelect.jsx
@@ -268,8 +268,10 @@ function GroupMultiSelect({
             type="text"
             role="combobox"
             aria-expanded={showDropdown}
-            aria-controls={listboxId}
-            aria-activedescendant={activeIndex >= 0 ? `${id}-opt-${activeIndex}` : undefined}
+            aria-controls={showDropdown ? listboxId : undefined}
+            aria-activedescendant={
+              showDropdown && activeIndex >= 0 ? `${id}-opt-${activeIndex}` : undefined
+            }
             aria-autocomplete="list"
             autoComplete="off"
             disabled={disabled}

--- a/client/src/features/admin/components/UserFormEditor.jsx
+++ b/client/src/features/admin/components/UserFormEditor.jsx
@@ -9,6 +9,7 @@ import {
 } from '../../../utils/schemaValidation';
 import AdminFormErrorSummary from './AdminFormErrorSummary';
 import { FormValidationProvider } from './formValidationContext';
+import GroupMultiSelect from './GroupMultiSelect';
 
 /**
  * UserFormEditor - Form-based editor for user configuration
@@ -18,7 +19,8 @@ function UserFormEditor({
   onChange,
   onValidationChange,
   isNewUser = false,
-  jsonSchema
+  jsonSchema,
+  availableGroups = []
 }) {
   const { t } = useTranslation();
   const [validationErrors, setValidationErrors] = useState({});
@@ -117,12 +119,7 @@ function UserFormEditor({
     onChange(updatedUser);
   };
 
-  const handleGroupsChange = groupsString => {
-    const groupsArray = groupsString
-      .split(',')
-      .map(g => g.trim())
-      .filter(g => g.length > 0);
-
+  const handleGroupsChange = groupsArray => {
     handleInputChange('internalGroups', groupsArray);
   };
 
@@ -423,45 +420,26 @@ function UserFormEditor({
                 {t('admin.users.groupMembership', 'Group Membership')}
               </h3>
               <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                Assign this user to groups to control their permissions and access levels
+                {t(
+                  'admin.users.groupMembershipDescription',
+                  'Assign this user to groups to control their permissions and access levels'
+                )}
               </p>
             </div>
             <div className="mt-5 md:col-span-2 md:mt-0">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Groups (comma-separated)
-                </label>
-                <input
-                  type="text"
-                  value={(user.internalGroups || []).join(', ')}
-                  onChange={e => handleGroupsChange(e.target.value)}
-                  className="mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                  placeholder="admin, users, editors"
-                />
-                <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                  Enter group names separated by commas. Users inherit permissions from all assigned
-                  groups.
-                </p>
-
-                {user.internalGroups && user.internalGroups.length > 0 && (
-                  <div className="mt-3">
-                    <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                      Current Groups:
-                    </p>
-                    <div className="flex flex-wrap gap-2">
-                      {user.internalGroups.map((group, index) => (
-                        <span
-                          key={index}
-                          className="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
-                        >
-                          <Icon name="users" size="xs" className="mr-1" />
-                          {group}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
+              <GroupMultiSelect
+                id="user-internal-groups"
+                label={t('admin.users.groups', 'Groups')}
+                value={user.internalGroups || []}
+                onChange={handleGroupsChange}
+                availableGroups={availableGroups}
+                placeholder={t('admin.users.groupsPlaceholder', 'Search groups or type a name…')}
+                emptyMessage={t('admin.users.groupsEmpty', 'No groups assigned yet')}
+                helpText={t(
+                  'admin.users.groupsHelp',
+                  'Search and select defined groups, or type a name and press Enter to add an external group mapping. Users inherit permissions from all assigned groups.'
                 )}
-              </div>
+              />
             </div>
           </div>
         </div>

--- a/client/src/features/admin/pages/AdminUserEditPage.jsx
+++ b/client/src/features/admin/pages/AdminUserEditPage.jsx
@@ -21,6 +21,7 @@ function AdminUserEditPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
   const [jsonSchema, setJsonSchema] = useState(null);
+  const [availableGroups, setAvailableGroups] = useState([]);
 
   const isNewUser = userId === 'new';
 
@@ -31,6 +32,7 @@ function AdminUserEditPage() {
 
   useEffect(() => {
     loadSchema();
+    loadGroups();
 
     if (isNewUser) {
       // Initialize new user with generated ID
@@ -84,6 +86,16 @@ function AdminUserEditPage() {
       setJsonSchema(schema);
     } catch (error) {
       console.error('Failed to load user schema:', error);
+    }
+  };
+
+  const loadGroups = async () => {
+    try {
+      const response = await makeAdminApiCall('/admin/groups');
+      const groups = response.data?.groups || {};
+      setAvailableGroups(Object.values(groups));
+    } catch (error) {
+      console.error('Failed to load groups:', error);
     }
   };
 
@@ -244,7 +256,8 @@ function AdminUserEditPage() {
             formComponent={UserFormEditor}
             formProps={{
               isNewUser,
-              jsonSchema
+              jsonSchema,
+              availableGroups
             }}
             jsonSchema={jsonSchema}
             title={

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -267,3 +267,17 @@ server error, which blocked installing or sideloading the add-in.
 - The generated manifest now uses the correct localized add-in name, task-pane button label, and
   description, with English defaults and German (`de-DE`) overrides.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Group Assignment Is Now a Searchable Picker
+
+Assigning groups on the user editor and adding external group mappings on the group editor now use
+a searchable picker instead of a plain comma-separated text field, so it is easier to pick the
+right group and harder to introduce typos.
+
+- Start typing to search your defined groups by name or id and add them with a click or the Enter
+  key; selected groups appear as removable chips.
+- You can still type a name that is not a defined group and press Enter to add it — needed for
+  external identity-provider group names used in mappings.
+- On the user editor, entries that do not match a defined group are highlighted so you can spot a
+  mistyped group at a glance.
+- No admin action is required — the change is purely in the admin UI.

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1482,7 +1482,13 @@
         "cancel": "Abbrechen",
         "save": "Benutzer speichern",
         "saving": "Speichern..."
-      }
+      },
+      "groups": "Gruppen",
+      "groupsPlaceholder": "Gruppen suchen oder Namen eingeben…",
+      "groupsEmpty": "Noch keine Gruppen zugewiesen",
+      "groupsHelp": "Definierte Gruppen suchen und auswählen oder einen Namen eingeben und Enter drücken, um eine externe Gruppenzuordnung hinzuzufügen. Benutzer erben die Berechtigungen aller zugewiesenen Gruppen.",
+      "groupMembership": "Gruppenzugehörigkeit",
+      "groupMembershipDescription": "Weisen Sie diesen Benutzer Gruppen zu, um seine Berechtigungen und Zugriffsebenen zu steuern"
     },
     "logging": {
       "loadError": "Fehler beim Laden der Logging-Konfiguration",
@@ -1874,6 +1880,24 @@
           "description": "iHub innerhalb von Nextcloud einbetten. Nutzer starten Chats aus Nextcloud Files mit vorausgewählten Dokumenten — analog zum Outlook-Add-in."
         }
       }
+    },
+    "groupSelect": {
+      "placeholder": "Gruppen suchen oder Namen eingeben…",
+      "empty": "Noch keine Gruppen ausgewählt",
+      "knownGroup": "Definierte Gruppe",
+      "customGroup": "Keine definierte Gruppe – wird als externe Gruppenzuordnung behandelt",
+      "addCustom": "„{{name}}“ hinzufügen",
+      "remove": "{{name}} entfernen",
+      "noMatches": "Keine passenden Gruppen",
+      "startTyping": "Zum Suchen von Gruppen tippen…"
+    },
+    "groups": {
+      "externalMappings": "Externe Gruppenzuordnungen",
+      "externalMappingsDescription": "Externe Gruppen von OIDC, LDAP oder anderen Anbietern dieser internen Gruppe zuordnen",
+      "externalGroupNames": "Externe Gruppennamen",
+      "externalMappingsPlaceholder": "Gruppennamen eingeben und Enter drücken…",
+      "externalMappingsEmpty": "Noch keine externen Zuordnungen",
+      "externalMappingsHelp": "Geben Sie externe Gruppennamen ein, die dieser Gruppe zugeordnet werden sollen. Benutzer mit diesen externen Gruppen werden automatisch dieser internen Gruppe zugewiesen."
     }
   },
   "cloudStorage": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1232,7 +1232,13 @@
         "cancel": "Cancel",
         "save": "Save User",
         "saving": "Saving..."
-      }
+      },
+      "groups": "Groups",
+      "groupsPlaceholder": "Search groups or type a name…",
+      "groupsEmpty": "No groups assigned yet",
+      "groupsHelp": "Search and select defined groups, or type a name and press Enter to add an external group mapping. Users inherit permissions from all assigned groups.",
+      "groupMembership": "Group Membership",
+      "groupMembershipDescription": "Assign this user to groups to control their permissions and access levels"
     },
     "logging": {
       "loadError": "Failed to load logging configuration",
@@ -1624,6 +1630,24 @@
           "description": "Embed iHub inside Nextcloud. Users start a chat from Nextcloud Files with documents pre-attached, similar to the Outlook add-in."
         }
       }
+    },
+    "groupSelect": {
+      "placeholder": "Search groups or type a name…",
+      "empty": "No groups selected yet",
+      "knownGroup": "Defined group",
+      "customGroup": "Not a defined group — treated as an external group mapping",
+      "addCustom": "Add \"{{name}}\"",
+      "remove": "Remove {{name}}",
+      "noMatches": "No matching groups",
+      "startTyping": "Start typing to search groups…"
+    },
+    "groups": {
+      "externalMappings": "External Group Mappings",
+      "externalMappingsDescription": "Map external groups from OIDC, LDAP, or other providers to this internal group",
+      "externalGroupNames": "External Group Names",
+      "externalMappingsPlaceholder": "Type a group name and press Enter…",
+      "externalMappingsEmpty": "No external mappings yet",
+      "externalMappingsHelp": "Enter external group names that should be mapped to this group. Users with these external groups will automatically be assigned to this internal group."
     }
   },
   "cloudStorage": {

--- a/tests/unit/client/group-multi-select.test.jsx
+++ b/tests/unit/client/group-multi-select.test.jsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * GroupMultiSelect Component Tests
+ *
+ * Covers the behaviour requested in issue #1922: a searchable group picker for
+ * the user admin page that also allows adding names for non-existing groups
+ * (used for external group mappings).
+ */
+
+// Mock i18n with simple interpolation so labels/aria-labels are realistic.
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, defaultValue, opts) => {
+      let str = defaultValue ?? key;
+      if (opts && typeof str === 'string') {
+        for (const [k, v] of Object.entries(opts)) {
+          str = str.replace(new RegExp(`{{${k}}}`, 'g'), v);
+        }
+      }
+      return str;
+    },
+    i18n: { language: 'en' }
+  })
+}));
+
+// Mock Icon so we can assert on which icon variant renders.
+jest.mock('../../../client/src/shared/components/Icon', () => {
+  return function Icon({ name }) {
+    return <span data-testid={`icon-${name}`}>{name}</span>;
+  };
+});
+
+import GroupMultiSelect from '../../../client/src/features/admin/components/GroupMultiSelect';
+
+const GROUPS = [
+  { id: 'admins', name: 'Admins', description: 'Full access' },
+  { id: 'users', name: 'Users' }
+];
+
+describe('GroupMultiSelect', () => {
+  test('renders known groups by display name and custom values verbatim', () => {
+    render(<GroupMultiSelect value={['admins', 'External-IdP-Group']} availableGroups={GROUPS} />);
+
+    // Known group id resolves to its display name.
+    expect(screen.getByText('Admins')).toBeInTheDocument();
+    // Custom/external value is shown as-is.
+    expect(screen.getByText('External-IdP-Group')).toBeInTheDocument();
+  });
+
+  test('clicking a matching group adds its id', () => {
+    const onChange = jest.fn();
+    render(<GroupMultiSelect value={[]} onChange={onChange} availableGroups={GROUPS} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'adm' } });
+
+    fireEvent.click(screen.getByRole('option', { name: /Admins/ }));
+
+    expect(onChange).toHaveBeenCalledWith(['admins']);
+  });
+
+  test('typing a non-existing name and pressing Enter adds it as a custom entry', () => {
+    const onChange = jest.fn();
+    render(<GroupMultiSelect value={[]} onChange={onChange} availableGroups={GROUPS} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'External-IdP-Group' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith(['External-IdP-Group']);
+  });
+
+  test('typing a known group display name resolves to its canonical id', () => {
+    const onChange = jest.fn();
+    render(<GroupMultiSelect value={[]} onChange={onChange} availableGroups={GROUPS} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'Admins' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith(['admins']);
+  });
+
+  test('does not add duplicates (case-insensitive)', () => {
+    const onChange = jest.fn();
+    render(<GroupMultiSelect value={['admins']} onChange={onChange} availableGroups={GROUPS} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'ADMINS' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('removing a chip emits the remaining values', () => {
+    const onChange = jest.fn();
+    render(
+      <GroupMultiSelect value={['admins', 'ext']} onChange={onChange} availableGroups={GROUPS} />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove Admins' }));
+
+    expect(onChange).toHaveBeenCalledWith(['ext']);
+  });
+
+  test('flags custom entries by default but not when warnOnCustom is false', () => {
+    const { rerender } = render(<GroupMultiSelect value={['ext']} availableGroups={[]} />);
+    // Default: unknown entry is flagged with a warning icon.
+    expect(screen.getByTestId('icon-exclamation-triangle')).toBeInTheDocument();
+
+    rerender(<GroupMultiSelect value={['ext']} availableGroups={[]} warnOnCustom={false} />);
+    // With warnOnCustom disabled (external-mappings use case) it renders neutrally.
+    expect(screen.queryByTestId('icon-exclamation-triangle')).not.toBeInTheDocument();
+    expect(screen.getByTestId('icon-users')).toBeInTheDocument();
+  });
+
+  test('does not offer a custom "add" option when allowCustom is false', () => {
+    render(<GroupMultiSelect value={[]} availableGroups={GROUPS} allowCustom={false} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, { target: { value: 'nope-not-a-group' } });
+
+    expect(screen.queryByText(/Add "/)).not.toBeInTheDocument();
+    expect(screen.getByText('No matching groups')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1922.

Group selection in the admin UI was a plain comma-separated text field, which made it easy to mistype a group name and gave no visibility into which groups actually exist. This replaces it with a **searchable multi-select** that lets admins pick from defined groups while still allowing free-form names for groups that are **not** defined — required because the same control is also used to add **external group mappings** (OIDC/LDAP group names that don't exist as internal groups).

## Changes

- **New `GroupMultiSelect` component** (`client/src/features/admin/components/GroupMultiSelect.jsx`)
  - Search/filter known groups by name or id; add via click or `Enter`.
  - Selected values render as removable chips.
  - Free-form entry for non-existing group names (`Add "…"` option / `Enter` / `,`).
  - Case-insensitive de-duplication and canonical id resolution when a group's display name is typed.
  - Keyboard navigation (arrows, Enter, Escape, Backspace-to-remove) with ARIA combobox/listbox wiring.
  - `warnOnCustom` prop toggles whether unknown entries are visually flagged.
- **User editor** (`UserFormEditor` + `AdminUserEditPage`): group membership uses the picker and loads defined groups from `/admin/groups`. Entries that don't match a defined group are highlighted so typos stand out.
- **Group editor** (`GroupFormEditor`): external group mappings reuse the same control in free-form mode (`warnOnCustom={false}`, since external names are expected to be "unknown").
- **i18n**: added English + German keys under `admin.groupSelect`, `admin.users.*`, and `admin.groups.*`.
- **Changelog**: entry added to `docs/releases/5.5.0/features.md`.

## Testing

- New unit suite `tests/unit/client/group-multi-select.test.jsx` (8 tests) covering search, id selection, custom add, name→id resolution, de-dup, chip removal, the `warnOnCustom` flag, and `allowCustom={false}`.
- `npm run test:ui` — all 14 client suites / 125 tests pass.
- `eslint` clean (0 errors) on changed files; client production build succeeds.

## Notes

- No admin action required on upgrade — the change is UI-only; stored data (`internalGroups` / `mappings` arrays of strings) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019WXk7tBcfUbPwUQ9JrGeB1

---
_Generated by [Claude Code](https://claude.ai/code/session_019WXk7tBcfUbPwUQ9JrGeB1)_