### PR TITLE
fix(admin): let content admins use the admin area (#1923)

### DIFF
--- a/client/src/api/adminApi.js
+++ b/client/src/api/adminApi.js
@@ -1,5 +1,4 @@
 import { apiClient } from './client.js';
-import { buildPath } from '../utils/runtimeBasePath';
 
 const isPlainObjectForBody = value =>
   value !== null &&
@@ -91,11 +90,15 @@ export const makeAdminApiCall = async (url, options = {}) => {
         // Dispatching is idempotent: handleTokenExpired guards against re-entry
         // and the auth gate won't re-show while it is already visible.
         window.dispatchEvent(new CustomEvent('authTokenExpired'));
-      } else if (window.location.pathname.startsWith('/admin')) {
-        // 403: authenticated but lacking admin permission. Send the user to the
-        // admin root, which renders an "Admin Access Required" message.
-        window.location.href = buildPath('/admin');
       }
+      // 403 (authenticated but not permitted for THIS endpoint) is intentionally
+      // NOT handled with a redirect. Entry to the admin area is already gated by
+      // AdminLayout via /admin/auth/status; individual endpoints are permission-
+      // scoped (e.g. content admins may call /admin/apps but not /admin/usage).
+      // A hard `window.location` redirect here caused an infinite reload loop for
+      // content admins: the Overview page fires full-admin-only calls that 403,
+      // the redirect reloaded /admin, which re-fired them, and so on (issue #1923).
+      // Let the 403 propagate so the calling component can handle it locally.
     }
     throw error;
   }

--- a/client/src/features/admin/hooks/useOverviewData.js
+++ b/client/src/features/admin/hooks/useOverviewData.js
@@ -1,12 +1,23 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { fetchAdminApps, makeAdminApiCall } from '../../../api/adminApi';
+import {
+  fetchAdminApps,
+  fetchAdminPrompts,
+  fetchAdminSources,
+  makeAdminApiCall
+} from '../../../api/adminApi';
 
 /**
  * Fetches and computes data for the admin Overview dashboard.
  * Uses Promise.allSettled so individual endpoint failures don't block others.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.contentAdminOnly] - When true, the caller is a
+ *   content-admin-only user (no full admin access). Only content endpoints
+ *   (apps/prompts/sources) are queried; the platform/usage/audit endpoints are
+ *   skipped because they require full admin and would return 403 (issue #1923).
  */
-export function useOverviewData() {
+export function useOverviewData({ contentAdminOnly = false } = {}) {
   const { t } = useTranslation();
   const [stats, setStats] = useState(null);
   const [platformInfo, setPlatformInfo] = useState(null);
@@ -16,6 +27,48 @@ export function useOverviewData() {
 
   useEffect(() => {
     let cancelled = false;
+
+    // Content-admin-only view: fetch just the resources they manage. These all
+    // pass contentAdminAuth on the server, so no 403s are triggered.
+    const loadContentAdmin = async () => {
+      const [appsResult, promptsResult, sourcesResult] = await Promise.allSettled([
+        fetchAdminApps(),
+        fetchAdminPrompts(),
+        fetchAdminSources()
+      ]);
+
+      if (cancelled) return;
+
+      const apps = appsResult.status === 'fulfilled' ? appsResult.value : [];
+      const prompts = promptsResult.status === 'fulfilled' ? promptsResult.value : [];
+      const sources = sourcesResult.status === 'fulfilled' ? sourcesResult.value : [];
+
+      const appCount = Array.isArray(apps) ? apps.length : 0;
+      const enabledApps = Array.isArray(apps) ? apps.filter(a => a.enabled !== false).length : 0;
+
+      setStats({
+        apps: {
+          value: appCount,
+          sub: t('admin.overview.apps.enabledCount', '{{count}} enabled', { count: enabledApps }),
+          href: '/admin/apps'
+        },
+        prompts: {
+          value: Array.isArray(prompts) ? prompts.length : 0,
+          sub: t('admin.overview.prompts.label', 'prompts'),
+          href: '/admin/prompts'
+        },
+        sources: {
+          value: Array.isArray(sources) ? sources.length : 0,
+          sub: t('admin.overview.sources.label', 'sources'),
+          href: '/admin/sources'
+        }
+      });
+
+      setPlatformInfo(null);
+      setRecentActivity(null);
+      setIsFreshInstance(appCount === 0);
+      setIsLoading(false);
+    };
 
     const load = async () => {
       const [
@@ -112,11 +165,15 @@ export function useOverviewData() {
       setIsLoading(false);
     };
 
-    load();
+    if (contentAdminOnly) {
+      loadContentAdmin();
+    } else {
+      load();
+    }
     return () => {
       cancelled = true;
     };
-  }, [t]);
+  }, [t, contentAdminOnly]);
 
   return { stats, platformInfo, recentActivity, isLoading, isFreshInstance };
 }

--- a/client/src/features/admin/pages/AdminOverview.jsx
+++ b/client/src/features/admin/pages/AdminOverview.jsx
@@ -20,6 +20,7 @@ import {
 } from '@heroicons/react/24/outline';
 import { useOverviewData } from '../hooks/useOverviewData';
 import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
+import { useAuth } from '../../../shared/contexts/AuthContext';
 
 function StatCard({
   label,
@@ -224,10 +225,56 @@ function QuickActions() {
   );
 }
 
-function CommonPages({ className = '' }) {
+// Quick actions limited to the resources a content admin can manage.
+function ContentQuickActions() {
   const { t } = useTranslation();
 
-  const links = [
+  const actions = [
+    {
+      label: t('admin.overview.actions.newApp', 'New App'),
+      href: '/admin/apps',
+      icon: PlusIcon,
+      color: 'bg-indigo-600 hover:bg-indigo-700 text-white'
+    },
+    {
+      label: t('admin.overview.actions.managePrompts', 'Manage Prompts'),
+      href: '/admin/prompts',
+      icon: TagIcon,
+      color:
+        'bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600'
+    },
+    {
+      label: t('admin.overview.actions.manageSources', 'Manage Sources'),
+      href: '/admin/sources',
+      icon: CircleStackIcon,
+      color:
+        'bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 border border-gray-300 dark:border-gray-600'
+    }
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      {actions.map(action => {
+        const Icon = action.icon;
+        return (
+          <Link
+            key={action.href}
+            to={action.href}
+            className={`inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-colors shadow-sm ${action.color}`}
+          >
+            <Icon className="w-4 h-4" aria-hidden="true" />
+            {action.label}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}
+
+function CommonPages({ className = '', links: customLinks }) {
+  const { t } = useTranslation();
+
+  const links = customLinks || [
     { label: t('admin.nav.apps', 'Apps'), href: '/admin/apps' },
     { label: t('admin.nav.models', 'Models'), href: '/admin/models' },
     { label: t('admin.nav.users', 'Users'), href: '/admin/users' },
@@ -461,7 +508,18 @@ function RecentActivityCard({ entries }) {
 export default function AdminOverview() {
   const { t, i18n } = useTranslation();
   const { uiConfig } = useUIConfig();
-  const { stats, platformInfo, recentActivity, isLoading, isFreshInstance } = useOverviewData();
+  const { user } = useAuth();
+
+  // Content-admin-only users (contentAdmin permission, no full adminAccess) get a
+  // content-focused overview: only the apps/prompts/sources they can manage, and
+  // none of the platform-admin panels/links they'd hit 403 on (issue #1923).
+  const isContentAdminOnly = Boolean(
+    user?.permissions?.contentAdmin && !user?.permissions?.adminAccess && !user?.isAdmin
+  );
+
+  const { stats, platformInfo, recentActivity, isLoading, isFreshInstance } = useOverviewData({
+    contentAdminOnly: isContentAdminOnly
+  });
 
   const currentLanguage = i18n.language;
   const { titleLight, titleBold, title } = uiConfig?.header ?? {};
@@ -470,38 +528,63 @@ export default function AdminOverview() {
       ? `${getLocalizedContent(titleLight, currentLanguage)}${getLocalizedContent(titleBold, currentLanguage)}`.trim()
       : getLocalizedContent(title, currentLanguage) || 'iHub Apps';
 
-  const statCards = stats
-    ? [
-        {
-          key: 'apps',
-          label: t('admin.overview.stats.apps', 'Apps'),
-          icon: WindowIcon,
-          iconColor: 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400',
-          ...stats.apps
-        },
-        {
-          key: 'users',
-          label: t('admin.overview.stats.users', 'Users'),
-          icon: UsersIcon,
-          iconColor: 'bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400',
-          ...stats.users
-        },
-        {
-          key: 'chats',
-          label: t('admin.overview.stats.conversations', 'Conversations'),
-          icon: ChatBubbleLeftRightIcon,
-          iconColor: 'bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400',
-          ...stats.chats
-        },
-        {
-          key: 'version',
-          label: t('admin.overview.stats.version', 'Version'),
-          icon: TagIcon,
-          iconColor: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
-          ...stats.version
-        }
-      ]
-    : [];
+  let statCards = [];
+  if (stats && isContentAdminOnly) {
+    statCards = [
+      {
+        key: 'apps',
+        label: t('admin.overview.stats.apps', 'Apps'),
+        icon: WindowIcon,
+        iconColor: 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400',
+        ...stats.apps
+      },
+      {
+        key: 'prompts',
+        label: t('admin.overview.stats.prompts', 'Prompts'),
+        icon: TagIcon,
+        iconColor: 'bg-purple-100 dark:bg-purple-900/30 text-purple-600 dark:text-purple-400',
+        ...stats.prompts
+      },
+      {
+        key: 'sources',
+        label: t('admin.overview.stats.sources', 'Sources'),
+        icon: CircleStackIcon,
+        iconColor: 'bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400',
+        ...stats.sources
+      }
+    ];
+  } else if (stats) {
+    statCards = [
+      {
+        key: 'apps',
+        label: t('admin.overview.stats.apps', 'Apps'),
+        icon: WindowIcon,
+        iconColor: 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400',
+        ...stats.apps
+      },
+      {
+        key: 'users',
+        label: t('admin.overview.stats.users', 'Users'),
+        icon: UsersIcon,
+        iconColor: 'bg-blue-100 dark:bg-blue-900/30 text-blue-600 dark:text-blue-400',
+        ...stats.users
+      },
+      {
+        key: 'chats',
+        label: t('admin.overview.stats.conversations', 'Conversations'),
+        icon: ChatBubbleLeftRightIcon,
+        iconColor: 'bg-green-100 dark:bg-green-900/30 text-green-600 dark:text-green-400',
+        ...stats.chats
+      },
+      {
+        key: 'version',
+        label: t('admin.overview.stats.version', 'Version'),
+        icon: TagIcon,
+        iconColor: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
+        ...stats.version
+      }
+    ];
+  }
 
   if (isLoading) {
     return (
@@ -512,6 +595,48 @@ export default function AdminOverview() {
             {[...Array(4)].map((_, i) => (
               <div key={i} className="h-28 bg-gray-200 dark:bg-gray-700 rounded-lg" />
             ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (isContentAdminOnly) {
+    const contentPages = [
+      { label: t('admin.nav.apps', 'Apps'), href: '/admin/apps' },
+      { label: t('admin.nav.prompts', 'Prompts'), href: '/admin/prompts' },
+      { label: t('admin.nav.sources', 'Sources'), href: '/admin/sources' }
+    ];
+    return (
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Header */}
+        <div className="mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">
+            {t('admin.overview.title', '{{name}} — Admin', { name: instanceName })}
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t('admin.overview.contentSubtitle', 'Manage apps, prompts, and sources')}
+          </p>
+        </div>
+
+        {/* Content stat cards */}
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+          {statCards.map(card => (
+            <StatCard key={card.key} {...card} />
+          ))}
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          <div className="lg:col-span-2 flex flex-col gap-6">
+            <div>
+              <h2 className="text-sm font-semibold text-gray-900 dark:text-gray-100 mb-3">
+                {t('admin.overview.quickActions', 'Quick actions')}
+              </h2>
+              <ContentQuickActions />
+            </div>
+          </div>
+          <div className="space-y-6">
+            <CommonPages links={contentPages} />
           </div>
         </div>
       </div>

--- a/client/src/features/auth/components/UserAuthMenu.jsx
+++ b/client/src/features/auth/components/UserAuthMenu.jsx
@@ -117,8 +117,12 @@ export default function UserAuthMenu({ variant = 'header', className = '' }) {
     setShowAllGroups(false);
   };
 
-  // Use the backend-calculated isAdmin flag instead of hardcoded group names
+  // Use the backend-calculated isAdmin flag instead of hardcoded group names.
+  // Content admins (permissions.contentAdmin) aren't full admins (isAdmin) but
+  // must still reach the admin area to manage apps/prompts/sources (issue #1923).
   const isAdmin = user?.isAdmin === true;
+  const isContentAdmin = user?.permissions?.contentAdmin === true;
+  const canAccessAdmin = isAdmin || isContentAdmin;
 
   return (
     <div className={`relative ${className}`} ref={dropdownRef}>
@@ -268,7 +272,7 @@ export default function UserAuthMenu({ variant = 'header', className = '' }) {
                   )}
 
                 {/* Admin Panel */}
-                {isAdmin && (
+                {canAccessAdmin && (
                   <Link
                     to="/admin"
                     role="menuitem"

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -267,3 +267,17 @@ server error, which blocked installing or sideloading the add-in.
 - The generated manifest now uses the correct localized add-in name, task-pane button label, and
   description, with English defaults and German (`de-DE`) overrides.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Content Admins Can Now Use the Admin Area
+
+Members of the **Content Admins** group (the `contentAdmin` permission, without full admin access)
+can now open and use the admin area to manage Apps, Prompts, and Sources. Previously they had no
+way in: the **Admin Panel** link was missing from the user menu, and opening `/admin` directly
+trapped the page in an endless reload loop.
+
+- The **Admin Panel** link now appears in the user menu for content admins, not just full admins.
+- Opening `/admin` no longer reloads endlessly. A per-request permission denial (403) on an
+  admin-only endpoint is now handled where it happens instead of hard-redirecting the whole page.
+- Content admins get a focused admin experience: the sidebar and the overview dashboard show only
+  Apps, Prompts, and Sources — the platform-only sections and stats they cannot access are hidden.
+- No admin action is required — the fix takes effect automatically on upgrade.

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -674,6 +674,12 @@ export default function registerAuthRoutes(app) {
               name: req.user.name,
               email: req.user.email,
               groups: req.user.groups,
+              // Expose resolved permissions so the client can distinguish a
+              // content admin (permissions.contentAdmin) from a full admin
+              // (isAdmin). Without this the admin sidebar can't filter its
+              // sections and the user menu can't show the admin link for
+              // content-admin-only users (issue #1923). Mirrors /api/auth/user.
+              permissions: req.user.permissions,
               isAdmin: req.user.isAdmin,
               authMethod: req.user.authMethod
             }


### PR DESCRIPTION
## Summary

Fixes #1923. Content admins (the `contentAdmin` permission, **without** full `adminAccess`) could not use the admin area at all. This PR makes them first-class: they can open `/admin` and manage Apps, Prompts, and Sources, without seeing (or looping on) the platform-admin features they can't access.

## The bug, and root causes

The reporter described three symptoms; I reproduced all three end-to-end with a real content-admin account (Playwright + a live server):

1. **No "Admin Panel" link in the user menu.** `UserAuthMenu` gated the link on `user.isAdmin === true`. Content admins have `isAdmin: false`, so the link never showed.
2. **Opening `/admin` reloaded endlessly** ("you will see the admin, it goes back, reloads, endlessly"). The Overview dashboard (`useOverviewData`) fires full-admin-only endpoints (`/admin/usage/*`, `/admin/overview/stats`, `/admin/version`, `/admin/audit-log`). For a content admin those return **403**, and `makeAdminApiCall` handled any 403 with `window.location.href = '/admin'` — a full-page reload that re-mounted the Overview, which re-fired the same calls → infinite loop.
3. **The sidebar showed everything.** `/api/auth/status` returned the user **without** `permissions`, so the client couldn't tell a content admin from a full admin, and `AdminSidebar`'s content-admin filter (`user.permissions.contentAdmin`) never triggered.

## Changes

- **`client/src/api/adminApi.js`** — Stop hard-redirecting on 403. Admin-area entry is already gated by `AdminLayout` (via `/admin/auth/status`), and individual endpoints are permission-scoped (content admins may call `/admin/apps` but not `/admin/usage`). 403s now propagate to the caller instead of reloading the page. This removes the loop.
- **`server/routes/auth.js`** — `/api/auth/status` now includes `user.permissions` (mirroring `/api/auth/user`), so the client can distinguish a content admin (`permissions.contentAdmin`) from a full admin (`isAdmin`). This is what re-enables the existing sidebar filter and the menu-link check.
- **`client/src/features/auth/components/UserAuthMenu.jsx`** — The Admin Panel link now shows for content admins too (`isAdmin || permissions.contentAdmin`).
- **`client/src/features/admin/pages/AdminOverview.jsx`** + **`hooks/useOverviewData.js`** — Content-admin-only users get a focused overview (Apps / Prompts / Sources counts, content-only quick actions and links) and the hook skips the admin-only fetches that would 403. The full-admin path is unchanged (gated by a flag that defaults to the existing behavior).
- **`docs/releases/5.5.0/features.md`** — Changelog entry for the in-product admin changelog.

## Verification

Reproduced against a booted server with a real `content-admins` user (`internalGroups: ["content-admins"]`), then verified the fix via Playwright:

| Role | Admin Panel link | `/admin` reload loop | Sidebar |
|------|:---:|:---:|---|
| **Content admin** | ✅ shown | ✅ gone (2 navs, stays on `/admin`) | Overview, Apps, Prompts, Sources only |
| **Full admin** (regression) | ✅ shown | ✅ none | all sections, unchanged |

API-level confirmation for the content admin: `/api/admin/apps|prompts|sources` → `200`; the full-admin-only endpoints → `403` (now harmless); `/api/auth/status` now carries `permissions.contentAdmin: true`.

`npm run lint`/`prettier` clean on all changed files (only pre-existing `no-array-index-key` warnings in untouched code).

## Notes

- No config migration needed — the `content-admins` group and `contentAdmin` permission already exist (migration `V043`) and the server-side `contentAdminAuth` gate is unchanged.
- No backend permission behavior changed: content admins are still blocked from full-admin endpoints server-side. This PR only fixes the client so they can reach and use the parts they're allowed to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015RAvNmXd2nmuAKuR5tzaGR)_