### PR TITLE
fix(chat): stop duplicate SSE error events and guarantee terminal done on tool-loop failures

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -259,6 +259,15 @@ admins no longer need to edit `platform.json` by hand.
 > Existing deployments that relied on the env var must set the key server-side for Azure to keep
 > working.
 
+## Tool-Enabled Chats No Longer Show a Duplicated Error or Hang When a Follow-Up Call Fails
+
+When an app with tools enabled hit a provider error (for example a rate limit) on a follow-up
+call after a tool ran, the error text could appear twice in the assistant bubble, and the chat
+stream sometimes never closed cleanly. Both are fixed: the error is now reported once, and the
+stream always ends with a proper terminal event.
+
+- No admin action required.
+
 ## Outlook Add-in: Manifest Download Restored
 
 Downloading the Outlook add-in manifest works again. The manifest endpoint had started returning a

--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -1249,6 +1249,16 @@ class ToolExecutor {
         actionTracker.trackError(chatId, { ...errMsg });
       }
 
+      // Every successful exit path above (no-tool-call turn, clarification,
+      // passthrough, or continueWithToolExecution's own paths) already emits a
+      // terminal 'done' event before returning, so reaching this catch means
+      // none did. Without this, a failed tool-loop request leaves the client
+      // stream open with no terminal event at all (see StreamingHandler's
+      // doneEmitted guard for the equivalent non-tool-calling path).
+      actionTracker.trackDone(chatId, {
+        finishReason: error.name === 'AbortError' ? 'connection_closed' : 'error'
+      });
+
       if (activeRequests.get(chatId) === controller) {
         activeRequests.delete(chatId);
       }
@@ -1565,31 +1575,13 @@ class ToolExecutor {
       } catch (error) {
         clearTimeout(timeoutId);
 
-        if (error.name !== 'AbortError') {
-          const errorDetails = getErrorDetails(error, model);
-          let localizedMessage = errorDetails.message;
-
-          if (error.code) {
-            const translated = await getLocalizedError(error.code, {}, clientLanguage);
-            if (translated && !translated.startsWith('Error:')) {
-              localizedMessage = translated;
-            }
-          }
-
-          const errMsg = {
-            message: localizedMessage,
-            code: error.code || errorDetails.code,
-            details: error.details || error.message
-          };
-
-          actionTracker.trackError(chatId, { ...errMsg });
-        }
-
         if (activeRequests.get(chatId) === controller) {
           activeRequests.delete(chatId);
         }
         // Clear source bookkeeping so a failed turn can't leak sources into the
-        // next turn on this chatId. The caller handles the error/done event.
+        // next turn on this chatId. The caller (processChatWithTools) is the
+        // single place that tracks the error/done event for this failure —
+        // tracking it here too would emit a duplicate 'error' event.
         this.resetKnowledgeSources(chatId);
         throw error; // Re-throw to let the calling method handle it
       }

--- a/server/tests/toolExecutor-error-done-events.test.js
+++ b/server/tests/toolExecutor-error-done-events.test.js
@@ -1,0 +1,132 @@
+/**
+ * Regression tests for #1792: a failed LLM call inside the tool-calling loop
+ * used to fire two 'error' SSE events for the same failure (one from
+ * continueWithToolExecution's own catch, one from processChatWithTools' catch
+ * after the re-throw) and never emitted a terminal 'done' event, leaving the
+ * client stream open with no closing event after an error.
+ *
+ * Note: The repo's source is native ESM (uses `import.meta.url`), so this file
+ * uses `jest.unstable_mockModule` + dynamic imports rather than the
+ * CommonJS-only `jest.mock` API. Run with `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../adapters/index.js', () => ({
+  createCompletionRequest: async () => ({
+    url: 'https://example.invalid/chat/completions',
+    method: 'POST',
+    headers: {},
+    body: {}
+  }),
+  // StreamingHandler (imported transitively by ToolExecutor) needs this export
+  // to exist even though the error paths under test never reach it.
+  getAdapter: () => {
+    throw new Error('getAdapter should not be called in this test');
+  }
+}));
+
+jest.unstable_mockModule('../requestThrottler.js', () => ({
+  throttledFetch: async () => {
+    throw new Error('simulated provider 500');
+  }
+}));
+
+// usageTracker.js schedules an un-refed, module-scope setInterval (its
+// periodic save-retry loop) that keeps the process alive forever once
+// imported — StreamingHandler.js (a transitive dependency of ToolExecutor.js)
+// imports it purely for token/usage recording, which this test never
+// exercises, so stub it out rather than dragging that timer into the suite.
+jest.unstable_mockModule('../usageTracker.js', () => ({
+  estimateTokens: () => 0,
+  recordChatRequest: async () => {},
+  recordChatResponse: async () => {}
+}));
+
+const { throttledFetch } = await import('../requestThrottler.js');
+const { actionTracker } = await import('../actionTracker.js');
+const { default: ToolExecutor } = await import('../services/chat/ToolExecutor.js');
+
+function collectFireSseEvents(chatId) {
+  const events = [];
+  const listener = payload => {
+    if (payload.chatId === chatId) events.push(payload);
+  };
+  actionTracker.on('fire-sse', listener);
+  return {
+    events,
+    stop: () => actionTracker.off('fire-sse', listener)
+  };
+}
+
+describe('ToolExecutor tool-loop failure SSE events (#1792)', () => {
+  test('continueWithToolExecution no longer tracks error/done itself on failure — it only cleans up and re-throws', async () => {
+    const toolExecutor = new ToolExecutor();
+    const chatId = 'test-chat-continue-failure';
+    const { events, stop } = collectFireSseEvents(chatId);
+
+    await expect(
+      toolExecutor.continueWithToolExecution({
+        model: { id: 'test-model', provider: 'openai' },
+        llmMessages: [{ role: 'user', content: 'hi' }],
+        apiKey: 'sk-test',
+        temperature: 0.7,
+        maxTokens: 100,
+        tools: [],
+        chatId,
+        buildLogData: () => ({}),
+        DEFAULT_TIMEOUT: 5000,
+        getLocalizedError: async () => null,
+        clientLanguage: 'en',
+        user: { id: 'test-user' }
+      })
+    ).rejects.toThrow('simulated provider 500');
+
+    stop();
+
+    const errorEvents = events.filter(e => e.event === 'error');
+    const doneEvents = events.filter(e => e.event === 'done');
+    expect(errorEvents).toHaveLength(0);
+    expect(doneEvents).toHaveLength(0);
+  });
+
+  test('processChatWithTools emits exactly one error event and one terminal done event on failure', async () => {
+    const toolExecutor = new ToolExecutor();
+    const chatId = 'test-chat-process-failure';
+    const { events, stop } = collectFireSseEvents(chatId);
+
+    await toolExecutor.processChatWithTools({
+      prep: {
+        request: { url: 'https://example.invalid/chat/completions', headers: {}, body: {} },
+        model: { id: 'test-model', provider: 'openai' },
+        llmMessages: [{ role: 'user', content: 'hi' }],
+        tools: [],
+        apiKey: 'sk-test',
+        temperature: 0.7,
+        maxTokens: 100,
+        responseFormat: undefined,
+        responseSchema: undefined,
+        app: {},
+        userFileData: null
+      },
+      chatId,
+      buildLogData: () => ({}),
+      DEFAULT_TIMEOUT: 5000,
+      getLocalizedError: async () => null,
+      clientLanguage: 'en',
+      user: { id: 'test-user' }
+    });
+
+    stop();
+
+    const errorEvents = events.filter(e => e.event === 'error');
+    const doneEvents = events.filter(e => e.event === 'done');
+    expect(errorEvents).toHaveLength(1);
+    expect(doneEvents).toHaveLength(1);
+    expect(doneEvents[0].finishReason).toBe('error');
+  });
+});
+
+// Keep the mocked throttledFetch referenced so bundlers/linters don't flag the
+// dynamic import as unused if the mock factory above is ever inlined.
+void throttledFetch;


### PR DESCRIPTION
## Summary

Fixes #1792.

When an LLM call inside `continueWithToolExecution` (the tool-calling follow-up loop) failed — e.g. a provider 429/500 on a round after a tool ran — its catch block tracked the error and re-threw; `processChatWithTools`' catch then computed the same localized message and tracked the error again. The client received two `error` SSE events for one failure. Additionally, unlike `StreamingHandler`, which guarantees a terminal `done` event via a `doneEmitted` guard, neither `ToolExecutor` catch emitted `trackDone`, so a failed tool-loop request could leave the stream with no terminal event at all.

- `continueWithToolExecution`'s catch (`server/services/chat/ToolExecutor.js`) now only cleans up (clears the timeout, removes the active request, resets knowledge sources) and re-throws — it no longer tracks the error itself.
- `processChatWithTools`' catch is now the single place that tracks the error, and it also emits `trackDone` (`finishReason: 'error'`, or `'connection_closed'` for an aborted request), mirroring `StreamingHandler`'s `doneEmitted` finally-guard pattern.

## Test plan

- [x] Added `server/tests/toolExecutor-error-done-events.test.js`:
  - Asserts `continueWithToolExecution` no longer emits any `error`/`done` SSE event on failure (cleanup + re-throw only).
  - Asserts `processChatWithTools` emits exactly one `error` event and exactly one terminal `done` event (`finishReason: 'error'`) when a follow-up LLM call fails.
- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/toolExecutor-error-done-events.test.js` passes.
- [x] Ran the full server test suite before/after the change — same 110 pre-existing failing suites in both cases (unrelated to this change, missing local env config), with 2 additional passing tests from this PR and no new failures.

https://claude.ai/code/session_01WaN3q5ivLzSqbziP3RWzUB


---
_Generated by [Claude Code](https://claude.ai/code/session_01WaN3q5ivLzSqbziP3RWzUB)_