### PR TITLE
fix(auth): make AuthContext the single owner of /auth/status

### DIFF
--- a/client/src/features/auth/components/LoginForm.jsx
+++ b/client/src/features/auth/components/LoginForm.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../../shared/contexts/AuthContext';
-import { usePlatformConfig } from '../../../shared/contexts/PlatformConfigContext';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 
 // localStorage key for the last successfully logged-in username so we can
@@ -38,7 +37,6 @@ const StandaloneWrapper = ({ children }) => (
 export default function LoginForm({ onSuccess, onCancel, embedded = false }) {
   const { t } = useTranslation();
   const { loginLocal, loginLdap, loginWithOidc, isLoading, error, authConfig } = useAuth();
-  const { platformConfig } = usePlatformConfig();
   const initialRememberedUsername = getRememberedUsername();
   const [formData, setFormData] = useState({
     username: initialRememberedUsername,
@@ -132,7 +130,7 @@ export default function LoginForm({ onSuccess, onCancel, embedded = false }) {
 
   // Show username/password form if either local or LDAP auth is enabled
   const hasUsernamePasswordAuth = hasLocalAuth || hasLdapAuth;
-  const showDemoAccounts = platformConfig?.localAuth?.showDemoAccounts === true;
+  const showDemoAccounts = authConfig?.authMethods?.local?.showDemoAccounts === true;
 
   // Determine if we should show method selection (both local and LDAP enabled)
   const showAuthMethodSelection = hasLocalAuth && hasLdapAuth && !selectedAuthMethod;

--- a/client/src/features/auth/components/UserAuthMenu.jsx
+++ b/client/src/features/auth/components/UserAuthMenu.jsx
@@ -42,10 +42,8 @@ export default function UserAuthMenu({ variant = 'header', className = '' }) {
     onClose: handleMenuClose
   });
 
-  const auth = platformConfig?.auth || {};
-  const authMode = authConfig?.authMode || auth.mode || 'anonymous';
-  const allowAnonymous =
-    authConfig?.anonymousAuth?.enabled ?? platformConfig?.anonymousAuth?.enabled !== false;
+  const authMode = authConfig?.authMode || 'anonymous';
+  const allowAnonymous = authConfig?.anonymousAuth?.enabled !== false;
 
   // Calculate user initials for sidebar variant
   const displayName = user?.name || user?.email || user?.username || user?.id || 'User';

--- a/client/src/shared/contexts/AuthContext.jsx
+++ b/client/src/shared/contexts/AuthContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useReducer, useEffect, useCallback, useRef } from 'react';
 import { apiClient } from '../../api/client.js';
+import { fetchAuthStatus } from '../../api';
 import { buildPath, buildApiUrl } from '../../utils/runtimeBasePath';
 
 // Auth action types
@@ -115,11 +116,7 @@ export function AuthProvider({ children }) {
     try {
       dispatch({ type: AUTH_ACTIONS.SET_LOADING, payload: true });
 
-      const response = await apiClient.get('/auth/status', {
-        headers: getAuthHeaders()
-      });
-
-      const data = response.data;
+      const data = await fetchAuthStatus({ skipCache: false });
 
       if (data.success !== false) {
         dispatch({
@@ -341,8 +338,7 @@ export function AuthProvider({ children }) {
 
         // Try to get fresh auth config to check for auto-redirect
         try {
-          const response = await apiClient.get('/auth/status');
-          const data = response.data;
+          const data = await fetchAuthStatus({ skipCache: true });
 
           // If auto-redirect is configured, redirect to the auth provider
           if (data.autoRedirect && !isLogoutPage) {
@@ -399,8 +395,17 @@ export function AuthProvider({ children }) {
     window.addEventListener('authTokenExpired', handleTokenExpired);
 
     // Listen for successful re-authentication from the auth gate overlay
-    const handleAuthGateSuccess = () => {
+    const handleAuthGateSuccess = async () => {
       console.log('🔓 Auth gate re-authentication successful - refreshing auth state');
+      // The auth gate is a standalone script that logs in via its own fetch calls,
+      // bypassing our cache module entirely, so the cached auth-status entry from
+      // before login is still present and must be cleared before refetching.
+      try {
+        const { clearApiCache } = await import('../../api/utils/cache');
+        clearApiCache();
+      } catch (error) {
+        console.warn('Could not clear API cache on auth gate success:', error);
+      }
       loadAuthStatus();
     };
     window.addEventListener('authGateSuccess', handleAuthGateSuccess);

--- a/client/src/shared/contexts/PlatformConfigContext.jsx
+++ b/client/src/shared/contexts/PlatformConfigContext.jsx
@@ -62,8 +62,6 @@ export function PlatformConfigProvider({ children }) {
           : platformCfg.features || {},
 
         // Additional auth status fields
-        authenticated: authStatus.authenticated,
-        user: authStatus.user,
         autoRedirect: authStatus.autoRedirect,
 
         // Setup wizard state


### PR DESCRIPTION
## Summary

Closes #1783.

`AuthContext` fetched `/auth/status` via two raw, uncached `apiClient.get()` calls (on mount and in the token-expiry handler), bypassing the cached/deduped `fetchAuthStatus()` helper that `PlatformConfigContext` already used for the same endpoint. That meant a fresh page load fired the endpoint from both providers independently, and it fired again on every OIDC callback and token-expiry re-check. Meanwhile `platformConfig.authenticated`/`platformConfig.user` were dead duplicate state — no component read them — and `UserAuthMenu`/`LoginForm` read auth-method flags off `platformConfig` instead of the richer `authConfig` already available from `useAuth()`.

- `AuthContext.loadAuthStatus()` / the token-expiry handler now call `fetchAuthStatus()` from the shared cache module instead of a raw `apiClient.get('/auth/status')`.
- `handleAuthGateSuccess` now clears the API cache before refetching. The auth-gate overlay (`auth-gate.js`) logs in via its own `fetch()` calls outside our cache module, so without this the post-login refetch would serve the stale pre-login cache entry — verified this regression locally (login would leave the user stuck on `/login`) and fixed it before pushing.
- Removed the unused `authenticated`/`user` fields from `PlatformConfigContext`'s `combinedConfig`.
- `UserAuthMenu.jsx` / `LoginForm.jsx` now read `authMode`, `anonymousAuth`, and `local.showDemoAccounts` from `authConfig` (via `useAuth()`) instead of `platformConfig`.

## Verification

Ran the dev server and drove it with a headless browser:
- Counted `/api/auth/status` network requests on a fresh boot: 4 → 2 (remaining 2 are React StrictMode's dev-only double-invoke; production fires once).
- Logged in as the local admin (`admin` / `password123`) end-to-end — confirmed the user menu renders "Demo Administrator", shows groups, the Admin Panel link, and Sign Out.
- Confirmed the login page's "Demo accounts" hint (driven by `authConfig.authMethods.local.showDemoAccounts`) still renders correctly.
- `npx eslint` on the four changed files: 0 errors (only pre-existing unrelated warnings).
- Client production build succeeds.

## Test plan

- [x] Fresh page load fires `/auth/status` fewer times than before (verified via network capture)
- [x] Local login via the auth-gate overlay reaches the authenticated app state (previously regressed, now fixed)
- [x] `UserAuthMenu` shows correct anonymous/authenticated/proxy-mode behavior
- [x] `LoginForm` demo-accounts hint still renders from the new `authConfig` source
- [x] Lint clean, production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014ibddBNTKcPq5gHJUvPA17)_