### PR TITLE
fix: apply Zod defaults via lenient fallback when strict schema rejects unknown keys

### DIFF
--- a/server/appsLoader.js
+++ b/server/appsLoader.js
@@ -1,5 +1,9 @@
 import { createResourceLoader, createSchemaValidator } from './utils/resourceLoader.js';
-import { appConfigSchema, knownAppKeys } from './validators/appConfigSchema.js';
+import {
+  appConfigSchema,
+  appConfigSchemaLenient,
+  knownAppKeys
+} from './validators/appConfigSchema.js';
 
 /**
  * Enhanced Apps Loader Service
@@ -15,7 +19,7 @@ const appsLoader = createResourceLoader({
   resourceName: 'Apps',
   legacyPath: 'config/apps.json',
   individualPath: 'apps',
-  validateItem: createSchemaValidator(appConfigSchema, knownAppKeys)
+  validateItem: createSchemaValidator(appConfigSchema, knownAppKeys, appConfigSchemaLenient)
 });
 
 /**

--- a/server/modelsLoader.js
+++ b/server/modelsLoader.js
@@ -1,5 +1,9 @@
 import { createResourceLoader, createSchemaValidator } from './utils/resourceLoader.js';
-import { modelConfigSchema, knownModelKeys } from './validators/modelConfigSchema.js';
+import {
+  modelConfigSchema,
+  modelConfigSchemaLenient,
+  knownModelKeys
+} from './validators/modelConfigSchema.js';
 import logger from './utils/logger.js';
 
 /**
@@ -46,7 +50,7 @@ const modelsLoader = createResourceLoader({
   resourceName: 'Models',
   legacyPath: 'config/models.json',
   individualPath: 'models',
-  validateItem: createSchemaValidator(modelConfigSchema, knownModelKeys),
+  validateItem: createSchemaValidator(modelConfigSchema, knownModelKeys, modelConfigSchemaLenient),
   postProcess: ensureOneDefaultModel
 });
 

--- a/server/tests/resourceLoader-lenient-schema.test.js
+++ b/server/tests/resourceLoader-lenient-schema.test.js
@@ -1,0 +1,106 @@
+/**
+ * Regression tests for createSchemaValidator's lenient-schema fallback (#1803).
+ *
+ * Both appConfigSchema and modelConfigSchema use z.strict(), so a config with a
+ * single stray/unknown key used to fail safeParse entirely and fall back to the
+ * raw, unvalidated item - silently dropping Zod defaults (enabled, sendChatHistory,
+ * etc.). createSchemaValidator now retries against a passthrough ("lenient")
+ * variant of the same schema when the strict parse fails, so defaults still apply.
+ */
+import { createSchemaValidator } from '../utils/resourceLoader.js';
+import {
+  appConfigSchema,
+  appConfigSchemaLenient,
+  knownAppKeys
+} from '../validators/appConfigSchema.js';
+import {
+  modelConfigSchema,
+  modelConfigSchemaLenient,
+  knownModelKeys
+} from '../validators/modelConfigSchema.js';
+
+function baseApp(overrides = {}) {
+  return {
+    id: 'my-app',
+    name: { en: 'My App' },
+    description: { en: 'An app' },
+    color: '#4F46E5',
+    icon: 'chat',
+    ...overrides
+  };
+}
+
+function baseModel(overrides = {}) {
+  return {
+    id: 'my-model',
+    modelId: 'gpt-4o',
+    name: { en: 'My Model' },
+    description: { en: 'A model' },
+    provider: 'openai',
+    ...overrides
+  };
+}
+
+describe('createSchemaValidator lenient fallback', () => {
+  test('applies app schema defaults when strict parse succeeds', () => {
+    const validate = createSchemaValidator(appConfigSchema, knownAppKeys, appConfigSchemaLenient);
+    const result = validate(baseApp(), 'contents/apps/my-app.json');
+
+    expect(result.enabled).toBe(true);
+    expect(result.sendChatHistory).toBe(true);
+  });
+
+  test('still applies app schema defaults when an unknown key would fail strict parsing', () => {
+    const validate = createSchemaValidator(appConfigSchema, knownAppKeys, appConfigSchemaLenient);
+    const item = baseApp({ someLegacyField: 'left over from an old version' });
+
+    // Confirm the premise: strict parsing does reject this input.
+    expect(appConfigSchema.safeParse(item).success).toBe(false);
+
+    const result = validate(item, 'contents/apps/my-app.json');
+
+    expect(result.enabled).toBe(true);
+    expect(result.sendChatHistory).toBe(true);
+    expect(result.someLegacyField).toBe('left over from an old version');
+  });
+
+  test('falls back to the raw item when the config is invalid for reasons other than unknown keys', () => {
+    const validate = createSchemaValidator(appConfigSchema, knownAppKeys, appConfigSchemaLenient);
+    // Missing required 'color' - lenient parsing must fail too.
+    const item = { id: 'my-app', name: { en: 'My App' }, description: { en: 'An app' } };
+
+    expect(appConfigSchemaLenient.safeParse(item).success).toBe(false);
+
+    const result = validate(item, 'contents/apps/my-app.json');
+
+    expect(result).toBe(item);
+    expect(result.enabled).toBeUndefined();
+  });
+
+  test('still applies model schema defaults when an unknown key would fail strict parsing', () => {
+    const validate = createSchemaValidator(
+      modelConfigSchema,
+      knownModelKeys,
+      modelConfigSchemaLenient
+    );
+    const item = baseModel({ legacyFlag: true });
+
+    expect(modelConfigSchema.safeParse(item).success).toBe(false);
+
+    const result = validate(item, 'contents/models/my-model.json');
+
+    expect(result.enabled).toBe(true);
+    expect(result.supportsTools).toBe(false);
+    expect(result.legacyFlag).toBe(true);
+  });
+
+  test('works unchanged with no lenient schema provided', () => {
+    const validate = createSchemaValidator(appConfigSchema, knownAppKeys);
+    const item = baseApp({ someLegacyField: 'x' });
+
+    const result = validate(item, 'contents/apps/my-app.json');
+
+    // No lenient fallback available - behaves like before the fix.
+    expect(result).toBe(item);
+  });
+});

--- a/server/utils/resourceLoader.js
+++ b/server/utils/resourceLoader.js
@@ -345,9 +345,12 @@ function extractResourceType(source) {
  * Helper function to create a schema validation function
  * @param {Object} schema - Zod schema object
  * @param {Array} knownKeys - Array of known valid keys
+ * @param {Object} [lenientSchema] - Same schema with unknown keys passed through instead of
+ *   rejected. Used as a fallback when `schema` fails validation only because of a stray/unknown
+ *   key, so Zod defaults are still applied instead of silently falling back to the raw item.
  * @returns {Function} Schema validation function that returns the validated/parsed item
  */
-export function createSchemaValidator(schema, knownKeys = []) {
+export function createSchemaValidator(schema, knownKeys = [], lenientSchema) {
   return function (item, source) {
     const resourceType = extractResourceType(source);
     const resourceId = item.id || 'unknown';
@@ -357,19 +360,34 @@ export function createSchemaValidator(schema, knownKeys = []) {
     // Validate with schema if provided
     if (schema) {
       const result = schema.safeParse(item);
-      if (!result.success) {
+      if (result.success) {
+        // Apply the parsed data which includes Zod defaults
+        validatedItem = result.data;
+      } else {
         const messages = result.error.errors
           .map(e => `${e.path.join('.')}: ${e.message}`)
           .join('; ');
-        logger.warn('Resource validation issues', {
-          component: 'ResourceLoader',
-          resourceType,
-          resourceId,
-          messages
-        });
-      } else {
-        // Apply the parsed data which includes Zod defaults
-        validatedItem = result.data;
+
+        const lenientResult = lenientSchema?.safeParse(item);
+        if (lenientResult?.success) {
+          // Strict validation failed only because of unknown/legacy keys - fall back to the
+          // lenient parse so defaults still apply, and keep the unknown keys around (the
+          // separate knownKeys check below will warn about them).
+          validatedItem = lenientResult.data;
+          logger.warn('Resource has unknown/invalid keys; applied defaults via lenient fallback', {
+            component: 'ResourceLoader',
+            resourceType,
+            resourceId,
+            messages
+          });
+        } else {
+          logger.warn('Resource validation issues', {
+            component: 'ResourceLoader',
+            resourceType,
+            resourceId,
+            messages
+          });
+        }
       }
     }
 

--- a/server/validators/appConfigSchema.js
+++ b/server/validators/appConfigSchema.js
@@ -379,30 +379,40 @@ const baseAppConfigSchema = z.object({
 // Export known app keys from base schema before adding refinements
 export const knownAppKeys = Object.keys(baseAppConfigSchema.shape);
 
+function applyAppRefinements(schema) {
+  return schema
+    .refine(
+      data => {
+        // For redirect type apps, redirectConfig is required
+        if (data.type === 'redirect') {
+          return data.redirectConfig !== undefined;
+        }
+        return true;
+      },
+      {
+        message: 'Redirect type apps require redirectConfig with url field'
+      }
+    )
+    .refine(
+      data => {
+        // For iframe type apps, iframeConfig is required
+        if (data.type === 'iframe') {
+          return data.iframeConfig !== undefined;
+        }
+        return true;
+      },
+      {
+        message: 'Iframe type apps require iframeConfig with url field'
+      }
+    );
+}
+
 // Add validation refinements and export the final schema
-export const appConfigSchema = baseAppConfigSchema
-  .strict() // Use strict instead of passthrough for better validation
-  .refine(
-    data => {
-      // For redirect type apps, redirectConfig is required
-      if (data.type === 'redirect') {
-        return data.redirectConfig !== undefined;
-      }
-      return true;
-    },
-    {
-      message: 'Redirect type apps require redirectConfig with url field'
-    }
-  )
-  .refine(
-    data => {
-      // For iframe type apps, iframeConfig is required
-      if (data.type === 'iframe') {
-        return data.iframeConfig !== undefined;
-      }
-      return true;
-    },
-    {
-      message: 'Iframe type apps require iframeConfig with url field'
-    }
-  );
+export const appConfigSchema = applyAppRefinements(
+  baseAppConfigSchema.strict() // Use strict instead of passthrough for better validation
+);
+
+// Lenient variant: same refinements, but unknown keys are passed through instead of
+// causing safeParse to fail — used as a fallback so Zod defaults still apply when a
+// config's only problem is a stray/unknown key.
+export const appConfigSchemaLenient = applyAppRefinements(baseAppConfigSchema.passthrough());

--- a/server/validators/modelConfigSchema.js
+++ b/server/validators/modelConfigSchema.js
@@ -65,107 +65,109 @@ const hintSchema = z
   })
   .strict();
 
-export const modelConfigSchema = z
-  .object({
-    // Required fields
-    id: z
-      .string()
-      .regex(
-        /^[a-z0-9._-]+$/,
-        'ID must contain only lowercase letters, numbers, underscores, dots, and hyphens'
-      )
-      .min(1, 'ID cannot be empty'),
-    modelId: z.string().min(1, 'Model ID cannot be empty'),
-    name: localizedStringSchema,
-    description: localizedStringSchema,
-    url: z
-      .string()
-      .min(1, 'URL cannot be empty')
-      .refine(
-        val => val.includes('${') || val.startsWith('http://') || val.startsWith('https://'),
-        'URL must be a valid URI format or environment variable reference'
-      )
-      .optional(),
-    provider: z.enum(
-      [
-        'openai',
-        'openai-responses',
-        'anthropic',
-        'google',
-        'mistral',
-        'local',
-        'iassistant-conversation',
-        'bedrock'
-      ],
-      {
-        errorMap: () => ({
-          message:
-            'Provider must be one of: openai, openai-responses, anthropic, google, mistral, local, iassistant-conversation, bedrock'
-        })
-      }
-    ),
-    // Total input+output tokens the model supports. Used for fitting documents
-    // and showing remaining capacity to the user — NOT sent to the provider.
-    contextWindow: z
-      .number()
-      .int()
-      .min(CONTEXT_WINDOW_MIN, `Context window must be at least ${CONTEXT_WINDOW_MIN}`)
-      .max(
-        CONTEXT_WINDOW_MAX,
-        `Context window cannot exceed ${CONTEXT_WINDOW_MAX.toLocaleString()}`
-      )
-      .nullable()
-      .optional(),
-    // Provider response cap, sent as max_tokens / maxOutputTokens.
-    maxOutputTokens: z
-      .number()
-      .int()
-      .min(MAX_OUTPUT_TOKENS_MIN, `Max output tokens must be at least ${MAX_OUTPUT_TOKENS_MIN}`)
-      .max(
-        MAX_OUTPUT_TOKENS_MAX,
-        `Max output tokens cannot exceed ${MAX_OUTPUT_TOKENS_MAX.toLocaleString()}`
-      )
-      .nullable()
-      .optional(),
+const baseModelConfigSchema = z.object({
+  // Required fields
+  id: z
+    .string()
+    .regex(
+      /^[a-z0-9._-]+$/,
+      'ID must contain only lowercase letters, numbers, underscores, dots, and hyphens'
+    )
+    .min(1, 'ID cannot be empty'),
+  modelId: z.string().min(1, 'Model ID cannot be empty'),
+  name: localizedStringSchema,
+  description: localizedStringSchema,
+  url: z
+    .string()
+    .min(1, 'URL cannot be empty')
+    .refine(
+      val => val.includes('${') || val.startsWith('http://') || val.startsWith('https://'),
+      'URL must be a valid URI format or environment variable reference'
+    )
+    .optional(),
+  provider: z.enum(
+    [
+      'openai',
+      'openai-responses',
+      'anthropic',
+      'google',
+      'mistral',
+      'local',
+      'iassistant-conversation',
+      'bedrock'
+    ],
+    {
+      errorMap: () => ({
+        message:
+          'Provider must be one of: openai, openai-responses, anthropic, google, mistral, local, iassistant-conversation, bedrock'
+      })
+    }
+  ),
+  // Total input+output tokens the model supports. Used for fitting documents
+  // and showing remaining capacity to the user — NOT sent to the provider.
+  contextWindow: z
+    .number()
+    .int()
+    .min(CONTEXT_WINDOW_MIN, `Context window must be at least ${CONTEXT_WINDOW_MIN}`)
+    .max(CONTEXT_WINDOW_MAX, `Context window cannot exceed ${CONTEXT_WINDOW_MAX.toLocaleString()}`)
+    .nullable()
+    .optional(),
+  // Provider response cap, sent as max_tokens / maxOutputTokens.
+  maxOutputTokens: z
+    .number()
+    .int()
+    .min(MAX_OUTPUT_TOKENS_MIN, `Max output tokens must be at least ${MAX_OUTPUT_TOKENS_MIN}`)
+    .max(
+      MAX_OUTPUT_TOKENS_MAX,
+      `Max output tokens cannot exceed ${MAX_OUTPUT_TOKENS_MAX.toLocaleString()}`
+    )
+    .nullable()
+    .optional(),
 
-    // Optional fields with validation
-    default: z.boolean().optional().default(false),
-    supportsTools: z.boolean().optional().default(false),
-    concurrency: z
-      .number()
-      .int()
-      .min(1, 'Concurrency must be at least 1')
-      .max(100, 'Concurrency cannot exceed 100')
-      .optional(),
-    requestDelayMs: z
-      .number()
-      .int()
-      .min(0, 'Request delay cannot be negative')
-      .max(10000, 'Request delay cannot exceed 10 seconds')
-      .optional(),
-    enabled: z.boolean().optional().default(true),
-    thinking: thinkingSchema.optional(),
+  // Optional fields with validation
+  default: z.boolean().optional().default(false),
+  supportsTools: z.boolean().optional().default(false),
+  concurrency: z
+    .number()
+    .int()
+    .min(1, 'Concurrency must be at least 1')
+    .max(100, 'Concurrency cannot exceed 100')
+    .optional(),
+  requestDelayMs: z
+    .number()
+    .int()
+    .min(0, 'Request delay cannot be negative')
+    .max(10000, 'Request delay cannot exceed 10 seconds')
+    .optional(),
+  enabled: z.boolean().optional().default(true),
+  thinking: thinkingSchema.optional(),
 
-    // Additional fields for specific providers
-    supportsImages: z.boolean().optional(),
-    supportsVision: z.boolean().optional(),
-    supportsAudio: z.boolean().optional(),
-    supportsStructuredOutput: z.boolean().optional(),
-    supportsUsageTracking: z.boolean().optional(),
-    supportsImageGeneration: z.boolean().optional().default(false),
-    imageGeneration: imageGenerationSchema.optional(),
-    config: z.record(z.any()).optional(), // Allow provider-specific configuration
+  // Additional fields for specific providers
+  supportsImages: z.boolean().optional(),
+  supportsVision: z.boolean().optional(),
+  supportsAudio: z.boolean().optional(),
+  supportsStructuredOutput: z.boolean().optional(),
+  supportsUsageTracking: z.boolean().optional(),
+  supportsImageGeneration: z.boolean().optional().default(false),
+  imageGeneration: imageGenerationSchema.optional(),
+  config: z.record(z.any()).optional(), // Allow provider-specific configuration
 
-    // Hint configuration - display important messages when model is selected
-    hint: hintSchema.optional(),
+  // Hint configuration - display important messages when model is selected
+  hint: hintSchema.optional(),
 
-    // API Key configuration - stored encrypted on server
-    apiKey: z.string().optional(), // Encrypted API key for this model
+  // API Key configuration - stored encrypted on server
+  apiKey: z.string().optional(), // Encrypted API key for this model
 
-    // Model auto-discovery - automatically detect model ID from /v1/models endpoint
-    // Useful for local LLM providers (vLLM, LM Studio, Jan.ai) where the active model can change
-    autoDiscovery: z.boolean().optional().default(false)
-  })
-  .strict(); // Use strict instead of passthrough for better validation
+  // Model auto-discovery - automatically detect model ID from /v1/models endpoint
+  // Useful for local LLM providers (vLLM, LM Studio, Jan.ai) where the active model can change
+  autoDiscovery: z.boolean().optional().default(false)
+});
 
-export const knownModelKeys = Object.keys(modelConfigSchema.shape);
+export const modelConfigSchema = baseModelConfigSchema.strict(); // Use strict instead of passthrough for better validation
+
+// Lenient variant: same fields/defaults, but unknown keys are passed through instead of
+// causing safeParse to fail — used as a fallback so Zod defaults still apply when a
+// config's only problem is a stray/unknown key.
+export const modelConfigSchemaLenient = baseModelConfigSchema.passthrough();
+
+export const knownModelKeys = Object.keys(baseModelConfigSchema.shape);


### PR DESCRIPTION
## Summary

- `createSchemaValidator` (`server/utils/resourceLoader.js`) only applied Zod's parsed output — including schema defaults like `enabled`, `sendChatHistory`, `preferredOutputFormat` — when `safeParse` succeeded. Because `appConfigSchema` and `modelConfigSchema` use `.strict()`, a single stray/legacy key on an otherwise-valid app or model config made `safeParse` fail entirely, so the loader silently fell back to the raw, unvalidated object with only a `logger.warn`, and defaults were never applied.
- Added `appConfigSchemaLenient` / `modelConfigSchemaLenient`: the same schemas (with the same refinements) but built with `.passthrough()` instead of `.strict()`, so unknown keys don't cause the whole parse to fail.
- `createSchemaValidator` now takes an optional third `lenientSchema` argument. When the strict parse fails, it retries against the lenient schema; if that succeeds, the defaults-applied/lenient-parsed data is used (and a distinguishing warning is logged) instead of the raw item. If the lenient parse also fails (i.e. the config is invalid for reasons other than unknown keys, like a missing required field), behavior is unchanged from before — raw item + warning.
- Wired the lenient schemas through `appsLoader.js` and `modelsLoader.js`.

This matches the recommended default from the issue's own open question: reject-vs-lenient-load is only changed for the "unknown key only" case; genuinely invalid configs keep today's behavior.

## Test plan

- [x] Added `server/tests/resourceLoader-lenient-schema.test.js` covering: defaults apply on a clean strict parse; defaults still apply via lenient fallback when an unrecognized key is present; raw item is still returned when the config is invalid for other reasons (missing required field); model schema gets the same treatment; and behavior is unchanged when no lenient schema is passed (agents/workflows loaders, unaffected).
- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/resourceLoader-lenient-schema.test.js` — 5/5 passing.
- [x] `npm run lint:fix && npm run format:fix` on changed files — clean.
- [x] `node server.js` boots and loads apps/models without errors.

Fixes #1803

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ev16aQNgfoj5Duc4uuF1A1

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ev16aQNgfoj5Duc4uuF1A1)_