### PR TITLE
refactor(agents): dedupe agent-run wiring into shared buildAgentRun + engine singleton

### DIFF
--- a/server/agents/runtime/buildAgentRun.js
+++ b/server/agents/runtime/buildAgentRun.js
@@ -1,0 +1,135 @@
+/**
+ * Agent Run Wiring
+ *
+ * Resolves an agent profile into a fully-configured workflow definition ready
+ * to hand to a WorkflowEngine. This is the piece that used to be duplicated
+ * between the manual-trigger route, the resume-from-terminated route (both in
+ * routes/agents/runs.js), and the boot-time interrupted-run resume path in
+ * server.js — any change to run wiring (a new override rule, a timeout tweak)
+ * had to be made in every copy or resumed runs would silently diverge from
+ * freshly-started ones.
+ *
+ * Deliberately NOT included here: building the run's `initialData`/`_agent`
+ * envelope. A manual trigger builds a fresh principal and empty artifact
+ * list; a boot-time resume restores an existing principal from the persisted
+ * state. That bookkeeping stays with each caller — this module only produces
+ * the `workflow` definition plus the two durable config blobs
+ * (`agentModelConfig`, `agentReviewConfig`) callers stash into run state.
+ */
+
+import configCache from '../../configCache.js';
+import { serializeProfile } from '../profile/profileWorkflowSerializer.js';
+import { resolveReviewSettings } from '../profile/reviewSettings.js';
+
+/**
+ * Apply a profile's per-step model overrides onto the resolved workflow.
+ * `nodeModels` maps node id → model id; each match sets that node's
+ * `config.modelId`, which the executors honor first (above the run-wide
+ * default). Mutates and returns the workflow. No-op when nodeModels is empty.
+ *
+ * @param {Object} workflow
+ * @param {Object<string,string>} [nodeModels]
+ * @returns {Object} the same workflow
+ */
+export function applyNodeModels(workflow, nodeModels) {
+  if (!workflow || !Array.isArray(workflow.nodes) || !nodeModels) return workflow;
+  for (const node of workflow.nodes) {
+    if (node && typeof node.id === 'string' && nodeModels[node.id]) {
+      node.config = { ...(node.config || {}), modelId: nodeModels[node.id] };
+    }
+  }
+  return workflow;
+}
+
+/**
+ * Inject resolved review knobs onto every verifier node's config. Mirrors
+ * applyNodeModels: external workflows ignore profile flags, so the run-start
+ * code wires per-node config. Mutates and returns the workflow.
+ * @param {Object} workflow
+ * @param {Object} resolved - from resolveReviewSettings()
+ */
+export function applyReviewSettings(workflow, resolved) {
+  if (!workflow || !Array.isArray(workflow.nodes) || !resolved) return workflow;
+  for (const node of workflow.nodes) {
+    if (node?.type !== 'verifier') continue;
+    node.config = {
+      ...(node.config || {}),
+      maxRetries: resolved.maxRetries,
+      stallLimit: resolved.stallLimit,
+      acceptPartial: resolved.acceptPartial,
+      acceptPartialAfterStall: resolved.acceptPartialAfterStall,
+      requirePass: resolved.requirePass,
+      ...(resolved.criteria ? { criteria: resolved.criteria } : {})
+    };
+  }
+  return workflow;
+}
+
+/**
+ * Resolve an agent profile into a ready-to-run workflow definition: picks the
+ * embedded or external workflow, wires the wall-time budget and default
+ * model, then applies per-node model and review overrides.
+ *
+ * @param {Object} profile - agent profile (contents/agents/*.json)
+ * @returns {{workflow: Object, agentModelConfig: Object, agentReviewConfig: Object}}
+ */
+export function buildAgentRun(profile) {
+  const serialized = serializeProfile(profile);
+
+  // Resolve workflow: either the profile's embedded definition or a reference
+  // to a hand-authored workflow in contents/workflows/. External refs let
+  // authors wire complex workflows (e.g. iterative-research-auto) to an agent
+  // profile without having to inline the whole definition into the profile
+  // file. Deep-clone the external definition — getWorkflowById returns the
+  // SHARED cached object and callers mutate config/nodes below (embedded
+  // definitions are already cloned by serializeProfile).
+  let workflow;
+  if (
+    serialized.workflow?.ref === 'external' &&
+    typeof serialized.workflow.workflowId === 'string'
+  ) {
+    const cached = configCache.getWorkflowById(serialized.workflow.workflowId);
+    if (!cached) {
+      const error = new Error(`External workflow ${serialized.workflow.workflowId} not found`);
+      error.code = 'WORKFLOW_NOT_FOUND';
+      throw error;
+    }
+    workflow = JSON.parse(JSON.stringify(cached));
+  } else {
+    workflow = serialized.workflow?.definition || {};
+  }
+  workflow.id = workflow.id || `agent:${profile.id}`;
+
+  // Calculate the wall-time deadline via workflow config. Also publish the
+  // profile's preferred model as the run's workflow-level default so EVERY
+  // LLM node inherits it (the prompt/agent node via getModel step 3, and the
+  // verifier via the same defaultModelId) — without this, an EXTERNAL
+  // workflow's nodes fall back to the global default model and the operator
+  // has no single place to set the run's model. A node may still override
+  // per-node with its own `config.modelId`.
+  const maxWallTimeSec = profile.budgets?.maxWallTimeSec ?? 600;
+  workflow.config = {
+    ...(workflow.config || {}),
+    maxExecutionTime: maxWallTimeSec * 1000,
+    ...(profile.preferredModel ? { defaultModelId: profile.preferredModel } : {})
+  };
+
+  // Per-step model overrides (profile.nodeModels) win over the run-wide
+  // default for the listed nodes.
+  applyNodeModels(workflow, profile.nodeModels);
+
+  // Inject resolved review knobs onto every verifier node so EXTERNAL
+  // workflows (which don't reference profile flags directly) pick up the
+  // operator's strictness / retry / acceptance configuration.
+  const agentReviewConfig = resolveReviewSettings(profile.review);
+  applyReviewSettings(workflow, agentReviewConfig);
+
+  const agentModelConfig = {
+    defaultModelId: profile.preferredModel || null,
+    nodeModels: profile.nodeModels || {}
+  };
+
+  return { workflow, agentModelConfig, agentReviewConfig };
+}
+
+export default { buildAgentRun, applyNodeModels, applyReviewSettings };

--- a/server/routes/agents/runs.js
+++ b/server/routes/agents/runs.js
@@ -17,75 +17,34 @@ import {
 import { buildServerPath } from '../../utils/basePath.js';
 import { validateIdForPath } from '../../utils/pathSecurity.js';
 import configCache from '../../configCache.js';
-import { WorkflowEngine, getExecutionRegistry } from '../../services/workflow/index.js';
+import { getAgentWorkflowEngine, getExecutionRegistry } from '../../services/workflow/index.js';
 import { buildAgentPrincipal } from '../../utils/authorization.js';
-import { serializeProfile } from '../../agents/profile/profileWorkflowSerializer.js';
-import { resolveReviewSettings } from '../../agents/profile/reviewSettings.js';
+import {
+  buildAgentRun,
+  applyNodeModels,
+  applyReviewSettings
+} from '../../agents/runtime/buildAgentRun.js';
 import { generateRunTitleAsync } from '../../agents/runtime/titleGenerator.js';
 import { HumanNodeExecutor } from '../../services/workflow/executors/HumanNodeExecutor.js';
 import { actionTracker } from '../../actionTracker.js';
 import { createSseChannel, startInactiveClientSweep } from '../../utils/sseChannel.js';
 import logger from '../../utils/logger.js';
 
-// Lazy-shared engine. WorkflowEngine state lives in StateManager (filesystem),
-// so multiple instances see the same executions; we use one per-worker.
-// 30-minute default node timeout: the phased planner node blocks while its
-// entire sub-workflow runs (up to 6 tasks × several minutes each), so the
-// 5-minute DEFAULT_NODE_TIMEOUT would kill it mid-run. 30 min matches
-// MAX_NODE_TIMEOUT in WorkflowEngine and is the ceiling _normalizeTimeout allows.
-let _engine = null;
+// WorkflowEngine state lives in StateManager (filesystem), so multiple
+// instances see the same executions; getAgentWorkflowEngine() still gives us
+// one shared instance per-worker (and the same one server.js's boot-time
+// resume path uses) rather than each constructing its own.
 function getEngine() {
-  if (!_engine) _engine = new WorkflowEngine({ defaultTimeout: 30 * 60 * 1000 });
-  return _engine;
+  return getAgentWorkflowEngine();
 }
+
+// Re-exported for server/tests/agent-node-models.test.js and
+// server/tests/agent-review-injection.test.js, which exercise these directly.
+export { applyNodeModels, applyReviewSettings };
 
 function lookupProfile(profileId) {
   const { data: profiles = [] } = configCache.getAgentProfiles(true);
   return profiles.find(p => p.id === profileId) || null;
-}
-
-/**
- * Apply a profile's per-step model overrides onto the resolved workflow.
- * `nodeModels` maps node id → model id; each match sets that node's
- * `config.modelId`, which the executors honor first (above the run-wide
- * default). Mutates and returns the workflow. No-op when nodeModels is empty.
- *
- * @param {Object} workflow
- * @param {Object<string,string>} [nodeModels]
- * @returns {Object} the same workflow
- */
-export function applyNodeModels(workflow, nodeModels) {
-  if (!workflow || !Array.isArray(workflow.nodes) || !nodeModels) return workflow;
-  for (const node of workflow.nodes) {
-    if (node && typeof node.id === 'string' && nodeModels[node.id]) {
-      node.config = { ...(node.config || {}), modelId: nodeModels[node.id] };
-    }
-  }
-  return workflow;
-}
-
-/**
- * Inject resolved review knobs onto every verifier node's config. Mirrors
- * applyNodeModels: external workflows ignore profile flags, so the run-start
- * code wires per-node config. Mutates and returns the workflow.
- * @param {Object} workflow
- * @param {Object} resolved - from resolveReviewSettings()
- */
-export function applyReviewSettings(workflow, resolved) {
-  if (!workflow || !Array.isArray(workflow.nodes) || !resolved) return workflow;
-  for (const node of workflow.nodes) {
-    if (node?.type !== 'verifier') continue;
-    node.config = {
-      ...(node.config || {}),
-      maxRetries: resolved.maxRetries,
-      stallLimit: resolved.stallLimit,
-      acceptPartial: resolved.acceptPartial,
-      acceptPartialAfterStall: resolved.acceptPartialAfterStall,
-      requirePass: resolved.requirePass,
-      ...(resolved.criteria ? { criteria: resolved.criteria } : {})
-    };
-  }
-  return workflow;
 }
 
 function countRunningProfileRuns(profileId) {
@@ -185,30 +144,15 @@ export default function registerAgentRunRoutes(app) {
         }
 
         const { brief, variables } = req.body || {};
-        const serialized = serializeProfile(profile);
 
-        // Resolve workflow: either the profile's embedded definition or a
-        // reference to a hand-authored workflow in contents/workflows/.
-        // External refs let authors wire complex workflows (e.g.
-        // iterative-research-auto) to an agent profile without having to
-        // inline the whole definition into the profile file.
-        let workflow;
-        if (
-          serialized.workflow?.ref === 'external' &&
-          typeof serialized.workflow.workflowId === 'string'
-        ) {
-          const wf = configCache.getWorkflowById(serialized.workflow.workflowId);
-          if (!wf) {
-            return sendBadRequest(
-              res,
-              `External workflow ${serialized.workflow.workflowId} not found`
-            );
-          }
-          workflow = JSON.parse(JSON.stringify(wf));
-        } else {
-          workflow = serialized.workflow.definition || {};
+        let runWiring;
+        try {
+          runWiring = buildAgentRun(profile);
+        } catch (error) {
+          if (error.code === 'WORKFLOW_NOT_FOUND') return sendBadRequest(res, error.message);
+          throw error;
         }
-        workflow.id = workflow.id || `agent:${profileId}`;
+        const { workflow, agentModelConfig, agentReviewConfig } = runWiring;
 
         const principal = buildAgentPrincipal(profile, {
           userId: req.user?.id || 'anonymous',
@@ -246,14 +190,11 @@ export default function registerAgentRunRoutes(app) {
           // refresh) so resolvers always land on the configured model. Copied
           // into child sub-workflows automatically (see PlannerNodeExecutor's
           // childInitial copy), so planner sub-tasks inherit it too.
-          _agentModelConfig: {
-            defaultModelId: profile.preferredModel || null,
-            nodeModels: profile.nodeModels || {}
-          },
+          _agentModelConfig: agentModelConfig,
           // DURABLE review config — stashed in run state so it survives workflow
           // config-cache refreshes and is available to all verifier nodes throughout
           // the run (including in child sub-workflows via PlannerNodeExecutor copy).
-          _agentReviewConfig: resolveReviewSettings(profile.review),
+          _agentReviewConfig: agentReviewConfig,
           // Pre-initialize mutable state slots so they're shared by reference
           // between any state-snapshot that an in-flight async caller (e.g.
           // the fire-and-forget title generator) may have captured before
@@ -267,27 +208,6 @@ export default function registerAgentRunRoutes(app) {
           _stepLogs: {},
           _taskTimings: {}
         };
-
-        // Calculate wall-time deadline via workflow config. Also publish the
-        // profile's preferred model as the run's workflow-level default so EVERY
-        // LLM node inherits it (the prompt/agent node via getModel step 3, and
-        // the verifier via the same defaultModelId) — without this, an EXTERNAL
-        // workflow's nodes fall back to the global default model and the
-        // operator has no single place to set the run's model. A node may still
-        // override per-node with its own `config.modelId`.
-        const maxWallTimeSec = profile.budgets?.maxWallTimeSec ?? 600;
-        workflow.config = {
-          ...(workflow.config || {}),
-          maxExecutionTime: maxWallTimeSec * 1000,
-          ...(profile.preferredModel ? { defaultModelId: profile.preferredModel } : {})
-        };
-        // Per-step model overrides (profile.nodeModels) win over the run-wide
-        // default for the listed nodes.
-        applyNodeModels(workflow, profile.nodeModels);
-        // Inject resolved review knobs onto every verifier node so EXTERNAL
-        // workflows (which don't reference profile flags directly) pick up the
-        // operator's strictness / retry / acceptance configuration.
-        applyReviewSettings(workflow, initialData._agentReviewConfig);
 
         // Persist a checkpoint after every node completes. Agent runs are
         // long-lived (each task is a multi-minute LLM call) and otherwise
@@ -624,8 +544,9 @@ export default function registerAgentRunRoutes(app) {
   //
   // Unlike standard workflow runs, agent runs don't persist `_workflowDefinition`
   // into state (the embedded workflow can be hefty — full system prompts etc),
-  // so we rebuild it here from the agent profile and pass it via options.
-  // Same logic used at run-start above (lines ~138-161).
+  // so we rebuild it here from the agent profile via buildAgentRun() — the
+  // same resolution the manual-trigger route above and the boot-time resume
+  // path in server.js use — and pass it via options.
   app.post(
     buildServerPath('/api/agents/runs/:runId/resume'),
     authRequired,
@@ -657,37 +578,17 @@ export default function registerAgentRunRoutes(app) {
         const profile = lookupProfile(profileId);
         if (!profile) return sendBadRequest(res, `Agent profile ${profileId} no longer exists`);
 
-        const serialized = serializeProfile(profile);
+        // Refreshes the wall-time budget, model, and review settings from the
+        // (possibly updated) profile so the resumed run uses the operator's
+        // current settings, not whatever was baked in when the run originally
+        // started.
         let workflow;
-        if (
-          serialized.workflow?.ref === 'external' &&
-          typeof serialized.workflow.workflowId === 'string'
-        ) {
-          const wf = configCache.getWorkflowById(serialized.workflow.workflowId);
-          if (!wf) {
-            return sendBadRequest(
-              res,
-              `External workflow ${serialized.workflow.workflowId} not found`
-            );
-          }
-          workflow = JSON.parse(JSON.stringify(wf));
-        } else {
-          workflow = serialized.workflow?.definition || {};
+        try {
+          ({ workflow } = buildAgentRun(profile));
+        } catch (error) {
+          if (error.code === 'WORKFLOW_NOT_FOUND') return sendBadRequest(res, error.message);
+          throw error;
         }
-        workflow.id = workflow.id || `agent:${profileId}`;
-        // Refresh the wall-time budget from the (possibly updated) profile so
-        // the resumed run uses the operator's current setting, not whatever
-        // was baked in when the run originally started.
-        const maxWallTimeSec = profile.budgets?.maxWallTimeSec ?? 600;
-        workflow.config = {
-          ...(workflow.config || {}),
-          maxExecutionTime: maxWallTimeSec * 1000,
-          ...(profile.preferredModel ? { defaultModelId: profile.preferredModel } : {})
-        };
-        applyNodeModels(workflow, profile.nodeModels);
-        // Re-inject review knobs on resume so the re-fetched workflow's verifier
-        // nodes reflect the operator's current profile settings.
-        applyReviewSettings(workflow, resolveReviewSettings(profile.review));
 
         const newState = await getEngine().resumeFromTerminated(runId, {
           user: req.user,

--- a/server/server.js
+++ b/server/server.js
@@ -627,18 +627,15 @@ if (cluster.isPrimary && workerCount > 1) {
   try {
     const { loadWorkflows } = await import('./routes/workflow/workflowRoutes.js');
     const { getTriggerManager } = await import('./services/workflow/triggers/TriggerManager.js');
-    const { WorkflowEngine } = await import('./services/workflow/WorkflowEngine.js');
+    const { getAgentWorkflowEngine } = await import('./services/workflow/agentEngineSingleton.js');
     const { resumeInterruptedRuns } = await import('./services/workflow/resumeManager.js');
     const { sweepOrphanedExecutions } = await import('./services/workflow/orphanSweeper.js');
-    const { serializeProfile } = await import('./agents/profile/profileWorkflowSerializer.js');
+    const { buildAgentRun } = await import('./agents/runtime/buildAgentRun.js');
     const { buildAgentPrincipal } = await import('./utils/authorization.js');
-    const { applyNodeModels, applyReviewSettings } = await import('./routes/agents/runs.js');
-    const { resolveReviewSettings } = await import('./agents/profile/reviewSettings.js');
 
-    // 30-minute default node timeout consistent with the agent-run engine in
-    // routes/agents/runs.js — needed so resumed agent runs (including phased
-    // planner nodes) don't hit the 5-minute DEFAULT_NODE_TIMEOUT on recovery.
-    const engine = new WorkflowEngine({ defaultTimeout: 30 * 60 * 1000 });
+    // Shared with routes/agents/runs.js's getEngine() so a resumed run and a
+    // freshly-triggered run see the same in-memory execution state.
+    const engine = getAgentWorkflowEngine();
     const triggerManager = getTriggerManager();
     triggerManager.setEngine(engine); // starts the scheduler-lock heartbeat
     triggerManager.setWorkflowLoader(loadWorkflows);
@@ -652,34 +649,19 @@ if (cluster.isPrimary && workerCount > 1) {
         const { data: profiles } = configCache.getAgentProfiles(true);
         const profile = profiles?.find(p => p.id === profileId);
         if (!profile) return null;
-        const serialized = serializeProfile(profile);
-        // External profiles reference a standalone workflow file by id;
-        // embedded profiles carry the rebuilt definition inline. Deep-clone the
-        // external definition — getWorkflowById returns the SHARED cached object
-        // and we mutate config/nodes below (embedded definitions are already
-        // cloned by serializeProfile).
-        let definition;
-        if (serialized.workflow?.ref === 'external' && serialized.workflow.workflowId) {
-          const cached = configCache.getWorkflowById(serialized.workflow.workflowId);
-          definition = cached ? JSON.parse(JSON.stringify(cached)) : null;
-        } else {
-          definition = serialized.workflow?.definition;
-        }
-        if (!definition) return null;
 
-        // Re-apply the same run-start wiring the request path sets
+        // Re-applies the same run-start wiring the request path sets
         // (routes/agents/runs.js) so a resumed run keeps its wall-time budget
         // and per-step model / review config. Without the wall-time budget,
         // resumeFromCheckpoint falls back to the engine's 5-minute default and
         // the resumed run trips MAX_EXECUTION_TIME shortly after recovery.
-        const maxWallTimeSec = profile.budgets?.maxWallTimeSec ?? 600;
-        definition.config = {
-          ...(definition.config || {}),
-          maxExecutionTime: maxWallTimeSec * 1000,
-          ...(profile.preferredModel ? { defaultModelId: profile.preferredModel } : {})
-        };
-        applyNodeModels(definition, profile.nodeModels);
-        applyReviewSettings(definition, resolveReviewSettings(profile.review));
+        let definition;
+        try {
+          ({ workflow: definition } = buildAgentRun(profile));
+        } catch (error) {
+          if (error.code === 'WORKFLOW_NOT_FOUND') return null;
+          throw error;
+        }
 
         const principal = buildAgentPrincipal(profile, state.data._agent?.triggeredBy || null);
         return { definition, options: { user: principal } };

--- a/server/services/workflow/agentEngineSingleton.js
+++ b/server/services/workflow/agentEngineSingleton.js
@@ -1,0 +1,36 @@
+import { WorkflowEngine } from './WorkflowEngine.js';
+
+/**
+ * Shared WorkflowEngine instance for agent runs, used by both the manual/
+ * triggered run-start path (routes/agents/runs.js) and the boot-time
+ * interrupted-run resume path (server.js). A single instance keeps the
+ * 30-minute default node timeout in one place instead of two constructor
+ * calls drifting apart, and — like getStateManager() — ensures every caller
+ * observes the same in-memory execution state.
+ *
+ * 30-minute default node timeout: the phased planner node blocks while its
+ * entire sub-workflow runs (up to 6 tasks × several minutes each), so the
+ * 5-minute DEFAULT_NODE_TIMEOUT would kill it mid-run. 30 min matches
+ * MAX_NODE_TIMEOUT in WorkflowEngine and is the ceiling _normalizeTimeout
+ * allows.
+ * @type {WorkflowEngine|null}
+ * @private
+ */
+let _engine = null;
+
+/**
+ * Returns the shared agent-run WorkflowEngine singleton, creating it on
+ * first call.
+ * @returns {WorkflowEngine}
+ */
+export function getAgentWorkflowEngine() {
+  if (!_engine) _engine = new WorkflowEngine({ defaultTimeout: 30 * 60 * 1000 });
+  return _engine;
+}
+
+/**
+ * Resets the singleton instance (for testing purposes only).
+ */
+export function resetAgentWorkflowEngine() {
+  _engine = null;
+}

--- a/server/services/workflow/index.js
+++ b/server/services/workflow/index.js
@@ -35,3 +35,4 @@ export {
   resetExecutionRegistry
 } from './ExecutionRegistry.js';
 export { WorkflowLLMHelper, default as workflowLLMHelper } from './WorkflowLLMHelper.js';
+export { getAgentWorkflowEngine, resetAgentWorkflowEngine } from './agentEngineSingleton.js';


### PR DESCRIPTION
## Summary

Closes #1777 (partially — see scope note below).

Agent-run construction was duplicated in three places:
- `server.js`'s boot-time interrupted-run resume path (`resolveDefinition`)
- `routes/agents/runs.js`'s manual-trigger handler (`POST /api/agents/profiles/:profileId/runs`)
- `routes/agents/runs.js`'s resume-from-terminated handler (`POST /api/agents/runs/:runId/resume`)

Each independently resolved a profile's workflow (embedded definition vs external `contents/workflows/*.json` reference), computed the wall-time budget and default model, and applied per-node model/review overrides. Any change to that wiring had to be made in three places, or resumed runs would silently diverge from freshly-started ones — exactly the risk the issue called out.

## Changes

- **`server/agents/runtime/buildAgentRun.js`** (new): `buildAgentRun(profile)` resolves the workflow definition and returns `{ workflow, agentModelConfig, agentReviewConfig }`. Also hosts `applyNodeModels`/`applyReviewSettings`, moved out of the route module.
- **`server/services/workflow/agentEngineSingleton.js`** (new): `getAgentWorkflowEngine()`, mirroring the existing `getStateManager()` singleton pattern, replacing two separate `new WorkflowEngine({ defaultTimeout: 30 * 60 * 1000 })` constructions (one in `server.js`, one in `routes/agents/runs.js`) with a single shared instance.
- **`server/routes/agents/runs.js`**: both the manual-trigger and resume-from-terminated handlers now call `buildAgentRun(profile)` instead of duplicating the resolution logic; `applyNodeModels`/`applyReviewSettings` are re-exported (unchanged import path) so `server/tests/agent-node-models.test.js` and `server/tests/agent-review-injection.test.js` keep working untouched.
- **`server/server.js`**: the boot-time `resolveDefinition` now calls the same `buildAgentRun(profile)` instead of re-importing `applyNodeModels`/`applyReviewSettings` from the route module and re-running the wiring inline.

## Scope note

Per the issue's own implementation-plan comment, this PR deliberately stays narrow:
- It does **not** touch the broader multi-`WorkflowEngine`-instance problem across `workflowRunner.js`/`workflowRoutes.js`/`agents/artifacts.js` — that's #1774.
- It does **not** move the ~150 lines of default planner/synthesizer prompts out of `profileWorkflowSerializer.js` into config files. That part of #1777 has open design questions (server-owned `server/defaults/` vs admin-editable `contents/config/`, and whether extracting the prompt text risks diffing against existing `overriddenFields` on customer profiles) that need a design decision before implementation, not a mechanical extraction.

## Verification

- `node server/tests/agent-node-models.test.js` and `node server/tests/agent-review-injection.test.js` pass unchanged.
- `node --check` on all changed/new files; `eslint` and `prettier` clean.
- Full server boot verified clean (clustered, 4 workers) — boot-time resume path (`resolveDefinition` → `buildAgentRun`) runs without error.
- Live smoke test against a real profile (`claude-style-agent`, temporarily enabled, reverted after): logged in as the local admin, triggered a manual run via `POST /api/agents/profiles/claude-style-agent/runs`, confirmed the external workflow resolved and `_agentModelConfig`/`_agentReviewConfig` landed correctly in run state, then exercised `POST /api/agents/runs/:runId/resume` against the same run to confirm the resume path's `buildAgentRun` call also works end-to-end.

## Test plan

- [x] Existing agent unit tests pass
- [x] Lint/format clean
- [x] Server boots without errors
- [x] Manual trigger route smoke-tested live
- [x] Resume-from-terminated route smoke-tested live

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01X4B43B9H3jySw6yXS5yVZ2)_