### PR TITLE
refactor(workflow): extract tool-value preview helper into shared module (#1775)

### DIFF
--- a/server/services/workflow/executors/InboxFinalizeNodeExecutor.js
+++ b/server/services/workflow/executors/InboxFinalizeNodeExecutor.js
@@ -23,6 +23,7 @@ import { BaseNodeExecutor } from './BaseNodeExecutor.js';
 import inboxStore from '../../../agents/inbox/inboxStore.js';
 import { actionTracker } from '../../../actionTracker.js';
 import { summarizePlanForEvent } from '../../../agents/runtime/taskRecord.js';
+import { previewToolValue } from './valuePreview.js';
 
 function emit(event, payload, chatId) {
   try {
@@ -119,8 +120,8 @@ export class InboxFinalizeNodeExecutor extends BaseNodeExecutor {
         toolCalls: [
           {
             name: 'inbox-store.markInboxItemDone',
-            args: this._previewToolValue({ inboxId, item: item.text, note }),
-            result: this._previewToolValue({ ok: true, version: result.version }),
+            args: previewToolValue({ inboxId, item: item.text, note }),
+            result: previewToolValue({ ok: true, version: result.version }),
             durationMs
           }
         ],
@@ -198,15 +199,6 @@ export class InboxFinalizeNodeExecutor extends BaseNodeExecutor {
       return this.createErrorResult(`Failed to mark inbox item done: ${err.message}`, {
         nodeId: node.id
       });
-    }
-  }
-
-  _previewToolValue(value) {
-    try {
-      const json = JSON.stringify(value);
-      return json.length > 1024 ? `${json.slice(0, 1024)}…` : json;
-    } catch {
-      return null;
     }
   }
 }

--- a/server/services/workflow/executors/InboxLoadNodeExecutor.js
+++ b/server/services/workflow/executors/InboxLoadNodeExecutor.js
@@ -21,6 +21,7 @@
 import { BaseNodeExecutor } from './BaseNodeExecutor.js';
 import inboxStore from '../../../agents/inbox/inboxStore.js';
 import { actionTracker } from '../../../actionTracker.js';
+import { previewToolValue } from './valuePreview.js';
 
 const PRIORITY_RANK = { p1: 1, p2: 2, p3: 3, unprioritized: 4 };
 
@@ -160,8 +161,8 @@ export class InboxLoadNodeExecutor extends BaseNodeExecutor {
       toolCalls: [
         {
           name: 'inbox-store.readInbox',
-          args: this._previewToolValue({ inboxId, status: 'all' }),
-          result: this._previewToolValue({
+          args: previewToolValue({ inboxId, status: 'all' }),
+          result: previewToolValue({
             inboxId,
             version: inbox.version,
             totalItems: inbox.items.length,
@@ -196,15 +197,6 @@ export class InboxLoadNodeExecutor extends BaseNodeExecutor {
     };
 
     return this.createSuccessResult(currentInboxItem, { stateUpdates });
-  }
-
-  _previewToolValue(value) {
-    try {
-      const json = JSON.stringify(value);
-      return json.length > 1024 ? `${json.slice(0, 1024)}…` : json;
-    } catch {
-      return null;
-    }
   }
 }
 

--- a/server/services/workflow/executors/MemoryFinalizeNodeExecutor.js
+++ b/server/services/workflow/executors/MemoryFinalizeNodeExecutor.js
@@ -27,6 +27,7 @@
 import { BaseNodeExecutor } from './BaseNodeExecutor.js';
 import memoryFile from '../../../agents/memory/memoryFile.js';
 import { actionTracker } from '../../../actionTracker.js';
+import { previewToolValue } from './valuePreview.js';
 
 function emit(event, payload, chatId) {
   try {
@@ -217,8 +218,8 @@ export class MemoryFinalizeNodeExecutor extends BaseNodeExecutor {
         });
         toolCalls.push({
           name: 'memory-file.writeMemory',
-          args: this._previewToolValue(args),
-          result: this._previewToolValue({ ok: false, error: err.message }),
+          args: previewToolValue(args),
+          result: previewToolValue({ ok: false, error: err.message }),
           durationMs: Date.now() - writeStartMs
         });
         continue;
@@ -233,8 +234,8 @@ export class MemoryFinalizeNodeExecutor extends BaseNodeExecutor {
       );
       toolCalls.push({
         name: 'memory-file.writeMemory',
-        args: this._previewToolValue(args),
-        result: this._previewToolValue({ ok: true, version: result.version }),
+        args: previewToolValue(args),
+        result: previewToolValue({ ok: true, version: result.version }),
         durationMs: Date.now() - writeStartMs
       });
     }
@@ -295,64 +296,6 @@ export class MemoryFinalizeNodeExecutor extends BaseNodeExecutor {
         }
       }
     );
-  }
-
-  /**
-   * Build a JSON-parseable preview of a tool-call value. Mirrors the helper
-   * in PromptNodeExecutor: we truncate long string fields IN PLACE before
-   * stringifying so the resulting preview stays valid JSON. The UI does
-   * JSON.parse on these previews to render details; truncating the JSON
-   * string itself produced an invalid suffix and broke that rendering.
-   * @private
-   */
-  _previewToolValue(value) {
-    const MAX_LEN = 1024;
-    const MAX_FIELD_LEN = 320;
-    if (value == null) return null;
-    if (typeof value === 'string') {
-      return value.length > MAX_LEN
-        ? `${value.slice(0, MAX_LEN)}…[truncated ${value.length - MAX_LEN} chars]`
-        : value;
-    }
-    if (typeof value === 'number' || typeof value === 'boolean') return value;
-    try {
-      const compact = this._compactStringsForPreview(value, MAX_FIELD_LEN, 0);
-      const json = JSON.stringify(compact);
-      return json.length > MAX_LEN
-        ? `${json.slice(0, MAX_LEN)}…[truncated ${json.length - MAX_LEN} chars]`
-        : json;
-    } catch {
-      return '[unserialisable]';
-    }
-  }
-
-  /** @private — see PromptNodeExecutor._compactStringsForPreview */
-  _compactStringsForPreview(value, maxFieldLen, depth) {
-    const MAX_DEPTH = 6;
-    const MAX_ARRAY_ITEMS = 20;
-    if (depth > MAX_DEPTH) return '[…]';
-    if (typeof value === 'string') {
-      return value.length > maxFieldLen
-        ? `${value.slice(0, maxFieldLen)}…[+${value.length - maxFieldLen}]`
-        : value;
-    }
-    if (Array.isArray(value)) {
-      const limited = value
-        .slice(0, MAX_ARRAY_ITEMS)
-        .map(v => this._compactStringsForPreview(v, maxFieldLen, depth + 1));
-      if (value.length > MAX_ARRAY_ITEMS) {
-        limited.push(`…[+${value.length - MAX_ARRAY_ITEMS} items]`);
-      }
-      return limited;
-    }
-    if (value && typeof value === 'object') {
-      const out = {};
-      for (const [k, v] of Object.entries(value)) {
-        out[k] = this._compactStringsForPreview(v, maxFieldLen, depth + 1);
-      }
-      return out;
-    }
-    return value;
   }
 }
 

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -24,6 +24,7 @@ import configCache from '../../../configCache.js';
 import WorkflowLLMHelper from '../WorkflowLLMHelper.js';
 import { ContextSummarizer } from '../ContextSummarizer.js';
 import { dedupeCitations } from '../citationUtils.js';
+import { previewToolValue } from './valuePreview.js';
 import { estimateTokens } from '../../../usageTracker.js';
 import SourceResolutionService from '../../SourceResolutionService.js';
 import { createSourceManager } from '../../../sources/index.js';
@@ -565,13 +566,13 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
         // nodes look like they returned nothing.
         //
         // The UI does `JSON.parse(stepLog.output)` on this string, so the
-        // value MUST be valid JSON. `_previewToolValue` now produces a
+        // value MUST be valid JSON. `previewToolValue` now produces a
         // JSON-parseable string for objects (it truncates long string
         // fields INSIDE the object before JSON.stringify, instead of
         // chopping the serialised string with a `…[truncated]` suffix
         // that breaks JSON.parse).
         try {
-          stepLog.output = this._previewToolValue(output);
+          stepLog.output = previewToolValue(output);
         } catch {
           // best effort — never fail a node on the preview helper
         }
@@ -1944,8 +1945,8 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
             toolId,
             appId,
             modelOverride: callerModelId,
-            args: this._previewToolValue(args),
-            result: this._previewToolValue(result),
+            args: previewToolValue(args),
+            result: previewToolValue(result),
             durationMs: appCallDurationMs
           });
         }
@@ -1969,7 +1970,7 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
             appId: toolId.slice('app__'.length),
             error: 'app_invocation_failed',
             message: error.message,
-            args: this._previewToolValue(args),
+            args: previewToolValue(args),
             durationMs: appCallDurationMs
           });
         }
@@ -2034,8 +2035,8 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
           name: toolCall.function.name,
           toolId,
           ...(isApp ? { appId: toolId.slice('app__'.length) } : {}),
-          args: this._previewToolValue(args),
-          result: this._previewToolValue(result),
+          args: previewToolValue(args),
+          result: previewToolValue(result),
           durationMs: toolCallDurationMs
         });
       }
@@ -2777,7 +2778,7 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
           nodeId: node.id,
           round: priorRound + 1,
           outputType: typeof output,
-          outputPreview: this._previewToolValue(output)
+          outputPreview: previewToolValue(output)
         });
       }
       this.logger.info('Review round completed', {
@@ -2892,77 +2893,6 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
       }
     }
     return null;
-  }
-
-  _previewToolValue(value) {
-    const MAX_LEN = 1024;
-    const MAX_FIELD_LEN = 320;
-    if (value == null) return null;
-    if (typeof value === 'string') {
-      return value.length > MAX_LEN
-        ? `${value.slice(0, MAX_LEN)}…[truncated ${value.length - MAX_LEN} chars]`
-        : value;
-    }
-    if (typeof value === 'number' || typeof value === 'boolean') return value;
-    // For objects/arrays we walk the structure and shorten long string fields
-    // IN PLACE, then JSON.stringify. The resulting preview stays parseable
-    // (the UI does JSON.parse on reviewer / memory-compose step output to
-    // render verdict details — a "…[truncated]" suffix appended to the JSON
-    // string itself broke that and showed a generic fallback).
-    try {
-      const compact = this._compactStringsForPreview(value, MAX_FIELD_LEN, 0);
-      const json = JSON.stringify(compact);
-      // Final safety net: if the compacted form is still huge, fall back to
-      // truncating the JSON string (and accept that the UI's JSON.parse will
-      // fail for this row — better than spilling MB of state to disk).
-      return json.length > MAX_LEN
-        ? `${json.slice(0, MAX_LEN)}…[truncated ${json.length - MAX_LEN} chars]`
-        : json;
-    } catch {
-      return '[unserialisable]';
-    }
-  }
-
-  /**
-   * Recursively shorten long string fields inside an object/array so the
-   * JSON.stringify output stays under ~1KB while remaining VALID JSON.
-   * String fields longer than `maxFieldLen` get a `…[+N]` suffix appended
-   * in the cloned copy. Depth is bounded to keep cyclic / pathological
-   * inputs from blowing the stack; arrays are capped at MAX_ARRAY_ITEMS
-   * with a trailing `…[+N items]` placeholder.
-   *
-   * Used by `_previewToolValue` so step-log previews of tool args/results
-   * AND structured-output rows (reviewer, memory-composer) all produce
-   * JSON the UI can `JSON.parse` to render details.
-   *
-   * @private
-   */
-  _compactStringsForPreview(value, maxFieldLen, depth) {
-    const MAX_DEPTH = 6;
-    const MAX_ARRAY_ITEMS = 20;
-    if (depth > MAX_DEPTH) return '[…]';
-    if (typeof value === 'string') {
-      return value.length > maxFieldLen
-        ? `${value.slice(0, maxFieldLen)}…[+${value.length - maxFieldLen}]`
-        : value;
-    }
-    if (Array.isArray(value)) {
-      const limited = value
-        .slice(0, MAX_ARRAY_ITEMS)
-        .map(v => this._compactStringsForPreview(v, maxFieldLen, depth + 1));
-      if (value.length > MAX_ARRAY_ITEMS) {
-        limited.push(`…[+${value.length - MAX_ARRAY_ITEMS} items]`);
-      }
-      return limited;
-    }
-    if (value && typeof value === 'object') {
-      const out = {};
-      for (const [k, v] of Object.entries(value)) {
-        out[k] = this._compactStringsForPreview(v, maxFieldLen, depth + 1);
-      }
-      return out;
-    }
-    return value;
   }
 
   /**

--- a/server/services/workflow/executors/valuePreview.js
+++ b/server/services/workflow/executors/valuePreview.js
@@ -1,0 +1,71 @@
+/**
+ * Build a JSON-parseable preview of a tool-call value. Long string fields are
+ * truncated IN PLACE before stringifying so the resulting preview stays valid
+ * JSON — the UI does `JSON.parse` on these previews (step-log tool args/
+ * results, reviewer / memory-composer structured output) to render details,
+ * and truncating the JSON string itself instead produces an invalid suffix
+ * that breaks that rendering.
+ *
+ * @module services/workflow/executors/valuePreview
+ */
+
+const MAX_LEN = 1024;
+const MAX_FIELD_LEN = 320;
+const MAX_DEPTH = 6;
+const MAX_ARRAY_ITEMS = 20;
+
+export function previewToolValue(value) {
+  if (value == null) return null;
+  if (typeof value === 'string') {
+    return value.length > MAX_LEN
+      ? `${value.slice(0, MAX_LEN)}…[truncated ${value.length - MAX_LEN} chars]`
+      : value;
+  }
+  if (typeof value === 'number' || typeof value === 'boolean') return value;
+  try {
+    const compact = compactStringsForPreview(value, MAX_FIELD_LEN, 0);
+    const json = JSON.stringify(compact);
+    // Final safety net: if the compacted form is still huge, fall back to
+    // truncating the JSON string (and accept that the UI's JSON.parse will
+    // fail for this row — better than spilling MB of state to disk).
+    return json.length > MAX_LEN
+      ? `${json.slice(0, MAX_LEN)}…[truncated ${json.length - MAX_LEN} chars]`
+      : json;
+  } catch {
+    return '[unserialisable]';
+  }
+}
+
+/**
+ * Recursively shorten long string fields inside an object/array so the
+ * JSON.stringify output stays under ~1KB while remaining VALID JSON. String
+ * fields longer than `maxFieldLen` get a `…[+N]` suffix appended in the
+ * cloned copy. Depth is bounded to keep cyclic / pathological inputs from
+ * blowing the stack; arrays are capped at MAX_ARRAY_ITEMS with a trailing
+ * `…[+N items]` placeholder.
+ */
+export function compactStringsForPreview(value, maxFieldLen, depth) {
+  if (depth > MAX_DEPTH) return '[…]';
+  if (typeof value === 'string') {
+    return value.length > maxFieldLen
+      ? `${value.slice(0, maxFieldLen)}…[+${value.length - maxFieldLen}]`
+      : value;
+  }
+  if (Array.isArray(value)) {
+    const limited = value
+      .slice(0, MAX_ARRAY_ITEMS)
+      .map(v => compactStringsForPreview(v, maxFieldLen, depth + 1));
+    if (value.length > MAX_ARRAY_ITEMS) {
+      limited.push(`…[+${value.length - MAX_ARRAY_ITEMS} items]`);
+    }
+    return limited;
+  }
+  if (value && typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = compactStringsForPreview(v, maxFieldLen, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}

--- a/server/tests/valuePreview.test.js
+++ b/server/tests/valuePreview.test.js
@@ -1,0 +1,126 @@
+// Plain-node test (node server/tests/valuePreview.test.js).
+//
+// previewToolValue/compactStringsForPreview used to be duplicated across
+// PromptNodeExecutor, MemoryFinalizeNodeExecutor, InboxLoadNodeExecutor, and
+// InboxFinalizeNodeExecutor. The Inbox executors carried an older, buggy
+// version — `JSON.stringify(value).slice(0, 1024)` — that truncates the
+// SERIALISED string, which can land mid-token and produce invalid JSON that
+// breaks the UI's `JSON.parse(stepLog...)` rendering. This module is the one
+// shared implementation (ported from PromptNodeExecutor) that truncates long
+// string fields INSIDE the object before stringifying, so the result always
+// stays valid JSON.
+import {
+  previewToolValue,
+  compactStringsForPreview
+} from '../services/workflow/executors/valuePreview.js';
+
+let failures = 0;
+function check(label, cond, detail) {
+  if (!cond) failures++;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && detail) console.log('   ' + detail);
+}
+
+// ---- primitives pass through / short-circuit ----
+check('null → null', previewToolValue(null) === null);
+check('undefined → null', previewToolValue(undefined) === null);
+check('number passes through', previewToolValue(42) === 42);
+check('boolean passes through', previewToolValue(false) === false);
+check('short string passes through', previewToolValue('hello') === 'hello');
+
+// ---- long top-level string gets truncated with a suffix (not valid JSON, by design) ----
+{
+  const longStr = 'x'.repeat(2000);
+  const out = previewToolValue(longStr);
+  check('long string truncated', out.startsWith('x'.repeat(1024)));
+  check('long string has truncation suffix', out.includes('…[truncated 976 chars]'));
+}
+
+// ---- objects/arrays: output must always be valid, parseable JSON ----
+{
+  const value = { note: 'y'.repeat(1000), ok: true };
+  const out = previewToolValue(value);
+  let parsed;
+  let parseError = null;
+  try {
+    parsed = JSON.parse(out);
+  } catch (err) {
+    parseError = err;
+  }
+  check('object preview is valid JSON', parseError === null, String(parseError));
+  check('long field truncated in place', parsed && parsed.note.includes('…[+680]'));
+  check('short field preserved', parsed && parsed.ok === true);
+}
+
+// ---- this is the exact bug the Inbox executors had: truncating the
+// serialised JSON string (not the fields) can cut mid-string and break parse.
+// Confirm our shared helper does NOT do that for a case where the naive
+// `JSON.stringify(value).slice(0, N)` approach would produce invalid JSON.
+{
+  const value = { text: 'z'.repeat(1200) };
+  const naiveBroken = JSON.stringify(value).slice(0, 1024);
+  let naiveParses = true;
+  try {
+    JSON.parse(naiveBroken);
+  } catch {
+    naiveParses = false;
+  }
+  check('naive slice-the-JSON-string approach is indeed broken here', naiveParses === false);
+
+  const safe = previewToolValue(value);
+  let safeParses = true;
+  try {
+    JSON.parse(safe);
+  } catch {
+    safeParses = false;
+  }
+  check('shared previewToolValue stays valid JSON for the same input', safeParses === true);
+}
+
+// ---- arrays: capped at 20 items with a placeholder ----
+{
+  const arr = Array.from({ length: 25 }, (_, i) => i);
+  const out = compactStringsForPreview(arr, 320, 0);
+  check('array capped at 20 items + placeholder', out.length === 21);
+  check('placeholder text correct', out[20] === '…[+5 items]');
+}
+
+// ---- depth is bounded to avoid pathological/cyclic-ish structures ----
+{
+  let nested = 'leaf';
+  for (let i = 0; i < 10; i++) nested = { child: nested };
+  const out = compactStringsForPreview(nested, 320, 0);
+  // Walk down until we hit the depth-limit placeholder.
+  let cur = out;
+  let depth = 0;
+  while (cur && typeof cur === 'object' && 'child' in cur) {
+    cur = cur.child;
+    depth++;
+  }
+  check('deep nesting hits the depth cutoff', cur === '[…]', `stopped at depth ${depth}`);
+}
+
+// ---- circular refs don't blow the stack — the depth cutoff bounds them ----
+// before JSON.stringify ever sees the (still-cyclic) original value.
+{
+  const circular = {};
+  circular.self = circular;
+  let out;
+  let threw = false;
+  try {
+    out = previewToolValue(circular);
+  } catch {
+    threw = true;
+  }
+  check('circular object does not throw', threw === false);
+  let parses = true;
+  try {
+    JSON.parse(out);
+  } catch {
+    parses = false;
+  }
+  check('circular object preview is still valid JSON', parses === true);
+}
+
+console.log(`\n${failures === 0 ? '✅ all passed' : `❌ ${failures} failed`}`);
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## Summary

Part of the split proposed in #1775 (`PromptNodeExecutor` bundles ~8 unrelated responsibilities). The issue's own implementation-plan comment calls out extraction #3 — "Preview/truncation utilities → shared util" — and specifically asks whether `_previewToolValue`/`_compactStringsForPreview` are duplicated in sibling executors before creating a new module. They are, in **four** places, not just `PromptNodeExecutor`: `MemoryFinalizeNodeExecutor`, `InboxLoadNodeExecutor`, and `InboxFinalizeNodeExecutor` each carry their own copy.

More importantly, two of those copies (`InboxLoadNodeExecutor`, `InboxFinalizeNodeExecutor`) carry an **older, buggy** version:

```js
_previewToolValue(value) {
  try {
    const json = JSON.stringify(value);
    return json.length > 1024 ? `${json.slice(0, 1024)}…` : json;
  } catch {
    return null;
  }
}
```

This truncates the *serialised JSON string* directly, which can cut mid-token and produce invalid JSON — exactly the failure mode `PromptNodeExecutor`'s version has a code comment explaining it was fixed to avoid ("a `…[truncated]` suffix appended to the JSON string itself broke [JSON.parse] and showed a generic fallback"). The UI does `JSON.parse()` on these step-log previews to render tool-call details, so the two Inbox executors were silently shipping the same class of bug the other two executors already fixed.

## Changes

- Added `server/services/workflow/executors/valuePreview.js`: `previewToolValue(value)` / `compactStringsForPreview(value, maxFieldLen, depth)` — the correct, field-truncating-before-stringify implementation, extracted as plain exported functions (no `this` dependency).
- `PromptNodeExecutor.js` and `MemoryFinalizeNodeExecutor.js`: removed their duplicated methods, import the shared helper instead. No behavior change.
- `InboxLoadNodeExecutor.js` and `InboxFinalizeNodeExecutor.js`: removed their buggy naive-truncation methods, switched to the shared (correct) helper. This is a genuine bug fix — malformed-JSON step-log previews for these two node types are no longer possible.
- Added `server/tests/valuePreview.test.js` (plain-node test, following the existing `citation-utils.test.js` pattern) covering primitives, in-place field truncation, array/depth capping, and — explicitly — a regression case demonstrating the naive slice-the-JSON-string approach produces invalid JSON while the shared helper doesn't, plus a circular-reference case verifying the depth cutoff prevents stack overflows without ever needing the `catch` fallback.

Remaining extractions from #1775 (template engine, citation helpers, auto-persist role branches) are left for follow-up PRs against the same issue, per its own recommendation to split this large-effort issue into independently reviewable slices.

## Test plan

- [x] `node server/tests/valuePreview.test.js` — all checks pass
- [x] `node server/tests/agent-citation-contract.test.js`, `promptService.test.js`, `empty-prompt-bug-validation.test.js` — no regressions
- [x] `npx eslint` on all changed/new files — 0 errors (one pre-existing unrelated warning in `PromptNodeExecutor.js` untouched)
- [x] `npm run format:fix` — clean
- [x] `node server/server.js` — boots and listens correctly with the changes in place

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01AQ8iMUChxw4oyEg7nwxoEq


---
_Generated by [Claude Code](https://claude.ai/code/session_01AQ8iMUChxw4oyEg7nwxoEq)_