### PR TITLE
refactor(workflow): extract template engine out of PromptNodeExecutor (#1775)

### DIFF
--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -24,6 +24,7 @@ import configCache from '../../../configCache.js';
 import WorkflowLLMHelper from '../WorkflowLLMHelper.js';
 import { ContextSummarizer } from '../ContextSummarizer.js';
 import { dedupeCitations } from '../citationUtils.js';
+import { resolveTemplateVariables as resolveTemplateVariablesEngine } from './promptTemplateEngine.js';
 import { estimateTokens } from '../../../usageTracker.js';
 import SourceResolutionService from '../../SourceResolutionService.js';
 import { createSourceManager } from '../../../sources/index.js';
@@ -724,16 +725,26 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
             }
           };
 
+    // Hooks the shared template engine defers to for the handful of
+    // placeholders/paths that need PromptNodeExecutor's own state.
+    const templateDeps = {
+      logger: this.logger,
+      formatPreviousTaskResults: (s, o) => this._formatPreviousTaskResults(s, o),
+      formatCitations: s => this._formatCitations(s),
+      resolveVariables: (value, s) => this.resolveVariables(value, s)
+    };
+
     // Add system message if configured
     if (config.system) {
       const systemTemplate = this.getLocalizedValue(config.system, language);
       // Resolve global placeholders ({{date}}, {{timezone}}, …) on the RAW
       // template first — resolveTemplateVariables strips unknown {{...}} tokens,
       // so the global pass must run before it, not after.
-      let systemContent = this.resolveTemplateVariables(
+      let systemContent = resolveTemplateVariablesEngine(
         this.applyGlobalPromptVars(systemTemplate, globalVars),
         state,
-        tplOpts
+        tplOpts,
+        templateDeps
       );
 
       // Prepend the temporal block so the date is the first thing the model reads.
@@ -793,10 +804,11 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
     let userContent;
     if (config.prompt) {
       const promptTemplate = this.getLocalizedValue(config.prompt, language);
-      userContent = this.resolveTemplateVariables(
+      userContent = resolveTemplateVariablesEngine(
         this.applyGlobalPromptVars(promptTemplate, globalVars),
         state,
-        tplOpts
+        tplOpts,
+        templateDeps
       );
     } else if (state.data?.input) {
       userContent = state.data.input;
@@ -939,302 +951,6 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
       return value[language] || value['en'] || Object.values(value)[0] || '';
     }
     return String(value || '');
-  }
-
-  /**
-   * Resolve template variables in a string.
-   * Supports multiple syntaxes:
-   * - {{variable}} - Simple Handlebars-style (looks up in state.data)
-   * - {{#if condition}}...{{/if}} - Simple conditional blocks
-   * - {{#each array}}...{{/each}} - Loop over arrays
-   * - {{@index}} - Current loop index (0-based)
-   * - {{this}} and {{this.property}} - Current item reference
-   * - {{#compare val1 "op" val2}}...{{/compare}} - Comparison blocks
-   * - $.path - JSONPath-style (via resolveVariables)
-   * - ${$.path} - Embedded JSONPath-style (via resolveVariables)
-   *
-   * @param {string} template - Template string
-   * @param {Object} state - Workflow state
-   * @returns {string} Resolved template
-   * @private
-   */
-  resolveTemplateVariables(template, state, opts = {}) {
-    if (typeof template !== 'string') {
-      return template;
-    }
-
-    let result = template;
-
-    // Handle {{#each array}}...{{/each}} blocks with proper nesting support
-    // Process from outermost to innermost using balanced matching
-    result = this.processEachBlocks(result, state);
-
-    // Handle {{#compare val1 "op" val2}}...{{/compare}} blocks
-    // Supports operators: <, >, <=, >=, ==, !=
-    result = result.replace(
-      /\{\{#compare\s+([^\s"]+)\s+"([^"]+)"\s+([^\s}]+)\s*\}\}([\s\S]*?)\{\{\/compare\}\}/g,
-      (match, left, operator, right, content) => {
-        // Resolve left value - could be a variable path or literal
-        let leftVal = this.getNestedValue(left.trim(), state.data || {});
-        if (leftVal === undefined) {
-          // Treat as literal if not found in state
-          leftVal = left.trim();
-        }
-
-        // Resolve right value - could be a variable path or literal
-        let rightVal = this.getNestedValue(right.trim(), state.data || {});
-        if (rightVal === undefined) {
-          // Treat as literal if not found in state
-          rightVal = right.trim();
-        }
-
-        let comparisonResult = false;
-
-        switch (operator) {
-          case '<':
-            comparisonResult = Number(leftVal) < Number(rightVal);
-            break;
-          case '>':
-            comparisonResult = Number(leftVal) > Number(rightVal);
-            break;
-          case '<=':
-            comparisonResult = Number(leftVal) <= Number(rightVal);
-            break;
-          case '>=':
-            comparisonResult = Number(leftVal) >= Number(rightVal);
-            break;
-          case '==':
-            comparisonResult = leftVal == rightVal;
-            break;
-          case '===':
-            comparisonResult = leftVal === rightVal;
-            break;
-          case '!=':
-            comparisonResult = leftVal != rightVal;
-            break;
-          case '!==':
-            comparisonResult = leftVal !== rightVal;
-            break;
-          default:
-            this.logger.warn('Unknown comparison operator', {
-              component: 'PromptNodeExecutor',
-              operator
-            });
-        }
-
-        return comparisonResult ? this.resolveTemplateVariables(content, state, opts) : '';
-      }
-    );
-
-    // Handle {{#if condition}}...{{/if}} blocks
-    result = result.replace(
-      /\{\{#if\s+([^}]+)\}\}([\s\S]*?)\{\{\/if\}\}/g,
-      (match, condition, content) => {
-        // Resolve the condition variable
-        const conditionValue = this.getNestedValue(condition.trim(), state.data || {});
-        if (conditionValue) {
-          // Recursively resolve variables in the content
-          return this.resolveTemplateVariables(content, state, opts);
-        }
-        return '';
-      }
-    );
-
-    // Handle simple {{variable}} or {{path.to.value}} substitution
-    // Exclude @index and this which are handled in each loops
-    result = result.replace(/\{\{([^#/@}][^}]*)\}\}/g, (match, variable) => {
-      const trimmed = variable.trim();
-
-      // Skip 'this' references outside of each loops (they should be empty)
-      if (trimmed === 'this' || trimmed.startsWith('this.')) {
-        return '';
-      }
-
-      // Special template variable populated by the runtime — formats the
-      // accumulated planner task results into a markdown block so the
-      // synthesizer (and intermediate plan tasks) can see prior work.
-      if (trimmed === 'previousTaskResults') {
-        return this._formatPreviousTaskResults(state, opts.previousTaskResults);
-      }
-
-      // Citations ledger collected from every search/extract tool call
-      // during the run. Renders a numbered list `[1] title — url` that the
-      // synthesizer cites inline. Named `citations` (NOT `sources`) so it
-      // doesn't collide with `profile.sources` — the configured knowledge
-      // bases the agent can look up via `source_*` tools. Citations are
-      // the runtime ledger of URLs the agent actually consulted; sources
-      // is the configured catalog it could consult.
-      if (trimmed === 'citations') {
-        return this._formatCitations(state);
-      }
-
-      // Inbox item — render clean. The state object stores the FULL parsed
-      // checklist line in `.raw`, which accumulates `-- done by …` notes
-      // every time the item gets re-checked. Stringifying the whole object
-      // bleeds that history (including prior hallucinated reports) into the
-      // current run's prompts and the synthesizer's final report. Render
-      // just `(P1) text` so the LLM sees what the user actually wrote.
-      if (trimmed === 'currentInboxItem') {
-        const item = state?.data?.currentInboxItem;
-        if (!item) return '';
-        if (typeof item === 'string') return item;
-        const text = (item.text || '').toString().trim();
-        if (!text) return '';
-        const priority =
-          item.priority && item.priority !== 'unprioritized'
-            ? `(${item.priority.toUpperCase()}) `
-            : '';
-        return `${priority}${text}`;
-      }
-
-      const value = this.getNestedValue(trimmed, state.data || {});
-      if (value !== undefined && value !== null) {
-        // Convert objects to JSON string to avoid [object Object]
-        if (typeof value === 'object') {
-          return JSON.stringify(value);
-        }
-        return String(value);
-      }
-      return ''; // Remove unresolved variables
-    });
-
-    // Finally, handle $.path syntax via existing resolveVariables
-    result = this.resolveVariables(result, state);
-
-    return result;
-  }
-
-  /**
-   * Get a nested value from an object using dot notation.
-   *
-   * @param {string} path - Dot-notation path like "user.name" or "items.0.id"
-   * @param {Object} obj - Object to search
-   * @returns {*} Value at path or undefined
-   * @private
-   */
-  getNestedValue(path, obj) {
-    const parts = path.split('.');
-    let current = obj;
-
-    for (const part of parts) {
-      if (current === undefined || current === null) {
-        return undefined;
-      }
-      current = current[part];
-    }
-
-    return current;
-  }
-
-  /**
-   * Process {{#each}}...{{/each}} blocks with proper nesting support.
-   * Uses balanced matching to correctly handle nested loops.
-   *
-   * @param {string} template - Template string to process
-   * @param {Object} state - Workflow state
-   * @returns {string} Processed template
-   * @private
-   */
-  processEachBlocks(template, state) {
-    let result = template;
-    let iterations = 0;
-    const maxIterations = 20; // Prevent infinite loops
-
-    // Process from outermost to innermost
-    // Find the first {{#each ...}} and its matching {{/each}} with balanced nesting
-    while (iterations < maxIterations) {
-      iterations++;
-
-      const startMatch = result.match(/\{\{#each\s+([^}]+)\}\}/);
-      if (!startMatch) {
-        break; // No more each blocks
-      }
-
-      const startIndex = startMatch.index;
-      const arrayPath = startMatch[1].trim();
-      const afterOpenTag = startIndex + startMatch[0].length;
-
-      // Find the matching closing tag with balanced nesting
-      let depth = 1;
-      let searchPos = afterOpenTag;
-      let closingIndex = -1;
-
-      while (depth > 0 && searchPos < result.length) {
-        const nextOpen = result.indexOf('{{#each', searchPos);
-        const nextClose = result.indexOf('{{/each}}', searchPos);
-
-        if (nextClose === -1) {
-          // No closing tag found - malformed template
-          break;
-        }
-
-        if (nextOpen !== -1 && nextOpen < nextClose) {
-          // Found another opening tag before the closing tag
-          depth++;
-          searchPos = nextOpen + 7; // Move past "{{#each"
-        } else {
-          // Found closing tag
-          depth--;
-          if (depth === 0) {
-            closingIndex = nextClose;
-          }
-          searchPos = nextClose + 9; // Move past "{{/each}}"
-        }
-      }
-
-      if (closingIndex === -1) {
-        // Couldn't find matching closing tag
-        this.logger.warn('Unbalanced {{#each}} block', {
-          component: 'PromptNodeExecutor',
-          arrayPath
-        });
-        break;
-      }
-
-      // Extract the content between opening and closing tags
-      const content = result.substring(afterOpenTag, closingIndex);
-      const fullMatch = result.substring(startIndex, closingIndex + 9);
-
-      // Get the array to iterate over
-      const array = this.getNestedValue(arrayPath, state.data || {});
-
-      let replacement = '';
-      if (Array.isArray(array) && array.length > 0) {
-        replacement = array
-          .map((item, index) => {
-            let itemContent = content;
-
-            // Replace {{@index}} with current index
-            itemContent = itemContent.replace(/\{\{@index\}\}/g, String(index));
-
-            // Replace {{this.property}} with item.property
-            itemContent = itemContent.replace(/\{\{this\.([^}]+)\}\}/g, (_, prop) => {
-              const propPath = prop.trim();
-              const val = this.getNestedValue(propPath, item);
-              if (val !== undefined && val !== null) {
-                return typeof val === 'object' ? JSON.stringify(val) : String(val);
-              }
-              return '';
-            });
-
-            // Replace {{this}} with JSON of item
-            itemContent = itemContent.replace(/\{\{this\}\}/g, () => {
-              return typeof item === 'object' ? JSON.stringify(item) : String(item);
-            });
-
-            // Recursively process any nested each blocks in this iteration
-            itemContent = this.processEachBlocks(itemContent, state);
-
-            return itemContent;
-          })
-          .join('');
-      }
-
-      // Replace the full match with the processed content
-      result = result.substring(0, startIndex) + replacement + result.substring(closingIndex + 9);
-    }
-
-    return result;
   }
 
   /**

--- a/server/services/workflow/executors/promptTemplateEngine.js
+++ b/server/services/workflow/executors/promptTemplateEngine.js
@@ -1,0 +1,322 @@
+/**
+ * Handlebars-subset template engine used to resolve `{{...}}` placeholders in
+ * agent-node prompts (system/user templates, per-task worker prompts).
+ *
+ * Extracted from `PromptNodeExecutor` (see #1775): this engine is
+ * provider-agnostic and doesn't depend on the executor's LLM/tool-loop state,
+ * but it does need three PromptNodeExecutor-specific hooks — `citations` and
+ * `previousTaskResults` placeholder rendering, and `$.path` resolution — so
+ * those are passed in via `deps` rather than imported directly.
+ *
+ * Deliberately NOT delegated to `services/templating/renderTemplate.js`: that
+ * renderer doesn't support the `{{#compare}}` comparison-operator blocks this
+ * engine does (see its module docstring). Consolidating the two is tracked as
+ * a separate follow-up rather than folded into this extraction.
+ *
+ * @module services/workflow/executors/promptTemplateEngine
+ */
+
+/**
+ * Get a nested value from an object using dot notation.
+ *
+ * @param {string} path - Dot-notation path like "user.name" or "items.0.id"
+ * @param {Object} obj - Object to search
+ * @returns {*} Value at path or undefined
+ */
+export function getNestedValue(path, obj) {
+  const parts = path.split('.');
+  let current = obj;
+
+  for (const part of parts) {
+    if (current === undefined || current === null) {
+      return undefined;
+    }
+    current = current[part];
+  }
+
+  return current;
+}
+
+/**
+ * Process {{#each}}...{{/each}} blocks with proper nesting support.
+ * Uses balanced matching to correctly handle nested loops.
+ *
+ * @param {string} template - Template string to process
+ * @param {Object} state - Workflow state
+ * @param {{logger?: Object}} [deps] - `logger` is used to warn on malformed templates
+ * @returns {string} Processed template
+ */
+export function processEachBlocks(template, state, deps = {}) {
+  const { logger } = deps;
+  let result = template;
+  let iterations = 0;
+  const maxIterations = 20; // Prevent infinite loops
+
+  // Process from outermost to innermost
+  // Find the first {{#each ...}} and its matching {{/each}} with balanced nesting
+  while (iterations < maxIterations) {
+    iterations++;
+
+    const startMatch = result.match(/\{\{#each\s+([^}]+)\}\}/);
+    if (!startMatch) {
+      break; // No more each blocks
+    }
+
+    const startIndex = startMatch.index;
+    const arrayPath = startMatch[1].trim();
+    const afterOpenTag = startIndex + startMatch[0].length;
+
+    // Find the matching closing tag with balanced nesting
+    let depth = 1;
+    let searchPos = afterOpenTag;
+    let closingIndex = -1;
+
+    while (depth > 0 && searchPos < result.length) {
+      const nextOpen = result.indexOf('{{#each', searchPos);
+      const nextClose = result.indexOf('{{/each}}', searchPos);
+
+      if (nextClose === -1) {
+        // No closing tag found - malformed template
+        break;
+      }
+
+      if (nextOpen !== -1 && nextOpen < nextClose) {
+        // Found another opening tag before the closing tag
+        depth++;
+        searchPos = nextOpen + 7; // Move past "{{#each"
+      } else {
+        // Found closing tag
+        depth--;
+        if (depth === 0) {
+          closingIndex = nextClose;
+        }
+        searchPos = nextClose + 9; // Move past "{{/each}}"
+      }
+    }
+
+    if (closingIndex === -1) {
+      // Couldn't find matching closing tag
+      logger?.warn('Unbalanced {{#each}} block', {
+        component: 'promptTemplateEngine',
+        arrayPath
+      });
+      break;
+    }
+
+    // Extract the content between opening and closing tags
+    const content = result.substring(afterOpenTag, closingIndex);
+
+    // Get the array to iterate over
+    const array = getNestedValue(arrayPath, state.data || {});
+
+    let replacement = '';
+    if (Array.isArray(array) && array.length > 0) {
+      replacement = array
+        .map((item, index) => {
+          let itemContent = content;
+
+          // Replace {{@index}} with current index
+          itemContent = itemContent.replace(/\{\{@index\}\}/g, String(index));
+
+          // Replace {{this.property}} with item.property
+          itemContent = itemContent.replace(/\{\{this\.([^}]+)\}\}/g, (_, prop) => {
+            const propPath = prop.trim();
+            const val = getNestedValue(propPath, item);
+            if (val !== undefined && val !== null) {
+              return typeof val === 'object' ? JSON.stringify(val) : String(val);
+            }
+            return '';
+          });
+
+          // Replace {{this}} with JSON of item
+          itemContent = itemContent.replace(/\{\{this\}\}/g, () => {
+            return typeof item === 'object' ? JSON.stringify(item) : String(item);
+          });
+
+          // Recursively process any nested each blocks in this iteration
+          itemContent = processEachBlocks(itemContent, state, deps);
+
+          return itemContent;
+        })
+        .join('');
+    }
+
+    // Replace the full match with the processed content
+    result = result.substring(0, startIndex) + replacement + result.substring(closingIndex + 9);
+  }
+
+  return result;
+}
+
+/**
+ * Resolve template variables in a string.
+ * Supports multiple syntaxes:
+ * - {{variable}} - Simple Handlebars-style (looks up in state.data)
+ * - {{#if condition}}...{{/if}} - Simple conditional blocks
+ * - {{#each array}}...{{/each}} - Loop over arrays
+ * - {{@index}} - Current loop index (0-based)
+ * - {{this}} and {{this.property}} - Current item reference
+ * - {{#compare val1 "op" val2}}...{{/compare}} - Comparison blocks
+ * - $.path - JSONPath-style (via deps.resolveVariables)
+ * - ${$.path} - Embedded JSONPath-style (via deps.resolveVariables)
+ *
+ * @param {string} template - Template string
+ * @param {Object} state - Workflow state
+ * @param {Object} [opts] - Options forwarded to `previousTaskResults` rendering
+ * @param {{
+ *   logger?: Object,
+ *   formatPreviousTaskResults?: (state: Object, opts?: Object) => string,
+ *   formatCitations?: (state: Object) => string,
+ *   resolveVariables?: (value: string, state: Object) => string
+ * }} [deps] - PromptNodeExecutor-specific hooks this engine defers to
+ * @returns {string} Resolved template
+ */
+export function resolveTemplateVariables(template, state, opts = {}, deps = {}) {
+  if (typeof template !== 'string') {
+    return template;
+  }
+
+  const { logger, formatPreviousTaskResults, formatCitations, resolveVariables } = deps;
+
+  let result = template;
+
+  // Handle {{#each array}}...{{/each}} blocks with proper nesting support
+  // Process from outermost to innermost using balanced matching
+  result = processEachBlocks(result, state, deps);
+
+  // Handle {{#compare val1 "op" val2}}...{{/compare}} blocks
+  // Supports operators: <, >, <=, >=, ==, !=
+  result = result.replace(
+    /\{\{#compare\s+([^\s"]+)\s+"([^"]+)"\s+([^\s}]+)\s*\}\}([\s\S]*?)\{\{\/compare\}\}/g,
+    (match, left, operator, right, content) => {
+      // Resolve left value - could be a variable path or literal
+      let leftVal = getNestedValue(left.trim(), state.data || {});
+      if (leftVal === undefined) {
+        // Treat as literal if not found in state
+        leftVal = left.trim();
+      }
+
+      // Resolve right value - could be a variable path or literal
+      let rightVal = getNestedValue(right.trim(), state.data || {});
+      if (rightVal === undefined) {
+        // Treat as literal if not found in state
+        rightVal = right.trim();
+      }
+
+      let comparisonResult = false;
+
+      switch (operator) {
+        case '<':
+          comparisonResult = Number(leftVal) < Number(rightVal);
+          break;
+        case '>':
+          comparisonResult = Number(leftVal) > Number(rightVal);
+          break;
+        case '<=':
+          comparisonResult = Number(leftVal) <= Number(rightVal);
+          break;
+        case '>=':
+          comparisonResult = Number(leftVal) >= Number(rightVal);
+          break;
+        case '==':
+          comparisonResult = leftVal == rightVal;
+          break;
+        case '===':
+          comparisonResult = leftVal === rightVal;
+          break;
+        case '!=':
+          comparisonResult = leftVal != rightVal;
+          break;
+        case '!==':
+          comparisonResult = leftVal !== rightVal;
+          break;
+        default:
+          logger?.warn('Unknown comparison operator', {
+            component: 'promptTemplateEngine',
+            operator
+          });
+      }
+
+      return comparisonResult ? resolveTemplateVariables(content, state, opts, deps) : '';
+    }
+  );
+
+  // Handle {{#if condition}}...{{/if}} blocks
+  result = result.replace(
+    /\{\{#if\s+([^}]+)\}\}([\s\S]*?)\{\{\/if\}\}/g,
+    (match, condition, content) => {
+      // Resolve the condition variable
+      const conditionValue = getNestedValue(condition.trim(), state.data || {});
+      if (conditionValue) {
+        // Recursively resolve variables in the content
+        return resolveTemplateVariables(content, state, opts, deps);
+      }
+      return '';
+    }
+  );
+
+  // Handle simple {{variable}} or {{path.to.value}} substitution
+  // Exclude @index and this which are handled in each loops
+  result = result.replace(/\{\{([^#/@}][^}]*)\}\}/g, (match, variable) => {
+    const trimmed = variable.trim();
+
+    // Skip 'this' references outside of each loops (they should be empty)
+    if (trimmed === 'this' || trimmed.startsWith('this.')) {
+      return '';
+    }
+
+    // Special template variable populated by the runtime — formats the
+    // accumulated planner task results into a markdown block so the
+    // synthesizer (and intermediate plan tasks) can see prior work.
+    if (trimmed === 'previousTaskResults') {
+      return formatPreviousTaskResults
+        ? formatPreviousTaskResults(state, opts.previousTaskResults)
+        : '';
+    }
+
+    // Citations ledger collected from every search/extract tool call
+    // during the run. Renders a numbered list `[1] title — url` that the
+    // synthesizer cites inline. Named `citations` (NOT `sources`) so it
+    // doesn't collide with `profile.sources` — the configured knowledge
+    // bases the agent can look up via `source_*` tools. Citations are
+    // the runtime ledger of URLs the agent actually consulted; sources
+    // is the configured catalog it could consult.
+    if (trimmed === 'citations') {
+      return formatCitations ? formatCitations(state) : '';
+    }
+
+    // Inbox item — render clean. The state object stores the FULL parsed
+    // checklist line in `.raw`, which accumulates `-- done by …` notes
+    // every time the item gets re-checked. Stringifying the whole object
+    // bleeds that history (including prior hallucinated reports) into the
+    // current run's prompts and the synthesizer's final report. Render
+    // just `(P1) text` so the LLM sees what the user actually wrote.
+    if (trimmed === 'currentInboxItem') {
+      const item = state?.data?.currentInboxItem;
+      if (!item) return '';
+      if (typeof item === 'string') return item;
+      const text = (item.text || '').toString().trim();
+      if (!text) return '';
+      const priority =
+        item.priority && item.priority !== 'unprioritized'
+          ? `(${item.priority.toUpperCase()}) `
+          : '';
+      return `${priority}${text}`;
+    }
+
+    const value = getNestedValue(trimmed, state.data || {});
+    if (value !== undefined && value !== null) {
+      // Convert objects to JSON string to avoid [object Object]
+      if (typeof value === 'object') {
+        return JSON.stringify(value);
+      }
+      return String(value);
+    }
+    return ''; // Remove unresolved variables
+  });
+
+  // Finally, handle $.path syntax via the executor's own resolveVariables
+  result = resolveVariables ? resolveVariables(result, state) : result;
+
+  return result;
+}

--- a/server/tests/promptTemplateEngine.test.js
+++ b/server/tests/promptTemplateEngine.test.js
@@ -1,0 +1,175 @@
+// Plain-node test (node server/tests/promptTemplateEngine.test.js).
+//
+// Extracted from PromptNodeExecutor (#1775) as part of shrinking the god-class:
+// this Handlebars-subset engine used to be three private methods on the
+// executor with no dedicated test — coverage was only indirect via the
+// agent-*.test.js integration tests. These cover the engine's own syntax
+// (each/if/compare/this/@index) plus the PromptNodeExecutor-specific hooks
+// (previousTaskResults/citations/$.path) it now takes via `deps` instead of
+// reading off `this`.
+import {
+  getNestedValue,
+  processEachBlocks,
+  resolveTemplateVariables
+} from '../services/workflow/executors/promptTemplateEngine.js';
+
+let failures = 0;
+function check(label, cond, detail) {
+  if (!cond) failures++;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && detail) console.log('   ' + detail);
+}
+
+// ---- getNestedValue ----
+check('simple path', getNestedValue('a.b', { a: { b: 1 } }) === 1);
+check('missing path → undefined', getNestedValue('a.x', { a: { b: 1 } }) === undefined);
+check('null intermediate → undefined', getNestedValue('a.b.c', { a: null }) === undefined);
+check('array index path', getNestedValue('items.1', { items: ['x', 'y'] }) === 'y');
+
+// ---- resolveTemplateVariables: plain variables ----
+{
+  const state = { data: { name: 'Ada', nested: { count: 3 } } };
+  check('simple {{variable}}', resolveTemplateVariables('Hi {{name}}', state) === 'Hi Ada');
+  check('nested {{path.to.value}}', resolveTemplateVariables('{{nested.count}}', state) === '3');
+  check('unresolved variable → empty', resolveTemplateVariables('{{missing}}', state) === '');
+  check(
+    'object value → JSON string',
+    resolveTemplateVariables('{{nested}}', state) === JSON.stringify(state.data.nested)
+  );
+}
+
+// ---- {{#if}} blocks ----
+{
+  const truthy = { data: { flag: true } };
+  const falsy = { data: { flag: false } };
+  check(
+    '{{#if}} true renders content',
+    resolveTemplateVariables('{{#if flag}}yes{{/if}}', truthy) === 'yes'
+  );
+  check(
+    '{{#if}} false renders empty',
+    resolveTemplateVariables('{{#if flag}}yes{{/if}}', falsy) === ''
+  );
+}
+
+// ---- {{#compare}} blocks ----
+{
+  const state = { data: { a: 5, b: 10 } };
+  check(
+    '{{#compare}} numeric <',
+    resolveTemplateVariables('{{#compare a "<" b}}less{{/compare}}', state) === 'less'
+  );
+  check(
+    '{{#compare}} numeric >',
+    resolveTemplateVariables('{{#compare a ">" b}}more{{/compare}}', state) === ''
+  );
+  check(
+    '{{#compare}} literal operands',
+    resolveTemplateVariables('{{#compare 1 "<" 2}}yes{{/compare}}', { data: {} }) === 'yes'
+  );
+}
+
+// ---- {{#each}} blocks (via processEachBlocks + resolveTemplateVariables) ----
+{
+  const state = { data: { items: [{ name: 'a' }, { name: 'b' }] } };
+  check(
+    'processEachBlocks renders {{this.property}} and {{@index}}',
+    processEachBlocks('{{#each items}}[{{@index}}:{{this.name}}]{{/each}}', state) === '[0:a][1:b]'
+  );
+  check(
+    'empty array → empty output',
+    processEachBlocks('{{#each items}}x{{/each}}', { data: { items: [] } }) === ''
+  );
+  check(
+    // Inner {{#each}} resolves its array path against state.data (not the
+    // outer loop's `item`), so a nested {{#each items}} re-iterates the same
+    // top-level array on every outer pass rather than scoping into `this`.
+    'nested each blocks each re-resolve against state.data',
+    processEachBlocks('{{#each items}}{{#each items}}{{this.name}}{{/each}}|{{/each}}', state) ===
+      'aa|bb|'
+  );
+  check(
+    'resolveTemplateVariables composes each + plain substitution',
+    resolveTemplateVariables('{{#each items}}{{this.name}} {{/each}}', state) === 'a b '
+  );
+}
+
+// ---- deps hooks: previousTaskResults / citations / resolveVariables ----
+{
+  const calls = [];
+  const deps = {
+    formatPreviousTaskResults: (_state, opts) => {
+      calls.push(['previousTaskResults', opts]);
+      return 'PTR';
+    },
+    formatCitations: () => {
+      calls.push(['citations']);
+      return 'CITES';
+    },
+    resolveVariables: value => `${value}+resolved`
+  };
+  const out = resolveTemplateVariables(
+    '{{previousTaskResults}} {{citations}}',
+    { data: {} },
+    { previousTaskResults: { maxResults: 1 } },
+    deps
+  );
+  check('previousTaskResults hook invoked with opts', calls[0][0] === 'previousTaskResults');
+  check('previousTaskResults opts forwarded', calls[0][1]?.maxResults === 1);
+  check(
+    'citations hook invoked',
+    calls.some(c => c[0] === 'citations')
+  );
+  check('hook outputs substituted', out.startsWith('PTR CITES'));
+  check('resolveVariables hook runs last (final $.path pass)', out.endsWith('+resolved'));
+}
+
+// ---- deps optional: missing hooks degrade gracefully instead of throwing ----
+{
+  check(
+    'no deps: previousTaskResults placeholder → empty, no throw',
+    resolveTemplateVariables('{{previousTaskResults}}', { data: {} }) === ''
+  );
+  check(
+    'no deps: citations placeholder → empty, no throw',
+    resolveTemplateVariables('{{citations}}', { data: {} }) === ''
+  );
+  check(
+    'no deps: $.path pass-through unresolved (no resolveVariables hook)',
+    resolveTemplateVariables('literal text', { data: {} }) === 'literal text'
+  );
+}
+
+// ---- currentInboxItem special-case (handled inline, no dep needed) ----
+{
+  check(
+    'currentInboxItem string form',
+    resolveTemplateVariables('{{currentInboxItem}}', {
+      data: { currentInboxItem: 'Do the thing' }
+    }) === 'Do the thing'
+  );
+  check(
+    'currentInboxItem object form with priority',
+    resolveTemplateVariables('{{currentInboxItem}}', {
+      data: { currentInboxItem: { text: 'Ship it', priority: 'p1' } }
+    }) === '(P1) Ship it'
+  );
+  check(
+    'currentInboxItem unprioritized omits the tag',
+    resolveTemplateVariables('{{currentInboxItem}}', {
+      data: { currentInboxItem: { text: 'Ship it', priority: 'unprioritized' } }
+    }) === 'Ship it'
+  );
+}
+
+// ---- logger dep: warns on malformed {{#each}} without throwing ----
+{
+  const warnings = [];
+  const deps = { logger: { warn: (msg, meta) => warnings.push({ msg, meta }) } };
+  const out = processEachBlocks('{{#each items}}unterminated', { data: { items: [1] } }, deps);
+  check('malformed each logs a warning', warnings.length === 1, JSON.stringify(warnings));
+  check('malformed each leaves template unresolved rather than throwing', out.includes('{{#each'));
+}
+
+console.log(`\n${failures === 0 ? '✅ all passed' : `❌ ${failures} failed`}`);
+process.exit(failures ? 1 : 0);


### PR DESCRIPTION
## Summary

Part of the split proposed in #1775 (`PromptNodeExecutor` bundles ~8 unrelated responsibilities). This is extraction #1 from the issue's implementation plan — the Handlebars-subset template engine (`resolveTemplateVariables`/`processEachBlocks`/`getNestedValue`) — following extraction #3 (preview/truncation helpers) already opened as #1943.

`resolveTemplateVariables`, `processEachBlocks`, and `getNestedValue` are provider-agnostic templating logic (no LLM/tool-loop state), but lived as private methods on the 3500+ line executor with no dedicated unit test — only indirect coverage via `agent-*.test.js` integration tests.

Per the issue's own recommendation, this is a **standalone extraction**, not a merge with `services/templating/renderTemplate.js` — that renderer's docstring explicitly says it doesn't support the `{{#compare}}` comparison-operator blocks this engine does. Consolidating the two is left as a separate follow-up.

## Changes

- Added `server/services/workflow/executors/promptTemplateEngine.js`: the three functions as plain exports. `resolveTemplateVariables`/`processEachBlocks` take a `deps` object for the handful of PromptNodeExecutor-specific hooks (`formatPreviousTaskResults`, `formatCitations`, `resolveVariables` for the final `$.path` pass, and `logger`) instead of reading them off `this` — so the engine has zero dependency on the executor and can be tested/reasoned about in isolation.
- `PromptNodeExecutor.js`: removed the three private methods (~300 lines). Both call sites in `buildMessages` now call the imported `resolveTemplateVariables` with a `templateDeps` object wired to the executor's own `_formatPreviousTaskResults`/`_formatCitations`/`resolveVariables`/`logger`. No behavior change — `templateDeps` is built once per `buildMessages` call and reused for both the system and user message templates.
- Added `server/tests/promptTemplateEngine.test.js`: covers `{{#each}}`/`{{#if}}`/`{{#compare}}`/nested-each/`{{this}}`/`{{@index}}`, the `deps` hooks (including graceful degradation to empty string when a hook is omitted, rather than throwing), the `currentInboxItem` special case, and the malformed-`{{#each}}` warning path via the `logger` dep.

Remaining extractions from #1775 (citation helpers → `citationUtils.js`, auto-persist role branches → per-role strategies) are left for follow-up PRs against the same issue.

## Test plan

- [x] `node server/tests/promptTemplateEngine.test.js` — new unit tests, all pass
- [x] `node server/tests/agent-task-context-bound.test.js` — exercises `buildMessages` end-to-end via `{{previousTaskResults}}` (bounded/unbounded budget paths) — all pass, no regression
- [x] `node server/tests/agent-temporal-context.test.js`, `agent-citation-contract.test.js`, `planReviewLoop.test.js`, `agent-artifact-versioning.test.js`, `agent-audit-trail.test.js` — no regressions
- [x] `npx eslint` on all changed/new files — 0 errors, 0 warnings
- [x] `npm run format:fix` (prettier) — clean
- [x] `node server/server.js` — boots and listens correctly with the changes in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013eL1kKc9sctERcUpt4QBpC


---
_Generated by [Claude Code](https://claude.ai/code/session_013eL1kKc9sctERcUpt4QBpC)_