### PR TITLE
refactor(chat): extract @mention workflow dispatch into chatBridge

### DIFF
--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -25,7 +25,8 @@ import {
 } from '../../utils/responseHelpers.js';
 import {
   buildReplayStepsFromState,
-  drainPendingFinish
+  drainPendingFinish,
+  tryHandleMentionWorkflow
 } from '../../services/workflow/chatBridge.js';
 import { activeWorkflowExecutions } from '../../tools/workflowRunner.js';
 
@@ -675,132 +676,47 @@ export default function registerSessionRoutes(
           timestamp: new Date().toISOString()
         });
 
-        // --- @mention workflow detection ---
-        // Check if the last user message contains an @workflow-name mention
-        const lastUserMsg = messages[messages.length - 1];
-        const lastUserContent = typeof lastUserMsg?.content === 'string' ? lastUserMsg.content : '';
-        const mentionMatch = lastUserContent.match(/@([\w.-]+)/);
-
-        if (mentionMatch) {
-          const mentionedId = mentionMatch[1];
-          const mentionedWorkflow = configCache.getWorkflowById(mentionedId);
-
-          // If the user explicitly @-mentioned a workflow but it is not
-          // chat-runnable, refuse the message instead of falling through to
-          // the LLM (which would happily pick a *different* registered
-          // workflow tool — the @human → @auto switch users have seen).
-          if (mentionedWorkflow) {
-            const isDisabled = mentionedWorkflow.enabled === false;
-            const noChatIntegration = !mentionedWorkflow.chatIntegration?.enabled;
-
-            if (isDisabled || noChatIntegration) {
-              const wfName =
-                (typeof mentionedWorkflow.name === 'object'
-                  ? mentionedWorkflow.name[clientLanguage] || mentionedWorkflow.name.en
-                  : mentionedWorkflow.name) || mentionedId;
-              const reason = isDisabled
-                ? `Workflow "${wfName}" is disabled.`
-                : `Workflow "${wfName}" is not configured for chat (chatIntegration.enabled is false).`;
-              actionTracker.trackError(chatId, { message: reason });
-              if (!clients.has(chatId)) {
-                return res.status(400).json({ status: 'error', message: reason });
-              }
-              actionTracker.trackChunk(chatId, { content: reason });
-              actionTracker.trackDone(chatId, { finishReason: 'error' });
-              return res.json({ status: 'streaming', chatId });
-            }
-          }
-
-          if (
-            mentionedWorkflow &&
-            mentionedWorkflow.enabled !== false &&
-            mentionedWorkflow.chatIntegration?.enabled
-          ) {
-            logger.info('@mention workflow triggered', {
-              component: 'sessionRoutes',
-              workflowId: mentionedId,
-              chatId
-            });
-
-            // Strip the @mention from the input
-            const strippedInput = lastUserContent.replace(/@[\w.-]+/, '').trim();
-
-            // Collect file data from the last message
-            const fileData = lastUserMsg.fileData || null;
-            const imageData = lastUserMsg.imageData || null;
-
-            // Build chat history from all prior messages (excluding the last)
-            const chatHistory = messages.slice(0, -1).map(m => ({
-              role: m.role,
-              content: m.content
-            }));
-
-            try {
-              const workflowRunnerMod = await import('../../tools/workflowRunner.js');
-
-              // Fire-and-forget: start workflow but don't await completion.
-              // The workflowRunner bridge streams step events and final output via SSE.
-              workflowRunnerMod
-                .default({
-                  workflowId: mentionedId,
-                  chatId,
-                  user: req.user,
-                  input: strippedInput,
-                  modelId,
-                  _chatHistory: chatHistory.length > 0 ? chatHistory : undefined,
-                  _fileData: fileData || imageData || undefined,
-                  language: clientLanguage
-                })
-                .catch(error => {
-                  logger.error('Error running @mention workflow', {
-                    component: 'sessionRoutes',
-                    error
-                  });
-                  actionTracker.trackError(chatId, {
-                    message: `Workflow execution failed: ${error.message}`
-                  });
-                });
-
-              // Return immediately — the SSE channel delivers all progress + final output
-              return res.json({ status: 'streaming', chatId });
-            } catch (error) {
-              logger.error('Error loading workflow runner', { component: 'sessionRoutes', error });
-              actionTracker.trackError(chatId, {
-                message: `Workflow execution failed: ${error.message}`
-              });
-              return res.json({ status: 'error', message: error.message });
-            }
-          }
+        const mentionResult = await tryHandleMentionWorkflow({
+          messages,
+          chatId,
+          modelId,
+          user: req.user,
+          clientLanguage
+        });
+        if (mentionResult.handled) {
+          return mentionResult.statusCode
+            ? res.status(mentionResult.statusCode).json(mentionResult.response)
+            : res.json(mentionResult.response);
         }
-        // --- end @mention detection ---
+
+        const chatRequestOptions = {
+          appId,
+          modelId,
+          messages,
+          temperature,
+          style,
+          outputFormat,
+          language: clientLanguage,
+          bypassAppPrompts,
+          thinkingEnabled,
+          thinkingBudget,
+          thinkingThoughts,
+          enabledTools,
+          websearchEnabled,
+          imageAspectRatio,
+          imageQuality,
+          requestedSkill,
+          documentIds,
+          user: req.user,
+          chatId
+        };
 
         if (!clients.has(chatId)) {
           logger.info('No active SSE connection, creating response without streaming', {
             component: 'sessionRoutes',
             chatId
           });
-          const prep = await chatService.prepareChatRequest({
-            appId,
-            modelId,
-            messages,
-            temperature,
-            style,
-            outputFormat,
-            language: clientLanguage,
-            bypassAppPrompts,
-            thinkingEnabled,
-            thinkingBudget,
-            thinkingThoughts,
-            enabledTools,
-            websearchEnabled,
-            imageAspectRatio,
-            imageQuality,
-            requestedSkill,
-            documentIds,
-            res,
-            user: req.user,
-            chatId
-          });
+          const prep = await chatService.prepareChatRequest({ ...chatRequestOptions, res });
           if (!prep.success) {
             const errMsg = await getLocalizedError(
               prep.error.code || 'internalError',
@@ -845,28 +761,7 @@ export default function registerSessionRoutes(
           const clientEntry = clients.get(chatId);
           const clientRes = clientEntry.response;
           clientEntry.lastActivity = new Date();
-          const prep = await chatService.prepareChatRequest({
-            appId,
-            modelId,
-            messages,
-            temperature,
-            style,
-            outputFormat,
-            language: clientLanguage,
-            bypassAppPrompts,
-            thinkingEnabled,
-            thinkingBudget,
-            thinkingThoughts,
-            enabledTools,
-            websearchEnabled,
-            imageAspectRatio,
-            imageQuality,
-            requestedSkill,
-            documentIds,
-            clientRes,
-            user: req.user,
-            chatId
-          });
+          const prep = await chatService.prepareChatRequest({ ...chatRequestOptions, clientRes });
           if (!prep.success) {
             const errMsg = await getLocalizedError(
               prep.error.code || 'internalError',

--- a/server/services/workflow/chatBridge.js
+++ b/server/services/workflow/chatBridge.js
@@ -17,6 +17,9 @@
  */
 
 import logger from '../../utils/logger.js';
+import configCache from '../../configCache.js';
+import { clients } from '../../sse.js';
+import { actionTracker } from '../../actionTracker.js';
 
 const PENDING_TTL_MS = 10 * 60 * 1000;
 const MAX_PENDING = 200;
@@ -125,4 +128,116 @@ export function buildReplayStepsFromState(state, workflow, language = 'en') {
   }
 
   return events;
+}
+
+/**
+ * Detect an `@workflow-name` mention in the last user message and, if it
+ * resolves to a chat-runnable workflow, dispatch it (fire-and-forget — the
+ * workflow streams its own progress/result over the chat's SSE channel).
+ *
+ * Returns `{ handled: true, response, statusCode? }` if the mention path
+ * fully handled the request (rejection or dispatch), or `{ handled: false }`
+ * to let the caller fall through to normal chat processing.
+ *
+ * @param {Object} params
+ * @param {Array}  params.messages - Full chat message history for this request.
+ * @param {string} params.chatId
+ * @param {string} params.modelId
+ * @param {Object} params.user
+ * @param {string} params.clientLanguage
+ */
+export async function tryHandleMentionWorkflow({
+  messages,
+  chatId,
+  modelId,
+  user,
+  clientLanguage
+}) {
+  const lastUserMsg = messages[messages.length - 1];
+  const lastUserContent = typeof lastUserMsg?.content === 'string' ? lastUserMsg.content : '';
+  const mentionMatch = lastUserContent.match(/@([\w.-]+)/);
+  if (!mentionMatch) return { handled: false };
+
+  const mentionedId = mentionMatch[1];
+  const mentionedWorkflow = configCache.getWorkflowById(mentionedId);
+  if (!mentionedWorkflow) return { handled: false };
+
+  const isDisabled = mentionedWorkflow.enabled === false;
+  const noChatIntegration = !mentionedWorkflow.chatIntegration?.enabled;
+
+  // If the user explicitly @-mentioned a workflow but it is not
+  // chat-runnable, refuse the message instead of falling through to
+  // the LLM (which would happily pick a *different* registered
+  // workflow tool — the @human → @auto switch users have seen).
+  if (isDisabled || noChatIntegration) {
+    const wfName =
+      (typeof mentionedWorkflow.name === 'object'
+        ? mentionedWorkflow.name[clientLanguage] || mentionedWorkflow.name.en
+        : mentionedWorkflow.name) || mentionedId;
+    const reason = isDisabled
+      ? `Workflow "${wfName}" is disabled.`
+      : `Workflow "${wfName}" is not configured for chat (chatIntegration.enabled is false).`;
+    actionTracker.trackError(chatId, { message: reason });
+    if (!clients.has(chatId)) {
+      return { handled: true, statusCode: 400, response: { status: 'error', message: reason } };
+    }
+    actionTracker.trackChunk(chatId, { content: reason });
+    actionTracker.trackDone(chatId, { finishReason: 'error' });
+    return { handled: true, response: { status: 'streaming', chatId } };
+  }
+
+  logger.info('@mention workflow triggered', {
+    component: 'ChatBridge',
+    workflowId: mentionedId,
+    chatId
+  });
+
+  // Strip the @mention from the input
+  const strippedInput = lastUserContent.replace(/@[\w.-]+/, '').trim();
+
+  // Collect file data from the last message
+  const fileData = lastUserMsg.fileData || null;
+  const imageData = lastUserMsg.imageData || null;
+
+  // Build chat history from all prior messages (excluding the last)
+  const chatHistory = messages.slice(0, -1).map(m => ({
+    role: m.role,
+    content: m.content
+  }));
+
+  try {
+    const workflowRunnerMod = await import('../../tools/workflowRunner.js');
+
+    // Fire-and-forget: start workflow but don't await completion.
+    // The workflowRunner bridge streams step events and final output via SSE.
+    workflowRunnerMod
+      .default({
+        workflowId: mentionedId,
+        chatId,
+        user,
+        input: strippedInput,
+        modelId,
+        _chatHistory: chatHistory.length > 0 ? chatHistory : undefined,
+        _fileData: fileData || imageData || undefined,
+        language: clientLanguage
+      })
+      .catch(error => {
+        logger.error('Error running @mention workflow', {
+          component: 'ChatBridge',
+          error
+        });
+        actionTracker.trackError(chatId, {
+          message: `Workflow execution failed: ${error.message}`
+        });
+      });
+
+    // Return immediately — the SSE channel delivers all progress + final output
+    return { handled: true, response: { status: 'streaming', chatId } };
+  } catch (error) {
+    logger.error('Error loading workflow runner', { component: 'ChatBridge', error });
+    actionTracker.trackError(chatId, {
+      message: `Workflow execution failed: ${error.message}`
+    });
+    return { handled: true, response: { status: 'error', message: error.message } };
+  }
 }

--- a/server/tests/chatBridge-mentionWorkflow.test.js
+++ b/server/tests/chatBridge-mentionWorkflow.test.js
@@ -1,0 +1,174 @@
+/**
+ * Unit tests for chatBridge.tryHandleMentionWorkflow — extracted from the
+ * POST /api/apps/:appId/chat/:chatId handler (routes/chat/sessionRoutes.js)
+ * so the @mention dispatch logic is testable without spinning up Express.
+ */
+
+import { jest } from '@jest/globals';
+
+const trackError = jest.fn();
+const trackChunk = jest.fn();
+const trackDone = jest.fn();
+const getWorkflowById = jest.fn();
+const clientsHas = jest.fn(() => false);
+const runWorkflow = jest.fn(async () => {});
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: { getWorkflowById }
+}));
+
+jest.unstable_mockModule('../sse.js', () => ({
+  clients: { has: clientsHas }
+}));
+
+jest.unstable_mockModule('../actionTracker.js', () => ({
+  actionTracker: { trackError, trackChunk, trackDone }
+}));
+
+jest.unstable_mockModule('../utils/logger.js', () => ({
+  default: { info: () => {}, error: () => {}, warn: () => {}, debug: () => {} }
+}));
+
+jest.unstable_mockModule('../tools/workflowRunner.js', () => ({
+  default: runWorkflow
+}));
+
+const { tryHandleMentionWorkflow } = await import('../services/workflow/chatBridge.js');
+
+function msg(content, extra = {}) {
+  return { role: 'user', content, ...extra };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clientsHas.mockReturnValue(false);
+});
+
+describe('tryHandleMentionWorkflow', () => {
+  it('falls through when the last message has no @mention', async () => {
+    const result = await tryHandleMentionWorkflow({
+      messages: [msg('hello there')],
+      chatId: 'c1',
+      modelId: 'm1',
+      user: { id: 'u1' },
+      clientLanguage: 'en'
+    });
+    expect(result).toEqual({ handled: false });
+    expect(getWorkflowById).not.toHaveBeenCalled();
+  });
+
+  it('falls through when the mention does not resolve to a known workflow', async () => {
+    getWorkflowById.mockReturnValue(undefined);
+    const result = await tryHandleMentionWorkflow({
+      messages: [msg('@unknown-workflow do the thing')],
+      chatId: 'c1',
+      modelId: 'm1',
+      user: { id: 'u1' },
+      clientLanguage: 'en'
+    });
+    expect(result).toEqual({ handled: false });
+    expect(getWorkflowById).toHaveBeenCalledWith('unknown-workflow');
+  });
+
+  it('rejects a disabled workflow with a 400 when there is no active SSE connection', async () => {
+    getWorkflowById.mockReturnValue({ enabled: false, name: 'My Flow', chatIntegration: {} });
+    clientsHas.mockReturnValue(false);
+
+    const result = await tryHandleMentionWorkflow({
+      messages: [msg('@my-flow go')],
+      chatId: 'c1',
+      modelId: 'm1',
+      user: { id: 'u1' },
+      clientLanguage: 'en'
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.statusCode).toBe(400);
+    expect(result.response).toEqual({
+      status: 'error',
+      message: 'Workflow "My Flow" is disabled.'
+    });
+    expect(trackError).toHaveBeenCalledWith('c1', { message: 'Workflow "My Flow" is disabled.' });
+    expect(runWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('rejects a workflow without chatIntegration via the streaming SSE path when a client is connected', async () => {
+    getWorkflowById.mockReturnValue({
+      enabled: true,
+      name: 'My Flow',
+      chatIntegration: { enabled: false }
+    });
+    clientsHas.mockReturnValue(true);
+
+    const result = await tryHandleMentionWorkflow({
+      messages: [msg('@my-flow go')],
+      chatId: 'c1',
+      modelId: 'm1',
+      user: { id: 'u1' },
+      clientLanguage: 'en'
+    });
+
+    expect(result.handled).toBe(true);
+    expect(result.statusCode).toBeUndefined();
+    expect(result.response).toEqual({ status: 'streaming', chatId: 'c1' });
+    expect(trackChunk).toHaveBeenCalledWith('c1', {
+      content: 'Workflow "My Flow" is not configured for chat (chatIntegration.enabled is false).'
+    });
+    expect(trackDone).toHaveBeenCalledWith('c1', { finishReason: 'error' });
+    expect(runWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('dispatches an enabled, chat-integrated workflow and strips the mention from the input', async () => {
+    getWorkflowById.mockReturnValue({ enabled: true, chatIntegration: { enabled: true } });
+
+    const result = await tryHandleMentionWorkflow({
+      messages: [msg('hi'), msg('@my-flow please summarize this')],
+      chatId: 'c1',
+      modelId: 'm1',
+      user: { id: 'u1' },
+      clientLanguage: 'en'
+    });
+
+    expect(result).toEqual({ handled: true, response: { status: 'streaming', chatId: 'c1' } });
+
+    // Fire-and-forget dispatch happens synchronously up to the await point.
+    await Promise.resolve();
+    expect(runWorkflow).toHaveBeenCalledWith({
+      workflowId: 'my-flow',
+      chatId: 'c1',
+      user: { id: 'u1' },
+      input: 'please summarize this',
+      modelId: 'm1',
+      _chatHistory: [{ role: 'user', content: 'hi' }],
+      _fileData: undefined,
+      language: 'en'
+    });
+  });
+
+  it('tracks an error and returns a handled error response when the workflow run rejects', async () => {
+    getWorkflowById.mockReturnValue({ enabled: true, chatIntegration: { enabled: true } });
+    let rejectRun;
+    runWorkflow.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectRun = reject;
+      })
+    );
+
+    const result = await tryHandleMentionWorkflow({
+      messages: [msg('@my-flow go')],
+      chatId: 'c1',
+      modelId: 'm1',
+      user: { id: 'u1' },
+      clientLanguage: 'en'
+    });
+
+    expect(result).toEqual({ handled: true, response: { status: 'streaming', chatId: 'c1' } });
+
+    rejectRun(new Error('boom'));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(trackError).toHaveBeenCalledWith('c1', {
+      message: 'Workflow execution failed: boom'
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1772.

The `POST /api/apps/:appId/chat/:chatId` handler in `server/routes/chat/sessionRoutes.js` mixed ~100 lines of `@mention` workflow business logic (detection, rejection, dynamic import + fire-and-forget dispatch of `workflowRunner`) with HTTP concerns, and built the same `prepareChatRequest` argument object twice — once for the non-streaming branch, once for the streaming branch — differing only in `res`/`clientRes`. This made the two branches easy to accidentally diverge and made the `@mention` flow untestable without spinning up Express.

- Extracted the `@mention` detection/dispatch block into `tryHandleMentionWorkflow()` in `server/services/workflow/chatBridge.js` (already the natural home — it bridges workflow execution to the chat SSE channel). It returns `{ handled: false }` to fall through to normal chat processing, or `{ handled: true, response, statusCode? }` for the route to relay back to the client.
- Built the shared `prepareChatRequest` options object (`chatRequestOptions`) once above the streaming/non-streaming branch, spreading in `res` or `clientRes` per branch instead of duplicating ~20 lines twice.
- No behavior change — same rejection messages, same status codes, same fire-and-forget dispatch semantics.

## Test plan

- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/chatBridge-mentionWorkflow.test.js` — 6 new unit tests covering: no mention, unknown workflow, disabled-workflow rejection (non-streaming 400), no-chatIntegration rejection (streaming SSE path), successful dispatch with mention-stripping, and workflow-runner rejection handling.
- [x] `npx eslint server/routes/chat/sessionRoutes.js server/services/workflow/chatBridge.js server/tests/chatBridge-mentionWorkflow.test.js` — clean.
- [x] `npx prettier --check` — clean.
- [x] `timeout 10s node server/server.js` — starts cleanly, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LjXDS63Pxq8qM1FCmrViS

---
_Generated by [Claude Code](https://claude.ai/code/session_012LjXDS63Pxq8qM1FCmrViS)_