### PR TITLE
perf(export): lazy-load docx/pptxgenjs/write-excel-file out of the eager bundle

### DIFF
--- a/client/src/api/endpoints/apps.js
+++ b/client/src/api/endpoints/apps.js
@@ -2,7 +2,7 @@ import { Marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { apiClient, streamingApiClient } from '../client';
 import { handleApiResponse } from '../utils/requestHandler';
-import { buildChatExportFilename, buildChatExportTitle } from '../../utils/exportFormats';
+import { buildChatExportFilename, buildChatExportTitle } from '../../utils/exportNaming';
 
 // Isolated marked instance for static exports (PDF/HTML). It intentionally does
 // NOT use the shared interactive markdown renderer, which injects toolbar

--- a/client/src/features/chat/components/ExportDialog.jsx
+++ b/client/src/features/chat/components/ExportDialog.jsx
@@ -3,13 +3,6 @@ import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
 import useFocusTrap from '../../../shared/hooks/useFocusTrap';
 import { exportChatToFormat } from '../../../api/endpoints/apps';
-import {
-  exportToXLSX,
-  exportToCSV,
-  exportToDOCX,
-  exportToTXT,
-  exportToPPTX
-} from '../../../utils/exportFormats';
 import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import useFeatureFlags from '../../../shared/hooks/useFeatureFlags';
@@ -220,7 +213,8 @@ function ExportDialog({
         case 'html':
           await exportChatToFormat(filteredMessages, exportSettings, 'html', options);
           break;
-        case 'xlsx':
+        case 'xlsx': {
+          const { exportToXLSX } = await import('../../../utils/exportFormats');
           await exportToXLSX(
             filteredMessages,
             exportSettings,
@@ -230,7 +224,9 @@ function ExportDialog({
             isSingleMessage
           );
           break;
-        case 'csv':
+        }
+        case 'csv': {
+          const { exportToCSV } = await import('../../../utils/exportFormats');
           await exportToCSV(
             filteredMessages,
             exportSettings,
@@ -240,7 +236,9 @@ function ExportDialog({
             isSingleMessage
           );
           break;
-        case 'docx':
+        }
+        case 'docx': {
+          const { exportToDOCX } = await import('../../../utils/exportFormats');
           await exportToDOCX(
             filteredMessages,
             exportSettings,
@@ -250,7 +248,9 @@ function ExportDialog({
             isSingleMessage
           );
           break;
-        case 'txt':
+        }
+        case 'txt': {
+          const { exportToTXT } = await import('../../../utils/exportFormats');
           await exportToTXT(
             filteredMessages,
             exportSettings,
@@ -260,7 +260,9 @@ function ExportDialog({
             isSingleMessage
           );
           break;
-        case 'pptx':
+        }
+        case 'pptx': {
+          const { exportToPPTX } = await import('../../../utils/exportFormats');
           await exportToPPTX(
             filteredMessages,
             exportSettings,
@@ -270,6 +272,7 @@ function ExportDialog({
             isSingleMessage
           );
           break;
+        }
         default:
           throw new Error(`Unsupported format: ${selectedFormat}`);
       }

--- a/client/src/utils/exportFormats.js
+++ b/client/src/utils/exportFormats.js
@@ -1,135 +1,25 @@
-import writeXlsxFile from 'write-excel-file';
-import { Document, Paragraph, TextRun, HeadingLevel, Table, TableRow, TableCell } from 'docx';
-import PptxGenJS from 'pptxgenjs';
+// docx/pptxgenjs/write-excel-file are heavy and only needed when a user
+// actually exports to one of those formats — they're dynamically imported
+// inside the exportTo* functions below instead of statically here, so this
+// module (and everything that imports it) doesn't pull them into the eager
+// bundle. Filename/title helpers live in exportNaming.js, which has no heavy
+// deps, so callers that only need those (e.g. api/endpoints/apps.js) can
+// import from there directly.
+export {
+  sanitizeForSpreadsheet,
+  slugifyForFilename,
+  getChatTopicSlug,
+  formatDateTimeForFilename,
+  formatDateTimeForTitle,
+  buildChatExportFilename,
+  buildChatExportTitle
+} from './exportNaming';
 
-/**
- * Filename- and title-building helpers shared by all chat export formats.
- *
- * Goal: replace generic "chat-export-2026-06-09T15-30-00.xlsx" filenames
- * and "Chat Export - iHub Apps" document titles with something meaningful
- * — the app name, a topic slug derived from the first user message, and a
- * readable date.
- */
-
-/**
- * Neutralize spreadsheet formula injection (OWASP CSV injection guidance).
- * Values starting with =, +, -, @, tab, or CR are interpreted as formulas by
- * Excel/LibreOffice; prefixing with a single quote forces them to render as
- * plain text instead of executing.
- */
-export const sanitizeForSpreadsheet = value => {
-  if (value === null || value === undefined) return '';
-  const stringValue = String(value);
-  return /^[=+\-@\t\r]/.test(stringValue) ? `'${stringValue}` : stringValue;
-};
-
-/** Strip markdown noise, collapse whitespace, ASCII-kebab-case, cap length. */
-export const slugifyForFilename = (text, maxChars = 40) => {
-  if (!text || typeof text !== 'string') return '';
-  return text
-    .replace(/```[\s\S]*?```/g, ' ') // drop fenced code
-    .replace(/`[^`]*`/g, ' ') // drop inline code
-    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // drop images
-    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // unwrap links
-    .replace(/[*_~#>]/g, ' ') // drop markdown markers
-    .normalize('NFKD')
-    .replace(/[̀-ͯ]/g, '') // strip accents
-    .replace(/[^a-zA-Z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-    .toLowerCase()
-    .slice(0, maxChars)
-    .replace(/-+$/, '');
-};
-
-/**
- * Derive a short topic slug from the first non-greeting user message.
- * Returns '' when the chat has no user content to summarize from.
- */
-export const getChatTopicSlug = messages => {
-  if (!Array.isArray(messages)) return '';
-  const firstUser = messages.find(m => m && m.role === 'user' && !m.isGreeting && m.content);
-  if (!firstUser) return '';
-  return slugifyForFilename(firstUser.content, 40);
-};
-
-const pad2 = n => String(n).padStart(2, '0');
-
-/** `2026-06-09_1530` — filesystem-safe, sortable. */
-export const formatDateTimeForFilename = (date = new Date()) =>
-  `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}_` +
-  `${pad2(date.getHours())}${pad2(date.getMinutes())}`;
-
-/** `2026-06-09 15:30` — human-readable, used in document titles. */
-export const formatDateTimeForTitle = (date = new Date()) =>
-  `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ` +
-  `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
-
-/**
- * Build a descriptive download filename.
- *
- *   Full chat with topic:  `sales-assistant-pricing-discussion-2026-06-09_1530.docx`
- *   Full chat, no topic:   `sales-assistant-chat-2026-06-09_1530.docx`
- *   Single message:        `sales-assistant-message-2026-06-09_1530.docx`
- *   No app context:        `chat-2026-06-09_1530.docx`
- */
-export const buildChatExportFilename = ({
-  format,
-  appName,
-  appId,
-  messages,
-  isSingleMessage = false,
-  date = new Date()
-}) => {
-  const ext = (format || '').toLowerCase();
-  const appSlug = slugifyForFilename(appId || appName || '', 30);
-  const dateStr = formatDateTimeForFilename(date);
-
-  let middle;
-  if (isSingleMessage) {
-    middle = 'message';
-  } else {
-    const topic = getChatTopicSlug(messages);
-    middle = topic || 'chat';
-  }
-
-  const parts = [appSlug, middle, dateStr].filter(Boolean);
-  return `${parts.join('-')}.${ext}`;
-};
-
-/**
- * Build a descriptive in-document title.
- *
- *   `Sales Assistant — Pricing Discussion (2026-06-09 15:30)`
- *   `Sales Assistant — Message (2026-06-09 15:30)`
- *   `Sales Assistant — Chat (2026-06-09 15:30)`
- */
-export const buildChatExportTitle = ({
-  appName,
-  messages,
-  isSingleMessage = false,
-  date = new Date()
-}) => {
-  const dateStr = formatDateTimeForTitle(date);
-  const app = appName || 'iHub Apps';
-
-  if (isSingleMessage) return `${app} — Message (${dateStr})`;
-
-  // Use the first user message as a short topic — capitalize words, cap length.
-  const firstUser = Array.isArray(messages)
-    ? messages.find(m => m && m.role === 'user' && !m.isGreeting && m.content)
-    : null;
-  if (firstUser?.content) {
-    const topic = firstUser.content
-      .replace(/```[\s\S]*?```/g, ' ')
-      .replace(/`[^`]*`/g, ' ')
-      .replace(/[*_~#>]/g, ' ')
-      .replace(/\s+/g, ' ')
-      .trim()
-      .slice(0, 60);
-    if (topic) return `${app} — ${topic} (${dateStr})`;
-  }
-  return `${app} — Chat (${dateStr})`;
-};
+import {
+  buildChatExportFilename,
+  buildChatExportTitle,
+  sanitizeForSpreadsheet
+} from './exportNaming';
 
 /**
  * Parse inline markdown formatting (bold, italic, code) within a text line
@@ -386,7 +276,8 @@ const parseMarkdown = content => {
 /**
  * Convert parsed markdown blocks to DOCX paragraphs
  */
-const markdownToDOCX = blocks => {
+const markdownToDOCX = (docxLib, blocks) => {
+  const { Paragraph, TextRun, HeadingLevel, Table, TableRow, TableCell } = docxLib;
   const paragraphs = [];
 
   blocks.forEach(block => {
@@ -700,6 +591,7 @@ export const exportToXLSX = async (
   const columns = [{ width: 15 }, { width: 20 }, { width: 80 }];
 
   // Write XLSX file
+  const { default: writeXlsxFile } = await import('write-excel-file');
   await writeXlsxFile(data, {
     columns,
     fileName: filename
@@ -794,6 +686,10 @@ export const exportToDOCX = async (
   });
   const docTitle = buildChatExportTitle({ appName, messages, isSingleMessage });
 
+  const docxLib = await import('docx');
+  const { Document, Paragraph, TextRun, HeadingLevel, Packer, AlignmentType, convertInchesToTwip } =
+    docxLib;
+
   const children = [];
 
   // Add title
@@ -861,7 +757,7 @@ export const exportToDOCX = async (
 
     // Parse markdown and convert to DOCX paragraphs
     const blocks = parseMarkdown(content);
-    const parsedParagraphs = markdownToDOCX(blocks);
+    const parsedParagraphs = markdownToDOCX(docxLib, blocks);
     children.push(...parsedParagraphs);
 
     children.push(new Paragraph({ text: '' }));
@@ -916,7 +812,6 @@ export const exportToDOCX = async (
   }
 
   // Create document with proper numbering support
-  const { AlignmentType, convertInchesToTwip } = await import('docx');
   const doc = new Document({
     numbering: {
       config: [
@@ -946,7 +841,6 @@ export const exportToDOCX = async (
   });
 
   // Use docx Packer to generate blob
-  const { Packer } = await import('docx');
   const blob = await Packer.toBlob(doc);
 
   // Download file
@@ -1044,6 +938,7 @@ export const exportToPPTX = async (
   });
   const docTitle = buildChatExportTitle({ appName, messages, isSingleMessage });
 
+  const { default: PptxGenJS } = await import('pptxgenjs');
   const pres = new PptxGenJS();
 
   // Title slide

--- a/client/src/utils/exportFormats.test.js
+++ b/client/src/utils/exportFormats.test.js
@@ -12,7 +12,7 @@
  * Run directly: `node client/src/utils/exportFormats.test.js`.
  */
 
-import { sanitizeForSpreadsheet } from './exportFormats.js';
+import { sanitizeForSpreadsheet } from './exportNaming.js';
 
 let failures = 0;
 function check(label, cond, details) {

--- a/client/src/utils/exportNaming.js
+++ b/client/src/utils/exportNaming.js
@@ -1,0 +1,133 @@
+/**
+ * Filename- and title-building helpers shared by all chat export formats.
+ *
+ * Goal: replace generic "chat-export-2026-06-09T15-30-00.xlsx" filenames
+ * and "Chat Export - iHub Apps" document titles with something meaningful
+ * — the app name, a topic slug derived from the first user message, and a
+ * readable date.
+ *
+ * Kept in its own module (no heavy export-library deps) so callers that only
+ * need filenames/titles — e.g. the PDF/JSON/HTML export helpers in
+ * api/endpoints/apps.js — don't pull docx/pptxgenjs/write-excel-file into
+ * their dependency graph.
+ */
+
+/**
+ * Neutralize spreadsheet formula injection (OWASP CSV injection guidance).
+ * Values starting with =, +, -, @, tab, or CR are interpreted as formulas by
+ * Excel/LibreOffice; prefixing with a single quote forces them to render as
+ * plain text instead of executing.
+ */
+export const sanitizeForSpreadsheet = value => {
+  if (value === null || value === undefined) return '';
+  const stringValue = String(value);
+  return /^[=+\-@\t\r]/.test(stringValue) ? `'${stringValue}` : stringValue;
+};
+
+/** Strip markdown noise, collapse whitespace, ASCII-kebab-case, cap length. */
+export const slugifyForFilename = (text, maxChars = 40) => {
+  if (!text || typeof text !== 'string') return '';
+  return text
+    .replace(/```[\s\S]*?```/g, ' ') // drop fenced code
+    .replace(/`[^`]*`/g, ' ') // drop inline code
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ') // drop images
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // unwrap links
+    .replace(/[*_~#>]/g, ' ') // drop markdown markers
+    .normalize('NFKD')
+    .replace(/[̀-ͯ]/g, '') // strip accents
+    .replace(/[^a-zA-Z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+    .slice(0, maxChars)
+    .replace(/-+$/, '');
+};
+
+/**
+ * Derive a short topic slug from the first non-greeting user message.
+ * Returns '' when the chat has no user content to summarize from.
+ */
+export const getChatTopicSlug = messages => {
+  if (!Array.isArray(messages)) return '';
+  const firstUser = messages.find(m => m && m.role === 'user' && !m.isGreeting && m.content);
+  if (!firstUser) return '';
+  return slugifyForFilename(firstUser.content, 40);
+};
+
+const pad2 = n => String(n).padStart(2, '0');
+
+/** `2026-06-09_1530` — filesystem-safe, sortable. */
+export const formatDateTimeForFilename = (date = new Date()) =>
+  `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}_` +
+  `${pad2(date.getHours())}${pad2(date.getMinutes())}`;
+
+/** `2026-06-09 15:30` — human-readable, used in document titles. */
+export const formatDateTimeForTitle = (date = new Date()) =>
+  `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())} ` +
+  `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+
+/**
+ * Build a descriptive download filename.
+ *
+ *   Full chat with topic:  `sales-assistant-pricing-discussion-2026-06-09_1530.docx`
+ *   Full chat, no topic:   `sales-assistant-chat-2026-06-09_1530.docx`
+ *   Single message:        `sales-assistant-message-2026-06-09_1530.docx`
+ *   No app context:        `chat-2026-06-09_1530.docx`
+ */
+export const buildChatExportFilename = ({
+  format,
+  appName,
+  appId,
+  messages,
+  isSingleMessage = false,
+  date = new Date()
+}) => {
+  const ext = (format || '').toLowerCase();
+  const appSlug = slugifyForFilename(appId || appName || '', 30);
+  const dateStr = formatDateTimeForFilename(date);
+
+  let middle;
+  if (isSingleMessage) {
+    middle = 'message';
+  } else {
+    const topic = getChatTopicSlug(messages);
+    middle = topic || 'chat';
+  }
+
+  const parts = [appSlug, middle, dateStr].filter(Boolean);
+  return `${parts.join('-')}.${ext}`;
+};
+
+/**
+ * Build a descriptive in-document title.
+ *
+ *   `Sales Assistant — Pricing Discussion (2026-06-09 15:30)`
+ *   `Sales Assistant — Message (2026-06-09 15:30)`
+ *   `Sales Assistant — Chat (2026-06-09 15:30)`
+ */
+export const buildChatExportTitle = ({
+  appName,
+  messages,
+  isSingleMessage = false,
+  date = new Date()
+}) => {
+  const dateStr = formatDateTimeForTitle(date);
+  const app = appName || 'iHub Apps';
+
+  if (isSingleMessage) return `${app} — Message (${dateStr})`;
+
+  // Use the first user message as a short topic — capitalize words, cap length.
+  const firstUser = Array.isArray(messages)
+    ? messages.find(m => m && m.role === 'user' && !m.isGreeting && m.content)
+    : null;
+  if (firstUser?.content) {
+    const topic = firstUser.content
+      .replace(/```[\s\S]*?```/g, ' ')
+      .replace(/`[^`]*`/g, ' ')
+      .replace(/[*_~#>]/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 60);
+    if (topic) return `${app} — ${topic} (${dateStr})`;
+  }
+  return `${app} — Chat (${dateStr})`;
+};


### PR DESCRIPTION
## Summary

Fixes #1770.

`client/src/utils/exportFormats.js` statically imported `docx`, `pptxgenjs`, and `write-excel-file` at module top. That module was pulled into the eager bundle two ways:
- `ExportDialog.jsx` statically imported the `exportTo*` functions from it.
- `api/endpoints/apps.js` statically imported `buildChatExportFilename`/`buildChatExportTitle` from it (for PDF/JSON/HTML export filenames, which don't need the heavy libs at all).

So every user downloaded ~800KB of export libraries on initial page load, even though they're only exercised by the minority who open the export dialog and pick a binary format.

### Changes
- Added `client/src/utils/exportNaming.js` containing the dependency-free filename/title helpers (`sanitizeForSpreadsheet`, `slugifyForFilename`, `getChatTopicSlug`, `formatDateTimeForFilename`, `formatDateTimeForTitle`, `buildChatExportFilename`, `buildChatExportTitle`).
- `exportFormats.js` now re-exports those from `exportNaming.js` (no behavior change for existing callers) and dynamically imports `docx`, `pptxgenjs`, and `write-excel-file` only inside the `exportToDOCX`/`exportToPPTX`/`exportToXLSX` functions that need them. `markdownToDOCX` now takes the resolved `docx` module as a parameter instead of relying on a module-level import.
- `api/endpoints/apps.js` now imports `buildChatExportFilename`/`buildChatExportTitle` from `exportNaming.js` directly, so it no longer statically pulls in `exportFormats.js`.
- `ExportDialog.jsx` now dynamically imports `exportFormats.js` per format inside `handleExport`, so nothing in the app statically imports it anymore — Vite/Rollup code-splits it and its heavy deps into on-demand chunks.
- Updated `exportFormats.test.js` to import `sanitizeForSpreadsheet` from the new `exportNaming.js`.

### Note on the `xlsx` dependency
The issue also claimed the `xlsx` (SheetJS) package was a dead dependency with known CVEs, based on `grep -rn "from 'xlsx'" client/` returning nothing. That grep pattern doesn't catch dynamic imports — `xlsx` is actually used via `await import('xlsx')` in `client/src/features/upload/utils/fileProcessing.js` (`loadXlsx()`) to parse uploaded spreadsheet files, separate from `write-excel-file` which is used for chat exports. It's already lazy-loaded and already has its own manual chunk in `vite.config.js`, so no change was needed there — left `package.json`, `package-lock.json`, and `vite.config.js` untouched.

## Verification
- `node client/src/utils/exportFormats.test.js` — all checks pass.
- `npm run build` (client) — confirmed `docx`/`pptxgenjs`/`write-excel-file` no longer appear in `main-*.js`; each now lands in its own on-demand chunk (`write-excel-file-*.js`, `pptxgen.es-*.js`, and `docx` inside the dynamically-loaded `exportFormats` chunk graph).
- `npm run lint:fix` — no new errors (pre-existing warnings only, none introduced by this change).

## Test plan
- [ ] Open the export dialog for a chat and export to DOCX — confirm the download works.
- [ ] Export to XLSX and PPTX — confirm both downloads work correctly.
- [ ] Upload an `.xlsx` file in the chat upload flow — confirm it's still parsed correctly (unaffected by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016y73tdyXcimVRXS6WvJYkb

---
_Generated by [Claude Code](https://claude.ai/code/session_016y73tdyXcimVRXS6WvJYkb)_