### PR TITLE
fix: add Dependabot coverage for client/server/nextcloud-app and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,83 @@ updates:
       all-minors:
         update-types:
           - "minor"
+
+  - package-ecosystem: 'npm'
+    directory: '/client'
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
+    groups:
+      all-patches:
+        update-types:
+          - "patch"
+      all-minors:
+        update-types:
+          - "minor"
+
+  - package-ecosystem: 'npm'
+    directory: '/server'
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
+    groups:
+      all-patches:
+        update-types:
+          - "patch"
+      all-minors:
+        update-types:
+          - "minor"
+
+  - package-ecosystem: 'npm'
+    directory: '/nextcloud-app'
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
+    groups:
+      all-patches:
+        update-types:
+          - "patch"
+      all-minors:
+        update-types:
+          - "minor"
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Berlin"
+    cooldown:
+      default-days: 3
+      semver-major-days: 7
+      semver-minor-days: 5
+      semver-patch-days: 3
+    groups:
+      all-patches:
+        update-types:
+          - "patch"
+      all-minors:
+        update-types:
+          - "minor"


### PR DESCRIPTION
## Summary

- `.github/dependabot.yml` previously declared a single `npm` ecosystem entry watching only the root manifest (`directory: '/'`). Since shipped code lives in `client/`, `server/`, and `nextcloud-app/` with their own `package.json` files, Dependabot never opened PRs against the manifests that actually determine what ships.
- Added three more `npm` entries (`/client`, `/server`, `/nextcloud-app`), each mirroring the existing root schedule/cooldown/grouping config.
- Added a `github-actions` ecosystem entry (`directory: '/'`) so workflow action versions (used across the 12 workflow files in `.github/workflows/`) get tracked too.

## Notes

- Root `package.json`'s `dependencies` is already empty (`{}`), so there were no client-only duplicate libs left to remove from root as originally described in the issue — that part of the evidence was stale by the time this was picked up.
- One remaining root/client divergence (`devDependencies.axios` at root vs `dependencies.axios` in `client/package.json`) looks like it may be intentional (root tooling scripts vs. shipped client code), so it was left untouched rather than assumed to be a bug — flagging for the repo owner to confirm separately if it needs consolidating.
- `browser-extension/` has no `package.json` (just `manifest.json`/`background.js`), so it needs no ecosystem entry.

Fixes #1766

## Test plan

- [x] Validated the updated `.github/dependabot.yml` parses as valid YAML (`yaml.safe_load`)
- [x] Confirmed `npx prettier --check .github/dependabot.yml` passes
- [ ] After merge, confirm in repo Insights → Dependency graph → Dependabot that 4 npm entries + 1 github-actions entry are recognized

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eKQi2YLtvpT8jz1NvsVsQ


---
_Generated by [Claude Code](https://claude.ai/code/session_018eKQi2YLtvpT8jz1NvsVsQ)_