### PR TITLE
fix: resolve all contents-directory paths through CONTENTS_DIR

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -389,6 +389,22 @@ trapped the page in an endless reload loop.
   Apps, Prompts, and Sources — the platform-only sections and stats they cannot access are hidden.
 - No admin action is required — the fix takes effect automatically on upgrade.
 
+## Admin Edits Now Always Target the Configured `CONTENTS_DIR`
+
+Deployments that set a custom `CONTENTS_DIR` (documented for subpath/custom-storage
+installations) could silently have admin saves, deletes, and backups write to the default
+`contents/` folder instead of the configured directory, while the running server kept reading
+from the correct location. The admin UI reported success, but nothing actually changed for the
+running server.
+
+- All admin routes (apps, models, prompts, groups, users, platform config, sources, tools,
+  workflows, credentials, MCP servers, pages, and more) now resolve paths through a single
+  shared helper that always honors `CONTENTS_DIR`.
+- Configuration backup/export and import now target the same directory the server actually
+  serves from, instead of a hardcoded `contents/` path.
+- No action is required for the default setup (`CONTENTS_DIR` unset); this only affects
+  deployments that explicitly set a custom `CONTENTS_DIR`.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/server/agents/inbox/inboxStore.js
+++ b/server/agents/inbox/inboxStore.js
@@ -18,7 +18,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteFile } from '../../utils/atomicWrite.js';
 import { resolveAndValidatePath } from '../../utils/pathSecurity.js';
 import logger from '../../utils/logger.js';
@@ -27,7 +27,7 @@ import { INBOX_ID_PATTERN } from '../../validators/agentInboxSchema.js';
 const INBOX_DIR = 'data/agent-inboxes';
 
 function inboxBaseDir() {
-  return path.join(getRootDir(), 'contents', INBOX_DIR);
+  return getContentsPath(INBOX_DIR);
 }
 
 // Validate inboxId with a strict regex, run through path.basename (a
@@ -79,7 +79,7 @@ function parseChecklistLine(line) {
 }
 
 export async function listInboxes() {
-  const dir = path.join(getRootDir(), 'contents', INBOX_DIR);
+  const dir = inboxBaseDir();
   try {
     const entries = await fs.readdir(dir);
     const inboxes = [];

--- a/server/agents/memory/memoryFile.js
+++ b/server/agents/memory/memoryFile.js
@@ -11,7 +11,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteFile } from '../../utils/atomicWrite.js';
 import { resolveAndValidatePath } from '../../utils/pathSecurity.js';
 import logger from '../../utils/logger.js';
@@ -20,7 +20,7 @@ import { AGENT_PROFILE_ID_PATTERN } from '../../validators/agentProfileSchema.js
 const MEMORY_DIR = 'agents/memory';
 
 function memoryBaseDir() {
-  return path.join(getRootDir(), 'contents', MEMORY_DIR);
+  return getContentsPath(MEMORY_DIR);
 }
 
 // Validate the profile id with a strict regex, run it through `path.basename`

--- a/server/agents/runtime/artifactStore.js
+++ b/server/agents/runtime/artifactStore.js
@@ -11,7 +11,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteFile } from '../../utils/atomicWrite.js';
 import { isValidId, resolveAndValidatePath } from '../../utils/pathSecurity.js';
 import { createSseEmitter } from '../../utils/sseEmitter.js';
@@ -71,7 +71,7 @@ async function resolveRunDir(rawRunId) {
   if (safeRunId !== rawRunId) {
     throw new Error(`writeArtifact: invalid runId: ${rawRunId}`);
   }
-  const artifactsRoot = path.join(getRootDir(), 'contents', 'data', 'agent-artifacts');
+  const artifactsRoot = getContentsPath('data', 'agent-artifacts');
   await fs.mkdir(artifactsRoot, { recursive: true });
   const dir = await resolveAndValidatePath(safeRunId, artifactsRoot);
   if (!dir) {

--- a/server/pathUtils.js
+++ b/server/pathUtils.js
@@ -11,3 +11,11 @@ export function getRootDir() {
     ? config.APP_ROOT_DIR || path.dirname(process.execPath)
     : path.join(__dirname, '..');
 }
+
+export function getContentsDir() {
+  return path.join(getRootDir(), config.CONTENTS_DIR);
+}
+
+export function getContentsPath(...segments) {
+  return path.join(getContentsDir(), ...segments);
+}

--- a/server/renderersLoader.js
+++ b/server/renderersLoader.js
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { getRootDir } from './pathUtils.js';
+import { getRootDir, getContentsPath } from './pathUtils.js';
 import logger from './utils/logger.js';
 
 /**
@@ -97,7 +97,7 @@ export async function loadAllRenderers(verbose = true) {
   const defaultRenderers = await loadRenderersFromDirectory(defaultsPath, 'defaults', verbose);
 
   // Load from contents directory (create if doesn't exist)
-  const contentsPath = join(rootDir, 'contents', 'renderers');
+  const contentsPath = getContentsPath('renderers');
 
   // Ensure contents/renderers directory exists
   if (!existsSync(contentsPath)) {

--- a/server/routes/admin/apps.js
+++ b/server/routes/admin/apps.js
@@ -1,7 +1,7 @@
 import { readFileSync } from 'fs';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { contentAdminAuth } from '../../middleware/contentAdminAuth.js';
@@ -608,8 +608,7 @@ export default function registerAdminAppsRoutes(app) {
         return sendBadRequest(res, 'App ID cannot be changed');
       }
 
-      const rootDir = getRootDir();
-      const appsDir = join(rootDir, 'contents', 'apps');
+      const appsDir = getContentsPath('apps');
       // Ensure directory exists before writing
       await fs.mkdir(appsDir, { recursive: true });
       // Find the actual file for this app ID (may not match ${appId}.json)
@@ -732,8 +731,7 @@ export default function registerAdminAppsRoutes(app) {
         return;
       }
 
-      const rootDir = getRootDir();
-      const appsDir = join(rootDir, 'contents', 'apps');
+      const appsDir = getContentsPath('apps');
       // Check for duplicate ID via configCache (covers filenames that differ from their ID)
       const { data: existingApps } = configCache.getApps(true);
       if (existingApps.some(a => a.id === newApp.id)) {
@@ -830,8 +828,7 @@ export default function registerAdminAppsRoutes(app) {
       }
       const newEnabledState = !app.enabled;
       app.enabled = newEnabledState;
-      const rootDir = getRootDir();
-      const appsDir = join(rootDir, 'contents', 'apps');
+      const appsDir = getContentsPath('apps');
       // Ensure directory exists before writing
       await fs.mkdir(appsDir, { recursive: true });
       // Find the actual file for this app ID (may not match ${appId}.json)
@@ -946,8 +943,7 @@ export default function registerAdminAppsRoutes(app) {
 
         const { data: apps } = configCache.getApps(true);
         const resolvedIds = ids.includes('*') ? apps.map(a => a.id) : ids;
-        const rootDir = getRootDir();
-        const appsDir = join(rootDir, 'contents', 'apps');
+        const appsDir = getContentsPath('apps');
         // Ensure directory exists before writing
         await fs.mkdir(appsDir, { recursive: true });
 
@@ -1049,8 +1045,7 @@ export default function registerAdminAppsRoutes(app) {
         return;
       }
 
-      const rootDir = getRootDir();
-      const appsDir = join(rootDir, 'contents', 'apps');
+      const appsDir = getContentsPath('apps');
       const filename = await findAppFile(appId, appsDir);
       if (!filename) {
         return sendNotFound(res, 'App');

--- a/server/routes/admin/auditLog.js
+++ b/server/routes/admin/auditLog.js
@@ -11,8 +11,7 @@ import { buildCsv } from '../../utils/csv.js';
 import configCache from '../../configCache.js';
 import logger from '../../utils/logger.js';
 import { promises as fs } from 'fs';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 
 // Accept the platform.json shape exactly: false (off), true (mask),
@@ -200,9 +199,7 @@ export default function registerAdminAuditLogRoutes(app) {
         );
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
+      const platformPath = getContentsPath('config', 'platform.json');
 
       const platformContent = await fs.readFile(platformPath, 'utf8');
       const platformConfig = JSON.parse(platformContent);

--- a/server/routes/admin/auth.js
+++ b/server/routes/admin/auth.js
@@ -1,6 +1,5 @@
 import { promises as fs } from 'fs';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth, isAdminAuthRequired } from '../../middleware/adminAuth.js';
@@ -252,8 +251,7 @@ export default function registerAdminAuthRoutes(app) {
    */
   app.get(buildServerPath('/api/admin/auth/users'), adminAuth, async (req, res) => {
     try {
-      const rootDir = getRootDir();
-      const usersFilePath = join(rootDir, 'contents', 'config', 'users.json');
+      const usersFilePath = getContentsPath('config', 'users.json');
 
       let usersData = { users: {}, metadata: {} };
       try {
@@ -370,8 +368,7 @@ export default function registerAdminAuthRoutes(app) {
         return sendBadRequest(res, 'Password must be at least 6 characters long');
       }
 
-      const rootDir = getRootDir();
-      const usersFilePath = join(rootDir, 'contents', 'config', 'users.json');
+      const usersFilePath = getContentsPath('config', 'users.json');
 
       // Load existing users
       let usersData = { users: {}, metadata: {} };
@@ -525,8 +522,7 @@ export default function registerAdminAuthRoutes(app) {
 
       const { email, name, password, internalGroups, active } = req.body;
 
-      const rootDir = getRootDir();
-      const usersFilePath = join(rootDir, 'contents', 'config', 'users.json');
+      const usersFilePath = getContentsPath('config', 'users.json');
 
       // Load existing users
       let usersData = { users: {}, metadata: {} };
@@ -638,8 +634,7 @@ export default function registerAdminAuthRoutes(app) {
         return;
       }
 
-      const rootDir = getRootDir();
-      const usersFilePath = join(rootDir, 'contents', 'config', 'users.json');
+      const usersFilePath = getContentsPath('config', 'users.json');
 
       // Load existing users
       let usersData = { users: {}, metadata: {} };

--- a/server/routes/admin/backup.js
+++ b/server/routes/admin/backup.js
@@ -3,8 +3,6 @@ import fs from 'fs/promises';
 import { createWriteStream } from 'fs';
 import archiver from 'archiver';
 import yauzl from 'yauzl';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
@@ -13,12 +11,10 @@ import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 import { runConfigMigrations } from '../../migrations/runner.js';
 import { logAudit } from '../../services/AuditLogService.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
+import { getContentsPath } from '../../pathUtils.js';
 
 // Define the contents directory path
-const contentsPath = path.join(__dirname, '../../../contents');
+const contentsPath = getContentsPath();
 
 /**
  * Get all files recursively from a directory

--- a/server/routes/admin/browserExtension.js
+++ b/server/routes/admin/browserExtension.js
@@ -2,7 +2,7 @@ import { join } from 'path';
 import { promises as fs } from 'fs';
 import archiver from 'archiver';
 import config from '../../config.js';
-import { getRootDir } from '../../pathUtils.js';
+import { getRootDir, getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
@@ -31,12 +31,11 @@ import { sendInternalError, sendBadRequest, sendNotFound } from '../../utils/res
 const SIGNING_KEY_FILE = '.browser-extension-key.pem';
 
 function signingKeyPath() {
-  return join(getRootDir(), 'contents', SIGNING_KEY_FILE);
+  return getContentsPath(SIGNING_KEY_FILE);
 }
 
 async function savePlatformConfig(updates) {
-  const rootDir = getRootDir();
-  const platformConfigPath = join(rootDir, 'contents', 'config', 'platform.json');
+  const platformConfigPath = getContentsPath('config', 'platform.json');
   const existing = configCache.getPlatform() || {};
   const merged = { ...existing, ...updates };
   await atomicWriteJSON(platformConfigPath, merged);

--- a/server/routes/admin/cache.js
+++ b/server/routes/admin/cache.js
@@ -1,6 +1,5 @@
 import { promises as fs } from 'fs';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { getUsage } from '../../usageTracker.js';
@@ -60,8 +59,7 @@ export default function registerAdminCacheRoutes(app) {
 
   app.post(buildServerPath('/api/admin/client/_refresh'), adminAuth, async (req, res) => {
     try {
-      const rootDir = getRootDir();
-      const platformConfigPath = join(rootDir, 'contents', 'config', 'platform.json');
+      const platformConfigPath = getContentsPath('config', 'platform.json');
       const platformConfigData = await fs.readFile(platformConfigPath, 'utf8');
       const platformConfig = JSON.parse(platformConfigData);
       if (!platformConfig.refreshSalt) {

--- a/server/routes/admin/changes.js
+++ b/server/routes/admin/changes.js
@@ -5,8 +5,7 @@ import { sendNotFound, sendBadRequest, sendInternalError } from '../../utils/res
 import { validateIdForPath } from '../../utils/pathSecurity.js';
 import configCache from '../../configCache.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { logAudit } from '../../services/AuditLogService.js';
 import logger from '../../utils/logger.js';
 
@@ -97,31 +96,30 @@ export default function registerAdminChangesRoutes(app) {
           return sendNotFound(res, 'Snapshot or before state');
         }
 
-        const rootDir = getRootDir();
         const beforeState = snapshot.before;
 
         // Rollback based on resource type
         switch (resource) {
           case 'app': {
-            const appFilePath = join(rootDir, 'contents', 'apps', `${id}.json`);
+            const appFilePath = getContentsPath('apps', `${id}.json`);
             await atomicWriteJSON(appFilePath, beforeState);
             await configCache.refreshAppsCache();
             break;
           }
           case 'prompt': {
-            const promptFilePath = join(rootDir, 'contents', 'prompts', `${id}.json`);
+            const promptFilePath = getContentsPath('prompts', `${id}.json`);
             await atomicWriteJSON(promptFilePath, beforeState);
             await configCache.refreshPromptsCache();
             break;
           }
           case 'model': {
-            const modelFilePath = join(rootDir, 'contents', 'models', `${id}.json`);
+            const modelFilePath = getContentsPath('models', `${id}.json`);
             await atomicWriteJSON(modelFilePath, beforeState);
             await configCache.refreshModelsCache();
             break;
           }
           case 'group': {
-            const groupsPath = join(rootDir, 'contents', 'config', 'groups.json');
+            const groupsPath = getContentsPath('config', 'groups.json');
             const { data: groupsConfig } = configCache.getGroups();
             const config = groupsConfig || { groups: {} };
             config.groups[id] = beforeState;
@@ -130,13 +128,13 @@ export default function registerAdminChangesRoutes(app) {
             break;
           }
           case 'platform': {
-            const platformPath = join(rootDir, 'contents', 'config', 'platform.json');
+            const platformPath = getContentsPath('config', 'platform.json');
             await atomicWriteJSON(platformPath, beforeState);
             await configCache.refreshCacheEntry('config/platform.json');
             break;
           }
           case 'feature': {
-            const featuresPath = join(rootDir, 'contents', 'config', 'features.json');
+            const featuresPath = getContentsPath('config', 'features.json');
             await atomicWriteJSON(featuresPath, beforeState);
             await configCache.refreshCacheEntry('config/features.json');
             break;

--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -1,6 +1,5 @@
 import { promises as fs } from 'fs';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
@@ -172,8 +171,7 @@ export default function registerAdminConfigRoutes(app) {
    */
   app.get(buildServerPath('/api/admin/configs/platform'), adminAuth, async (req, res) => {
     try {
-      const rootDir = getRootDir();
-      const platformConfigPath = join(rootDir, 'contents', 'config', 'platform.json');
+      const platformConfigPath = getContentsPath('config', 'platform.json');
 
       let platformConfig = {};
       try {
@@ -285,8 +283,7 @@ export default function registerAdminConfigRoutes(app) {
         return sendBadRequest(res, 'Invalid configuration data');
       }
 
-      const rootDir = getRootDir();
-      const platformConfigPath = join(rootDir, 'contents', 'config', 'platform.json');
+      const platformConfigPath = getContentsPath('config', 'platform.json');
 
       // Load existing config to preserve other fields and track changes
       let existingConfig = {};

--- a/server/routes/admin/cors.js
+++ b/server/routes/admin/cors.js
@@ -3,9 +3,8 @@ import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 import configCache from '../../configCache.js';
 import { promises as fs } from 'fs';
-import { join } from 'path';
 import { buildServerPath } from '../../utils/basePath.js';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 
 const DEFAULT_CORS_CONFIG = {
@@ -128,9 +127,7 @@ export default function registerAdminCorsRoutes(app) {
         }
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
+      const platformPath = getContentsPath('config', 'platform.json');
 
       const platformContent = await fs.readFile(platformPath, 'utf8');
       const platformConfig = JSON.parse(platformContent);

--- a/server/routes/admin/credentials.js
+++ b/server/routes/admin/credentials.js
@@ -1,6 +1,5 @@
 import { promises as fs } from 'fs';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
@@ -33,7 +32,7 @@ const COMPONENT = 'AdminCredentials';
  * @returns {string}
  */
 function getCredentialsFilePath() {
-  return join(getRootDir(), 'contents', 'config', 'credentials.json');
+  return getContentsPath('config', 'credentials.json');
 }
 
 /**

--- a/server/routes/admin/features.js
+++ b/server/routes/admin/features.js
@@ -1,8 +1,7 @@
 import { promises as fs } from 'fs';
-import { join } from 'path';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { resolveFeatures, featureCategories, featureRegistry } from '../../featureRegistry.js';
@@ -85,8 +84,7 @@ export default function registerAdminFeaturesRoutes(app) {
       }
 
       // Read existing features.json
-      const rootDir = getRootDir();
-      const featuresPath = join(rootDir, 'contents', 'config', 'features.json');
+      const featuresPath = getContentsPath('config', 'features.json');
 
       let existing = {};
       try {

--- a/server/routes/admin/groups.js
+++ b/server/routes/admin/groups.js
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
@@ -231,8 +231,7 @@ export default function registerAdminGroupRoutes(app) {
    */
   app.get(buildServerPath('/api/admin/groups'), adminAuth, async (req, res) => {
     try {
-      const rootDir = getRootDir();
-      const groupsFilePath = join(rootDir, 'contents', 'config', 'groups.json');
+      const groupsFilePath = getContentsPath('config', 'groups.json');
 
       let groupsData = { groups: {}, metadata: {} };
       try {
@@ -305,10 +304,8 @@ export default function registerAdminGroupRoutes(app) {
    */
   app.get(buildServerPath('/api/admin/groups/resources'), adminAuth, async (req, res) => {
     try {
-      const rootDir = getRootDir();
-
       // Get apps
-      const appsPath = join(rootDir, 'contents', 'apps');
+      const appsPath = getContentsPath('apps');
       const appFiles = await fs.readdir(appsPath);
       const apps = [];
 
@@ -332,7 +329,7 @@ export default function registerAdminGroupRoutes(app) {
       }
 
       // Get models
-      const modelsPath = join(rootDir, 'contents', 'models');
+      const modelsPath = getContentsPath('models');
       const modelFiles = await fs.readdir(modelsPath);
       const models = [];
 
@@ -356,7 +353,7 @@ export default function registerAdminGroupRoutes(app) {
       }
 
       // Get prompts
-      const promptsPath = join(rootDir, 'contents', 'prompts');
+      const promptsPath = getContentsPath('prompts');
       const prompts = [];
 
       try {
@@ -384,7 +381,7 @@ export default function registerAdminGroupRoutes(app) {
       }
 
       // Get workflows
-      const workflowsPath = join(rootDir, 'contents', 'workflows');
+      const workflowsPath = getContentsPath('workflows');
       const workflows = [];
 
       try {
@@ -547,8 +544,7 @@ export default function registerAdminGroupRoutes(app) {
         return sendBadRequest(res, 'Valid permissions object is required');
       }
 
-      const rootDir = getRootDir();
-      const groupsFilePath = join(rootDir, 'contents', 'config', 'groups.json');
+      const groupsFilePath = getContentsPath('config', 'groups.json');
 
       // Load existing groups
       let groupsData = { groups: {}, metadata: {} };
@@ -688,8 +684,7 @@ export default function registerAdminGroupRoutes(app) {
 
       const { name, description, permissions, mappings, inherits } = req.body;
 
-      const rootDir = getRootDir();
-      const groupsFilePath = join(rootDir, 'contents', 'config', 'groups.json');
+      const groupsFilePath = getContentsPath('config', 'groups.json');
 
       // Load existing groups
       let groupsData = { groups: {}, metadata: {} };
@@ -861,8 +856,7 @@ export default function registerAdminGroupRoutes(app) {
         return sendBadRequest(res, `Cannot delete protected system group: ${groupId}`);
       }
 
-      const rootDir = getRootDir();
-      const groupsFilePath = join(rootDir, 'contents', 'config', 'groups.json');
+      const groupsFilePath = getContentsPath('config', 'groups.json');
 
       // Load existing groups
       let groupsData = { groups: {}, metadata: {} };

--- a/server/routes/admin/logging.js
+++ b/server/routes/admin/logging.js
@@ -3,9 +3,8 @@ import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 import configCache from '../../configCache.js';
 import { promises as fs } from 'fs';
-import { join } from 'path';
 import { buildServerPath } from '../../utils/basePath.js';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 
 export default function registerAdminLoggingRoutes(app) {
@@ -89,9 +88,7 @@ export default function registerAdminLoggingRoutes(app) {
 
       // Optionally persist to platform.json
       if (persist) {
-        const rootDir = getRootDir();
-        const contentsDir = process.env.CONTENTS_DIR || 'contents';
-        const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
+        const platformPath = getContentsPath('config', 'platform.json');
 
         // Read current platform config
         const platformContent = await fs.readFile(platformPath, 'utf8');
@@ -194,9 +191,7 @@ export default function registerAdminLoggingRoutes(app) {
     try {
       const newLoggingConfig = req.body;
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
+      const platformPath = getContentsPath('config', 'platform.json');
 
       // Read current platform config
       const platformContent = await fs.readFile(platformPath, 'utf8');

--- a/server/routes/admin/mcpServers.js
+++ b/server/routes/admin/mcpServers.js
@@ -9,13 +9,9 @@ import {
 import mcpClientManager from '../../services/mcp/McpClientManager.js';
 import configCache from '../../configCache.js';
 import logger from '../../utils/logger.js';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { getContentsPath } from '../../pathUtils.js';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const MCP_FILE_PATH = path.join(__dirname, '../../../contents/config/mcpServers.json');
+const MCP_FILE_PATH = getContentsPath('config', 'mcpServers.json');
 
 async function readConfig() {
   const { data } = configCache.getMcpServers();

--- a/server/routes/admin/models.js
+++ b/server/routes/admin/models.js
@@ -1,7 +1,6 @@
 import { readFileSync, existsSync } from 'fs';
 import { promises as fs } from 'fs';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { getLocalizedContent } from '../../../shared/localize.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
@@ -151,8 +150,7 @@ export default function registerAdminModelsRoutes(app) {
           // Masked value - need to preserve existing key
           // CRITICAL FIX: Read from disk, not cache, to ensure we have the apiKey field
           // The cache might not have the apiKey due to TTL expiration or race conditions
-          const rootDir = getRootDir();
-          const modelFilePath = join(rootDir, 'contents', 'models', `${modelId}.json`);
+          const modelFilePath = getContentsPath('models', `${modelId}.json`);
 
           try {
             if (existsSync(modelFilePath)) {
@@ -188,7 +186,7 @@ export default function registerAdminModelsRoutes(app) {
         const allModels = modelsResponse.data || modelsResponse;
         for (const model of allModels) {
           if (model.id !== modelId && model.default === true) {
-            const otherModelPath = join(getRootDir(), 'contents', 'models', `${model.id}.json`);
+            const otherModelPath = getContentsPath('models', `${model.id}.json`);
             model.default = false;
             await fs.writeFile(otherModelPath, JSON.stringify(model, null, 2));
           }
@@ -198,8 +196,7 @@ export default function registerAdminModelsRoutes(app) {
       const { data: currentModels } = configCache.getModels(true);
       const oldModel = currentModels.find(m => m.id === modelId);
 
-      const rootDir = getRootDir();
-      const modelFilePath = join(rootDir, 'contents', 'models', `${modelId}.json`);
+      const modelFilePath = getContentsPath('models', `${modelId}.json`);
       await fs.writeFile(modelFilePath, JSON.stringify(updatedModel, null, 2));
       await configCache.refreshModelsCache();
       if (oldModel) {
@@ -259,8 +256,7 @@ export default function registerAdminModelsRoutes(app) {
       delete newModel.apiKeySet;
       delete newModel.apiKeyMasked;
 
-      const rootDir = getRootDir();
-      const modelFilePath = join(rootDir, 'contents', 'models', `${newModel.id}.json`);
+      const modelFilePath = getContentsPath('models', `${newModel.id}.json`);
       try {
         readFileSync(modelFilePath, 'utf8');
         return sendErrorResponse(res, 409, 'Model with this ID already exists');
@@ -272,7 +268,7 @@ export default function registerAdminModelsRoutes(app) {
         const allModels = modelsResponse.data || modelsResponse;
         for (const model of allModels) {
           if (model.default === true) {
-            const otherModelPath = join(getRootDir(), 'contents', 'models', `${model.id}.json`);
+            const otherModelPath = getContentsPath('models', `${model.id}.json`);
             model.default = false;
             await fs.writeFile(otherModelPath, JSON.stringify(model, null, 2));
           }
@@ -313,18 +309,12 @@ export default function registerAdminModelsRoutes(app) {
         const enabledModels = models.filter(m => m.id !== modelId && m.enabled === true);
         if (enabledModels.length > 0) {
           enabledModels[0].default = true;
-          const newDefaultPath = join(
-            getRootDir(),
-            'contents',
-            'models',
-            `${enabledModels[0].id}.json`
-          );
+          const newDefaultPath = getContentsPath('models', `${enabledModels[0].id}.json`);
           await fs.writeFile(newDefaultPath, JSON.stringify(enabledModels[0], null, 2));
         }
         model.default = false;
       }
-      const rootDir = getRootDir();
-      const modelFilePath = join(rootDir, 'contents', 'models', `${modelId}.json`);
+      const modelFilePath = getContentsPath('models', `${modelId}.json`);
       await fs.writeFile(modelFilePath, JSON.stringify(model, null, 2));
       await configCache.refreshModelsCache();
       await logAudit({
@@ -360,7 +350,6 @@ export default function registerAdminModelsRoutes(app) {
 
       const { data: models } = configCache.getModels(true);
       const resolvedIds = ids.includes('*') ? models.map(m => m.id) : ids;
-      const rootDir = getRootDir();
 
       for (const id of resolvedIds) {
         const model = models.find(m => m.id === id);
@@ -369,7 +358,7 @@ export default function registerAdminModelsRoutes(app) {
         if (!enabled) {
           model.default = false;
         }
-        const modelFilePath = join(rootDir, 'contents', 'models', `${id}.json`);
+        const modelFilePath = getContentsPath('models', `${id}.json`);
         await fs.writeFile(modelFilePath, JSON.stringify(model, null, 2));
       }
 
@@ -377,7 +366,7 @@ export default function registerAdminModelsRoutes(app) {
       const enabledModels = models.filter(m => m.enabled);
       if (enabledModels.length > 0 && !enabledModels.some(m => m.default)) {
         enabledModels[0].default = true;
-        const defaultPath = join(rootDir, 'contents', 'models', `${enabledModels[0].id}.json`);
+        const defaultPath = getContentsPath('models', `${enabledModels[0].id}.json`);
         await fs.writeFile(defaultPath, JSON.stringify(enabledModels[0], null, 2));
       }
 
@@ -417,17 +406,11 @@ export default function registerAdminModelsRoutes(app) {
         const otherModels = models.filter(m => m.id !== modelId && m.enabled === true);
         if (otherModels.length > 0) {
           otherModels[0].default = true;
-          const newDefaultPath = join(
-            getRootDir(),
-            'contents',
-            'models',
-            `${otherModels[0].id}.json`
-          );
+          const newDefaultPath = getContentsPath('models', `${otherModels[0].id}.json`);
           await fs.writeFile(newDefaultPath, JSON.stringify(otherModels[0], null, 2));
         }
       }
-      const rootDir = getRootDir();
-      const modelFilePath = join(rootDir, 'contents', 'models', `${modelId}.json`);
+      const modelFilePath = getContentsPath('models', `${modelId}.json`);
       if (!existsSync(modelFilePath)) {
         return sendNotFound(res, 'Model file');
       }

--- a/server/routes/admin/nextcloudEmbed.js
+++ b/server/routes/admin/nextcloudEmbed.js
@@ -1,5 +1,4 @@
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
@@ -10,8 +9,7 @@ import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 
 async function savePlatformConfig(updates) {
-  const rootDir = getRootDir();
-  const platformConfigPath = join(rootDir, 'contents', 'config', 'platform.json');
+  const platformConfigPath = getContentsPath('config', 'platform.json');
   // platform.json no longer stores any at-rest secrets — all integration
   // secrets live in the central credential store (contents/config/credentials.json)
   // referenced by `*Ref` fields — so a plain merge is safe here.

--- a/server/routes/admin/officeIntegration.js
+++ b/server/routes/admin/officeIntegration.js
@@ -1,5 +1,4 @@
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
@@ -10,8 +9,7 @@ import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 
 async function savePlatformConfig(updates) {
-  const rootDir = getRootDir();
-  const platformConfigPath = join(rootDir, 'contents', 'config', 'platform.json');
+  const platformConfigPath = getContentsPath('config', 'platform.json');
   const existing = configCache.getPlatform() || {};
   const merged = { ...existing, ...updates };
   await atomicWriteJSON(platformConfigPath, merged);

--- a/server/routes/admin/pages.js
+++ b/server/routes/admin/pages.js
@@ -1,7 +1,6 @@
 import { readFileSync } from 'fs';
 import { promises as fs } from 'fs';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteFile, atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
@@ -51,8 +50,7 @@ export default function registerAdminPagesRoutes(app) {
         return sendNotFound(res, 'Page');
       }
       const content = {};
-      const rootDir = getRootDir();
-      const contentsBase = join(rootDir, 'contents');
+      const contentsBase = getContentsPath();
       for (const [lang, relPath] of Object.entries(page.filePath || {})) {
         try {
           // Validate stored path stays within contents directory
@@ -102,8 +100,7 @@ export default function registerAdminPagesRoutes(app) {
         return;
       }
 
-      const rootDir = getRootDir();
-      const uiPath = join(rootDir, 'contents', 'config', 'ui.json');
+      const uiPath = getContentsPath('config', 'ui.json');
       const uiConfig = JSON.parse(readFileSync(uiPath, 'utf8'));
       uiConfig.pages = uiConfig.pages || {};
       if (uiConfig.pages[id]) {
@@ -120,10 +117,10 @@ export default function registerAdminPagesRoutes(app) {
       uiConfig.pages[id] = { title, filePath: {}, authRequired, allowedGroups, contentType };
       const fileExtension = contentType === 'react' ? 'jsx' : 'md';
       for (const [lang, contentText] of Object.entries(content)) {
-        const dir = join(rootDir, 'contents', 'pages', lang);
+        const dir = getContentsPath('pages', lang);
         await fs.mkdir(dir, { recursive: true });
         const rel = `pages/${lang}/${id}.${fileExtension}`;
-        await atomicWriteFile(join(rootDir, 'contents', rel), contentText);
+        await atomicWriteFile(getContentsPath(rel), contentText);
         uiConfig.pages[id].filePath[lang] = rel;
       }
       await atomicWriteJSON(uiPath, uiConfig);
@@ -154,8 +151,7 @@ export default function registerAdminPagesRoutes(app) {
       if (!id || id !== pageId) {
         return sendBadRequest(res, 'Invalid page ID');
       }
-      const rootDir = getRootDir();
-      const uiPath = join(rootDir, 'contents', 'config', 'ui.json');
+      const uiPath = getContentsPath('config', 'ui.json');
       const uiConfig = JSON.parse(readFileSync(uiPath, 'utf8'));
       const pageEntry = uiConfig.pages?.[pageId];
       if (!pageEntry) {
@@ -176,10 +172,10 @@ export default function registerAdminPagesRoutes(app) {
       pageEntry.filePath = pageEntry.filePath || {};
       const fileExtension = contentType === 'react' ? 'jsx' : 'md';
       for (const [lang, contentText] of Object.entries(content)) {
-        const dir = join(rootDir, 'contents', 'pages', lang);
+        const dir = getContentsPath('pages', lang);
         await fs.mkdir(dir, { recursive: true });
         const rel = pageEntry.filePath[lang] || `pages/${lang}/${pageId}.${fileExtension}`;
-        await atomicWriteFile(join(rootDir, 'contents', rel), contentText);
+        await atomicWriteFile(getContentsPath(rel), contentText);
         pageEntry.filePath[lang] = rel;
       }
       await atomicWriteJSON(uiPath, uiConfig);
@@ -199,14 +195,13 @@ export default function registerAdminPagesRoutes(app) {
         return;
       }
 
-      const rootDir = getRootDir();
-      const uiPath = join(rootDir, 'contents', 'config', 'ui.json');
+      const uiPath = getContentsPath('config', 'ui.json');
       const uiConfig = JSON.parse(readFileSync(uiPath, 'utf8'));
       const pageEntry = uiConfig.pages?.[pageId];
       if (!pageEntry) {
         return sendNotFound(res, 'Page');
       }
-      const contentsBase = join(rootDir, 'contents');
+      const contentsBase = getContentsPath();
       for (const rel of Object.values(pageEntry.filePath || {})) {
         try {
           // Validate stored path stays within contents directory

--- a/server/routes/admin/prompts.js
+++ b/server/routes/admin/prompts.js
@@ -1,8 +1,6 @@
 import { readFileSync, existsSync } from 'fs';
 import { promises as fs } from 'fs';
-import { join, resolve } from 'path';
-import path from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import configCache from '../../configCache.js';
 import { contentAdminAuth } from '../../middleware/contentAdminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
@@ -541,8 +539,7 @@ export default function registerAdminPromptsRoutes(app) {
       }
       const { data: currentPrompts } = configCache.getPrompts(true);
       const oldPrompt = currentPrompts.find(p => p.id === promptId);
-      const rootDir = getRootDir();
-      const promptFilePath = join(rootDir, 'contents', 'prompts', `${promptId}.json`);
+      const promptFilePath = getContentsPath('prompts', `${promptId}.json`);
       await fs.writeFile(promptFilePath, JSON.stringify(updatedPrompt, null, 2));
       await configCache.refreshPromptsCache();
       if (oldPrompt) {
@@ -676,8 +673,7 @@ export default function registerAdminPromptsRoutes(app) {
         return;
       }
 
-      const rootDir = getRootDir();
-      const promptFilePath = join(rootDir, 'contents', 'prompts', `${newPrompt.id}.json`);
+      const promptFilePath = getContentsPath('prompts', `${newPrompt.id}.json`);
       try {
         readFileSync(promptFilePath, 'utf8');
         return sendErrorResponse(res, 409, 'Prompt with this ID already exists');
@@ -794,8 +790,7 @@ export default function registerAdminPromptsRoutes(app) {
         }
         const newEnabledState = !prompt.enabled;
         prompt.enabled = newEnabledState;
-        const rootDir = getRootDir();
-        const promptFilePath = join(rootDir, 'contents', 'prompts', `${promptId}.json`);
+        const promptFilePath = getContentsPath('prompts', `${promptId}.json`);
         await fs.writeFile(promptFilePath, JSON.stringify(prompt, null, 2));
         await configCache.refreshPromptsCache();
         await logAudit({
@@ -940,14 +935,13 @@ export default function registerAdminPromptsRoutes(app) {
 
         const { data: prompts } = configCache.getPrompts(true);
         const resolvedIds = ids.includes('*') ? prompts.map(p => p.id) : ids;
-        const rootDir = getRootDir();
 
         for (const id of resolvedIds) {
           const prompt = prompts.find(p => p.id === id);
           if (!prompt) continue;
           if (prompt.enabled !== enabled) {
             prompt.enabled = enabled;
-            const promptFilePath = join(rootDir, 'contents', 'prompts', `${id}.json`);
+            const promptFilePath = getContentsPath('prompts', `${id}.json`);
             await fs.writeFile(promptFilePath, JSON.stringify(prompt, null, 2));
           }
         }
@@ -1059,8 +1053,7 @@ export default function registerAdminPromptsRoutes(app) {
 
         const { data: currentPrompts } = configCache.getPrompts(true);
         const oldPrompt = currentPrompts.find(p => p.id === promptId);
-        const rootDir = getRootDir();
-        const promptsDir = join(rootDir, 'contents', 'prompts');
+        const promptsDir = getContentsPath('prompts');
         const normalizedPromptFilePath = await resolveAndValidatePath(
           `${promptId}.json`,
           promptsDir

--- a/server/routes/admin/providers.js
+++ b/server/routes/admin/providers.js
@@ -1,7 +1,6 @@
 import { promises as fs } from 'fs';
 import { existsSync } from 'fs';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
@@ -127,9 +126,8 @@ export default function registerAdminProvidersRoutes(app) {
       }
 
       // Define paths once at the top
-      const rootDir = getRootDir();
-      const providersPath = join(rootDir, 'contents', 'config', 'providers.json');
-      const providersDir = join(rootDir, 'contents', 'config');
+      const providersPath = getContentsPath('config', 'providers.json');
+      const providersDir = getContentsPath('config');
 
       // Handle API key encryption
       if (updatedProvider.apiKey) {
@@ -240,9 +238,8 @@ export default function registerAdminProvidersRoutes(app) {
         return;
       }
 
-      const rootDir = getRootDir();
-      const providersPath = join(rootDir, 'contents', 'config', 'providers.json');
-      const providersDir = join(rootDir, 'contents', 'config');
+      const providersPath = getContentsPath('config', 'providers.json');
+      const providersDir = getContentsPath('config');
 
       // Load current providers
       let providers = [];
@@ -347,8 +344,7 @@ export default function registerAdminProvidersRoutes(app) {
         );
       }
 
-      const rootDir = getRootDir();
-      const providersPath = join(rootDir, 'contents', 'config', 'providers.json');
+      const providersPath = getContentsPath('config', 'providers.json');
 
       // Load current providers
       let providers = [];

--- a/server/routes/admin/sources.js
+++ b/server/routes/admin/sources.js
@@ -1,6 +1,5 @@
 import crypto from 'crypto';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { contentAdminAuth } from '../../middleware/contentAdminAuth.js';
@@ -2026,7 +2025,7 @@ export default function registerAdminSourcesRoutes(app) {
  * @param {Array} sources - Array of source configurations
  */
 async function saveSourcesConfig(sources) {
-  const sourcesPath = join(getRootDir(), 'contents', 'config', 'sources.json');
+  const sourcesPath = getContentsPath('config', 'sources.json');
 
   // Validate entire array
   const validation = validateSourcesArray(sources);

--- a/server/routes/admin/ssl.js
+++ b/server/routes/admin/ssl.js
@@ -3,9 +3,8 @@ import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 import configCache from '../../configCache.js';
 import { promises as fs } from 'fs';
-import { join } from 'path';
 import { buildServerPath } from '../../utils/basePath.js';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 
 export default function registerAdminSSLRoutes(app) {
@@ -103,9 +102,7 @@ export default function registerAdminSSLRoutes(app) {
         }
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
+      const platformPath = getContentsPath('config', 'platform.json');
 
       // Read current platform config
       const platformContent = await fs.readFile(platformPath, 'utf8');

--- a/server/routes/admin/ssrf.js
+++ b/server/routes/admin/ssrf.js
@@ -3,9 +3,8 @@ import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 import configCache from '../../configCache.js';
 import { promises as fs } from 'fs';
-import { join } from 'path';
 import { buildServerPath } from '../../utils/basePath.js';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 
 export default function registerAdminSsrfRoutes(app) {
@@ -104,9 +103,7 @@ export default function registerAdminSsrfRoutes(app) {
         cleaned.push(trimmed);
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
+      const platformPath = getContentsPath('config', 'platform.json');
 
       const platformContent = await fs.readFile(platformPath, 'utf8');
       const platformConfig = JSON.parse(platformContent);

--- a/server/routes/admin/tools.js
+++ b/server/routes/admin/tools.js
@@ -2,7 +2,7 @@ import { readFileSync, existsSync } from 'fs';
 import { promises as fs } from 'fs';
 import { join, basename } from 'path';
 import { createHash } from 'crypto';
-import { getRootDir } from '../../pathUtils.js';
+import { getRootDir, getContentsPath } from '../../pathUtils.js';
 import configCache from '../../configCache.js';
 import { loadAllTools } from '../../toolsLoader.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
@@ -376,9 +376,7 @@ export default function registerAdminToolsRoutes(app) {
         }
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const toolsDir = join(rootDir, contentsDir, 'tools');
+      const toolsDir = getContentsPath('tools');
 
       // Load existing tools (raw, unexpanded) to confirm the tool exists
       const tools = await loadRawTools();
@@ -486,9 +484,7 @@ export default function registerAdminToolsRoutes(app) {
         }
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const toolsDir = join(rootDir, contentsDir, 'tools');
+      const toolsDir = getContentsPath('tools');
 
       // Load existing tools (raw, unexpanded)
       const tools = await loadRawTools();
@@ -590,9 +586,7 @@ export default function registerAdminToolsRoutes(app) {
         return;
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const toolsDir = join(rootDir, contentsDir, 'tools');
+      const toolsDir = getContentsPath('tools');
 
       // Load existing tools (raw, unexpanded) to confirm the tool exists
       const tools = await loadRawTools();
@@ -604,7 +598,7 @@ export default function registerAdminToolsRoutes(app) {
 
       // Delete the script file if it exists (only for non-special tools)
       if (tool.script && !tool.isSpecialTool && !tool.provider) {
-        const scriptsBaseDir = join(rootDir, 'server', 'tools');
+        const scriptsBaseDir = join(getRootDir(), 'server', 'tools');
         try {
           const scriptPath = await resolveAndValidatePath(tool.script, scriptsBaseDir);
           if (!scriptPath) {
@@ -714,9 +708,7 @@ export default function registerAdminToolsRoutes(app) {
         return;
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const toolsDir = join(rootDir, contentsDir, 'tools');
+      const toolsDir = getContentsPath('tools');
 
       // Load existing tools (raw, unexpanded)
       const tools = await loadRawTools();

--- a/server/routes/admin/usage.js
+++ b/server/routes/admin/usage.js
@@ -1,11 +1,9 @@
 import { promises as fs } from 'fs';
-import { join } from 'path';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
-import config from '../../config.js';
 import { getTrackingMode, reloadConfig } from '../../usageTracker.js';
 import { getDailyRollups, getMonthlyRollups, runRollups } from '../../services/UsageAggregator.js';
 import { readEvents } from '../../services/UsageEventLog.js';
@@ -155,8 +153,7 @@ export default function registerAdminUsageRoutes(app) {
         );
       }
 
-      const rootDir = getRootDir();
-      const platformPath = join(rootDir, 'contents', 'config', 'platform.json');
+      const platformPath = getContentsPath('config', 'platform.json');
       let platform = {};
       try {
         const data = await fs.readFile(platformPath, 'utf8');
@@ -240,9 +237,7 @@ export default function registerAdminUsageRoutes(app) {
       const limitNum = parseInt(limit, 10);
       const offsetNum = parseInt(offset, 10);
 
-      const rootDir = getRootDir();
-      const contentsDir = config.CONTENTS_DIR;
-      const feedbackFile = join(rootDir, contentsDir, 'data', 'feedback.jsonl');
+      const feedbackFile = getContentsPath('data', 'feedback.jsonl');
 
       // Check if feedback file exists
       try {

--- a/server/routes/agents/artifacts.js
+++ b/server/routes/agents/artifacts.js
@@ -16,7 +16,7 @@ import {
 } from '../../utils/responseHelpers.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import { validateIdForPath, resolveAndValidatePath } from '../../utils/pathSecurity.js';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { WorkflowEngine } from '../../services/workflow/index.js';
 import { buildContentDisposition } from '../../utils/safeContentDisposition.js';
 
@@ -27,7 +27,7 @@ function getEngine() {
 }
 
 function artifactsRootDir() {
-  return path.join(getRootDir(), 'contents', 'data', 'agent-artifacts');
+  return getContentsPath('data', 'agent-artifacts');
 }
 
 // Returns a validated absolute directory path for the run, or null on any

--- a/server/routes/setup.js
+++ b/server/routes/setup.js
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { httpFetch } from '../utils/httpConfig.js';
-import { getRootDir } from '../pathUtils.js';
+import { getContentsPath } from '../pathUtils.js';
 import configCache from '../configCache.js';
 import tokenStorageService from '../services/TokenStorageService.js';
 import { buildServerPath } from '../utils/basePath.js';
@@ -61,8 +61,7 @@ async function testApiKey(providerId, apiKey) {
  * Mark setup as completed by setting setup.configured = true in platform.json.
  */
 async function markSetupConfigured() {
-  const rootDir = getRootDir();
-  const platformPath = join(rootDir, 'contents', 'config', 'platform.json');
+  const platformPath = getContentsPath('config', 'platform.json');
   const raw = await fs.readFile(platformPath, 'utf8');
   const platform = JSON.parse(raw);
   platform.setup = { ...(platform.setup || {}), configured: true };
@@ -167,8 +166,7 @@ export default function registerSetupRoutes(app) {
         enabled: true
       };
 
-      const rootDir = getRootDir();
-      const providersDir = join(rootDir, 'contents', 'config');
+      const providersDir = getContentsPath('config');
       const providersPath = join(providersDir, 'providers.json');
 
       await fs.mkdir(providersDir, { recursive: true });

--- a/server/routes/workflow/workflowRoutes.js
+++ b/server/routes/workflow/workflowRoutes.js
@@ -20,7 +20,7 @@ import { actionTracker } from '../../actionTracker.js';
 import { createSseChannel, startInactiveClientSweep } from '../../utils/sseChannel.js';
 import { workflowConfigSchema } from '../../validators/workflowConfigSchema.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import {
   isValidWorkflowVersion,
   validateIdForPath,
@@ -174,8 +174,7 @@ function buildModelsList(workflow) {
  * @returns {Promise<Object[]>} Array of workflow definitions
  */
 async function loadWorkflows(includeDisabled = false) {
-  const rootDir = getRootDir();
-  const workflowsDir = join(rootDir, 'contents', 'workflows');
+  const workflowsDir = getContentsPath('workflows');
 
   try {
     // Create directory if it doesn't exist
@@ -561,8 +560,7 @@ export default function registerWorkflowRoutes(app, deps = {}) {
         }
 
         // Check if workflow already exists
-        const rootDir = getRootDir();
-        const workflowsDir = join(rootDir, 'contents', 'workflows');
+        const workflowsDir = getContentsPath('workflows');
         await fs.mkdir(workflowsDir, { recursive: true });
 
         const existingFile = await findWorkflowFile(workflowData.id, workflowsDir);
@@ -661,8 +659,7 @@ export default function registerWorkflowRoutes(app, deps = {}) {
         }
 
         // Find existing workflow file
-        const rootDir = getRootDir();
-        const workflowsDir = join(rootDir, 'contents', 'workflows');
+        const workflowsDir = getContentsPath('workflows');
         const filename = await findWorkflowFile(id, workflowsDir);
 
         if (!filename) {
@@ -738,8 +735,7 @@ export default function registerWorkflowRoutes(app, deps = {}) {
         }
 
         // Find workflow file
-        const rootDir = getRootDir();
-        const workflowsDir = join(rootDir, 'contents', 'workflows');
+        const workflowsDir = getContentsPath('workflows');
         const filename = await findWorkflowFile(id, workflowsDir);
 
         if (!filename) {
@@ -1982,8 +1978,7 @@ export default function registerWorkflowRoutes(app, deps = {}) {
         }
 
         // Find workflow file
-        const rootDir = getRootDir();
-        const workflowsDir = join(rootDir, 'contents', 'workflows');
+        const workflowsDir = getContentsPath('workflows');
         const filename = await findWorkflowFile(id, workflowsDir);
 
         if (!filename) {
@@ -2191,8 +2186,7 @@ export default function registerWorkflowRoutes(app, deps = {}) {
       }
 
       try {
-        const rootDir = getRootDir();
-        const workflowsDir = join(rootDir, 'contents', 'workflows');
+        const workflowsDir = getContentsPath('workflows');
         const historyRoot = join(workflowsDir, '.history');
         // Defense-in-depth: resolve the per-workflow history dir and
         // assert it stays inside .history. validateIdForPath already
@@ -2292,8 +2286,7 @@ export default function registerWorkflowRoutes(app, deps = {}) {
       }
 
       try {
-        const rootDir = getRootDir();
-        const workflowsDir = join(rootDir, 'contents', 'workflows');
+        const workflowsDir = getContentsPath('workflows');
 
         // Load current workflow
         const filename = await findWorkflowFile(id, workflowsDir);
@@ -2405,8 +2398,7 @@ export default function registerWorkflowRoutes(app, deps = {}) {
       }
 
       try {
-        const rootDir = getRootDir();
-        const workflowsDir = join(rootDir, 'contents', 'workflows');
+        const workflowsDir = getContentsPath('workflows');
         const historyRoot = join(workflowsDir, '.history');
         const historyDir = await resolveAndValidatePath(id, historyRoot);
         if (!historyDir) {

--- a/server/services/AuditLogService.js
+++ b/server/services/AuditLogService.js
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import { join, dirname } from 'path';
 import { randomUUID } from 'crypto';
-import { getRootDir } from '../pathUtils.js';
+import { getContentsPath } from '../pathUtils.js';
 import logger from '../utils/logger.js';
 import configCache from '../configCache.js';
 import { getContext } from '../utils/requestContext.js';
@@ -150,7 +150,7 @@ export async function flushAuditLog() {
   // thereby duplicate — entries that already landed on disk.
   for (const [date, entries] of byDate) {
     try {
-      const filePath = join(getRootDir(), 'contents', AUDIT_LOG_DIR, `${date}.jsonl`);
+      const filePath = getContentsPath(AUDIT_LOG_DIR, `${date}.jsonl`);
       await fs.mkdir(dirname(filePath), { recursive: true });
       const lines = entries.map(e => JSON.stringify(e)).join('\n') + '\n';
       await fs.appendFile(filePath, lines, 'utf8');
@@ -319,7 +319,7 @@ export async function queryAuditLog({
   const fromDate =
     from || new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
 
-  const auditDir = join(getRootDir(), 'contents', AUDIT_LOG_DIR);
+  const auditDir = getContentsPath(AUDIT_LOG_DIR);
 
   // Collect all matching JSONL files
   let files;
@@ -400,7 +400,7 @@ export async function cleanupAuditLog(retentionDays) {
     return { deleted: [], retainedFrom: null };
   }
 
-  const auditDir = join(getRootDir(), 'contents', AUDIT_LOG_DIR);
+  const auditDir = getContentsPath(AUDIT_LOG_DIR);
   let files;
   try {
     files = await fs.readdir(auditDir);

--- a/server/services/ChangeHistoryService.js
+++ b/server/services/ChangeHistoryService.js
@@ -1,6 +1,6 @@
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { getRootDir } from '../pathUtils.js';
+import { getContentsPath } from '../pathUtils.js';
 import logger from '../utils/logger.js';
 
 const HISTORY_DIR = 'data/change-history';
@@ -10,7 +10,7 @@ const MAX_SNAPSHOTS = 20;
  * Get the directory for a specific resource's change history.
  */
 function getResourceDir(resource, id) {
-  return join(getRootDir(), 'contents', HISTORY_DIR, resource, id);
+  return getContentsPath(HISTORY_DIR, resource, id);
 }
 
 /**

--- a/server/services/marketplace/ContentInstaller.js
+++ b/server/services/marketplace/ContentInstaller.js
@@ -24,21 +24,11 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import { isValidId, resolveAndValidatePath } from '../../utils/pathSecurity.js';
-import { getRootDir } from '../../pathUtils.js';
-import config from '../../config.js';
+import { getContentsDir } from '../../pathUtils.js';
 import registryService from './RegistryService.js';
 import logger from '../../utils/logger.js';
 
 const COMPONENT = 'ContentInstaller';
-
-/**
- * Return the absolute path to the contents directory.
- *
- * @returns {string}
- */
-function getContentsDir() {
-  return path.join(getRootDir(), config.CONTENTS_DIR);
-}
 
 /**
  * Content type dispatch table.

--- a/server/services/marketplace/RegistryService.js
+++ b/server/services/marketplace/RegistryService.js
@@ -23,8 +23,7 @@ import { validateCatalog } from '../../validators/catalogSchema.js';
 import { validateRegistryConfig } from '../../validators/registryConfigSchema.js';
 import tokenStorageService from '../TokenStorageService.js';
 import logger from '../../utils/logger.js';
-import { getRootDir } from '../../pathUtils.js';
-import config from '../../config.js';
+import { getContentsDir } from '../../pathUtils.js';
 
 const COMPONENT = 'RegistryService';
 
@@ -133,15 +132,6 @@ function buildAuthHeaders(auth) {
 // ---------------------------------------------------------------------------
 // Helpers — paths
 // ---------------------------------------------------------------------------
-
-/**
- * Return the absolute path to the contents directory.
- *
- * @returns {string}
- */
-function getContentsDir() {
-  return path.join(getRootDir(), config.CONTENTS_DIR);
-}
 
 /**
  * Return the absolute path to the registry catalog cache directory.

--- a/server/services/tools/OpenApiToolRunner.js
+++ b/server/services/tools/OpenApiToolRunner.js
@@ -4,7 +4,7 @@ import SwaggerParser from '@apidevtools/swagger-parser';
 // js-yaml v5 is ESM-only with named exports — a default import throws
 // "does not provide an export named 'default'" at module load time.
 import { load as parseYaml, JSON_SCHEMA } from 'js-yaml';
-import { getRootDir } from '../../pathUtils.js';
+import { getContentsPath } from '../../pathUtils.js';
 import { safeFetch } from '../mcp/safeFetch.js';
 import { throttledRun } from '../../requestThrottler.js';
 import credentialService from '../CredentialService.js';
@@ -72,8 +72,7 @@ async function _parseSource(source, ssrfOpts) {
     return parseOpenApiText(text);
   }
   if (source.type === 'file') {
-    const root = getRootDir();
-    const contentsDir = normalize(join(root, 'contents'));
+    const contentsDir = normalize(getContentsPath());
     const resolved = normalize(join(contentsDir, source.path));
     // Confine to contentsDir. The trailing-separator check prevents a sibling
     // like `/.../contents2` from passing a naive startsWith(`/.../contents`).

--- a/server/sources/PageHandler.js
+++ b/server/sources/PageHandler.js
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import path from 'path';
 import SourceHandler from './SourceHandler.js';
-import { getRootDir } from '../pathUtils.js';
+import { getContentsPath } from '../pathUtils.js';
 import { isValidId, isValidLanguageCode } from '../utils/pathSecurity.js';
 
 /**
@@ -14,7 +14,7 @@ import { isValidId, isValidLanguageCode } from '../utils/pathSecurity.js';
 class PageHandler extends SourceHandler {
   constructor(config = {}) {
     super(config);
-    this.pagesBasePath = config.pagesBasePath || path.join(getRootDir(), 'contents', 'pages');
+    this.pagesBasePath = config.pagesBasePath || getContentsPath('pages');
     this.defaultLanguage = config.defaultLanguage || 'en';
     this.baseUrl = config.baseUrl || process.env.BASE_URL || '';
   }

--- a/server/sources/SourceManager.js
+++ b/server/sources/SourceManager.js
@@ -578,8 +578,7 @@ class SourceManager {
   async testFilesystemSource(config) {
     const { path: filePath, encoding = 'utf-8' } = config;
     const fs = await import('fs');
-    const path = await import('path');
-    const { getRootDir } = await import('../pathUtils.js');
+    const { getContentsPath } = await import('../pathUtils.js');
 
     try {
       if (!filePath) {
@@ -587,7 +586,7 @@ class SourceManager {
       }
 
       // Resolve path relative to contents directory
-      const contentsDir = path.join(getRootDir(), 'contents');
+      const contentsDir = getContentsPath();
       const fullPath = await resolveAndValidatePath(filePath, contentsDir);
       if (!fullPath) {
         throw new Error('Invalid file path: Path must be within contents directory');

--- a/server/tests/ContentInstaller.skill-path-traversal.test.js
+++ b/server/tests/ContentInstaller.skill-path-traversal.test.js
@@ -25,7 +25,9 @@ import path from 'path';
 const state = { rootDir: os.tmpdir() };
 
 jest.unstable_mockModule('../pathUtils.js', () => ({
-  getRootDir: () => state.rootDir
+  getRootDir: () => state.rootDir,
+  getContentsDir: () => path.join(state.rootDir, 'contents'),
+  getContentsPath: (...segments) => path.join(state.rootDir, 'contents', ...segments)
 }));
 
 const { default: contentInstaller } = await import('../services/marketplace/ContentInstaller.js');

--- a/server/tests/admin-tools-script-path.test.js
+++ b/server/tests/admin-tools-script-path.test.js
@@ -35,7 +35,8 @@ const mockGroups = {
 const state = { rootDir: null, tools: [] };
 
 jest.unstable_mockModule('../pathUtils.js', () => ({
-  getRootDir: () => state.rootDir
+  getRootDir: () => state.rootDir,
+  getContentsPath: (...segments) => path.join(state.rootDir, 'contents', ...segments)
 }));
 
 jest.unstable_mockModule('../toolsLoader.js', () => ({

--- a/server/tests/agent-artifact-quota.test.js
+++ b/server/tests/agent-artifact-quota.test.js
@@ -14,7 +14,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
-import { getRootDir } from '../pathUtils.js';
+import { getContentsPath } from '../pathUtils.js';
 import { writeArtifactDirect } from '../agents/runtime/artifactStore.js';
 
 let failures = 0;
@@ -28,7 +28,7 @@ async function run() {
   // Use a unique run id under the real artifacts root. The store creates
   // the directory itself; we clean it up at the end.
   const runId = `quota-test-${Date.now()}`;
-  const root = path.join(getRootDir(), 'contents', 'data', 'agent-artifacts');
+  const root = getContentsPath('data', 'agent-artifacts');
   const runDir = path.join(root, runId);
 
   try {

--- a/server/utils/authorization.js
+++ b/server/utils/authorization.js
@@ -1,12 +1,8 @@
 import fs from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
 import { sendAuthRequired, sendInsufficientPermissions } from './responseHelpers.js';
 import logger from './logger.js';
 import configCache from '../configCache.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import { getContentsPath } from '../pathUtils.js';
 
 /**
  * Resolve group inheritance by merging permissions from parent groups
@@ -181,7 +177,7 @@ export function resolveGroupInheritance(groupsConfig) {
  */
 export function loadGroupsConfiguration() {
   try {
-    const configPath = path.join(__dirname, '../../contents/config/groups.json');
+    const configPath = getContentsPath('config', 'groups.json');
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 
     // Resolve group inheritance

--- a/server/utils/providerMigration.js
+++ b/server/utils/providerMigration.js
@@ -1,7 +1,7 @@
 import { promises as fs } from 'fs';
 import { existsSync } from 'fs';
 import { join } from 'path';
-import { getRootDir } from '../pathUtils.js';
+import { getRootDir, getContentsPath } from '../pathUtils.js';
 import logger from './logger.js';
 
 /**
@@ -11,7 +11,7 @@ import logger from './logger.js';
 export async function ensureDefaultProviders() {
   try {
     const rootDir = getRootDir();
-    const providersPath = join(rootDir, 'contents', 'config', 'providers.json');
+    const providersPath = getContentsPath('config', 'providers.json');
     const defaultProvidersPath = join(rootDir, 'server', 'defaults', 'config', 'providers.json');
 
     // Read default providers

--- a/server/utils/rehashPasswords.js
+++ b/server/utils/rehashPasswords.js
@@ -1,10 +1,6 @@
-import path from 'path';
-import { fileURLToPath } from 'url';
 import logger from './logger.js';
 import { hashPasswordWithUserId, loadUsers, saveUsers } from './userManager.js';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+import { getContentsPath } from '../pathUtils.js';
 
 function parseKnownPasswords() {
   const arg = process.argv.find(value => value.startsWith('--passwords='));
@@ -28,7 +24,7 @@ function parseKnownPasswords() {
  * Rehash existing user passwords with the new method
  */
 async function rehashUserPasswords() {
-  const usersFilePath = path.join(__dirname, '../../contents/config/users.json');
+  const usersFilePath = getContentsPath('config', 'users.json');
 
   try {
     const usersData = loadUsers(usersFilePath);

--- a/server/utils/resourceLoader.js
+++ b/server/utils/resourceLoader.js
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs';
 import { promises as fs } from 'fs';
 import { join } from 'path';
-import { getRootDir } from '../pathUtils.js';
+import { getContentsPath } from '../pathUtils.js';
 import logger from './logger.js';
 
 /**
@@ -45,8 +45,7 @@ export function createResourceLoader({
    * @returns {Array} Array of resource objects
    */
   async function loadFromFiles(verbose = true) {
-    const rootDir = getRootDir();
-    const resourceDir = join(rootDir, 'contents', individualPath);
+    const resourceDir = getContentsPath(individualPath);
 
     if (!existsSync(resourceDir)) {
       if (verbose) {
@@ -133,8 +132,7 @@ export function createResourceLoader({
    * @returns {Array} Array of resource objects
    */
   async function loadFromLegacyFile(verbose = true) {
-    const rootDir = getRootDir();
-    const legacyFilePath = join(rootDir, 'contents', legacyPath);
+    const legacyFilePath = getContentsPath(legacyPath);
 
     if (!existsSync(legacyFilePath)) {
       if (verbose) {


### PR DESCRIPTION
## Summary

Fixes #1767.

The platform documents `CONTENTS_DIR` as a supported deployment option, and `configCache`/`configLoader`/`FileSystemHandler` correctly resolve through it. However, ~90 call sites across admin routes, services, agent runtime, and sources hardcoded `contents/`, used a third `process.env.CONTENTS_DIR || 'contents'` variant, or built `__dirname`-relative paths that additionally ignored packaged-binary/`APP_ROOT_DIR` handling.

On a deployment with a custom `CONTENTS_DIR`, this meant admin saves/deletes, config backup export/import, audit logs, change-history snapshots, group/authorization loading, and more would silently write to (or read from) the default `contents/` directory instead of the one the running server actually serves — the API reports success, but nothing changes for the running server.

- Added `getContentsDir()` / `getContentsPath(...segments)` helpers to `server/pathUtils.js`, built on the existing `getRootDir()` + `config.CONTENTS_DIR`.
- Swept every affected file (all `routes/admin/*`, `routes/workflow/workflowRoutes.js`, `routes/agents/artifacts.js`, `routes/setup.js`, agent runtime/inbox/memory stores, `ChangeHistoryService`, `AuditLogService`, `authorization.js`'s `loadGroupsConfiguration`, `rehashPasswords.js`, `mcpServers.js`, `SourceManager.js`, `PageHandler.js`, `OpenApiToolRunner.js`) to use the shared helper instead of the three divergent resolution styles.
- Deduplicated two existing local re-implementations of the same helper (`ContentInstaller.js`, `RegistryService.js`) to reuse the shared one.
- Left `server/migrations/V042__add_agent_factory.js` and `V068__split_tools_config_into_individual_files.js` untouched — migration files must never be modified after being applied.
- `backup.js`'s `contents/` references inside the ZIP archive format itself (the on-disk backup convention) are unrelated to `CONTENTS_DIR` and were left as-is; only its real filesystem `contentsPath` now uses the shared helper.

## Verification

- Started the server with `CONTENTS_DIR=contents2` pointing at a sibling directory, logged in as the local admin, and toggled a feature via `PUT /api/admin/features` — confirmed the write landed in `contents2/config/features.json` and left `contents/config/features.json` untouched.
- `npm run lint:fix` — no new warnings/errors introduced (a handful of pre-existing unrelated warnings remain).
- Full server boot log reviewed — no new errors.
- Ran the two Jest suites that mock `pathUtils.js` (`admin-tools-script-path.test.js`, `ContentInstaller.skill-path-traversal.test.js`) and `agent-artifact-quota.test.js` / `ntlmAuth-domain.test.js` — all green after updating their mocks to include the new exports.
- Ran the full `server` Jest suite before and after the change — same ~113 pre-existing failing suites in both runs (unrelated environment/test-harness issues), confirming no regressions.

## Test plan

- [x] Custom `CONTENTS_DIR` end-to-end write test (admin feature toggle)
- [x] `npm run lint:fix`
- [x] Server boot smoke test
- [x] Affected Jest suites pass
- [x] Full Jest suite shows no new failures vs. baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014U1w7UwEvvAoeP3RYGQun1

---
_Generated by [Claude Code](https://claude.ai/code/session_014U1w7UwEvvAoeP3RYGQun1)_