### PR TITLE
fix: reset garbage version string and harden release version sync

### DIFF
--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -298,7 +298,9 @@ jobs:
     name: Commit Version Changes
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'
+    # Only commit version changes for real releases; workflow_dispatch inputs
+    # are not guaranteed to be valid release tags (see #1765).
+    if: github.event_name == 'release'
     permissions:
       contents: write
     steps:
@@ -319,11 +321,7 @@ jobs:
 
       - name: Set version for commit job
         run: |
-          if [ "${{ github.event_name }}" == "release" ]; then
-            echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          else
-            echo "VERSION=${{ github.event.inputs.release_tag }}" >> $GITHUB_ENV
-          fi
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
         shell: bash
 
       - name: Sync and commit version changes

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ihub-apps-client",
-  "version": "fix-issue-1137-lVuXg",
+  "version": "5.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ihub-apps-client",
-      "version": "fix-issue-1137-lVuXg",
+      "version": "5.4.13",
       "dependencies": {
         "@babel/standalone": "^7.28.1",
         "@dagrejs/dagre": "^2.0.4",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ihub-apps-client",
   "private": true,
-  "version": "fix-issue-1137-lVuXg",
+  "version": "5.4.13",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -389,6 +389,15 @@ trapped the page in an endless reload loop.
   Apps, Prompts, and Sources — the platform-only sections and stats they cannot access are hidden.
 - No admin action is required — the fix takes effect automatically on upgrade.
 
+## Displayed Version Number Fixed
+
+The version shown in the admin UI and documentation footer is corrected back to a real release
+number. A release-automation run had previously committed a stray branch name as the app version,
+which also broke downstream update checks.
+
+- The release-sync script now rejects any non-semver input, so this cannot recur.
+- No admin action is required — the fix takes effect automatically on upgrade.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/docs/theme/head.hbs
+++ b/docs/theme/head.hbs
@@ -17,7 +17,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="theme-color" content="#ffffff">
 <meta name="generator" content="mdBook">
-<meta name="version" content="fix-issue-1137-lVuXg">
+<meta name="version" content="5.4.13">
 
 <link rel="icon" href="{{path_to_root}}favicon.svg">
 <link rel="shortcut icon" href="{{path_to_root}}favicon.png">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ihub-apps",
-  "version": "fix-issue-1137-lVuXg",
+  "version": "5.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ihub-apps",
-      "version": "fix-issue-1137-lVuXg",
+      "version": "5.4.13",
       "bin": {
         "ihub-apps": "server/sea-server.cjs"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ihub-apps",
-  "version": "fix-issue-1137-lVuXg",
+  "version": "5.4.13",
   "description": "iHub Applications Platform",
   "type": "module",
   "bin": {

--- a/scripts/sync-release-version.js
+++ b/scripts/sync-release-version.js
@@ -27,6 +27,13 @@ async function syncReleaseVersion() {
     // Remove 'v' prefix if present
     const version = releaseTag.startsWith('v') ? releaseTag.slice(1) : releaseTag;
 
+    if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z-.]+)?$/.test(version)) {
+      console.error(
+        `❌ Error: "${releaseTag}" is not a valid semver version (expected e.g. 1.2.3 or v1.2.3)`
+      );
+      process.exit(1);
+    }
+
     console.log(`🔄 Syncing version with release tag: ${releaseTag}`);
     console.log(`📦 Target version: ${version}`);
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ihub-apps-server",
-  "version": "fix-issue-1137-lVuXg",
+  "version": "5.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ihub-apps-server",
-      "version": "fix-issue-1137-lVuXg",
+      "version": "5.4.13",
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",
         "@hyzyla/pdfium": "^2.1.12",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ihub-apps-server",
-  "version": "fix-issue-1137-lVuXg",
+  "version": "5.4.13",
   "description": "iHub Apps Applications Server",
   "type": "module",
   "main": "server.js",


### PR DESCRIPTION
## Summary

Fixes #1765.

The `build-binaries` workflow's `commit-version` job had previously run off a `workflow_dispatch` input that was a branch name (`fix-issue-1137-lVuXg`) rather than a release tag, and `sync-release-version.js` committed it verbatim into every `package.json`/lockfile with zero validation. This broke:

- Release binary naming (`build-sea.cjs`)
- `updateService.compareVersions` (non-numeric segments parse to `0`, so update checks always compared `0.0.0`)
- `electron-builder`, which rejects non-semver versions for `electron:build`
- The version shown in the admin UI and the docs footer (`docs/theme/head.hbs`)

## Changes

- Reset the version back to the latest real release, `5.4.13`, in:
  - `package.json`, `client/package.json`, `server/package.json`
  - `package-lock.json`, `client/package-lock.json`, `server/package-lock.json` (both the top-level and nested `packages[""].version` entries)
  - `docs/theme/head.hbs`
- `scripts/sync-release-version.js` now rejects any non-semver input with a clear error and non-zero exit instead of silently accepting it.
- `.github/workflows/build-binaries.yml`: the `commit-version` job now only runs on real `release` events (not `workflow_dispatch`), since a manual dispatch input is not guaranteed to be a valid release tag. Simplified the now-dead `workflow_dispatch` branch in its "Set version for commit job" step accordingly.
- Added a changelog entry under `docs/releases/5.5.0/features.md`.

## Test plan

- [x] `node scripts/sync-release-version.js 5.4.13` run locally to regenerate `package.json`/docs consistently, then lockfiles patched to match.
- [x] Verified `node scripts/sync-release-version.js fix-issue-1137-lVuXg` (the exact bad input that caused this bug) now exits non-zero with a clear error instead of committing.
- [x] All modified `package.json`/`package-lock.json` files parse as valid JSON.
- [x] `grep -rn "fix-issue-1137-lVuXg"` across the repo now only matches the historical review report/skill doc that reference the string as a past example, not any live version field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PFAtsFzDpnoqozRpTTqbey


---
_Generated by [Claude Code](https://claude.ai/code/session_01PFAtsFzDpnoqozRpTTqbey)_