### PR TITLE
fix(workflow): share one WorkflowEngine instance across all entry points

### DIFF
--- a/server/routes/agents/artifacts.js
+++ b/server/routes/agents/artifacts.js
@@ -17,13 +17,11 @@ import {
 import { buildServerPath } from '../../utils/basePath.js';
 import { validateIdForPath, resolveAndValidatePath } from '../../utils/pathSecurity.js';
 import { getRootDir } from '../../pathUtils.js';
-import { WorkflowEngine } from '../../services/workflow/index.js';
+import { getWorkflowEngine } from '../../services/workflow/index.js';
 import { buildContentDisposition } from '../../utils/safeContentDisposition.js';
 
-let _engine = null;
 function getEngine() {
-  if (!_engine) _engine = new WorkflowEngine();
-  return _engine;
+  return getWorkflowEngine();
 }
 
 function artifactsRootDir() {

--- a/server/routes/agents/runs.js
+++ b/server/routes/agents/runs.js
@@ -17,7 +17,7 @@ import {
 import { buildServerPath } from '../../utils/basePath.js';
 import { validateIdForPath } from '../../utils/pathSecurity.js';
 import configCache from '../../configCache.js';
-import { WorkflowEngine, getExecutionRegistry } from '../../services/workflow/index.js';
+import { getWorkflowEngine, getExecutionRegistry } from '../../services/workflow/index.js';
 import { buildAgentPrincipal } from '../../utils/authorization.js';
 import { serializeProfile } from '../../agents/profile/profileWorkflowSerializer.js';
 import { resolveReviewSettings } from '../../agents/profile/reviewSettings.js';
@@ -27,17 +27,20 @@ import { actionTracker } from '../../actionTracker.js';
 import { createSseChannel, startInactiveClientSweep } from '../../utils/sseChannel.js';
 import logger from '../../utils/logger.js';
 
-// Lazy-shared engine. WorkflowEngine state lives in StateManager (filesystem),
-// so multiple instances see the same executions; we use one per-worker.
-// 30-minute default node timeout: the phased planner node blocks while its
-// entire sub-workflow runs (up to 6 tasks × several minutes each), so the
-// 5-minute DEFAULT_NODE_TIMEOUT would kill it mid-run. 30 min matches
-// MAX_NODE_TIMEOUT in WorkflowEngine and is the ceiling _normalizeTimeout allows.
-let _engine = null;
+// Shared WorkflowEngine singleton — see getWorkflowEngine() for why this must
+// be shared rather than a per-module instance (abort/cancel coherence).
 function getEngine() {
-  if (!_engine) _engine = new WorkflowEngine({ defaultTimeout: 30 * 60 * 1000 });
-  return _engine;
+  return getWorkflowEngine();
 }
+
+// 30-minute node timeout for agent runs: the phased planner node blocks while
+// its entire sub-workflow runs (up to 6 tasks × several minutes each), so the
+// engine's 5-minute default would kill it mid-run. 30 min matches
+// MAX_NODE_TIMEOUT in WorkflowEngine and is the ceiling _normalizeTimeout
+// allows. Passed per-call (not via the engine constructor) since the engine
+// instance is now shared with non-agent workflow entry points that should
+// keep the shorter default.
+const AGENT_NODE_TIMEOUT_MS = 30 * 60 * 1000;
 
 function lookupProfile(profileId) {
   const { data: profiles = [] } = configCache.getAgentProfiles(true);
@@ -299,7 +302,8 @@ export default function registerAgentRunRoutes(app) {
         // dominated by the LLM call time, so the I/O is negligible.
         const state = await getEngine().start(workflow, initialData, {
           user: principal,
-          checkpointOnNode: true
+          checkpointOnNode: true,
+          timeout: AGENT_NODE_TIMEOUT_MS
         });
 
         // Register the run in the ExecutionRegistry so the /api/agents/runs
@@ -692,7 +696,8 @@ export default function registerAgentRunRoutes(app) {
         const newState = await getEngine().resumeFromTerminated(runId, {
           user: req.user,
           workflow,
-          checkpointOnNode: true
+          checkpointOnNode: true,
+          timeout: AGENT_NODE_TIMEOUT_MS
         });
         logger.info('Agent run resumed from terminated state', {
           component: 'AgentRunsRoute',
@@ -785,7 +790,15 @@ export default function registerAgentRunRoutes(app) {
           }
         });
 
-        const newState = await getEngine().resume(runId, {}, { user: req.user, workflow });
+        const newState = await getEngine().resume(
+          runId,
+          {},
+          {
+            user: req.user,
+            workflow,
+            timeout: AGENT_NODE_TIMEOUT_MS
+          }
+        );
         res.json({ ok: true, status: newState.status });
       } catch (error) {
         if (error.code === 'EXECUTION_NOT_FOUND') return sendNotFound(res, 'Run');

--- a/server/routes/workflow/workflowRoutes.js
+++ b/server/routes/workflow/workflowRoutes.js
@@ -13,7 +13,7 @@ import { join } from 'path';
 import { authRequired } from '../../middleware/authRequired.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
-import { WorkflowEngine } from '../../services/workflow/WorkflowEngine.js';
+import { getWorkflowEngine } from '../../services/workflow/WorkflowEngine.js';
 import { getExecutionRegistry } from '../../services/workflow/ExecutionRegistry.js';
 import { HumanNodeExecutor } from '../../services/workflow/executors/HumanNodeExecutor.js';
 import { actionTracker } from '../../actionTracker.js';
@@ -301,7 +301,7 @@ function validateWorkflow(workflow) {
  * @param {WorkflowEngine} deps.workflowEngine - Optional custom workflow engine instance
  */
 export default function registerWorkflowRoutes(app, deps = {}) {
-  const workflowEngine = deps.workflowEngine || new WorkflowEngine();
+  const workflowEngine = deps.workflowEngine || getWorkflowEngine();
 
   // Recover persisted executions from disk on startup
   const registry = getExecutionRegistry();

--- a/server/server.js
+++ b/server/server.js
@@ -627,7 +627,7 @@ if (cluster.isPrimary && workerCount > 1) {
   try {
     const { loadWorkflows } = await import('./routes/workflow/workflowRoutes.js');
     const { getTriggerManager } = await import('./services/workflow/triggers/TriggerManager.js');
-    const { WorkflowEngine } = await import('./services/workflow/WorkflowEngine.js');
+    const { getWorkflowEngine } = await import('./services/workflow/WorkflowEngine.js');
     const { resumeInterruptedRuns } = await import('./services/workflow/resumeManager.js');
     const { sweepOrphanedExecutions } = await import('./services/workflow/orphanSweeper.js');
     const { serializeProfile } = await import('./agents/profile/profileWorkflowSerializer.js');
@@ -635,13 +635,17 @@ if (cluster.isPrimary && workerCount > 1) {
     const { applyNodeModels, applyReviewSettings } = await import('./routes/agents/runs.js');
     const { resolveReviewSettings } = await import('./agents/profile/reviewSettings.js');
 
-    // 30-minute default node timeout consistent with the agent-run engine in
-    // routes/agents/runs.js — needed so resumed agent runs (including phased
-    // planner nodes) don't hit the 5-minute DEFAULT_NODE_TIMEOUT on recovery.
-    const engine = new WorkflowEngine({ defaultTimeout: 30 * 60 * 1000 });
+    const engine = getWorkflowEngine();
     const triggerManager = getTriggerManager();
     triggerManager.setEngine(engine); // starts the scheduler-lock heartbeat
     triggerManager.setWorkflowLoader(loadWorkflows);
+
+    // 30-minute node timeout for resumed runs, consistent with the agent-run
+    // engine in routes/agents/runs.js — needed so resumed agent runs
+    // (including phased planner nodes) don't hit the engine's 5-minute
+    // default on recovery. Passed per-call rather than via the (now shared)
+    // engine's constructor so it doesn't leak into non-resume entry points.
+    const RESUME_NODE_TIMEOUT_MS = 30 * 60 * 1000;
 
     // Reconstruct the full definition for a persisted run: agent runs are
     // re-serialized from their profile (with the agent principal restored);
@@ -682,14 +686,17 @@ if (cluster.isPrimary && workerCount > 1) {
         applyReviewSettings(definition, resolveReviewSettings(profile.review));
 
         const principal = buildAgentPrincipal(profile, state.data._agent?.triggeredBy || null);
-        return { definition, options: { user: principal } };
+        return { definition, options: { user: principal, timeout: RESUME_NODE_TIMEOUT_MS } };
       }
       const workflows = await loadWorkflows(false);
       const definition = workflows.find(w => w.id === state.workflowId);
       if (!definition) return null;
       return {
         definition,
-        options: { user: { id: 'system', name: 'System (resumed)', groups: [] } }
+        options: {
+          user: { id: 'system', name: 'System (resumed)', groups: [] },
+          timeout: RESUME_NODE_TIMEOUT_MS
+        }
       };
     };
 

--- a/server/services/workflow/WorkflowEngine.js
+++ b/server/services/workflow/WorkflowEngine.js
@@ -58,6 +58,49 @@ const MAX_EXECUTION_ITERATIONS = 10000;
  * const state = await engine.start(workflowDefinition, { userInput: 'Hello' });
  * console.log('Execution ID:', state.executionId);
  */
+/**
+ * Singleton WorkflowEngine instance shared across all entry points
+ * (workflowRunner, workflowRoutes, agents/runs, agents/artifacts, and the
+ * boot-time resume path). `abortControllers` is per-instance state, so a
+ * cancel() routed through a different instance than the one running the
+ * loop cannot fire that run's abort signal — it can only flip the
+ * persisted status, which is only picked up between nodes. Sharing one
+ * instance makes cancellation coherent across every entry point.
+ * @type {WorkflowEngine|null}
+ * @private
+ */
+let _singletonInstance = null;
+
+/**
+ * Returns the shared WorkflowEngine singleton instance.
+ * Creates one on first call. All callers should use this instead of
+ * `new WorkflowEngine()` so abort controllers and cancellation stay
+ * coherent across entry points.
+ *
+ * Do not pass a `defaultTimeout` override here — since the instance is
+ * shared, whichever caller happens to construct it first would silently
+ * decide the default for everyone else. Callers that need a longer
+ * per-run timeout (e.g. agent runs) should pass `timeout` explicitly in
+ * the `options` of each `start`/`resume`/`resumeFromCheckpoint`/
+ * `resumeFromTerminated` call instead — `_normalizeTimeout` already
+ * prefers a per-call `options.timeout` over `this.defaultTimeout`.
+ * @param {Object} [options] - Options passed to constructor on first creation
+ * @returns {WorkflowEngine}
+ */
+export function getWorkflowEngine(options) {
+  if (!_singletonInstance) {
+    _singletonInstance = new WorkflowEngine(options);
+  }
+  return _singletonInstance;
+}
+
+/**
+ * Resets the singleton instance (for testing purposes only).
+ */
+export function resetWorkflowEngine() {
+  _singletonInstance = null;
+}
+
 export class WorkflowEngine {
   /**
    * Creates a new WorkflowEngine instance

--- a/server/services/workflow/index.js
+++ b/server/services/workflow/index.js
@@ -21,7 +21,12 @@
  * const state = await engine.start(workflowDefinition, initialData);
  */
 
-export { WorkflowEngine, default as workflowEngine } from './WorkflowEngine.js';
+export {
+  WorkflowEngine,
+  getWorkflowEngine,
+  resetWorkflowEngine,
+  default as workflowEngine
+} from './WorkflowEngine.js';
 export { DAGScheduler } from './DAGScheduler.js';
 export {
   StateManager,

--- a/server/tests/workflowEngineSingleton.test.js
+++ b/server/tests/workflowEngineSingleton.test.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+
+/**
+ * Unit tests for the shared WorkflowEngine singleton (getWorkflowEngine):
+ *   - repeated calls return the identical instance (and its abortControllers
+ *     Map, the only genuinely per-instance state)
+ *   - resetWorkflowEngine() forces a fresh instance
+ *   - the actual bug this fixes: a cancel() issued through one "entry point"
+ *     reference now aborts a run started through a different reference,
+ *     because both resolve to the same instance. Before this fix, every
+ *     entry point (workflowRunner, workflowRoutes, agents/runs,
+ *     agents/artifacts, boot-time resume) built its own `new WorkflowEngine()`
+ *     with an independent `abortControllers` Map, so a cancel from one
+ *     surface could only flip the persisted status (picked up between
+ *     nodes) — it could not interrupt a mid-node await tracked by a
+ *     different instance's AbortController.
+ *
+ * Run directly: `node server/tests/workflowEngineSingleton.test.js`.
+ */
+
+import os from 'os';
+import path from 'path';
+import { mkdtempSync } from 'fs';
+import { getWorkflowEngine, resetWorkflowEngine } from '../services/workflow/WorkflowEngine.js';
+import { StateManager } from '../services/workflow/StateManager.js';
+
+let failures = 0;
+function check(label, cond, details) {
+  if (!cond) failures += 1;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && details) console.log(`   ${details}`);
+}
+
+async function waitFor(predicate, { timeoutMs = 2000, intervalMs = 10 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+  return predicate();
+}
+
+/**
+ * Node executor that blocks until its abortSignal fires, so a test can
+ * observe whether an in-flight node execution actually gets interrupted
+ * (rather than only checking the persisted status, which would pass even
+ * against the pre-fix code).
+ */
+class HoldExecutor {
+  constructor() {
+    this.invoked = false;
+    this.aborted = false;
+  }
+
+  async execute(_node, _state, context) {
+    this.invoked = true;
+    const signal = context.abortSignal;
+    if (signal?.aborted) {
+      this.aborted = true;
+      throw Object.assign(new Error('aborted before start'), { code: 'ABORTED' });
+    }
+    return new Promise((_resolve, reject) => {
+      signal?.addEventListener('abort', () => {
+        this.aborted = true;
+        reject(Object.assign(new Error('aborted'), { code: 'ABORTED' }));
+      });
+    });
+  }
+}
+
+async function run() {
+  console.log('🧪 getWorkflowEngine() singleton identity\n');
+  {
+    resetWorkflowEngine();
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), 'ihub-engine-singleton-'));
+    const stateManager = new StateManager({ stateDir });
+
+    const engineFromRunner = getWorkflowEngine({ stateManager });
+    const engineFromRoutes = getWorkflowEngine();
+    const engineFromAgentsRuns = getWorkflowEngine({
+      stateManager: new StateManager({ stateDir })
+    });
+
+    check(
+      'second call returns the identical instance (ignores new options)',
+      engineFromRoutes === engineFromRunner
+    );
+    check(
+      'a third call site also gets the identical instance',
+      engineFromAgentsRuns === engineFromRunner
+    );
+    check(
+      'abortControllers map is the same object across references',
+      engineFromRoutes.abortControllers === engineFromRunner.abortControllers
+    );
+
+    resetWorkflowEngine();
+    const engineAfterReset = getWorkflowEngine({ stateManager });
+    check('resetWorkflowEngine() forces a fresh instance', engineAfterReset !== engineFromRunner);
+  }
+
+  console.log('\n🧪 cancel() through a different reference aborts an in-flight node\n');
+  {
+    resetWorkflowEngine();
+    const stateDir = mkdtempSync(path.join(os.tmpdir(), 'ihub-engine-singleton-cancel-'));
+    const stateManager = new StateManager({ stateDir });
+
+    // Simulates workflowRunner.js obtaining the engine and starting a run.
+    const engineA = getWorkflowEngine({ stateManager });
+    const holdExecutor = new HoldExecutor();
+    engineA.registerExecutor('hold', holdExecutor);
+
+    const workflow = {
+      id: 'wf-singleton-cancel-test',
+      nodes: [{ id: 'n1', type: 'hold' }],
+      edges: [],
+      config: {}
+    };
+
+    const state = await engineA.start(workflow, {}, { user: { id: 'tester' } });
+
+    const nodeStarted = await waitFor(() => holdExecutor.invoked);
+    check('the node executor actually started running', nodeStarted);
+
+    // Simulates a DIFFERENT entry point (e.g. an admin/agents route) fetching
+    // "its own" engine reference and issuing the cancel.
+    const engineB = getWorkflowEngine();
+    check('cancelling reference is the same instance as the starting one', engineB === engineA);
+
+    await engineB.cancel(state.executionId, 'test_cross_reference_cancel');
+
+    const nodeAborted = await waitFor(() => holdExecutor.aborted);
+    check(
+      'the in-flight node executor observed the abort signal (not just a status flip)',
+      nodeAborted,
+      'holdExecutor.aborted stayed false — cancel() did not reach the running node'
+    );
+
+    // Note: the node's rejected promise and cancel()'s own status update race
+    // independently — _handleNodeError unconditionally sets FAILED, which can
+    // overwrite the CANCELLED status cancel() just persisted. That race is a
+    // pre-existing WorkflowEngine behavior unrelated to the singleton fix
+    // under test here, so this only asserts the run reached SOME terminal
+    // state rather than being left running.
+    const finalState = await engineA.getState(state.executionId);
+    check(
+      'run reached a terminal state after cancel',
+      ['cancelled', 'failed'].includes(finalState?.status),
+      `status was ${finalState?.status}`
+    );
+  }
+
+  console.log(`\n${failures === 0 ? '✅ all passed' : `❌ ${failures} failed`}`);
+  process.exit(failures ? 1 : 0);
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/server/tools/workflowRunner.js
+++ b/server/tools/workflowRunner.js
@@ -11,7 +11,7 @@
  * @module tools/workflowRunner
  */
 
-import { WorkflowEngine } from '../services/workflow/WorkflowEngine.js';
+import { getWorkflowEngine } from '../services/workflow/WorkflowEngine.js';
 import { getExecutionRegistry } from '../services/workflow/ExecutionRegistry.js';
 import { recordPendingFinish } from '../services/workflow/chatBridge.js';
 import { actionTracker } from '../actionTracker.js';
@@ -237,7 +237,7 @@ export default async function workflowRunner(params = {}) {
   }
 
   // 4. Start workflow
-  const engine = new WorkflowEngine();
+  const engine = getWorkflowEngine();
   let state;
   try {
     state = await engine.start(workflow, initialData, { user, checkpointOnNode: true });


### PR DESCRIPTION
## Summary

Closes #1774.

`WorkflowEngine` was independently instantiated in five places:
- `server/tools/workflowRunner.js` — `new WorkflowEngine()` on **every** chat-triggered workflow invocation
- `server/routes/workflow/workflowRoutes.js` — module-level `new WorkflowEngine()`
- `server/routes/agents/runs.js` — lazy singleton, `new WorkflowEngine({ defaultTimeout: 30 * 60 * 1000 })`
- `server/routes/agents/artifacts.js` — lazy singleton, `new WorkflowEngine()`
- `server/server.js` — boot-time resume engine, `new WorkflowEngine({ defaultTimeout: 30 * 60 * 1000 })`

`StateManager` was already a shared singleton (`getStateManager()`), so persisted state was consistent across instances — but `abortControllers` is genuinely per-instance state. A `cancel()` routed through a different `WorkflowEngine` instance than the one running the loop could only flip the persisted status (picked up between nodes); it could not interrupt a mid-node await, since that instance's `AbortController` was never touched.

## Changes

- **`server/services/workflow/WorkflowEngine.js`**: added `getWorkflowEngine()` / `resetWorkflowEngine()`, mirroring the existing `getStateManager()` singleton pattern exactly.
- **`server/services/workflow/index.js`**: re-exports the new accessors.
- Replaced all five construction sites (`workflowRunner.js`, `workflowRoutes.js`, `agents/artifacts.js`, `agents/runs.js`, `server.js`) with `getWorkflowEngine()`.
- **Timeout handling**: two of the five sites relied on a constructor-level `defaultTimeout: 30 * 60 * 1000` override (agent runs need 30 minutes per node instead of the 5-minute class default, since a phased planner node blocks on its entire sub-workflow). A single shared instance can only have one constructor-time default, so — per the issue's own implementation plan — both sites now pass `timeout: 30 * 60 * 1000` explicitly in the `options` of each `start`/`resume`/`resumeFromTerminated`/`resumeFromCheckpoint` call instead (`_normalizeTimeout` already prefers a per-call `options.timeout` over `this.defaultTimeout`). This preserves the exact prior behavior without leaking the override into unrelated entry points.
- Test-only `new WorkflowEngine(...)` instantiations (`workflow-resume.test.js`, `agent-plan-reconciliation.test.js`, `WorkflowEngine.executeWithTimeout.test.js`) are left untouched — they intentionally construct isolated instances with test-local state managers.

## New test

`server/tests/workflowEngineSingleton.test.js` (run via `node server/tests/workflowEngineSingleton.test.js`):
- repeated `getWorkflowEngine()` calls return the identical instance (and share the same `abortControllers` map), even when a later call passes different constructor options
- `resetWorkflowEngine()` forces a fresh instance
- the actual regression this fixes: starts a workflow via one `getWorkflowEngine()` reference, then cancels it via a **second** reference (simulating a different route module) obtained by calling `getWorkflowEngine()` again — asserts the in-flight node executor actually observed the abort signal, not just that the persisted status flipped to `cancelled` (which would have passed even against the old, broken code).

## Verification

- `node --check` on all changed files; `eslint --fix` and `prettier --write` clean.
- `node server/tests/workflowEngineSingleton.test.js` — all 8 checks pass.
- `node server/tests/workflow-resume.test.js` and `node server/tests/agent-plan-reconciliation.test.js` — still pass unchanged.
- `node --experimental-vm-modules node_modules/jest/bin/jest.js services/workflow/WorkflowEngine.executeWithTimeout.test.js` — 6/6 pass.
- Full clustered server boot (`node server/server.js`, 4 workers) verified clean — boot-time resume path (`getWorkflowEngine()` + explicit `timeout`) runs without error, workflow triggers initialize normally.

## Test plan

- [x] New regression test passes
- [x] Existing workflow engine tests pass unchanged
- [x] Lint/format clean
- [x] Server boots cleanly (clustered, 4 workers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ez9xnisq1RjgmHucasUCW8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ez9xnisq1RjgmHucasUCW8)_