### PR TITLE
fix(chat): record usage/telemetry for tool-enabled chats

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -389,6 +389,18 @@ trapped the page in an endless reload loop.
   Apps, Prompts, and Sources — the platform-only sections and stats they cannot access are hidden.
 - No admin action is required — the fix takes effect automatically on upgrade.
 
+## Tool-Enabled Apps Now Show Up in Usage and Telemetry Dashboards
+
+Chats with an app that has **tools** enabled now record token usage, OpenTelemetry `gen_ai.*`
+spans, and stream-outcome metrics for every LLM call, the same as ordinary chats. Previously the
+tool-calling path recorded none of this, so any app with tools configured was invisible in usage
+tracking, cost accounting, and telemetry dashboards — and the gap grew with every tool-loop
+iteration, since each iteration is its own billable LLM call.
+
+- Each LLM round-trip in a tool-calling conversation — including every iteration of a multi-step
+  tool loop — is now counted individually, matching how the standard chat path is measured.
+- No configuration or admin action required; historical usage prior to this fix is not backfilled.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/server/services/chat/StreamingHandler.js
+++ b/server/services/chat/StreamingHandler.js
@@ -1,5 +1,4 @@
 import { logInteraction } from '../../utils.js';
-import { estimateTokens, recordChatRequest, recordChatResponse } from '../../usageTracker.js';
 import { activeRequests } from '../../sse.js';
 import { actionTracker } from '../../actionTracker.js';
 import { throttledFetch } from '../../requestThrottler.js';
@@ -10,29 +9,12 @@ import { getReadableStream } from '../../utils/streamUtils.js';
 import conversationStateManager from '../integrations/ConversationStateManager.js';
 import PromptService from '../PromptService.js';
 import logger from '../../utils/logger.js';
-import { getGenAIInstrumentation } from '../../telemetry.js';
 import {
-  recordAppUsage,
-  recordConversation,
-  recordError,
-  recordStreamOutcome
-} from '../../telemetry/metrics.js';
-import activityTracker from '../../telemetry/ActivityTracker.js';
-import { resolveProviderName, resolveOperation } from '../../telemetry/providerMap.js';
-
-/**
- * Merge usage data from streaming chunks, preferring non-zero values from incoming data.
- * Handles Anthropic's split delivery (prompt tokens in message_start, completion in message_delta).
- */
-function mergeUsage(existing, incoming) {
-  if (!incoming) return existing;
-  if (!existing) return { ...incoming };
-  return {
-    promptTokens: incoming.promptTokens || existing.promptTokens,
-    completionTokens: incoming.completionTokens || existing.completionTokens,
-    totalTokens: incoming.totalTokens || existing.totalTokens
-  };
-}
+  mergeUsage,
+  beginLLMCallTelemetry,
+  recordLLMCallCompletion,
+  finalizeLLMCallTelemetry
+} from './llmCallTelemetry.js';
 
 class StreamingHandler {
   constructor() {
@@ -285,60 +267,13 @@ class StreamingHandler {
     }
     activeRequests.set(chatId, controller);
 
-    const baseLog = buildLogData(true);
-    const promptTokens = llmMessages
-      .map(m => estimateTokens(m.content || ''))
-      .reduce((a, b) => a + b, 0);
-    await recordChatRequest({
-      userId: baseLog.userSessionId,
-      appId: baseLog.appId,
-      modelId: model.id,
-      tokens: promptTokens,
-      tokenSource: 'estimate',
-      user: baseLog.user
+    const telemetryCtx = await beginLLMCallTelemetry({
+      request,
+      chatId,
+      buildLogData,
+      model,
+      llmMessages
     });
-
-    // ---- OpenTelemetry instrumentation (streaming) ----
-    activityTracker.recordActivity({
-      userId: baseLog.user?.id || baseLog.userSessionId,
-      chatId
-    });
-    if (baseLog.appId) {
-      // Standard gen_ai.* keys so the metrics.js allow-list passes them
-      // through as labels. Per-user / per-chat / per-message dimensions
-      // are intentionally span-only.
-      const sharedMetricLabels = {
-        'gen_ai.provider.name': resolveProviderName(model.provider),
-        'gen_ai.request.model': model.modelId
-      };
-      recordAppUsage(baseLog.appId, baseLog.user?.id || baseLog.userSessionId, sharedMetricLabels);
-      recordConversation(chatId, llmMessages.length > 2, {
-        'app.id': baseLog.appId,
-        ...sharedMetricLabels
-      });
-    }
-
-    const instrumentation = getGenAIInstrumentation();
-    let llmSpan = null;
-    const spanStart = Date.now();
-    if (instrumentation && instrumentation.isEnabled()) {
-      const operation = resolveOperation(model.provider);
-      const providerName = resolveProviderName(model.provider);
-      llmSpan = instrumentation.createLLMSpan(operation, model, providerName, {
-        appId: baseLog.appId,
-        userId: baseLog.user?.id || baseLog.userSessionId,
-        chatId,
-        messageCount: llmMessages.length,
-        isFollowUp: llmMessages.length > 2
-      });
-      const requestOptions = {
-        temperature: request.body?.temperature,
-        maxTokens: request.body?.max_tokens || request.body?.maxOutputTokens,
-        topP: request.body?.top_p,
-        stream: true
-      };
-      instrumentation.recordRequest(llmSpan, model, llmMessages, requestOptions);
-    }
 
     let timeoutId;
     const setupTimeout = () => {
@@ -368,6 +303,9 @@ class StreamingHandler {
     // Declared up here so the finally block can read accumulated streaming usage
     // for telemetry span/metric finalization.
     let accumulatedUsage = null;
+    // Set in the catch block so the finally block's single finalizeLLMCallTelemetry
+    // call can close the span/record the error metric without a second call site.
+    let caughtError = null;
 
     try {
       const llmResponse = await throttledFetch(model.id, request.url, {
@@ -556,16 +494,10 @@ class StreamingHandler {
             buildLogData(true, { responseType: 'success', response: fullResponse })
           );
 
-          const completionTokens =
-            accumulatedUsage?.completionTokens ?? estimateTokens(fullResponse);
-          const tokenSource = accumulatedUsage ? 'provider' : 'estimate';
-          await recordChatResponse({
-            userId: baseLog.userSessionId,
-            appId: baseLog.appId,
-            modelId: model.id,
-            tokens: completionTokens,
-            tokenSource,
-            user: baseLog.user
+          await recordLLMCallCompletion(telemetryCtx, {
+            model,
+            accumulatedUsage,
+            fullResponseText: fullResponse
           });
           break;
         }
@@ -576,20 +508,7 @@ class StreamingHandler {
       // failure) surfaces as an error/aborted turn — don't stamp an answer
       // source badge in the finally below.
       errorEmitted = true;
-
-      // End telemetry span with error
-      if (instrumentation && llmSpan) {
-        const duration = (Date.now() - spanStart) / 1000;
-        instrumentation.endSpan(llmSpan, error, duration);
-        llmSpan = null;
-      }
-      if (baseLog.appId) {
-        recordError(error.name || 'Error', 'llm_call_streaming', {
-          'app.id': baseLog.appId,
-          'gen_ai.provider.name': resolveProviderName(model.provider),
-          'gen_ai.request.model': model.modelId
-        });
-      }
+      caughtError = error;
 
       logger.error('Caught error in executeStreamingResponse', {
         component: 'StreamingHandler',
@@ -671,40 +590,16 @@ class StreamingHandler {
         activeRequests.delete(chatId);
       }
 
-      // Stream outcome metric. Aborts come from controller.abort() (client
-      // disconnect or our own timeout), normal completion from the model
-      // emitting a stop finish reason. Translate finishReason into one of
-      // {completed, aborted, error} so dashboards can distinguish "user
-      // closed the tab" from "model returned cleanly."
-      const streamOutcome =
-        finishReason === 'error' ? 'error' : doneEmitted ? 'completed' : 'aborted';
-      if (baseLog.appId) {
-        recordStreamOutcome(streamOutcome, {
-          'app.id': baseLog.appId,
-          'gen_ai.provider.name': resolveProviderName(model.provider),
-          'gen_ai.request.model': model.modelId
-        });
-      }
-
-      // Ensure the telemetry span is always closed, even if no error path was taken
-      if (instrumentation && llmSpan) {
-        const duration = (Date.now() - spanStart) / 1000;
-        const usage = accumulatedUsage
-          ? {
-              inputTokens: accumulatedUsage.promptTokens,
-              outputTokens: accumulatedUsage.completionTokens
-            }
-          : undefined;
-        instrumentation.recordResponse(
-          llmSpan,
-          {
-            finishReasons: finishReason ? [finishReason] : undefined,
-            model: model.modelId
-          },
-          usage
-        );
-        instrumentation.endSpan(llmSpan, null, duration);
-      }
+      // Stream outcome metric, error metric, and telemetry span closure — all
+      // handled by a single call so the two possible closing paths (error vs.
+      // clean/aborted completion) can't double-record.
+      finalizeLLMCallTelemetry(telemetryCtx, {
+        model,
+        finishReason,
+        doneEmitted,
+        accumulatedUsage,
+        error: caughtError
+      });
     }
   }
 }

--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -12,6 +12,12 @@ import StreamingHandler from './StreamingHandler.js';
 import PromptService from '../PromptService.js';
 import logger from '../../utils/logger.js';
 import { MAX_CLARIFICATIONS_PER_CONVERSATION, validateAskUserParams } from '../../tools/askUser.js';
+import {
+  mergeUsage,
+  beginLLMCallTelemetry,
+  recordLLMCallCompletion,
+  finalizeLLMCallTelemetry
+} from './llmCallTelemetry.js';
 
 /**
  * Maximum number of clarification requests allowed per conversation
@@ -894,156 +900,197 @@ class ToolExecutor {
     };
     setupTimeout();
 
+    let telemetryCtx;
+    let assistantContent = '';
+    const collectedToolCalls = [];
+    let finishReason = null;
+    let done = false;
+    let accumulatedUsage = null;
+    let llmCallError = null;
+
     try {
-      const llmResponse = await throttledFetch(model.id, request.url, {
-        method: 'POST',
-        headers: request.headers,
-        body: JSON.stringify(request.body),
-        signal: controller.signal
+      telemetryCtx = await beginLLMCallTelemetry({
+        request,
+        chatId,
+        buildLogData,
+        model,
+        llmMessages
       });
 
-      clearTimeout(timeoutId);
-
-      if (!llmResponse.ok) {
-        const errorInfo = await this.errorHandler.createEnhancedLLMApiError(
-          llmResponse,
-          model,
-          clientLanguage
-        );
-
-        throw Object.assign(new Error(errorInfo.message), {
-          code: errorInfo.code,
-          details: errorInfo.details
+      try {
+        const llmResponse = await throttledFetch(model.id, request.url, {
+          method: 'POST',
+          headers: request.headers,
+          body: JSON.stringify(request.body),
+          signal: controller.signal
         });
-      }
 
-      // Use getReadableStream to handle both native fetch (Web Streams) and node-fetch (Node.js streams)
-      const readableStream = this.streamingHandler.getReadableStream(llmResponse);
-      const reader = readableStream.getReader();
-      const decoder = new TextDecoder();
-      const events = [];
-      const parser = createParser({ onEvent: e => events.push(e) });
+        clearTimeout(timeoutId);
 
-      let assistantContent = '';
-      const collectedToolCalls = [];
-      let finishReason = null;
-      let done = false;
+        if (!llmResponse.ok) {
+          const errorInfo = await this.errorHandler.createEnhancedLLMApiError(
+            llmResponse,
+            model,
+            clientLanguage
+          );
 
-      while (!done) {
-        const { value, done: readerDone } = await reader.read();
-        if (readerDone || !activeRequests.has(chatId)) {
-          if (!activeRequests.has(chatId)) reader.cancel();
-          break;
+          throw Object.assign(new Error(errorInfo.message), {
+            code: errorInfo.code,
+            details: errorInfo.details
+          });
         }
 
-        const chunk = decoder.decode(value, { stream: true });
-        parser.feed(chunk);
+        // Use getReadableStream to handle both native fetch (Web Streams) and node-fetch (Node.js streams)
+        const readableStream = this.streamingHandler.getReadableStream(llmResponse);
+        const reader = readableStream.getReader();
+        const decoder = new TextDecoder();
+        const events = [];
+        const parser = createParser({ onEvent: e => events.push(e) });
 
-        while (events.length > 0) {
-          const evt = events.shift();
-          const result = await convertResponseToGeneric(evt.data, model.provider, chatId);
-
-          if (result.error) {
-            throw Object.assign(new Error(result.errorMessage || 'Error processing response'), {
-              code: 'PROCESSING_ERROR'
-            });
-          }
-
-          // logger.info(`Result for chat ID ${chatId}:`, result);
-          if (result.content?.length > 0) {
-            for (const text of result.content) {
-              assistantContent += text;
-              actionTracker.trackChunk(chatId, { content: text });
-            }
-          }
-
-          // Process images (important for image generation with tools like google_search)
-          this.streamingHandler.processImages(result, chatId);
-
-          // Process thinking content
-          this.streamingHandler.processThinking(result, chatId);
-
-          // Process grounding metadata (for Google Search grounding)
-          this.streamingHandler.processGroundingMetadata(result, chatId);
-
-          // logger.info(`Tool calls for chat ID ${chatId}:`, result.tool_calls);
-          if (result.tool_calls?.length > 0) {
-            result.tool_calls.forEach(call => {
-              let existingCall = collectedToolCalls.find(c => c.index === call.index);
-
-              if (existingCall) {
-                // Merge properties into the existing tool call
-                if (call.id) existingCall.id = call.id;
-                if (call.type) existingCall.type = call.type;
-                // Preserve metadata (critical for thoughtSignature in Gemini 3)
-                if (call.metadata) existingCall.metadata = call.metadata;
-                if (call.function) {
-                  if (call.function.name) existingCall.function.name = call.function.name;
-
-                  // Handle arguments accumulation for streaming
-                  let callArgs = call.function.arguments;
-                  if (call.arguments && call.arguments.__raw_arguments) {
-                    callArgs = call.arguments.__raw_arguments;
-                  }
-                  if (callArgs) {
-                    // Smart concatenation: avoid empty {} + real args pattern
-                    const existing = existingCall.function.arguments;
-                    if (!existing || existing === '{}' || existing.trim() === '') {
-                      // If existing is empty or just {}, replace it entirely
-                      existingCall.function.arguments = callArgs;
-                    } else if (callArgs !== '{}' && callArgs.trim() !== '') {
-                      // Only concatenate if new args aren't empty
-                      existingCall.function.arguments += callArgs;
-                    }
-                  }
-                }
-              } else if (call.index !== undefined) {
-                // Create a new tool call if it doesn't exist
-                let initialArgs = call.function?.arguments || '';
-                if (call.arguments && call.arguments.__raw_arguments) {
-                  initialArgs = call.arguments.__raw_arguments;
-                }
-
-                // Clean up initial args - avoid starting with empty {}
-                if (initialArgs === '{}' || initialArgs.trim() === '') {
-                  initialArgs = '';
-                }
-
-                collectedToolCalls.push({
-                  index: call.index,
-                  id: call.id || null,
-                  type: call.type || 'function',
-                  metadata: call.metadata || {}, // Preserve metadata (critical for thoughtSignature)
-                  function: {
-                    name: call.function?.name || '',
-                    arguments: initialArgs
-                  }
-                });
-              }
-            });
-          }
-
-          // logger.info(`Finish Reason for chat ID ${chatId}:`, finishReason);
-          if (result.finishReason) {
-            finishReason = result.finishReason;
-          }
-
-          // logger.info(
-          //   `Completed processing for chat ID ${chatId} - done? ${done}:`,
-          //   JSON.stringify({ finishReason, collectedToolCalls }, null, 2)
-          // );
-          if (result.complete) {
-            done = true;
+        while (!done) {
+          const { value, done: readerDone } = await reader.read();
+          if (readerDone || !activeRequests.has(chatId)) {
+            if (!activeRequests.has(chatId)) reader.cancel();
             break;
           }
-        }
-      }
 
-      // Whether the stream finished naturally, was superseded by a newer
-      // request on this chatId, or the reader was cancelled mid-flight,
-      // discard any leftover tool-call accumulation state so it can't be
-      // finalized by a future, unrelated stream reusing this chatId.
-      clearStreamingState(model.provider, chatId);
+          const chunk = decoder.decode(value, { stream: true });
+          parser.feed(chunk);
+
+          while (events.length > 0) {
+            const evt = events.shift();
+            const result = await convertResponseToGeneric(evt.data, model.provider, chatId);
+
+            if (result.error) {
+              throw Object.assign(new Error(result.errorMessage || 'Error processing response'), {
+                code: 'PROCESSING_ERROR'
+              });
+            }
+
+            // Usage may arrive either at the top level or under metadata.usage
+            // depending on which converter emitted it.
+            if (result.usage) {
+              accumulatedUsage = mergeUsage(accumulatedUsage, result.usage);
+            }
+            if (result.metadata?.usage) {
+              accumulatedUsage = mergeUsage(accumulatedUsage, result.metadata.usage);
+            }
+
+            // logger.info(`Result for chat ID ${chatId}:`, result);
+            if (result.content?.length > 0) {
+              for (const text of result.content) {
+                assistantContent += text;
+                actionTracker.trackChunk(chatId, { content: text });
+              }
+            }
+
+            // Process images (important for image generation with tools like google_search)
+            this.streamingHandler.processImages(result, chatId);
+
+            // Process thinking content
+            this.streamingHandler.processThinking(result, chatId);
+
+            // Process grounding metadata (for Google Search grounding)
+            this.streamingHandler.processGroundingMetadata(result, chatId);
+
+            // logger.info(`Tool calls for chat ID ${chatId}:`, result.tool_calls);
+            if (result.tool_calls?.length > 0) {
+              result.tool_calls.forEach(call => {
+                let existingCall = collectedToolCalls.find(c => c.index === call.index);
+
+                if (existingCall) {
+                  // Merge properties into the existing tool call
+                  if (call.id) existingCall.id = call.id;
+                  if (call.type) existingCall.type = call.type;
+                  // Preserve metadata (critical for thoughtSignature in Gemini 3)
+                  if (call.metadata) existingCall.metadata = call.metadata;
+                  if (call.function) {
+                    if (call.function.name) existingCall.function.name = call.function.name;
+
+                    // Handle arguments accumulation for streaming
+                    let callArgs = call.function.arguments;
+                    if (call.arguments && call.arguments.__raw_arguments) {
+                      callArgs = call.arguments.__raw_arguments;
+                    }
+                    if (callArgs) {
+                      // Smart concatenation: avoid empty {} + real args pattern
+                      const existing = existingCall.function.arguments;
+                      if (!existing || existing === '{}' || existing.trim() === '') {
+                        // If existing is empty or just {}, replace it entirely
+                        existingCall.function.arguments = callArgs;
+                      } else if (callArgs !== '{}' && callArgs.trim() !== '') {
+                        // Only concatenate if new args aren't empty
+                        existingCall.function.arguments += callArgs;
+                      }
+                    }
+                  }
+                } else if (call.index !== undefined) {
+                  // Create a new tool call if it doesn't exist
+                  let initialArgs = call.function?.arguments || '';
+                  if (call.arguments && call.arguments.__raw_arguments) {
+                    initialArgs = call.arguments.__raw_arguments;
+                  }
+
+                  // Clean up initial args - avoid starting with empty {}
+                  if (initialArgs === '{}' || initialArgs.trim() === '') {
+                    initialArgs = '';
+                  }
+
+                  collectedToolCalls.push({
+                    index: call.index,
+                    id: call.id || null,
+                    type: call.type || 'function',
+                    metadata: call.metadata || {}, // Preserve metadata (critical for thoughtSignature)
+                    function: {
+                      name: call.function?.name || '',
+                      arguments: initialArgs
+                    }
+                  });
+                }
+              });
+            }
+
+            // logger.info(`Finish Reason for chat ID ${chatId}:`, finishReason);
+            if (result.finishReason) {
+              finishReason = result.finishReason;
+            }
+
+            // logger.info(
+            //   `Completed processing for chat ID ${chatId} - done? ${done}:`,
+            //   JSON.stringify({ finishReason, collectedToolCalls }, null, 2)
+            // );
+            if (result.complete) {
+              done = true;
+              break;
+            }
+          }
+        }
+
+        // Whether the stream finished naturally, was superseded by a newer
+        // request on this chatId, or the reader was cancelled mid-flight,
+        // discard any leftover tool-call accumulation state so it can't be
+        // finalized by a future, unrelated stream reusing this chatId.
+        clearStreamingState(model.provider, chatId);
+
+        if (done) {
+          await recordLLMCallCompletion(telemetryCtx, {
+            model,
+            accumulatedUsage,
+            fullResponseText: assistantContent
+          });
+        }
+      } catch (innerError) {
+        llmCallError = innerError;
+        throw innerError;
+      } finally {
+        finalizeLLMCallTelemetry(telemetryCtx, {
+          model,
+          finishReason,
+          doneEmitted: done,
+          accumulatedUsage,
+          error: llmCallError
+        });
+      }
 
       if (finishReason !== 'tool_calls' && collectedToolCalls.length === 0) {
         logger.info('No tool calls to process', {
@@ -1330,6 +1377,15 @@ class ToolExecutor {
         }
       }, DEFAULT_TIMEOUT);
 
+      let telemetryCtx;
+      let assistantContent = '';
+      const collectedToolCalls = [];
+      const collectedThoughtSignatures = []; // Collect all thoughtSignatures from response
+      let finishReason = null;
+      let done = false;
+      let accumulatedUsage = null;
+      let llmCallError = null;
+
       try {
         // Determine HTTP method and body based on adapter requirements
         const fetchOptions = {
@@ -1343,121 +1399,153 @@ class ToolExecutor {
           fetchOptions.body = JSON.stringify(followRequest.body);
         }
 
-        const llmResponse = await throttledFetch(model.id, followRequest.url, fetchOptions);
+        telemetryCtx = await beginLLMCallTelemetry({
+          request: followRequest,
+          chatId,
+          buildLogData,
+          model,
+          llmMessages
+        });
 
-        clearTimeout(timeoutId);
+        try {
+          const llmResponse = await throttledFetch(model.id, followRequest.url, fetchOptions);
 
-        if (!llmResponse.ok) {
-          const errorInfo = await this.errorHandler.createEnhancedLLMApiError(
-            llmResponse,
-            model,
-            clientLanguage
-          );
+          clearTimeout(timeoutId);
 
-          throw Object.assign(new Error(errorInfo.message), {
-            code: errorInfo.code,
-            details: errorInfo.details
-          });
-        }
+          if (!llmResponse.ok) {
+            const errorInfo = await this.errorHandler.createEnhancedLLMApiError(
+              llmResponse,
+              model,
+              clientLanguage
+            );
 
-        // Use getReadableStream to handle both native fetch (Web Streams) and node-fetch (Node.js streams)
-        const readableStream = this.streamingHandler.getReadableStream(llmResponse);
-        const reader = readableStream.getReader();
-        const decoder = new TextDecoder();
-        const events = [];
-        const parser = createParser({ onEvent: e => events.push(e) });
-
-        let assistantContent = '';
-        const collectedToolCalls = [];
-        const collectedThoughtSignatures = []; // Collect all thoughtSignatures from response
-        let finishReason = null;
-        let done = false;
-
-        while (!done) {
-          const { value, done: readerDone } = await reader.read();
-          if (readerDone || !activeRequests.has(chatId)) {
-            if (!activeRequests.has(chatId)) reader.cancel();
-            break;
+            throw Object.assign(new Error(errorInfo.message), {
+              code: errorInfo.code,
+              details: errorInfo.details
+            });
           }
 
-          const chunk = decoder.decode(value, { stream: true });
-          parser.feed(chunk);
+          // Use getReadableStream to handle both native fetch (Web Streams) and node-fetch (Node.js streams)
+          const readableStream = this.streamingHandler.getReadableStream(llmResponse);
+          const reader = readableStream.getReader();
+          const decoder = new TextDecoder();
+          const events = [];
+          const parser = createParser({ onEvent: e => events.push(e) });
 
-          while (events.length > 0) {
-            const evt = events.shift();
-            const result = await convertResponseToGeneric(evt.data, model.provider, chatId);
-
-            if (result.error) {
-              throw Object.assign(new Error(result.errorMessage || 'Error processing response'), {
-                code: 'PROCESSING_ERROR'
-              });
-            }
-
-            if (result.content?.length > 0) {
-              for (const text of result.content) {
-                assistantContent += text;
-                actionTracker.trackChunk(chatId, { content: text });
-              }
-            }
-
-            if (result.tool_calls?.length > 0) {
-              result.tool_calls.forEach(call => {
-                let existingCall = collectedToolCalls.find(c => c.index === call.index);
-
-                if (existingCall) {
-                  if (call.id) existingCall.id = call.id;
-                  if (call.type) existingCall.type = call.type;
-                  if (call.function) {
-                    if (call.function.name) existingCall.function.name = call.function.name;
-                    if (call.function.arguments)
-                      existingCall.function.arguments += call.function.arguments;
-                  }
-                  // Merge metadata (important for Gemini thoughtSignatures)
-                  if (call.metadata) {
-                    existingCall.metadata = { ...existingCall.metadata, ...call.metadata };
-                  }
-                } else if (call.index !== undefined) {
-                  const toolCall = {
-                    index: call.index,
-                    id: call.id || null,
-                    type: call.type || 'function',
-                    function: {
-                      name: call.function?.name || '',
-                      arguments: call.function?.arguments || ''
-                    },
-                    // Preserve metadata for provider-specific requirements (e.g., Gemini thoughtSignatures)
-                    metadata: call.metadata || {}
-                  };
-                  collectedToolCalls.push(toolCall);
-                }
-              });
-            }
-
-            // Collect thoughtSignatures for Google Gemini thinking models
-            if (result.thoughtSignatures && result.thoughtSignatures.length > 0) {
-              collectedThoughtSignatures.push(...result.thoughtSignatures);
-              logger.info('Collected thoughtSignatures from response', {
-                component: 'ToolExecutor',
-                count: result.thoughtSignatures.length
-              });
-            }
-
-            if (result.finishReason) {
-              finishReason = result.finishReason;
-            }
-
-            if (result.complete) {
-              done = true;
+          while (!done) {
+            const { value, done: readerDone } = await reader.read();
+            if (readerDone || !activeRequests.has(chatId)) {
+              if (!activeRequests.has(chatId)) reader.cancel();
               break;
             }
-          }
-        }
 
-        // Whether the stream finished naturally, was superseded by a newer
-        // request on this chatId, or the reader was cancelled mid-flight,
-        // discard any leftover tool-call accumulation state so it can't be
-        // finalized by a future, unrelated stream reusing this chatId.
-        clearStreamingState(model.provider, chatId);
+            const chunk = decoder.decode(value, { stream: true });
+            parser.feed(chunk);
+
+            while (events.length > 0) {
+              const evt = events.shift();
+              const result = await convertResponseToGeneric(evt.data, model.provider, chatId);
+
+              if (result.error) {
+                throw Object.assign(new Error(result.errorMessage || 'Error processing response'), {
+                  code: 'PROCESSING_ERROR'
+                });
+              }
+
+              // Usage may arrive either at the top level or under metadata.usage
+              // depending on which converter emitted it.
+              if (result.usage) {
+                accumulatedUsage = mergeUsage(accumulatedUsage, result.usage);
+              }
+              if (result.metadata?.usage) {
+                accumulatedUsage = mergeUsage(accumulatedUsage, result.metadata.usage);
+              }
+
+              if (result.content?.length > 0) {
+                for (const text of result.content) {
+                  assistantContent += text;
+                  actionTracker.trackChunk(chatId, { content: text });
+                }
+              }
+
+              if (result.tool_calls?.length > 0) {
+                result.tool_calls.forEach(call => {
+                  let existingCall = collectedToolCalls.find(c => c.index === call.index);
+
+                  if (existingCall) {
+                    if (call.id) existingCall.id = call.id;
+                    if (call.type) existingCall.type = call.type;
+                    if (call.function) {
+                      if (call.function.name) existingCall.function.name = call.function.name;
+                      if (call.function.arguments)
+                        existingCall.function.arguments += call.function.arguments;
+                    }
+                    // Merge metadata (important for Gemini thoughtSignatures)
+                    if (call.metadata) {
+                      existingCall.metadata = { ...existingCall.metadata, ...call.metadata };
+                    }
+                  } else if (call.index !== undefined) {
+                    const toolCall = {
+                      index: call.index,
+                      id: call.id || null,
+                      type: call.type || 'function',
+                      function: {
+                        name: call.function?.name || '',
+                        arguments: call.function?.arguments || ''
+                      },
+                      // Preserve metadata for provider-specific requirements (e.g., Gemini thoughtSignatures)
+                      metadata: call.metadata || {}
+                    };
+                    collectedToolCalls.push(toolCall);
+                  }
+                });
+              }
+
+              // Collect thoughtSignatures for Google Gemini thinking models
+              if (result.thoughtSignatures && result.thoughtSignatures.length > 0) {
+                collectedThoughtSignatures.push(...result.thoughtSignatures);
+                logger.info('Collected thoughtSignatures from response', {
+                  component: 'ToolExecutor',
+                  count: result.thoughtSignatures.length
+                });
+              }
+
+              if (result.finishReason) {
+                finishReason = result.finishReason;
+              }
+
+              if (result.complete) {
+                done = true;
+                break;
+              }
+            }
+          }
+
+          // Whether the stream finished naturally, was superseded by a newer
+          // request on this chatId, or the reader was cancelled mid-flight,
+          // discard any leftover tool-call accumulation state so it can't be
+          // finalized by a future, unrelated stream reusing this chatId.
+          clearStreamingState(model.provider, chatId);
+
+          if (done) {
+            await recordLLMCallCompletion(telemetryCtx, {
+              model,
+              accumulatedUsage,
+              fullResponseText: assistantContent
+            });
+          }
+        } catch (innerError) {
+          llmCallError = innerError;
+          throw innerError;
+        } finally {
+          finalizeLLMCallTelemetry(telemetryCtx, {
+            model,
+            finishReason,
+            doneEmitted: done,
+            accumulatedUsage,
+            error: llmCallError
+          });
+        }
 
         // If no tool calls, this is the final response - stream it back to client
         if (finishReason !== 'tool_calls' && collectedToolCalls.length === 0) {

--- a/server/services/chat/llmCallTelemetry.js
+++ b/server/services/chat/llmCallTelemetry.js
@@ -1,0 +1,171 @@
+import { estimateTokens, recordChatRequest, recordChatResponse } from '../../usageTracker.js';
+import { getGenAIInstrumentation } from '../../telemetry.js';
+import {
+  recordAppUsage,
+  recordConversation,
+  recordError,
+  recordStreamOutcome
+} from '../../telemetry/metrics.js';
+import activityTracker from '../../telemetry/ActivityTracker.js';
+import { resolveProviderName, resolveOperation } from '../../telemetry/providerMap.js';
+
+/**
+ * Merge usage data from streaming chunks, preferring non-zero values from incoming data.
+ * Handles Anthropic's split delivery (prompt tokens in message_start, completion in message_delta).
+ */
+export function mergeUsage(existing, incoming) {
+  if (!incoming) return existing;
+  if (!existing) return { ...incoming };
+  return {
+    promptTokens: incoming.promptTokens || existing.promptTokens,
+    completionTokens: incoming.completionTokens || existing.completionTokens,
+    totalTokens: incoming.totalTokens || existing.totalTokens
+  };
+}
+
+/**
+ * Record request-side usage/telemetry for one LLM HTTP round-trip and open its
+ * OTel span. Call once per LLM call — including once per iteration of a
+ * tool-calling loop, since each iteration is its own billable request.
+ * @returns {Object} context to pass to recordLLMCallCompletion/finalizeLLMCallTelemetry
+ */
+export async function beginLLMCallTelemetry({ request, chatId, buildLogData, model, llmMessages }) {
+  const baseLog = buildLogData(true);
+  const promptTokens = llmMessages
+    .map(m => estimateTokens(m.content || ''))
+    .reduce((a, b) => a + b, 0);
+
+  await recordChatRequest({
+    userId: baseLog.userSessionId,
+    appId: baseLog.appId,
+    modelId: model.id,
+    tokens: promptTokens,
+    tokenSource: 'estimate',
+    user: baseLog.user
+  });
+
+  activityTracker.recordActivity({
+    userId: baseLog.user?.id || baseLog.userSessionId,
+    chatId
+  });
+
+  if (baseLog.appId) {
+    // Standard gen_ai.* keys so the metrics.js allow-list passes them through
+    // as labels. Per-user / per-chat / per-message dimensions are intentionally
+    // span-only.
+    const sharedMetricLabels = {
+      'gen_ai.provider.name': resolveProviderName(model.provider),
+      'gen_ai.request.model': model.modelId
+    };
+    recordAppUsage(baseLog.appId, baseLog.user?.id || baseLog.userSessionId, sharedMetricLabels);
+    recordConversation(chatId, llmMessages.length > 2, {
+      'app.id': baseLog.appId,
+      ...sharedMetricLabels
+    });
+  }
+
+  const instrumentation = getGenAIInstrumentation();
+  let llmSpan = null;
+  const spanStart = Date.now();
+  if (instrumentation && instrumentation.isEnabled()) {
+    const operation = resolveOperation(model.provider);
+    const providerName = resolveProviderName(model.provider);
+    llmSpan = instrumentation.createLLMSpan(operation, model, providerName, {
+      appId: baseLog.appId,
+      userId: baseLog.user?.id || baseLog.userSessionId,
+      chatId,
+      messageCount: llmMessages.length,
+      isFollowUp: llmMessages.length > 2
+    });
+    const requestOptions = {
+      temperature: request.body?.temperature,
+      maxTokens: request.body?.max_tokens || request.body?.maxOutputTokens,
+      topP: request.body?.top_p,
+      stream: true
+    };
+    instrumentation.recordRequest(llmSpan, model, llmMessages, requestOptions);
+  }
+
+  return { baseLog, promptTokens, instrumentation, llmSpan, spanStart };
+}
+
+/**
+ * Record completion-token usage once the provider signals a completed answer
+ * (a `result.complete` chunk). Call at most once per LLM call, only on the
+ * success path — finalizeLLMCallTelemetry records the stream outcome either way.
+ */
+export async function recordLLMCallCompletion(ctx, { model, accumulatedUsage, fullResponseText }) {
+  const completionTokens = accumulatedUsage?.completionTokens ?? estimateTokens(fullResponseText);
+  const tokenSource = accumulatedUsage ? 'provider' : 'estimate';
+  await recordChatResponse({
+    userId: ctx.baseLog.userSessionId,
+    appId: ctx.baseLog.appId,
+    modelId: model.id,
+    tokens: completionTokens,
+    tokenSource,
+    user: ctx.baseLog.user
+  });
+}
+
+/**
+ * Close out an LLM call's OTel span, error metric, and stream-outcome metric.
+ * Call exactly once per call, in a finally block, regardless of how it ended.
+ * @param {Object} ctx - the object returned by beginLLMCallTelemetry
+ * @param {Error} [options.error] - set when the call is being finalized from a catch block;
+ *   ends the span with the error and records an error metric before the outcome metric.
+ */
+export function finalizeLLMCallTelemetry(
+  ctx,
+  { model, finishReason, doneEmitted, accumulatedUsage, error }
+) {
+  const { baseLog, instrumentation, spanStart } = ctx;
+  let { llmSpan } = ctx;
+
+  if (error) {
+    if (instrumentation && llmSpan) {
+      const duration = (Date.now() - spanStart) / 1000;
+      instrumentation.endSpan(llmSpan, error, duration);
+      llmSpan = null;
+    }
+    if (baseLog.appId) {
+      recordError(error.name || 'Error', 'llm_call_streaming', {
+        'app.id': baseLog.appId,
+        'gen_ai.provider.name': resolveProviderName(model.provider),
+        'gen_ai.request.model': model.modelId
+      });
+    }
+  }
+
+  // Aborts come from the request's own AbortController (client disconnect or
+  // our own timeout), normal completion from the model emitting a stop finish
+  // reason. Translate finishReason into one of {completed, aborted, error} so
+  // dashboards can distinguish "user closed the tab" from "model returned
+  // cleanly."
+  const streamOutcome = finishReason === 'error' ? 'error' : doneEmitted ? 'completed' : 'aborted';
+  if (baseLog.appId) {
+    recordStreamOutcome(streamOutcome, {
+      'app.id': baseLog.appId,
+      'gen_ai.provider.name': resolveProviderName(model.provider),
+      'gen_ai.request.model': model.modelId
+    });
+  }
+
+  if (instrumentation && llmSpan) {
+    const duration = (Date.now() - spanStart) / 1000;
+    const usage = accumulatedUsage
+      ? {
+          inputTokens: accumulatedUsage.promptTokens,
+          outputTokens: accumulatedUsage.completionTokens
+        }
+      : undefined;
+    instrumentation.recordResponse(
+      llmSpan,
+      {
+        finishReasons: finishReason ? [finishReason] : undefined,
+        model: model.modelId
+      },
+      usage
+    );
+    instrumentation.endSpan(llmSpan, null, duration);
+  }
+}

--- a/server/tests/toolExecutor-usage-telemetry.test.js
+++ b/server/tests/toolExecutor-usage-telemetry.test.js
@@ -1,0 +1,180 @@
+/**
+ * Regression tests for #1724: ToolExecutor (the path taken by every
+ * tool-enabled app) never recorded usage tokens for its LLM round-trips —
+ * every app with `tools` configured was invisible in usage tracking. These
+ * tests assert `recordChatRequest`/`recordChatResponse` now fire once per LLM
+ * call, including once per iteration of the tool-calling loop.
+ *
+ * Note: The repo's source is native ESM (uses `import.meta.url`), so this file
+ * uses `jest.unstable_mockModule` + dynamic imports rather than the
+ * CommonJS-only `jest.mock` API. Run with `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+
+const recordChatRequestMock = jest.fn(async () => {});
+const recordChatResponseMock = jest.fn(async () => {});
+
+jest.unstable_mockModule('../adapters/index.js', () => ({
+  createCompletionRequest: async (model, _messages, _apiKey, opts) => ({
+    url: 'https://example.invalid/chat/completions',
+    method: 'POST',
+    headers: {},
+    body: { model: model.modelId, temperature: opts.temperature }
+  }),
+  // StreamingHandler (imported transitively by ToolExecutor) needs this export
+  // to exist even though these tests never reach it.
+  getAdapter: () => {
+    throw new Error('getAdapter should not be called in this test');
+  }
+}));
+
+jest.unstable_mockModule('../adapters/toolCalling/index.js', () => ({
+  normalizeToolName: id => id,
+  isFailureFinishReason: () => false,
+  clearStreamingState: () => {},
+  // Each mocked SSE event's `data` is a JSON-encoded generic result chunk —
+  // bypass real provider-specific parsing since that's not what's under test.
+  convertResponseToGeneric: async data => JSON.parse(data)
+}));
+
+// usageTracker.js also schedules an un-refed, module-scope setInterval (its
+// periodic save-retry loop) that keeps the process alive forever once
+// imported for real — stub it out with spies so these tests can assert on it
+// without dragging that timer into the suite.
+jest.unstable_mockModule('../usageTracker.js', () => ({
+  estimateTokens: text => Math.max(1, Math.ceil((text || '').length / 4)),
+  recordChatRequest: recordChatRequestMock,
+  recordChatResponse: recordChatResponseMock
+}));
+
+jest.unstable_mockModule('../toolLoader.js', () => ({
+  // Other modules transitively imported by ToolExecutor.js (e.g. configCache.js)
+  // statically import several of these named exports, so they all need to
+  // exist even though this suite only exercises runTool.
+  loadConfiguredTools: async () => [],
+  discoverMcpTools: async () => [],
+  loadTools: async () => [],
+  resolveNativeWebSearchProvider: () => null,
+  resolveAppNativeWebSearch: () => null,
+  getToolsForApp: async () => [],
+  localizeTools: tools => tools,
+  runTool: async () => ({ result: 'ok' })
+}));
+
+let throttledFetchImpl;
+jest.unstable_mockModule('../requestThrottler.js', () => ({
+  throttledFetch: (...args) => throttledFetchImpl(...args)
+}));
+
+const { default: ToolExecutor } = await import('../services/chat/ToolExecutor.js');
+
+/**
+ * Build a fetch-like Response whose body streams the given generic result
+ * chunks as SSE `data:` events (matching what convertResponseToGeneric, mocked
+ * above, expects to receive as its raw `data` argument).
+ */
+function sseResponse(chunks) {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
+      }
+      controller.close();
+    }
+  });
+  return { ok: true, body };
+}
+
+function buildLogData() {
+  return { appId: 'test-app', userSessionId: 'test-session', user: { id: 'test-user' } };
+}
+
+describe('ToolExecutor usage/telemetry recording (#1724)', () => {
+  beforeEach(() => {
+    recordChatRequestMock.mockClear();
+    recordChatResponseMock.mockClear();
+  });
+
+  test('processChatWithTools records one request/response pair for a no-tool-call turn', async () => {
+    throttledFetchImpl = async () =>
+      sseResponse([{ content: ['hi there'], complete: true, finishReason: 'stop' }]);
+
+    const toolExecutor = new ToolExecutor();
+    const chatId = 'telemetry-no-tools';
+
+    await toolExecutor.processChatWithTools({
+      prep: {
+        request: { url: 'https://example.invalid/chat/completions', headers: {}, body: {} },
+        model: { id: 'test-model', modelId: 'test-model', provider: 'openai' },
+        llmMessages: [{ role: 'user', content: 'hi' }],
+        tools: [],
+        apiKey: 'sk-test',
+        temperature: 0.7,
+        maxTokens: 100,
+        responseFormat: undefined,
+        responseSchema: undefined,
+        app: {},
+        userFileData: null
+      },
+      chatId,
+      buildLogData,
+      DEFAULT_TIMEOUT: 5000,
+      getLocalizedError: async () => null,
+      clientLanguage: 'en',
+      user: { id: 'test-user' }
+    });
+
+    expect(recordChatRequestMock).toHaveBeenCalledTimes(1);
+    expect(recordChatResponseMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('continueWithToolExecution records one request/response pair per LLM call, not once per conversation', async () => {
+    let callCount = 0;
+    throttledFetchImpl = async () => {
+      callCount++;
+      if (callCount === 1) {
+        // First iteration: model asks for a tool call.
+        return sseResponse([
+          {
+            tool_calls: [
+              {
+                index: 0,
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'noop_tool', arguments: '{}' }
+              }
+            ],
+            complete: false
+          },
+          { complete: true, finishReason: 'tool_calls' }
+        ]);
+      }
+      // Second iteration: model returns the final answer.
+      return sseResponse([{ content: ['final answer'], complete: true, finishReason: 'stop' }]);
+    };
+
+    const toolExecutor = new ToolExecutor();
+    const chatId = 'telemetry-tool-loop';
+
+    await toolExecutor.continueWithToolExecution({
+      model: { id: 'test-model', modelId: 'test-model', provider: 'openai' },
+      llmMessages: [{ role: 'user', content: 'hi' }],
+      apiKey: 'sk-test',
+      temperature: 0.7,
+      maxTokens: 100,
+      tools: [{ id: 'noop_tool' }],
+      chatId,
+      buildLogData,
+      DEFAULT_TIMEOUT: 5000,
+      getLocalizedError: async () => null,
+      clientLanguage: 'en',
+      user: { id: 'test-user' }
+    });
+
+    expect(callCount).toBe(2);
+    expect(recordChatRequestMock).toHaveBeenCalledTimes(2);
+    expect(recordChatResponseMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1724.

`ToolExecutor` (the LLM-call path taken by every tool-enabled app) never recorded usage tokens, OpenTelemetry `gen_ai.*` spans, or stream-outcome metrics — only the non-tool `StreamingHandler` path did. This meant any app with `tools` configured was invisible in usage tracking, cost accounting, and telemetry dashboards, and the gap grew with every tool-loop iteration since each iteration is its own billable LLM call.

- Extracted `StreamingHandler`'s per-call instrumentation (`recordChatRequest`/`recordChatResponse`, OTel span creation/closing, `recordAppUsage`/`recordConversation`/`recordError`/`recordStreamOutcome`, and the `mergeUsage` helper) into a new shared module, `server/services/chat/llmCallTelemetry.js`, as three functions: `beginLLMCallTelemetry`, `recordLLMCallCompletion`, and `finalizeLLMCallTelemetry`.
- Refactored `StreamingHandler.executeStreamingResponse` to call these helpers instead of the inline logic — pure extraction, no behavior change.
- Wired the same helpers into both of `ToolExecutor`'s LLM call sites: the initial call in `processChatWithTools`, and each iteration of the tool-calling loop in `continueWithToolExecution`. Each network round-trip is now scoped by its own nested `try/finally`, so usage/telemetry is recorded once per LLM call — including once per tool-loop iteration, not once per conversation turn.

## Test plan

- [x] Added `server/tests/toolExecutor-usage-telemetry.test.js`: asserts `recordChatRequest`/`recordChatResponse` fire exactly once for a no-tool-call turn, and exactly once per iteration (2x) for a 2-iteration tool-calling loop.
- [x] Existing `server/tests/toolExecutor-error-done-events.test.js` (SSE error/done event regression) still passes unchanged.
- [x] Ran the full server test suite before/after and diffed per-suite pass/fail status — no pre-existing suite changed status; the only difference is the new suite passing.
- [x] `npx eslint` and `npx prettier --check` clean on all changed/added files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VXX93ouQQKJoSQFcy1Lg4B

---
_Generated by [Claude Code](https://claude.ai/code/session_01VXX93ouQQKJoSQFcy1Lg4B)_