### PR TITLE
fix(google): give streamed Gemini tool calls a monotonic per-stream index

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -186,6 +186,16 @@ indication anything was missing.
 - Meeting invites (`.ics`) are parsed into a short summary: subject, time, location, and organizer.
 - OneDrive/SharePoint attachments (share links, not the file itself) now include the link as a
   reference instead of being dropped without a trace.
+
+## Gemini Apps No Longer Corrupt Parallel Tool Calls
+
+Fixed a bug where Gemini (Google) models calling more than one tool in the same turn could
+silently lose one of the calls. When two tool calls arrived in separate streaming chunks, the
+second one collided with the first instead of being tracked separately, corrupting its arguments
+into invalid JSON and dropping the call entirely — with no error shown to the user.
+
+- Apps and agent workflows on Gemini models that trigger multiple tools per turn (a common pattern
+  for tool-using agents) now execute every tool call correctly.
 - Attachments larger than 20 MB are skipped up front instead of being downloaded into the task
   pane, which could previously stall the pane on a large attachment.
 - On Outlook hosts older than Mailbox 1.8 (which can't fetch attachment content at all), the

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -186,6 +186,10 @@ indication anything was missing.
 - Meeting invites (`.ics`) are parsed into a short summary: subject, time, location, and organizer.
 - OneDrive/SharePoint attachments (share links, not the file itself) now include the link as a
   reference instead of being dropped without a trace.
+- Attachments larger than 20 MB are skipped up front instead of being downloaded into the task
+  pane, which could previously stall the pane on a large attachment.
+- On Outlook hosts older than Mailbox 1.8 (which can't fetch attachment content at all), the
+  banner now shows one explanation instead of repeating the same error on every attachment.
 
 ## Gemini Apps No Longer Corrupt Parallel Tool Calls
 
@@ -196,10 +200,6 @@ into invalid JSON and dropping the call entirely — with no error shown to the 
 
 - Apps and agent workflows on Gemini models that trigger multiple tools per turn (a common pattern
   for tool-using agents) now execute every tool call correctly.
-- Attachments larger than 20 MB are skipped up front instead of being downloaded into the task
-  pane, which could previously stall the pane on a large attachment.
-- On Outlook hosts older than Mailbox 1.8 (which can't fetch attachment content at all), the
-  banner now shows one explanation instead of repeating the same error on every attachment.
 
 ## Answer-Source Badge Fixed When a Tool-Enabled App Answers an Upload Directly
 

--- a/server/adapters/toolCalling/GoogleConverter.js
+++ b/server/adapters/toolCalling/GoogleConverter.js
@@ -180,11 +180,18 @@ export function convertGoogleFunctionResponseToGeneric(googleResponse) {
 /**
  * Convert Google streaming response to generic format
  * @param {string} data - Raw Google response data
- * @param {string} streamId - Stream identifier for stateful processing (unused for Google)
+ * @param {string} streamId - Stream identifier for stateful processing
  * @returns {Promise<import('./GenericToolCalling.js').GenericStreamingResponse>} Generic streaming response
  */
-export async function convertGoogleResponseToGeneric(data, _streamId = 'default') {
+const streamingState = new Map();
+
+export async function convertGoogleResponseToGeneric(data, streamId = 'default') {
   const result = createGenericStreamingResponse();
+
+  if (!streamingState.has(streamId)) {
+    streamingState.set(streamId, { toolCallIndex: 0 });
+  }
+  const state = streamingState.get(streamId);
 
   if (!data) return result;
 
@@ -252,12 +259,13 @@ export async function convertGoogleResponseToGeneric(data, _streamId = 'default'
             if (part.thoughtSignature) {
               metadata.thoughtSignature = part.thoughtSignature;
             }
+            const toolCallIndex = state.toolCallIndex++;
             result.tool_calls.push(
               createGenericToolCall(
-                `call_${result.tool_calls.length}_${Date.now()}`,
+                `call_${toolCallIndex}_${Date.now()}`,
                 part.functionCall.name,
                 part.functionCall.args || {},
-                result.tool_calls.length,
+                toolCallIndex,
                 metadata
               )
             );
@@ -271,6 +279,7 @@ export async function convertGoogleResponseToGeneric(data, _streamId = 'default'
         }
       }
       result.complete = true;
+      streamingState.delete(streamId);
       const fr = parsed.candidates[0].finishReason;
       // Only set finishReason from Google if we don't already have tool_calls
       // Check both the finishReason flag AND the actual tool_calls array
@@ -325,12 +334,13 @@ export async function convertGoogleResponseToGeneric(data, _streamId = 'default'
             if (part.thoughtSignature) {
               metadata.thoughtSignature = part.thoughtSignature;
             }
+            const toolCallIndex = state.toolCallIndex++;
             result.tool_calls.push(
               createGenericToolCall(
-                `call_${result.tool_calls.length}_${Date.now()}`,
+                `call_${toolCallIndex}_${Date.now()}`,
                 part.functionCall.name,
                 part.functionCall.args || {},
-                result.tool_calls.length,
+                toolCallIndex,
                 metadata
               )
             );
@@ -380,6 +390,7 @@ export async function convertGoogleResponseToGeneric(data, _streamId = 'default'
         // If we have tool_calls, mark as complete but preserve the tool_calls finish reason
         result.complete = true;
       }
+      streamingState.delete(streamId);
     }
   } catch (jsonError) {
     logger.error('Failed to parse Google response as JSON', {
@@ -402,10 +413,20 @@ export async function convertGoogleResponseToGeneric(data, _streamId = 'default'
       result.finishReason = 'stop';
       result.complete = true;
       result.error = false; // Clear error if we could extract some content
+      streamingState.delete(streamId);
     }
   }
 
   return result;
+}
+
+/**
+ * Discard accumulated per-stream state (e.g. tool call index counter) for a stream
+ * that errored or was aborted before reaching its natural completion event.
+ * @param {string} streamId - Stream identifier to clear
+ */
+export function clearGoogleStreamingState(streamId = 'default') {
+  streamingState.delete(streamId);
 }
 
 /**

--- a/server/adapters/toolCalling/ToolCallingConverter.js
+++ b/server/adapters/toolCalling/ToolCallingConverter.js
@@ -156,8 +156,8 @@ export async function convertResponseToGeneric(data, sourceProvider, streamId = 
 /**
  * Discard accumulated per-stream state (e.g. pending tool call accumulation) for a
  * stream that errored, was aborted, or otherwise ended without reaching its natural
- * completion event. Providers without stateful streaming (e.g. Google, Mistral) have
- * no clear function and this is a no-op for them.
+ * completion event. Providers without stateful streaming (e.g. Mistral) have no clear
+ * function and this is a no-op for them.
  * @param {string} sourceProvider - Source provider name
  * @param {string} streamId - Stream identifier to clear
  */

--- a/server/tests/gemini-parallel-tool-calls.test.js
+++ b/server/tests/gemini-parallel-tool-calls.test.js
@@ -1,0 +1,101 @@
+/**
+ * Regression test for #1722: Google streaming emitted the same tool_calls index (0)
+ * for every chunk because GoogleConverter derived it from result.tool_calls.length,
+ * which resets to 0 on every fresh streaming chunk. When Gemini splits parallel
+ * function calls across separate SSE chunks, ToolExecutor's dedup-by-index merge
+ * (collectedToolCalls.find(c => c.index === call.index)) then collided the second
+ * call into the first, concatenating JSON arguments into an invalid '{...}{...}'
+ * blob and silently dropping a tool call.
+ */
+
+import assert from 'assert';
+import {
+  convertGoogleResponseToGeneric,
+  clearGoogleStreamingState
+} from '../adapters/toolCalling/GoogleConverter.js';
+import logger from '../utils/logger.js';
+
+logger.info('Testing Google parallel tool call streaming indices...\n');
+
+const STREAM_ID = 'chat-1722';
+
+function chunkWithFunctionCall(name, args) {
+  return JSON.stringify({
+    candidates: [
+      {
+        content: {
+          parts: [{ functionCall: { name, args } }]
+        }
+      }
+    ]
+  });
+}
+
+const finishChunk = JSON.stringify({ candidates: [{ finishReason: 'STOP' }] });
+
+// Test 1: two parallel tool calls arriving in separate streaming chunks must get
+// distinct, monotonically increasing indices instead of both landing on 0.
+logger.info('Test 1: parallel tool calls in separate chunks get distinct indices');
+const chunk1 = await convertGoogleResponseToGeneric(
+  chunkWithFunctionCall('webSearch', { query: 'first query' }),
+  STREAM_ID
+);
+const chunk2 = await convertGoogleResponseToGeneric(
+  chunkWithFunctionCall('webContentExtractor', { url: 'https://example.com' }),
+  STREAM_ID
+);
+
+assert.strictEqual(chunk1.tool_calls.length, 1, 'Chunk 1 should have one tool call');
+assert.strictEqual(chunk2.tool_calls.length, 1, 'Chunk 2 should have one tool call');
+assert.strictEqual(chunk1.tool_calls[0].index, 0, 'First call should get index 0');
+assert.strictEqual(chunk2.tool_calls[0].index, 1, 'Second call should get index 1, not 0');
+logger.info('✓ Test 1 passed\n');
+
+// Test 2: simulate ToolExecutor's dedup-by-index merge to prove both tool calls
+// survive independently with valid, non-concatenated JSON arguments.
+logger.info('Test 2: simulated ToolExecutor merge keeps both calls intact');
+const collectedToolCalls = [];
+for (const result of [chunk1, chunk2]) {
+  for (const call of result.tool_calls) {
+    const existingCall = collectedToolCalls.find(c => c.index === call.index);
+    if (existingCall) {
+      existingCall.function.arguments += call.function.arguments;
+    } else {
+      collectedToolCalls.push({
+        index: call.index,
+        id: call.id,
+        function: { name: call.function.name, arguments: call.function.arguments }
+      });
+    }
+  }
+}
+
+assert.strictEqual(collectedToolCalls.length, 2, 'Both tool calls should survive the merge');
+for (const call of collectedToolCalls) {
+  assert.doesNotThrow(
+    () => JSON.parse(call.function.arguments),
+    `Arguments for ${call.function.name} should be valid JSON`
+  );
+}
+assert.strictEqual(collectedToolCalls[0].function.name, 'webSearch');
+assert.strictEqual(collectedToolCalls[1].function.name, 'webContentExtractor');
+logger.info('✓ Test 2 passed\n');
+
+// Test 3: once the stream completes, state is cleared so a new stream reusing the
+// same streamId value restarts its index counter at 0 instead of leaking forever.
+logger.info('Test 3: index counter resets after stream completion');
+await convertGoogleResponseToGeneric(finishChunk, STREAM_ID);
+const freshChunk = await convertGoogleResponseToGeneric(
+  chunkWithFunctionCall('webSearch', { query: 'new stream' }),
+  STREAM_ID
+);
+assert.strictEqual(
+  freshChunk.tool_calls[0].index,
+  0,
+  'A new stream reusing the same streamId should restart at index 0'
+);
+logger.info('✓ Test 3 passed\n');
+
+clearGoogleStreamingState(STREAM_ID);
+
+logger.info('All parallel tool call tests passed! ✓');


### PR DESCRIPTION
## Summary

Fixes #1722.

- `GoogleConverter.convertGoogleResponseToGeneric` assigned each streamed `functionCall` an index of `result.tool_calls.length` — a counter that resets to `0` for every SSE chunk because a fresh `result` object is created per event.
- `ToolExecutor` deduplicates streamed tool calls by index (`collectedToolCalls.find(c => c.index === call.index)`). When Gemini emits multiple parallel function calls across separate streaming chunks, the second complete call matched the first's index `0`: its id/name overwrote the first call and its full JSON arguments got concatenated onto the first call's arguments, producing invalid JSON like `'{...}{...}'` and silently dropping a tool call.
- Added per-`streamId` state to `GoogleConverter.js` (mirroring the existing pattern in `OpenAIConverter.js`/`AnthropicConverter.js`/`VLLMConverter.js`) with a monotonically increasing `toolCallIndex` counter, cleared on every stream-completion path and via a new `clearGoogleStreamingState` export (picked up automatically by `ToolCallingConverter.clearStreamingState`'s dispatcher for aborted streams).
- Updated a stale comment in `ToolCallingConverter.js` that listed Google among providers without stateful streaming.

`ToolExecutor.js` itself needed no changes — once Google emits genuinely unique, monotonically increasing indices, its existing dedup-by-index merge logic naturally treats each new index as a new tool call.

## Test plan

- [x] Added `server/tests/gemini-parallel-tool-calls.test.js`: two chunks with distinct parallel tool calls now get indices `0`/`1` instead of colliding on `0`; simulates the `ToolExecutor` merge to confirm both calls survive with valid JSON; verifies the index counter resets after stream completion.
- [x] Verified against the pre-fix code that both chunks previously produced index `0` (bug reproduced), and that the fix produces `0`/`1`.
- [x] Ran existing Google/Gemini converter tests (`gemini3-tool-calling`, `gemini-malformed-function-call`, `googleSearchFunctionCallingConflict`, `provider-specific-tool-filtering`) — all pass, unchanged from baseline.
- [x] `npx eslint` / `npx prettier --check` on changed files — clean.
- [x] Added a changelog entry under `docs/releases/5.5.0/features.md`.

https://claude.ai/code/session_01LFwMohxHjgy65qrydoiCAq


---
_Generated by [Claude Code](https://claude.ai/code/session_01LFwMohxHjgy65qrydoiCAq)_