### PR TITLE
Clean up retired tool entries and warn on missing tool scripts

### DIFF
--- a/examples/config/tools.json
+++ b/examples/config/tools.json
@@ -23,7 +23,9 @@
           }
         }
       },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     }
   },
   {
@@ -67,7 +69,9 @@
           }
         }
       },
-      "required": ["url"]
+      "required": [
+        "url"
+      ]
     }
   },
   {
@@ -121,202 +125,9 @@
           "maximum": 10000
         }
       },
-      "required": ["query"]
-    }
-  },
-  {
-    "id": "deepResearch",
-    "name": "deepResearch",
-    "title": {
-      "en": "Deep Research",
-      "de": "Tiefgehende Recherche"
-    },
-    "description": {
-      "en": "Perform iterative web research with progress updates through SSE events.",
-      "de": "Führen Sie iterative Webrecherchen mit Fortschrittsupdates über SSE-Ereignisse durch."
-    },
-    "script": "deepResearch.js",
-    "parameters": {
-      "type": "object",
-      "properties": {
-        "query": {
-          "type": "string",
-          "description": {
-            "en": "Initial search query",
-            "de": "Erste Suchanfrage"
-          }
-        },
-        "maxRounds": {
-          "type": "integer",
-          "description": {
-            "en": "Number of search iterations",
-            "de": "Anzahl der Suchiterationen"
-          },
-          "default": 5,
-          "minimum": 5,
-          "maximum": 10
-        },
-        "maxResults": {
-          "type": "integer",
-          "description": {
-            "en": "Number of results to process per round",
-            "de": "Anzahl der pro Runde zu verarbeitenden Ergebnisse"
-          },
-          "default": 5,
-          "minimum": 1,
-          "maximum": 10
-        },
-        "contentMaxLength": {
-          "type": "integer",
-          "description": {
-            "en": "Maximum length of extracted content per page",
-            "de": "Maximale Länge der extrahierten Inhalte pro Seite"
-          },
-          "default": 5000,
-          "minimum": 500,
-          "maximum": 10000
-        },
-        "chatId": {
-          "type": "string",
-          "description": {
-            "en": "Chat session ID",
-            "de": "Chat-Sitzungs-ID"
-          }
-        }
-      },
-      "required": ["query"]
-    }
-  },
-  {
-    "id": "researchPlanner",
-    "name": "researchPlanner",
-    "title": {
-      "en": "Research Planner",
-      "de": "Recherche-Planer"
-    },
-    "description": {
-      "en": "Break down a research topic into different investigative tasks",
-      "de": "Zerlegen Sie ein Forschungsthema in verschiedene investigative Aufgaben"
-    },
-    "script": "researchPlanner.js",
-    "parameters": {
-      "type": "object",
-      "properties": {
-        "question": {
-          "type": "string",
-          "description": {
-            "en": "Research topic",
-            "de": "Forschungsthema"
-          }
-        },
-        "teamSize": {
-          "type": "integer",
-          "description": {
-            "en": "Number of tasks to generate",
-            "de": "Anzahl der zu generierenden Aufgaben"
-          },
-          "default": 3,
-          "minimum": 1,
-          "maximum": 10
-        },
-        "soundBites": {
-          "type": "string",
-          "description": {
-            "en": "Additional context",
-            "de": "Zusätzlicher Kontext"
-          }
-        }
-      },
-      "required": ["question"]
-    }
-  },
-  {
-    "id": "evaluator",
-    "name": "evaluator",
-    "title": {
-      "en": "Answer Evaluator",
-      "de": "Antwort-Bewerter"
-    },
-    "description": {
-      "en": "Evaluate answers for certainty, freshness, and completeness.",
-      "de": "Bewerten Sie Antworten auf Bestimmtheit, Aktualität und Vollständigkeit."
-    },
-    "script": "evaluator.js",
-    "parameters": {
-      "type": "object",
-      "properties": {
-        "question": {
-          "type": "string",
-          "description": {
-            "en": "Original user question",
-            "de": "Ursprüngliche Benutzerfrage"
-          }
-        },
-        "answer": {
-          "type": "string",
-          "description": {
-            "en": "Draft answer to evaluate",
-            "de": "Entwurfsantwort zur Bewertung"
-          }
-        },
-        "model": {
-          "type": "string",
-          "description": {
-            "en": "Model ID for evaluation",
-            "de": "Modell-ID für die Bewertung"
-          },
-          "default": "gemini-1.5-flash"
-        }
-      },
-      "required": ["question", "answer"]
-    }
-  },
-  {
-    "id": "queryRewriter",
-    "name": "queryRewriter",
-    "title": {
-      "en": "Query Rewriter",
-      "de": "Anfragen-Umschreiber"
-    },
-    "description": {
-      "en": "Rewrite user search queries into optimized variants.",
-      "de": "Schreiben Sie Benutzersuchanfragen in optimierte Varianten um."
-    },
-    "script": "queryRewriter.js",
-    "parameters": {
-      "type": "object",
-      "properties": {
-        "query": {
-          "type": "string",
-          "description": {
-            "en": "Search query to rewrite",
-            "de": "Suchanfrage zum Umschreiben"
-          }
-        },
-        "think": {
-          "type": "string",
-          "description": {
-            "en": "User motivation",
-            "de": "Benutzermotivation"
-          }
-        },
-        "context": {
-          "type": "string",
-          "description": {
-            "en": "Optional context",
-            "de": "Optionaler Kontext"
-          }
-        },
-        "model": {
-          "type": "string",
-          "description": {
-            "en": "Model ID",
-            "de": "Modell-ID"
-          },
-          "default": "gemini-2.5-flash-preview-05-20"
-        }
-      },
-      "required": ["query"]
+      "required": [
+        "query"
+      ]
     }
   },
   {
@@ -343,7 +154,10 @@
         },
         "format": {
           "type": "string",
-          "enum": ["png", "pdf"],
+          "enum": [
+            "png",
+            "pdf"
+          ],
           "default": "png",
           "description": {
             "en": "Output format (png or pdf)",
@@ -359,34 +173,9 @@
           }
         }
       },
-      "required": ["url"]
-    }
-  },
-  {
-    "id": "answerReducer",
-    "name": "answerReducer",
-    "title": {
-      "en": "Answer Reducer",
-      "de": "Antwort-Reduzierer"
-    },
-    "description": {
-      "en": "Consolidate multiple text passages into a single concise article.",
-      "de": "Führen Sie mehrere Textpassagen zu einem einzigen prägnanten Artikel zusammen."
-    },
-    "script": "answerReducer.js",
-    "parameters": {
-      "type": "object",
-      "properties": {
-        "answers": {
-          "type": "array",
-          "items": { "type": "string" },
-          "description": {
-            "en": "Text passages to consolidate",
-            "de": "Zu vereinende Texte"
-          }
-        }
-      },
-      "required": ["answers"]
+      "required": [
+        "url"
+      ]
     }
   },
   {
@@ -413,7 +202,10 @@
         },
         "format": {
           "type": "string",
-          "enum": ["png", "pdf"],
+          "enum": [
+            "png",
+            "pdf"
+          ],
           "default": "png",
           "description": {
             "en": "Output format (png or pdf)",
@@ -429,7 +221,9 @@
           }
         }
       },
-      "required": ["url"]
+      "required": [
+        "url"
+      ]
     }
   },
   {
@@ -461,7 +255,9 @@
               }
             }
           },
-          "required": ["name"]
+          "required": [
+            "name"
+          ]
         }
       },
       "getAllUserDetails": {
@@ -480,7 +276,9 @@
               }
             }
           },
-          "required": ["userId"]
+          "required": [
+            "userId"
+          ]
         }
       },
       "getUserManager": {
@@ -499,7 +297,9 @@
               }
             }
           },
-          "required": ["userId"]
+          "required": [
+            "userId"
+          ]
         }
       },
       "getUserGroups": {
@@ -518,7 +318,9 @@
               }
             }
           },
-          "required": ["userId"]
+          "required": [
+            "userId"
+          ]
         }
       },
       "getTeamMembers": {
@@ -537,7 +339,9 @@
               }
             }
           },
-          "required": ["teamId"]
+          "required": [
+            "teamId"
+          ]
         }
       },
       "getUserPhotoBase64": {
@@ -556,7 +360,9 @@
               }
             }
           },
-          "required": ["userId"]
+          "required": [
+            "userId"
+          ]
         }
       }
     }
@@ -608,14 +414,18 @@
             },
             "returnFields": {
               "type": "array",
-              "items": { "type": "string" },
+              "items": {
+                "type": "string"
+              },
               "description": {
                 "en": "Fields to return in search results (optional)",
                 "de": "In Suchergebnissen zurückzugebende Felder (optional)"
               }
             }
           },
-          "required": ["query"]
+          "required": [
+            "query"
+          ]
         }
       },
       "getContent": {
@@ -651,7 +461,9 @@
               "maximum": 50000
             }
           },
-          "required": ["documentId"]
+          "required": [
+            "documentId"
+          ]
         }
       },
       "getMetadata": {
@@ -677,7 +489,9 @@
               }
             }
           },
-          "required": ["documentId"]
+          "required": [
+            "documentId"
+          ]
         }
       }
     }

--- a/server/tests/toolsLoader-missing-script-warning.test.js
+++ b/server/tests/toolsLoader-missing-script-warning.test.js
@@ -1,0 +1,58 @@
+/**
+ * Regression test for #1764: tools configured with a `script` file that
+ * doesn't exist under server/tools/ used to fail silently until the tool
+ * was actually invoked (ERR_MODULE_NOT_FOUND). warnAboutMissingToolScripts
+ * should surface this at load time instead.
+ */
+
+import { describe, it, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import logger from '../utils/logger.js';
+import { warnAboutMissingToolScripts, loadAllTools } from '../toolsLoader.js';
+
+describe('warnAboutMissingToolScripts', () => {
+  const originalWarn = logger.warn;
+  const warnings = [];
+
+  afterEach(() => {
+    logger.warn = originalWarn;
+    warnings.length = 0;
+  });
+
+  it('warns for a tool whose script file does not exist', () => {
+    logger.warn = (...args) => warnings.push(args);
+
+    warnAboutMissingToolScripts([{ id: 'ghostTool', script: 'doesNotExist.js' }]);
+
+    assert.strictEqual(warnings.length, 1);
+    const [message, meta] = warnings[0];
+    assert.match(message, /does not exist/i);
+    assert.strictEqual(meta.toolId, 'ghostTool');
+    assert.strictEqual(meta.script, 'doesNotExist.js');
+  });
+
+  it('does not warn for a tool whose script file exists', () => {
+    logger.warn = (...args) => warnings.push(args);
+
+    warnAboutMissingToolScripts([{ id: 'braveSearch', script: 'braveSearch.js' }]);
+
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  it('skips tools without a script field (MCP/OpenAPI/special tools)', () => {
+    logger.warn = (...args) => warnings.push(args);
+
+    warnAboutMissingToolScripts([{ id: 'someMcpTool', _mcp: { serverId: 'x' } }]);
+
+    assert.strictEqual(warnings.length, 0);
+  });
+
+  it('loadAllTools does not warn about any shipped default tool', async () => {
+    logger.warn = (...args) => warnings.push(args);
+
+    await loadAllTools(true, false);
+
+    const missingScriptWarnings = warnings.filter(([message]) => /does not exist/i.test(message));
+    assert.deepStrictEqual(missingScriptWarnings, []);
+  });
+});

--- a/server/toolsLoader.js
+++ b/server/toolsLoader.js
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { fileURLToPath } from 'url';
 import { createResourceLoader, createValidator } from './utils/resourceLoader.js';
+import { getRootDir } from './pathUtils.js';
 import logger from './utils/logger.js';
 
 /**
@@ -12,9 +12,6 @@ import logger from './utils/logger.js';
  * config/tools.json support — installations are migrated to individual files
  * by V068__split_tools_config_into_individual_files.js.
  */
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const SCRIPTS_DIR = path.join(__dirname, 'tools');
 
 const toolsLoader = createResourceLoader({
   resourceName: 'Tools',
@@ -49,9 +46,10 @@ function sortTools(a, b) {
  * @param {Array} tools - Loaded tool definitions
  */
 export function warnAboutMissingToolScripts(tools) {
+  const scriptsDir = path.join(getRootDir(), 'server', 'tools');
   for (const tool of tools) {
     if (!tool.script) continue;
-    const scriptPath = path.join(SCRIPTS_DIR, tool.script);
+    const scriptPath = path.join(scriptsDir, tool.script);
     if (!fs.existsSync(scriptPath)) {
       logger.warn('Tool references a script file that does not exist', {
         component: 'ToolsLoader',

--- a/server/toolsLoader.js
+++ b/server/toolsLoader.js
@@ -1,4 +1,8 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { createResourceLoader, createValidator } from './utils/resourceLoader.js';
+import logger from './utils/logger.js';
 
 /**
  * Tools Configuration Loader
@@ -8,6 +12,9 @@ import { createResourceLoader, createValidator } from './utils/resourceLoader.js
  * config/tools.json support — installations are migrated to individual files
  * by V068__split_tools_config_into_individual_files.js.
  */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPTS_DIR = path.join(__dirname, 'tools');
 
 const toolsLoader = createResourceLoader({
   resourceName: 'Tools',
@@ -35,6 +42,27 @@ function sortTools(a, b) {
 }
 
 /**
+ * Warn (without throwing) about tools whose configured `script` file doesn't
+ * exist under server/tools/. Catches typos or hand-edited contents/tools/*.json
+ * entries at load time instead of failing silently with ERR_MODULE_NOT_FOUND
+ * the first time the tool is invoked.
+ * @param {Array} tools - Loaded tool definitions
+ */
+export function warnAboutMissingToolScripts(tools) {
+  for (const tool of tools) {
+    if (!tool.script) continue;
+    const scriptPath = path.join(SCRIPTS_DIR, tool.script);
+    if (!fs.existsSync(scriptPath)) {
+      logger.warn('Tool references a script file that does not exist', {
+        component: 'ToolsLoader',
+        toolId: tool.id,
+        script: tool.script
+      });
+    }
+  }
+}
+
+/**
  * Load all tools from individual files in contents/tools/.
  * @param {boolean} includeDisabled - Include disabled tools
  * @param {boolean} verbose - Whether to log verbose output
@@ -42,6 +70,7 @@ function sortTools(a, b) {
  */
 export async function loadAllTools(includeDisabled = false, verbose = true) {
   const tools = await toolsLoader.loadFromFiles(verbose);
+  warnAboutMissingToolScripts(tools);
   const filtered = includeDisabled ? tools : tools.filter(tool => tool.enabled !== false);
   return filtered.sort(sortTools);
 }


### PR DESCRIPTION
## Summary

Closes the remaining scope of #1764. The original crash (`ERR_MODULE_NOT_FOUND` for `deepResearch`/`researchPlanner`/`evaluator`/`queryRewriter`/`answerReducer`) was already fixed by #1879 and migration `V068`, which removed these tools from the shipped defaults. Two smaller items were still open, per the maintainer's own follow-up comment on the issue:

- **`examples/config/tools.json`** still advertised the five retired tools (with `script` fields pointing at files that no longer exist in `server/tools/`). Removed them so this example file matches the real default configuration.
- **No load-time validation existed** for a tool's `script` field pointing at a missing file — a typo or bad hand-edit of `contents/tools/*.json` would fail silently until the tool was actually invoked. Added `warnAboutMissingToolScripts()` in `server/toolsLoader.js`, called from `loadAllTools()`, which logs a `warn`-level message (not a hard failure) for any tool whose script file is missing.

## Test plan

- [x] `node server/tests/toolsLoader-missing-script-warning.test.js` — new regression tests: warns for a missing script, doesn't warn for a valid script, skips scriptless tools (MCP/OpenAPI/special), and confirms `loadAllTools()` produces no such warnings for the shipped defaults.
- [x] `node server/tests/toolLoader-localization.test.js` — unaffected, still passing.
- [x] `npx eslint server/toolsLoader.js server/tests/toolsLoader-missing-script-warning.test.js` — clean.
- [x] `npx prettier --check` on changed files — clean.

Closes #1764


---
_Generated by [Claude Code](https://claude.ai/code/session_01TcjyTsRCHH585UWZLT1TDc)_