### PR TITLE
fix: align magic-prompt rate limiter/audit path with its singular route

### DIFF
--- a/docs/pii-data-handling.md
+++ b/docs/pii-data-handling.md
@@ -134,7 +134,7 @@ to `contents/data/audit-log/YYYY-MM-DD.jsonl` (`server/services/AuditLogService.
 }
 ```
 
-Inference, chat, sessions, magic-prompts, short-links, feedback, translations
+Inference, chat, sessions, magic-prompt, short-links, feedback, translations
 and page reads are explicitly **excluded** from the audit log
 (`server/middleware/auditLogger.js`). Email-shaped actor identifiers are
 masked by default (`audit.includeEmail: false`).

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -22,7 +22,7 @@ The system supports six different types of rate limiters, each configurable thro
   - `/api/configs`
   - `/api/sessions`
   - `/api/pages`
-  - `/api/magic-prompts`
+  - `/api/magic-prompt`
   - `/api/short-links`
 
 ### 2. Admin API Rate Limiter

--- a/server/middleware/auditLogger.js
+++ b/server/middleware/auditLogger.js
@@ -26,7 +26,7 @@ const EXCLUDED_SEGMENTS = [
   'inference',
   'session',
   'sessions',
-  'magic-prompts',
+  'magic-prompt',
   'short-links',
   'feedback',
   'translations',

--- a/server/middleware/setup.js
+++ b/server/middleware/setup.js
@@ -568,7 +568,7 @@ export function setupMiddleware(app, platformConfig = {}) {
   app.use(buildApiPath('/configs'), rateLimiters.publicApiLimiter);
   app.use(buildApiPath('/sessions'), rateLimiters.publicApiLimiter);
   app.use(buildApiPath('/pages'), rateLimiters.publicApiLimiter);
-  app.use(buildApiPath('/magic-prompts'), rateLimiters.publicApiLimiter);
+  app.use(buildApiPath('/magic-prompt'), rateLimiters.publicApiLimiter);
   app.use(buildApiPath('/short-links'), rateLimiters.publicApiLimiter);
   app.use(buildApiPath('/integrations'), rateLimiters.publicApiLimiter);
 

--- a/server/tests/auditLogger.test.js
+++ b/server/tests/auditLogger.test.js
@@ -70,6 +70,13 @@ describe('auditLogger gating', () => {
     expect(onSpy).not.toHaveBeenCalled();
   });
 
+  test('excludes magic-prompt (matches the singular route segment)', () => {
+    const { req, res } = makeReqRes({ url: '/api/magic-prompt' });
+    const onSpy = jest.spyOn(res, 'on');
+    mw(req, res, jest.fn());
+    expect(onSpy).not.toHaveBeenCalled();
+  });
+
   test('skips non-api paths', () => {
     const { req, res } = makeReqRes({ url: '/healthz' });
     const onSpy = jest.spyOn(res, 'on');

--- a/server/tests/magicPromptRateLimit.test.js
+++ b/server/tests/magicPromptRateLimit.test.js
@@ -1,0 +1,14 @@
+/**
+ * Regression test for the magic-prompt singular/plural path mismatch: the
+ * public rate limiter is mounted via buildApiPath, while the route itself is
+ * registered via buildServerPath. Both must resolve to the same path or the
+ * limiter silently never applies to the route (Express app.use() prefix
+ * matching won't bridge a plural/singular mismatch).
+ */
+import { buildApiPath, buildServerPath } from '../utils/basePath.js';
+
+describe('magic-prompt rate limiter path coverage', () => {
+  test('the rate limiter mount path matches the actual route path', () => {
+    expect(buildApiPath('/magic-prompt')).toBe(buildServerPath('/api/magic-prompt'));
+  });
+});


### PR DESCRIPTION
## Summary

- `POST /api/magic-prompt` (singular) calls `simpleCompletion()` — a real, billable LLM request — but the public rate limiter was mounted on `/api/magic-prompts` (plural). Express `app.use()` prefix matching never bridges a plural/singular mismatch, so the limiter silently never applied to the endpoint, leaving it as an unthrottled abuse/cost vector.
- The same plural string was in `auditLogger.js`'s `EXCLUDED_SEGMENTS`, so magic-prompt POSTs were also mis-classified for audit purposes instead of being excluded from the audit log as intended.
- Fixed both references to the singular `magic-prompt` to match the actual route (`server/routes/magicPromptRoutes.js:18`), left the route path itself unchanged since renaming it would be a breaking API change and isn't needed to close the gap.
- Updated `docs/rate-limiting.md` and `docs/pii-data-handling.md`, which also referenced the plural path.
- Added a regression test asserting the rate limiter's mount path (`buildApiPath('/magic-prompt')`) matches the route's actual path (`buildServerPath('/api/magic-prompt')`), plus a test confirming `/api/magic-prompt` is excluded from the audit-log safety net.

Fixes #1761

## Test plan

- [x] `npx eslint` on all changed files — clean
- [x] `npx prettier --check` on all changed files — clean
- [x] `server/tests/auditLogger.test.js` — passes, including new `/api/magic-prompt` exclusion test
- [x] `server/tests/magicPromptRateLimit.test.js` (new) — passes, asserts rate limiter path matches route path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RbxYFWLBQGASVFiJSYYUcY)_