### PR TITLE
fix(admin): add optimistic concurrency to platform config save

### DIFF
--- a/client/src/api/adminApi.js
+++ b/client/src/api/adminApi.js
@@ -110,6 +110,47 @@ export const fetchAdminUsageData = async () => {
   return response.data;
 };
 
+/**
+ * Fetches the platform configuration for admin editing. The response includes
+ * a `_version` field (a content hash) — pass it back to
+ * `updateAdminPlatformConfig` to detect if someone else saved a change in the
+ * meantime, instead of silently overwriting it.
+ *
+ * @returns {Promise<Object>} Sanitized platform config, including `_version`
+ */
+export const fetchAdminPlatformConfig = async () => {
+  const response = await makeAdminApiCall('/admin/configs/platform');
+  return response.data;
+};
+
+/**
+ * Saves the platform configuration. When `baseVersion` is provided (the
+ * `_version` from the last `fetchAdminPlatformConfig`/save response), the
+ * server rejects the save with a conflict instead of overwriting a change
+ * made by another admin session since that version was loaded.
+ *
+ * @param {Object} configData - The full platform config to save
+ * @param {string} [baseVersion] - The `_version` this edit was based on
+ * @returns {Promise<{conflict: boolean, data: Object}>} `conflict: true` means
+ *   the save was rejected (HTTP 409); `data` is either the save result or,
+ *   on conflict, `{ message, config }` describing the current server state.
+ */
+export const updateAdminPlatformConfig = async (configData, baseVersion) => {
+  const body = baseVersion ? { ...configData, _baseVersion: baseVersion } : configData;
+  try {
+    const response = await makeAdminApiCall('/admin/configs/platform', {
+      method: 'POST',
+      body
+    });
+    return { conflict: false, data: response.data };
+  } catch (error) {
+    if (error.response?.status === 409) {
+      return { conflict: true, data: error.response.data };
+    }
+    throw error;
+  }
+};
+
 export const fetchAdminCacheStats = async () => {
   const response = await makeAdminApiCall('/admin/cache/stats');
   return response.data;
@@ -918,6 +959,8 @@ export const fetchAdminFeedbackEntries = async (limit = 100, offset = 0) => {
 export const adminApi = {
   // Existing functions
   makeAdminApiCall,
+  fetchAdminPlatformConfig,
+  updateAdminPlatformConfig,
   fetchAdminUsageData,
   fetchAdminUsageTimeline,
   fetchAdminUsageMeta,

--- a/client/src/features/admin/pages/AdminAuthPage.jsx
+++ b/client/src/features/admin/pages/AdminAuthPage.jsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
 import DualModeEditor from '../../../shared/components/DualModeEditor';
 import PlatformFormEditor from '../components/PlatformFormEditor';
-import { makeAdminApiCall } from '../../../api/adminApi';
+import { fetchAdminPlatformConfig, updateAdminPlatformConfig } from '../../../api/adminApi';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import { usePlatformConfig } from '../../../shared/contexts/PlatformConfigContext';
 import { getSchemaByType } from '../../../utils/schemaService';
@@ -15,6 +15,10 @@ function AdminAuthPage() {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
   const [jsonSchema, setJsonSchema] = useState(null);
+  // Content-hash version of the config as last loaded/saved from the server,
+  // used to detect if another admin session saved a change in the meantime
+  // (see updateAdminPlatformConfig).
+  const [configVersion, setConfigVersion] = useState(null);
   const [config, setConfig] = useState({
     auth: {
       mode: 'proxy',
@@ -98,13 +102,13 @@ function AdminAuthPage() {
 
   const loadConfiguration = async () => {
     try {
-      const response = await makeAdminApiCall('/admin/configs/platform');
-      const data = response.data;
+      const data = await fetchAdminPlatformConfig();
 
       setConfig(prevConfig => ({
         ...prevConfig,
         ...data
       }));
+      setConfigVersion(data._version ?? null);
     } catch (error) {
       setMessage({
         type: 'error',
@@ -120,17 +124,24 @@ function AdminAuthPage() {
 
     setSaving(true);
     setMessage('');
+    let conflictMessage = null;
 
     try {
-      await makeAdminApiCall('/admin/configs/platform', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: data
-      });
+      const result = await updateAdminPlatformConfig(data, configVersion);
 
-      // Success - axios doesn't have response.ok, successful responses are returned directly
+      if (result.conflict) {
+        // Someone else saved a change since this page loaded its config. The
+        // server rejected the save rather than silently overwriting it —
+        // surface that instead of pretending it succeeded.
+        setConfigVersion(result.data?.config?._version ?? null);
+        conflictMessage =
+          result.data?.message ||
+          'This configuration was changed elsewhere. Reload the page to see the latest version, then reapply your changes.';
+        setMessage({ type: 'error', text: conflictMessage });
+        throw new Error(conflictMessage);
+      }
+
+      setConfigVersion(result.data?.config?._version ?? null);
       setMessage({
         type: 'success',
         text: 'Authentication configuration saved successfully!'
@@ -138,10 +149,12 @@ function AdminAuthPage() {
       // Refresh the platform config context to update navigation
       refreshConfig();
     } catch (error) {
-      setMessage({
-        type: 'error',
-        text: `Failed to save configuration: ${error.message}`
-      });
+      if (!conflictMessage) {
+        setMessage({
+          type: 'error',
+          text: `Failed to save configuration: ${error.message}`
+        });
+      }
       throw error; // Re-throw to let DualModeEditor handle it
     } finally {
       setSaving(false);

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -461,6 +461,19 @@ field) and the multimodal audio-upload path (which sends audio to a chat LLM).
 **Before using:** add or enable a transcription model under **Admin → Models** (model type
 "Transcription"), set its realtime URL, then enable transcription on the desired app.
 
+## Authentication Config Save No Longer Silently Overwrites Concurrent Changes
+
+The **Admin → Authentication Configuration** page now detects when the platform configuration was
+changed by another admin session since the page was loaded, instead of silently overwriting it on
+save (a "last write wins" data-loss risk, since this page also holds security-relevant settings
+like SSO and local auth).
+
+- Saving now fails with a clear message ("this configuration was changed elsewhere — reload and
+  reapply your changes") if someone else saved a change in the meantime, rather than silently
+  clobbering it.
+- No admin action is required — the fix takes effect automatically on upgrade. Other admin config
+  pages that write `platform.json` will be migrated to the same protection in follow-up releases.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -1,4 +1,5 @@
 import { promises as fs } from 'fs';
+import { createHash } from 'crypto';
 import { join } from 'path';
 import { getRootDir } from '../../pathUtils.js';
 import { atomicWriteJSON } from '../../utils/atomicWrite.js';
@@ -66,6 +67,82 @@ function encryptSecretIfNeeded(value) {
   if (isEnvVarPlaceholder(value)) return value;
   if (tokenStorageService.isEncrypted(value)) return value;
   return tokenStorageService.encryptString(value);
+}
+
+/**
+ * Compute a short content-hash "version" of a platform config object, used for
+ * optimistic-concurrency checks on the read-modify-write admin save endpoint.
+ * Two admins loading the config at the same moment get the same version; the
+ * first save to succeed changes it, so the second save can detect the conflict
+ * instead of silently overwriting the first admin's change.
+ * @param {Object} config
+ * @returns {string}
+ */
+function computeConfigVersion(config) {
+  return createHash('sha256')
+    .update(JSON.stringify(config ?? {}))
+    .digest('hex')
+    .slice(0, 16);
+}
+
+/**
+ * Build the client-facing view of the platform config: strips real secret
+ * values down to '***REDACTED***' (preserving ${ENV_VAR} placeholders) so raw
+ * secrets are never sent to the browser.
+ * @param {Object} platformConfig
+ * @returns {Object}
+ */
+function sanitizePlatformConfigForResponse(platformConfig) {
+  const sanitizedConfig = { ...platformConfig };
+
+  if (sanitizedConfig.auth?.jwtSecret) {
+    sanitizedConfig.auth = {
+      ...sanitizedConfig.auth,
+      jwtSecret: sanitizeSecret(sanitizedConfig.auth.jwtSecret)
+    };
+  }
+
+  if (sanitizedConfig.localAuth?.jwtSecret) {
+    sanitizedConfig.localAuth = {
+      ...sanitizedConfig.localAuth,
+      jwtSecret: sanitizeSecret(sanitizedConfig.localAuth.jwtSecret)
+    };
+  }
+
+  if (sanitizedConfig.speech?.realtime?.apiKey) {
+    sanitizedConfig.speech = {
+      ...sanitizedConfig.speech,
+      realtime: {
+        ...sanitizedConfig.speech.realtime,
+        apiKey: sanitizeSecret(sanitizedConfig.speech.realtime.apiKey)
+      }
+    };
+  }
+
+  if (sanitizedConfig.speech?.azure?.subscriptionKey) {
+    sanitizedConfig.speech = {
+      ...sanitizedConfig.speech,
+      azure: {
+        ...sanitizedConfig.speech.azure,
+        subscriptionKey: sanitizeSecret(sanitizedConfig.speech.azure.subscriptionKey)
+      }
+    };
+  }
+
+  if (sanitizedConfig.proxyAuth?.jwtProviders) {
+    sanitizedConfig.proxyAuth = {
+      ...sanitizedConfig.proxyAuth,
+      jwtProviders: sanitizedConfig.proxyAuth.jwtProviders.map(provider => ({
+        name: provider.name,
+        header: provider.header,
+        issuer: provider.issuer,
+        audience: provider.audience
+        // Exclude jwkUrl and any other potentially sensitive configuration
+      }))
+    };
+  }
+
+  return sanitizedConfig;
 }
 
 /**
@@ -214,61 +291,13 @@ export default function registerAdminConfigRoutes(app) {
       // live in platform.json — they are stored in the central credential store
       // and referenced by *Ref ids, so there is nothing to sanitize for them
       // here. Only the JWT secrets and proxy JWT provider config remain inline.
-      const sanitizedConfig = { ...platformConfig };
+      const sanitizedConfig = sanitizePlatformConfigForResponse(platformConfig);
 
-      // Sanitize JWT secret from auth config
-      if (sanitizedConfig.auth?.jwtSecret) {
-        sanitizedConfig.auth = {
-          ...sanitizedConfig.auth,
-          jwtSecret: sanitizeSecret(sanitizedConfig.auth.jwtSecret)
-        };
-      }
-
-      // Sanitize JWT secret from localAuth config
-      if (sanitizedConfig.localAuth?.jwtSecret) {
-        sanitizedConfig.localAuth = {
-          ...sanitizedConfig.localAuth,
-          jwtSecret: sanitizeSecret(sanitizedConfig.localAuth.jwtSecret)
-        };
-      }
-
-      // Sanitize the realtime speech API key (server-side secret).
-      if (sanitizedConfig.speech?.realtime?.apiKey) {
-        sanitizedConfig.speech = {
-          ...sanitizedConfig.speech,
-          realtime: {
-            ...sanitizedConfig.speech.realtime,
-            apiKey: sanitizeSecret(sanitizedConfig.speech.realtime.apiKey)
-          }
-        };
-      }
-
-      // Sanitize the Azure Speech subscription key (server-side secret).
-      if (sanitizedConfig.speech?.azure?.subscriptionKey) {
-        sanitizedConfig.speech = {
-          ...sanitizedConfig.speech,
-          azure: {
-            ...sanitizedConfig.speech.azure,
-            subscriptionKey: sanitizeSecret(sanitizedConfig.speech.azure.subscriptionKey)
-          }
-        };
-      }
-
-      // Sanitize proxy auth JWT provider secrets
-      if (sanitizedConfig.proxyAuth?.jwtProviders) {
-        sanitizedConfig.proxyAuth = {
-          ...sanitizedConfig.proxyAuth,
-          jwtProviders: sanitizedConfig.proxyAuth.jwtProviders.map(provider => ({
-            name: provider.name,
-            header: provider.header,
-            issuer: provider.issuer,
-            audience: provider.audience
-            // Exclude jwkUrl and any other potentially sensitive configuration
-          }))
-        };
-      }
-
-      res.json(sanitizedConfig);
+      // `_version` is a content hash of the on-disk config at read time. Admin
+      // pages that want conflict detection on save should echo it back as
+      // `_baseVersion` in the POST body (see the POST handler below); pages
+      // that don't send it get the previous, unchecked last-write-wins behavior.
+      res.json({ ...sanitizedConfig, _version: computeConfigVersion(platformConfig) });
     } catch (error) {
       return sendInternalError(res, error, 'get platform configuration');
     }
@@ -279,11 +308,18 @@ export default function registerAdminConfigRoutes(app) {
    */
   app.post(buildServerPath('/api/admin/configs/platform'), adminAuth, async (req, res) => {
     try {
-      const newConfig = req.body;
-
-      if (!newConfig || typeof newConfig !== 'object') {
+      if (!req.body || typeof req.body !== 'object') {
         return sendBadRequest(res, 'Invalid configuration data');
       }
+
+      // `_baseVersion` (or `_version`, echoed straight back from the GET
+      // response) is an optional optimistic-concurrency token. Callers that
+      // don't send it keep the previous last-write-wins behavior; callers that
+      // do get a 409 instead of silently overwriting a concurrent change.
+      const newConfig = { ...req.body };
+      const baseVersion = newConfig._baseVersion ?? newConfig._version;
+      delete newConfig._baseVersion;
+      delete newConfig._version;
 
       const rootDir = getRootDir();
       const platformConfigPath = join(rootDir, 'contents', 'config', 'platform.json');
@@ -296,6 +332,21 @@ export default function registerAdminConfigRoutes(app) {
       } catch {
         // File doesn't exist, start with empty config
         logger.info('Creating new platform config file', { component: 'AdminConfigs' });
+      }
+
+      if (baseVersion) {
+        const currentVersion = computeConfigVersion(existingConfig);
+        if (currentVersion !== baseVersion) {
+          return res.status(409).json({
+            error: 'conflict',
+            message:
+              'Platform configuration was changed by someone else since you loaded it. Reload the page to see the latest version and reapply your changes.',
+            config: {
+              ...sanitizePlatformConfigForResponse(existingConfig),
+              _version: currentVersion
+            }
+          });
+        }
       }
 
       // Merge the authentication-related config with existing config
@@ -462,7 +513,7 @@ export default function registerAdminConfigRoutes(app) {
       });
       res.json({
         message: 'Platform configuration updated successfully',
-        config: responseConfig,
+        config: { ...responseConfig, _version: computeConfigVersion(mergedConfig) },
         reconfiguration: {
           reconfigured: reconfigResults.reconfigured,
           requiresRestart: reconfigResults.requiresRestart,

--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -293,11 +293,13 @@ export default function registerAdminConfigRoutes(app) {
       // here. Only the JWT secrets and proxy JWT provider config remain inline.
       const sanitizedConfig = sanitizePlatformConfigForResponse(platformConfig);
 
-      // `_version` is a content hash of the on-disk config at read time. Admin
+      // `_version` is a content hash of the *sanitized* config at read time —
+      // computed after secrets are redacted so the hash never has raw secret
+      // material (JWT/API keys, OAuth client secrets) flowing into it. Admin
       // pages that want conflict detection on save should echo it back as
       // `_baseVersion` in the POST body (see the POST handler below); pages
       // that don't send it get the previous, unchecked last-write-wins behavior.
-      res.json({ ...sanitizedConfig, _version: computeConfigVersion(platformConfig) });
+      res.json({ ...sanitizedConfig, _version: computeConfigVersion(sanitizedConfig) });
     } catch (error) {
       return sendInternalError(res, error, 'get platform configuration');
     }
@@ -335,16 +337,19 @@ export default function registerAdminConfigRoutes(app) {
       }
 
       if (baseVersion) {
-        const currentVersion = computeConfigVersion(existingConfig);
+        // Hash the sanitized (secret-redacted) view, not the raw config — the
+        // version is a change-detection token, not a credential digest, and
+        // must never let secret material flow into a fast hash exposed to
+        // clients (CodeQL: use of password/secret hash with insufficient
+        // computational effort).
+        const sanitizedExisting = sanitizePlatformConfigForResponse(existingConfig);
+        const currentVersion = computeConfigVersion(sanitizedExisting);
         if (currentVersion !== baseVersion) {
           return res.status(409).json({
             error: 'conflict',
             message:
               'Platform configuration was changed by someone else since you loaded it. Reload the page to see the latest version and reapply your changes.',
-            config: {
-              ...sanitizePlatformConfigForResponse(existingConfig),
-              _version: currentVersion
-            }
+            config: { ...sanitizedExisting, _version: currentVersion }
           });
         }
       }
@@ -486,16 +491,11 @@ export default function registerAdminConfigRoutes(app) {
       logger.info('Platform authentication configuration updated', { component: 'AdminConfigs' });
 
       // Sanitize the remaining inline secrets in the response — the admin UI
-      // should see ***REDACTED*** for JWT secrets, not raw values. Integration
-      // secrets no longer live in platform.json (they are in the credential
-      // store), so only the JWT secrets need sanitizing here.
-      const responseConfig = JSON.parse(JSON.stringify(mergedConfig));
-      if (responseConfig.auth?.jwtSecret) {
-        responseConfig.auth.jwtSecret = sanitizeSecret(responseConfig.auth.jwtSecret);
-      }
-      if (responseConfig.localAuth?.jwtSecret) {
-        responseConfig.localAuth.jwtSecret = sanitizeSecret(responseConfig.localAuth.jwtSecret);
-      }
+      // should see ***REDACTED*** for JWT/speech secrets, not raw values.
+      // Integration secrets no longer live in platform.json (they are in the
+      // credential store), so this only needs to handle JWT/speech secrets and
+      // the proxy JWT provider list — the same set the GET handler redacts.
+      const responseConfig = sanitizePlatformConfigForResponse(mergedConfig);
 
       await saveSnapshot({
         resource: 'platform',
@@ -513,7 +513,7 @@ export default function registerAdminConfigRoutes(app) {
       });
       res.json({
         message: 'Platform configuration updated successfully',
-        config: { ...responseConfig, _version: computeConfigVersion(mergedConfig) },
+        config: { ...responseConfig, _version: computeConfigVersion(responseConfig) },
         reconfiguration: {
           reconfigured: reconfigResults.reconfigured,
           requiresRestart: reconfigResults.requiresRestart,

--- a/server/tests/admin-platform-config-concurrency.test.js
+++ b/server/tests/admin-platform-config-concurrency.test.js
@@ -1,0 +1,204 @@
+/**
+ * Regression tests for #1763: concurrent admin saves to platform.json.
+ *
+ * GET /api/admin/configs/platform now returns a `_version` content-hash of
+ * the on-disk config. POST /api/admin/configs/platform accepts that value
+ * back as `_baseVersion` (or `_version`) and rejects the save with 409 if the
+ * on-disk config has changed since it was read, instead of silently
+ * overwriting a concurrent admin's change (the "last write wins" bug the
+ * issue describes). Callers that don't send a base version keep the previous
+ * unchecked behavior, so unmigrated admin pages are unaffected.
+ *
+ * Note: The repo's source is native ESM (uses `import.meta.url`), so this
+ * file uses `jest.unstable_mockModule` + dynamic imports rather than the
+ * CommonJS-only `jest.mock` API. Run with
+ * `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+const mockAdminUser = {
+  id: 'admin-user',
+  username: 'admin',
+  groups: ['admin']
+};
+
+const mockGroups = {
+  admin: {
+    id: 'admin',
+    permissions: { adminAccess: true }
+  }
+};
+
+// Mutable holder so each test can point getRootDir() at a fresh temp root
+// without re-registering the mock factory.
+const state = { rootDir: os.tmpdir() };
+
+jest.unstable_mockModule('../pathUtils.js', () => ({
+  getRootDir: () => state.rootDir
+}));
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: {
+    refreshCacheEntry: async () => {},
+    getPlatform: () => ({})
+  }
+}));
+
+jest.unstable_mockModule('../services/TokenStorageService.js', () => ({
+  default: {
+    isEncrypted: () => false,
+    encryptString: value => value,
+    decryptString: value => value
+  }
+}));
+
+jest.unstable_mockModule('../middleware/oidcAuth.js', () => ({
+  reconfigureOidcProviders: () => {}
+}));
+
+jest.unstable_mockModule('../websocket/realtimeTranscription.js', () => ({
+  testRealtimeConnection: async () => ({ ok: true })
+}));
+
+jest.unstable_mockModule('../services/AuditLogService.js', () => ({
+  logAudit: async () => {}
+}));
+
+jest.unstable_mockModule('../services/ChangeHistoryService.js', () => ({
+  saveSnapshot: async () => {}
+}));
+
+jest.unstable_mockModule('../utils/authorization.js', () => ({
+  loadGroupsConfiguration: () => ({ groups: mockGroups }),
+  enhanceUserWithPermissions: user => user,
+  isAnonymousAccessAllowed: () => false
+}));
+
+const { default: registerAdminConfigRoutes } = await import('../routes/admin/configs.js');
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.user = mockAdminUser;
+    next();
+  });
+  registerAdminConfigRoutes(app);
+  return app;
+}
+
+async function readPlatformConfig(tmpRoot) {
+  const raw = await fs.readFile(path.join(tmpRoot, 'contents', 'config', 'platform.json'), 'utf8');
+  return JSON.parse(raw);
+}
+
+describe('Admin platform config optimistic concurrency (#1763)', () => {
+  let tmpRoot;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'ihub-platform-config-'));
+    await fs.mkdir(path.join(tmpRoot, 'contents', 'config'), { recursive: true });
+    await fs.writeFile(
+      path.join(tmpRoot, 'contents', 'config', 'platform.json'),
+      JSON.stringify({ auth: { mode: 'local' }, anonymousAuth: { enabled: false } }, null, 2)
+    );
+    state.rootDir = tmpRoot;
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  test('GET returns a non-empty _version content hash', async () => {
+    const app = createTestApp();
+    const response = await request(app).get('/api/admin/configs/platform');
+
+    expect(response.status).toBe(200);
+    expect(typeof response.body._version).toBe('string');
+    expect(response.body._version.length).toBeGreaterThan(0);
+  });
+
+  test('POST without a base version overwrites unconditionally (back-compat)', async () => {
+    const app = createTestApp();
+
+    const first = await request(app)
+      .post('/api/admin/configs/platform')
+      .send({ auth: { mode: 'local' }, anonymousAuth: { enabled: true } });
+    expect(first.status).toBe(200);
+
+    const second = await request(app)
+      .post('/api/admin/configs/platform')
+      .send({ auth: { mode: 'proxy' }, anonymousAuth: { enabled: false } });
+    expect(second.status).toBe(200);
+
+    const onDisk = await readPlatformConfig(tmpRoot);
+    expect(onDisk.auth.mode).toBe('proxy');
+  });
+
+  test('POST with a stale base version is rejected with 409 and does not clobber the winning save', async () => {
+    const app = createTestApp();
+
+    const loaded = await request(app).get('/api/admin/configs/platform');
+    const baseVersion = loaded.body._version;
+
+    // Admin tab A saves first, based on the same version, changing a value.
+    const saveA = await request(app)
+      .post('/api/admin/configs/platform')
+      .send({
+        auth: { mode: 'local' },
+        anonymousAuth: { enabled: true },
+        _baseVersion: baseVersion
+      });
+    expect(saveA.status).toBe(200);
+    expect(saveA.body.config._version).not.toBe(baseVersion);
+
+    // Admin tab B, still holding the config it loaded before A's save, tries
+    // to save based on the now-stale version.
+    const saveB = await request(app)
+      .post('/api/admin/configs/platform')
+      .send({
+        auth: { mode: 'oidc' },
+        anonymousAuth: { enabled: false },
+        _baseVersion: baseVersion
+      });
+
+    expect(saveB.status).toBe(409);
+    expect(saveB.body.error).toBe('conflict');
+    expect(saveB.body.config._version).toBe(saveA.body.config._version);
+
+    // B's change must not have overwritten A's already-persisted save.
+    const onDisk = await readPlatformConfig(tmpRoot);
+    expect(onDisk.auth.mode).toBe('local');
+    expect(onDisk.anonymousAuth.enabled).toBe(true);
+  });
+
+  test('POST with the current base version succeeds and returns a fresh version', async () => {
+    const app = createTestApp();
+
+    const loaded = await request(app).get('/api/admin/configs/platform');
+    const baseVersion = loaded.body._version;
+
+    const save = await request(app)
+      .post('/api/admin/configs/platform')
+      .send({
+        auth: { mode: 'proxy' },
+        anonymousAuth: { enabled: false },
+        _baseVersion: baseVersion
+      });
+
+    expect(save.status).toBe(200);
+    expect(save.body.config._version).toBeTruthy();
+    expect(save.body.config._version).not.toBe(baseVersion);
+
+    const onDisk = await readPlatformConfig(tmpRoot);
+    expect(onDisk.auth.mode).toBe('proxy');
+    expect(onDisk._version).toBeUndefined();
+    expect(onDisk._baseVersion).toBeUndefined();
+  });
+});

--- a/server/tests/admin-platform-config-concurrency.test.js
+++ b/server/tests/admin-platform-config-concurrency.test.js
@@ -124,6 +124,33 @@ describe('Admin platform config optimistic concurrency (#1763)', () => {
     expect(response.body._version.length).toBeGreaterThan(0);
   });
 
+  test('_version is computed from the sanitized config, not raw secret material', async () => {
+    // Regression test for a CodeQL "hash of insufficiently protected secret"
+    // finding: the version must be derived from the redacted view (every real
+    // secret collapses to the same '***REDACTED***' placeholder) so two
+    // configs that differ only in their raw secret value hash identically,
+    // proving the raw secret never flows into the hash.
+    await fs.writeFile(
+      path.join(tmpRoot, 'contents', 'config', 'platform.json'),
+      JSON.stringify({ auth: { mode: 'local', jwtSecret: 'super-secret-value-one' } }, null, 2)
+    );
+    const app = createTestApp();
+    const first = await request(app).get('/api/admin/configs/platform');
+    expect(first.body.auth.jwtSecret).toBe('***REDACTED***');
+
+    await fs.writeFile(
+      path.join(tmpRoot, 'contents', 'config', 'platform.json'),
+      JSON.stringify(
+        { auth: { mode: 'local', jwtSecret: 'a-totally-different-secret-value' } },
+        null,
+        2
+      )
+    );
+    const second = await request(app).get('/api/admin/configs/platform');
+
+    expect(second.body._version).toBe(first.body._version);
+  });
+
   test('POST without a base version overwrites unconditionally (back-compat)', async () => {
     const app = createTestApp();
 


### PR DESCRIPTION
## Summary

Closes part of #1763 (first slice). 12+ admin pages/components do a full read-modify-write of `platform.json` via `GET`/`POST /api/admin/configs/platform` with no concurrency check, so two admins editing the config in separate tabs at the same time can silently clobber each other's changes — last write wins, with no error surfaced. This includes security-relevant settings (auth mode, SSO, local auth, etc.), so a lost update here isn't just an annoyance.

This PR adds optimistic concurrency to the shared save endpoint and migrates the first (and, per the issue's own analysis, worst-affected) consumer — `AdminAuthPage` — to use it.

## Changes

- **`server/routes/admin/configs.js`**:
  - `GET /api/admin/configs/platform` now returns a `_version` field: a short content-hash of the on-disk config at read time.
  - `POST /api/admin/configs/platform` accepts an optional `_baseVersion` (or `_version`, echoed straight back from the GET response) in the body. If present and it no longer matches the current on-disk config, the save is rejected with `409 { error: 'conflict', message, config }` instead of silently overwriting the concurrent change. If absent, behavior is unchanged (last-write-wins) — so the ~11 other admin pages that still POST the whole config directly are unaffected and can be migrated incrementally.
  - Extracted the secret-sanitization logic (previously duplicated inline in the GET handler) into a shared `sanitizePlatformConfigForResponse()` helper, reused by the GET response, the 409 conflict response, and the success response.
- **`client/src/api/adminApi.js`**: added `fetchAdminPlatformConfig()` / `updateAdminPlatformConfig(configData, baseVersion)` helpers that wrap the version-echo/409-handling logic in one place.
- **`client/src/features/admin/pages/AdminAuthPage.jsx`**: migrated from raw `makeAdminApiCall` to the new helpers. Tracks the loaded/saved `_version` in state and, on a `409`, shows a clear "this configuration was changed elsewhere — reload and reapply your changes" message instead of pretending the save succeeded.
- **`server/tests/admin-platform-config-concurrency.test.js`** (new): regression tests covering the `_version` field on GET, back-compat (no base version → unconditional save), a stale-version save being rejected with 409 without clobbering the winning save, and a current-version save succeeding with a fresh version returned.
- **`docs/releases/5.5.0/features.md`**: changelog entry per the repo's release-documentation convention.

## Scope / follow-ups

Per the issue's own "questions to consider," this is deliberately split into a first, independently-reviewable slice:
- The remaining ~11 admin pages/components that POST the whole `platform.json` (`JiraConfig`, `CloudStorageConfig`, `AdminLoggingPage`, `AdminTelemetryPage`, the OAuth/MCP-gateway pages, etc.) still use the old unchecked path and are left for follow-up PRs against #1763.
- The separate `authDebug`/`ntlmAuth` hardcoded-client-defaults question raised in the issue (whether to add real server defaults + a migration, or strip the dead UI) is a distinct design decision and is intentionally **not** addressed here — `AdminAuthPage`'s existing default-merge behavior is otherwise unchanged.

## Verification

- [x] `node server/routes/admin/configs.js` — syntax check
- [x] `npx eslint` on all changed files — 0 new errors/warnings (one pre-existing unrelated warning in `configs.js` untouched)
- [x] `npx prettier --check` — clean
- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/admin-platform-config-concurrency.test.js` — all 4 new tests pass
- [x] Ran the existing `admin-tools-script-path.test.js` and `CredentialService.test.js` suites alongside — no regressions
- [x] `node server/server.js` — boots cleanly with the changes in place
- [x] `npm run build` (client) — succeeds, `AdminAuthPage` chunk builds without errors

## Test plan

- [x] GET returns a `_version` field
- [x] POST without a base version still succeeds unconditionally (back-compat for unmigrated pages)
- [x] POST with a stale base version is rejected with 409 and does not overwrite the concurrent winning save
- [x] POST with the current base version succeeds and returns a fresh version
- [ ] Manual: open the Authentication Configuration page in two browser tabs, save in one, then save in the other — confirm the second tab shows the conflict message instead of silently overwriting

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhWnGEqwh9VBRPQLrUXqTE


---
_Generated by [Claude Code](https://claude.ai/code/session_01WhWnGEqwh9VBRPQLrUXqTE)_