### PR TITLE
fix(ci): dedupe mdBook/Rust setup, drop archived actions-rs/toolchain

### DIFF
--- a/.github/actions/setup-mdbook-rust/action.yml
+++ b/.github/actions/setup-mdbook-rust/action.yml
@@ -1,0 +1,35 @@
+name: 'Setup mdBook and Rust toolchain'
+description: 'Installs mdBook, a Rust toolchain, caches Cargo binaries, and installs mdbook-mermaid'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Install mdBook
+      uses: peaceiris/actions-mdbook@v1
+      with:
+        mdbook-version: 'latest'
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Cargo binaries
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+        key: ${{ runner.os }}-cargo-mdbook-${{ hashFiles('**/book.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-mdbook-
+
+    - name: Install mdbook-mermaid
+      shell: bash
+      run: |
+        if ! command -v mdbook-mermaid &> /dev/null; then
+          echo "Installing mdbook-mermaid..."
+          cargo install mdbook-mermaid
+        else
+          echo "mdbook-mermaid already installed"
+        fi

--- a/.github/workflows/build-binaries.yml
+++ b/.github/workflows/build-binaries.yml
@@ -34,51 +34,14 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - name: Install mdBook
-        uses: peaceiris/actions-mdbook@v1
-        with:
-          mdbook-version: 'latest'
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Cache Cargo binaries
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-mdbook-${{ hashFiles('**/book.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-mdbook-
-
-      - name: Install mdbook-mermaid
-        run: |
-          if ! command -v mdbook-mermaid &> /dev/null; then
-            echo "Installing mdbook-mermaid..."
-            cargo install mdbook-mermaid
-          else
-            echo "mdbook-mermaid already installed"
-          fi
-        shell: bash
+      - name: Setup mdBook and Rust toolchain
+        uses: ./.github/actions/setup-mdbook-rust
 
       - name: Install dependencies
         run: |
           npm ci
           cd client && npm ci && cd ..
           cd server && npm ci && cd ..
-
-      - name: Install client dependencies with uuid package
-        run: |
-          cd client
-          npm install
-          npm install uuid
-          cd ..
 
       - name: Build client
         run: |
@@ -132,43 +95,13 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - name: Install mdBook
-        uses: peaceiris/actions-mdbook@v1
-        with:
-          mdbook-version: 'latest'
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Cache Cargo binaries
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-mdbook-${{ hashFiles('**/book.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-mdbook-
-
-      - name: Install mdbook-mermaid
-        run: |
-          if ! command -v mdbook-mermaid &> /dev/null; then
-            echo "Installing mdbook-mermaid..."
-            cargo install mdbook-mermaid
-          else
-            echo "mdbook-mermaid already installed"
-          fi
-        shell: bash
+      - name: Setup mdBook and Rust toolchain
+        uses: ./.github/actions/setup-mdbook-rust
 
       - name: Install dependencies
         run: |
           npm ci
-          cd client && npm ci && npm install uuid && cd ..
+          cd client && npm ci && cd ..
           cd server && npm ci && cd ..
 
       - name: Set version

--- a/.github/workflows/build-client-binaries.yml
+++ b/.github/workflows/build-client-binaries.yml
@@ -44,43 +44,13 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - name: Install mdBook
-        uses: peaceiris/actions-mdbook@v1
-        with:
-          mdbook-version: 'latest'
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Cache Cargo binaries
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-mdbook-${{ hashFiles('**/book.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-mdbook-
-
-      - name: Install mdbook-mermaid
-        run: |
-          if ! command -v mdbook-mermaid &> /dev/null; then
-            echo "Installing mdbook-mermaid..."
-            cargo install mdbook-mermaid
-          else
-            echo "mdbook-mermaid already installed"
-          fi
-        shell: bash
+      - name: Setup mdBook and Rust toolchain
+        uses: ./.github/actions/setup-mdbook-rust
 
       - name: Install dependencies
         run: |
           npm ci
-          cd client && npm ci && npm install uuid && cd ..
+          cd client && npm ci && cd ..
           cd server && npm ci && cd ..
 
       - name: Set version

--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -24,45 +24,8 @@ jobs:
           node-version: '24'
           cache: 'npm'
 
-      - name: Install mdBook
-        uses: peaceiris/actions-mdbook@v1
-        with:
-          mdbook-version: 'latest'
-
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-
-      - name: Cache Cargo binaries
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-          key: ${{ runner.os }}-cargo-mdbook-${{ hashFiles('**/book.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-mdbook-
-
-      - name: Install mdBook backends
-        run: |
-          # Check if already cached, install if not
-          # if ! command -v mdbook-pdf &> /dev/null; then
-          #   echo "Installing mdbook-pdf..."
-          #   cargo install mdbook-pdf
-          # else
-          #   echo "mdbook-pdf already installed"
-          # fi
-
-          if ! command -v mdbook-mermaid &> /dev/null; then
-            echo "Installing mdbook-mermaid..."
-            cargo install mdbook-mermaid
-          else
-            echo "mdbook-mermaid already installed"
-          fi
+      - name: Setup mdBook and Rust toolchain
+        uses: ./.github/actions/setup-mdbook-rust
 
       # - name: Install Chromium (for PDF generation)
       #   run: |


### PR DESCRIPTION
## Summary

Closes #1759.

- Extracts the "install mdBook + Rust toolchain + cache cargo + install mdbook-mermaid" block — previously duplicated across `build-binaries.yml` (twice: `build-check` and `build` jobs), `build-client-binaries.yml`, and `mdbook.yml` — into a new composite action at `.github/actions/setup-mdbook-rust/action.yml`.
- Replaces the archived/unmaintained `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain@stable` inside that composite action, fixing the deprecation warning at all four call sites in one place.
- Removes the redundant `npm install uuid` steps in `build-binaries.yml` and `build-client-binaries.yml` — `uuid` is already a declared dependency in `client/package.json` and gets installed by the preceding `npm ci`, so the extra install only risked silently mutating the lockfile mid-CI.

This is a pure CI/infra refactor with no change to build triggers, outputs, or artifacts.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` on all four changed/added YAML files — all parse cleanly.
- [x] Confirmed no remaining references to `actions-rs/toolchain` or `npm install uuid` anywhere under `.github/`.
- [ ] Since this only affects GitHub Actions workflows, verify the actual runs (`build-check` on this PR, and a manual `workflow_dispatch` of `build-client-binaries.yml`/`mdbook.yml`) succeed once CI executes on this branch.

https://claude.ai/code/session_01QcGrLfYbd7paXmH7WofvyS


---
_Generated by [Claude Code](https://claude.ai/code/session_01QcGrLfYbd7paXmH7WofvyS)_