### PR TITLE
fix: enable ESLint no-undef and fix all surfaced ReferenceError bugs

### DIFF
--- a/client/src/auth-gate/auth-gate.js
+++ b/client/src/auth-gate/auth-gate.js
@@ -14,6 +14,7 @@
  * before DOM insertion. Only static template strings and escaped values
  * are used with innerHTML for rendering the login UI.
  */
+/* global __authGateI18n */
 (function authGate() {
   'use strict';
 

--- a/client/src/config/marked.config.js
+++ b/client/src/config/marked.config.js
@@ -114,7 +114,7 @@ const createRenderer = t => {
   };
 
   // --- Link Renderer ---
-  renderer.link = token => {
+  renderer.link = function (token) {
     // In marked v5+, the renderer receives a token object instead of separate parameters
     // Extract href, title, and text from the token
     let actualHref = token.href;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,7 +47,8 @@ export default [
           caughtErrorsIgnorePattern: '^_'
         }
       ],
-      'no-console': 'off'
+      'no-console': 'off',
+      'no-undef': 'error'
       // Removed all formatting rules that conflict with Prettier
       // Prettier handles: indent, quotes, semi, no-multiple-empty-lines, eol-last,
       // comma-dangle, object-curly-spacing, array-bracket-spacing, space-before-function-paren,
@@ -105,6 +106,27 @@ export default [
       globals: {
         ...globals.node,
         ...globals.es2024
+      }
+    }
+  },
+  {
+    files: ['tests/**/*.js', 'tests/**/*.jsx', 'server/tests/**/*.js', '**/__tests__/**/*.js'],
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
+      },
+      globals: {
+        ...globals.jest
+      }
+    }
+  },
+  {
+    files: ['browser-extension/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.webextensions
       }
     }
   }

--- a/server/adapters/toolCalling/OpenAIConverter.js
+++ b/server/adapters/toolCalling/OpenAIConverter.js
@@ -382,7 +382,7 @@ export async function convertOpenAIResponseToGeneric(data, streamId = 'default')
             } catch (error) {
               logger.warn('Failed to parse accumulated OpenAI tool arguments', {
                 component: 'OpenAIConverter',
-                error: e
+                error
               });
               parsedArgs = { __raw_arguments: pending.arguments };
             }

--- a/server/adapters/toolCalling/index.js
+++ b/server/adapters/toolCalling/index.js
@@ -20,6 +20,9 @@
  * // Now you have a uniform response format regardless of provider
  */
 
+import { createUnifiedInterface } from './ToolCallingConverter.js';
+import { normalizeToolName } from './GenericToolCalling.js';
+
 // Export main converter interface
 export {
   convertToolsToGeneric,

--- a/server/middleware/proxyAuth.js
+++ b/server/middleware/proxyAuth.js
@@ -18,7 +18,7 @@ async function getJwks(jwkUrl) {
     jwksCache.set(jwkUrl, jwks);
     return jwks;
   } catch (error) {
-    logger.error('Error fetching JWKs', { component: 'ProxyAuth', error: err });
+    logger.error('Error fetching JWKs', { component: 'ProxyAuth', error });
     return null;
   }
 }
@@ -41,7 +41,7 @@ async function verifyJwt(token, provider) {
 
     return payload;
   } catch (error) {
-    logger.error('JWT verification failed', { component: 'ProxyAuth', error: err });
+    logger.error('JWT verification failed', { component: 'ProxyAuth', error });
     return null;
   }
 }

--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -408,7 +408,7 @@ export default function registerAdminConfigRoutes(app) {
             component: 'AdminConfigs'
           });
         } catch (error) {
-          logger.warn('Could not reset iFinder caches', { component: 'AdminConfigs', error: err });
+          logger.warn('Could not reset iFinder caches', { component: 'AdminConfigs', error });
         }
       }
 

--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -344,8 +344,8 @@ export default function registerSessionRoutes(
     chatAuthRequired,
     validate(chatConnectSchema),
     async (req, res) => {
+      const { appId, chatId } = req.params;
       try {
-        const { appId, chatId } = req.params;
         const channel = createSseChannel({
           req,
           res,

--- a/server/routes/shortLinkRoutes.js
+++ b/server/routes/shortLinkRoutes.js
@@ -118,7 +118,7 @@ export default function registerShortLinkRoutes(app) {
       }
       res.redirect(link.url);
     } catch (error) {
-      logger.error('Error redirecting short link', { component: 'ShortLinkRoutes', error: e });
+      logger.error('Error redirecting short link', { component: 'ShortLinkRoutes', error });
       res.status(500).send('Error');
     }
   });

--- a/server/services/PromptService.js
+++ b/server/services/PromptService.js
@@ -375,7 +375,7 @@ class PromptService {
         } catch (error) {
           logger.error('Error loading skills for system prompt', {
             component: 'PromptService',
-            error: err
+            error
           });
         }
       }
@@ -403,7 +403,7 @@ class PromptService {
           logger.error('Error pre-activating skill', {
             component: 'PromptService',
             requestedSkill,
-            error: err
+            error
           });
         }
       }
@@ -422,7 +422,7 @@ class PromptService {
             });
           }
         } catch (error) {
-          logger.error('Error loading styles', { component: 'PromptService', error: err });
+          logger.error('Error loading styles', { component: 'PromptService', error });
         }
       }
 

--- a/server/services/UsageAggregator.js
+++ b/server/services/UsageAggregator.js
@@ -171,7 +171,7 @@ export async function generateDailyRollups() {
     logger.info('Generated daily rollups', { component: 'UsageAggregator', daysGenerated });
     return { eventsProcessed: events.length, daysGenerated };
   } catch (error) {
-    logger.error('Failed to generate daily rollups', { component: 'UsageAggregator', error: e });
+    logger.error('Failed to generate daily rollups', { component: 'UsageAggregator', error });
     return { eventsProcessed: 0, daysGenerated: 0 };
   }
 }
@@ -212,7 +212,7 @@ export async function generateMonthlyRollups() {
     logger.info('Generated monthly rollups', { component: 'UsageAggregator', monthsGenerated });
     return { monthsGenerated };
   } catch (error) {
-    logger.error('Failed to generate monthly rollups', { component: 'UsageAggregator', error: e });
+    logger.error('Failed to generate monthly rollups', { component: 'UsageAggregator', error });
     return { monthsGenerated: 0 };
   }
 }

--- a/server/services/integrations/Office365Service.js
+++ b/server/services/integrations/Office365Service.js
@@ -963,7 +963,7 @@ class Office365Service {
           logger.warn('Could not load drives for site', {
             component: 'Office365Service',
             siteName: site.displayName,
-            error: e
+            error
           });
         }
       }

--- a/server/services/marketplace/ContentInstaller.js
+++ b/server/services/marketplace/ContentInstaller.js
@@ -242,7 +242,7 @@ async function buildSkillContent(item, skillMd, authHeaders) {
     try {
       companions = await registryService.discoverCompanions(item.source.url, authHeaders);
     } catch (error) {
-      logger.warn('Companion discovery fallback failed', { component: COMPONENT, error: err });
+      logger.warn('Companion discovery fallback failed', { component: COMPONENT, error });
     }
   }
 
@@ -278,7 +278,7 @@ async function buildSkillContent(item, skillMd, authHeaders) {
         logger.warn('Failed to fetch companion file', {
           component: COMPONENT,
           relativePath,
-          error: err
+          error
         });
       }
     })

--- a/server/services/workflow/ExecutionRegistry.js
+++ b/server/services/workflow/ExecutionRegistry.js
@@ -435,7 +435,7 @@ export class ExecutionRegistry {
         if (error.code !== 'ENOENT') {
           logger.warn('Error loading registry file, will rebuild from checkpoints', {
             component: 'ExecutionRegistry',
-            error: err
+            error
           });
         }
       }
@@ -515,7 +515,7 @@ export class ExecutionRegistry {
           logger.debug('Skipping directory without valid checkpoint', {
             component: 'ExecutionRegistry',
             executionId,
-            error: err
+            error
           });
         }
       }
@@ -524,7 +524,7 @@ export class ExecutionRegistry {
         // State directory doesn't exist yet, that's fine
         logger.debug('State directory does not exist yet', { component: 'ExecutionRegistry' });
       } else {
-        throw err;
+        throw error;
       }
     }
   }

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -534,7 +534,8 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
         tools,
         config,
         context: contextForLLM,
-        nodeId: node.id
+        nodeId: node.id,
+        nativeWebSearch
       });
 
       // Finalise the step transcript with timing + outcome.
@@ -1392,7 +1393,7 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
    * @returns {Promise<Object>} Final response with content
    * @private
    */
-  async executeLLMWithTools({ model, messages, tools, config, context, nodeId }) {
+  async executeLLMWithTools({ model, messages, tools, config, context, nodeId, nativeWebSearch }) {
     // Budget-driven continuation (Claude Code TOKEN_BUDGET analog). The agent
     // runs as long as the task and budget require, rather than a fixed count.
     // `maxToolRoundsPerNode` is a safety backstop above the token budget; the

--- a/server/shortLinkManager.js
+++ b/server/shortLinkManager.js
@@ -51,7 +51,7 @@ function scheduleSave() {
     try {
       await saveLinks();
     } catch (error) {
-      logger.error('Failed to save short link data', { component: 'ShortLinkManager', error: e });
+      logger.error('Failed to save short link data', { component: 'ShortLinkManager', error });
     }
   }, SAVE_INTERVAL_MS);
 }

--- a/server/utils/installationCleanup.js
+++ b/server/utils/installationCleanup.js
@@ -34,7 +34,7 @@ export async function removeMarketplaceInstallation(type, itemId) {
       component: 'InstallationCleanup',
       type,
       itemId,
-      error: err
+      error
     });
   }
 }

--- a/tests/unit/client/outlook-mail-context.test.jsx
+++ b/tests/unit/client/outlook-mail-context.test.jsx
@@ -14,6 +14,7 @@
  *   - Context reads are serialized behind the module's mailbox lock so they
  *     can't interleave with a load/unload cycle.
  */
+/* global Office */
 
 import '@testing-library/jest-dom';
 


### PR DESCRIPTION
## Summary

Closes #1762.

`eslint.config.js` never enabled any of `@eslint/js`'s recommended rules, so `no-undef` (and friends like `no-dupe-keys`, `no-unreachable`) were silently disabled repo-wide. This let a whole class of `ReferenceError` bugs ship without lint ever catching them — mostly copy-pasted `catch (error) { ... error: err/e ... }` typos where the logged variable doesn't match the bound catch parameter.

- Added `'no-undef': 'error'` to the base ESLint rule block.
- Added scoped `globals` blocks so `no-undef` doesn't false-positive on legitimate cases:
  - `tests/**` / `server/tests/**` / `**/__tests__/**`: Jest globals, plus JSX parsing for `.test.jsx` files (previously failed to parse entirely under the base config).
  - `browser-extension/**`: `webextensions` globals (`chrome`).
- Fixed every violation `no-undef` surfaced (24 errors across 15 files):
  - ~15 `catch (error) { ... error: err }` / `error: e` typos across `proxyAuth.js`, `PromptService.js`, `UsageAggregator.js`, `ExecutionRegistry.js` (×3, including a `throw err` → `throw error`), `shortLinkManager.js`, `shortLinkRoutes.js`, `admin/configs.js`, `Office365Service.js`, `ContentInstaller.js` (×2), `installationCleanup.js`, `OpenAIConverter.js`.
  - `server/routes/chat/sessionRoutes.js`: `chatId` was destructured *inside* the outer `try` block, so the sibling `catch` couldn't see it — moved the destructure above the `try`.
  - `server/services/workflow/executors/PromptNodeExecutor.js`: `nativeWebSearch` was computed in `execute()` but referenced in the unrelated `executeLLMWithTools()` method — threaded it through as an explicit parameter.
  - `server/adapters/toolCalling/index.js`: `createUnifiedInterface` / `normalizeToolName` were only re-exported (`export { x } from './y.js'`), which doesn't bring them into local scope — added local imports alongside the re-exports.
  - `client/src/config/marked.config.js`: an arrow function referenced `arguments`, which arrow functions don't have — converted to a regular function.
  - Legitimate cross-script/runtime globals given `/* global X */` annotations rather than "fixed": `client/src/auth-gate/auth-gate.js` (`__authGateI18n`, inlined at build time by the Vite auth-gate plugin) and `tests/unit/client/outlook-mail-context.test.jsx` (`Office`, matching the same convention already used in the source module under test).

No functional/behavioral changes beyond the above bug fixes — this is a lint-gate hardening pass plus the ReferenceErrors it surfaced.

## Test plan

- [x] `npm run lint` — 0 errors (647 pre-existing warnings, unrelated to this change)
- [x] `npm run format` — all touched files pass Prettier
- [x] `npm run test:unit` — 28/28 suites, 240/240 tests pass
- [x] `npm run test:integration` — same 5 pre-existing failures as on `main` before this change (verified via `git stash`), no new failures introduced
- [x] Verified server boots cleanly (`node server/server.js`) with no startup errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016oF58YmF44kxd8YeBa9nf2)_