### PR TITLE
fix(admin): serialize platform.json section writes through a shared helper

### DIFF
--- a/server/configCache.js
+++ b/server/configCache.js
@@ -1,3 +1,5 @@
+import { promises as fs } from 'fs';
+import { join } from 'path';
 import { loadJson, loadBuiltinLocaleJson, listBuiltinLocales } from './configLoader.js';
 import { loadAllApps } from './appsLoader.js';
 import { loadAllModels } from './modelsLoader.js';
@@ -18,6 +20,9 @@ import ApiKeyVerifier from './utils/ApiKeyVerifier.js';
 import tokenStorageService from './services/TokenStorageService.js';
 import { SECRET_FIELDS_BY_TYPE } from './validators/credentialSchema.js';
 import logger from './utils/logger.js';
+import { getRootDir } from './pathUtils.js';
+import config from './config.js';
+import { atomicWriteJSON } from './utils/atomicWrite.js';
 
 /**
  * Resolve environment variables in a string
@@ -287,6 +292,9 @@ class ConfigCache {
     this.isInitialized = false;
     this.localeLoadingLocks = new Map();
     this.apiKeyVerifier = new ApiKeyVerifier();
+    // Serializes updatePlatformSection() calls so concurrent admin saves to
+    // different sections of platform.json can't race and clobber each other.
+    this.platformWriteQueue = Promise.resolve();
 
     // Cache TTL in milliseconds (default: 5 minutes for production, shorter for development)
     this.cacheTTL = process.env.NODE_ENV === 'production' ? 5 * 60 * 1000 : 60 * 1000;
@@ -1107,6 +1115,47 @@ class ConfigCache {
    */
   getPlatform() {
     return this.get('config/platform.json').data;
+  }
+
+  /**
+   * Update platform.json under a serialized write queue: reads the file
+   * fresh from disk (not the decrypted in-memory cache, so secrets already
+   * on disk are never round-tripped as plaintext), applies `mutator`,
+   * atomically writes the result, and refreshes the cache entry.
+   *
+   * Concurrent callers are queued one after another so two admin saves to
+   * different sections of platform.json can't race and silently overwrite
+   * each other.
+   *
+   * @param {(platformConfig: object) => (object|void)} mutator - Receives
+   *   the config parsed from disk (defaults to `{}` if the file is
+   *   missing). May mutate it in place or return a replacement object.
+   * @returns {Promise<object>} the platform config as written to disk
+   */
+  async updatePlatformSection(mutator) {
+    const task = this.platformWriteQueue.then(() => this._updatePlatformSection(mutator));
+    // Keep the queue moving even if this update fails; the caller still
+    // gets the rejection via the returned `task` promise.
+    this.platformWriteQueue = task.catch(() => {});
+    return task;
+  }
+
+  async _updatePlatformSection(mutator) {
+    const platformConfigPath = join(getRootDir(), config.CONTENTS_DIR, 'config', 'platform.json');
+    let platformConfig;
+    try {
+      const raw = await fs.readFile(platformConfigPath, 'utf8');
+      platformConfig = JSON.parse(raw);
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+      platformConfig = {};
+    }
+
+    const mutated = await mutator(platformConfig);
+    const result = mutated ?? platformConfig;
+    await atomicWriteJSON(platformConfigPath, result);
+    await this.refreshCacheEntry('config/platform.json');
+    return result;
   }
 
   /**

--- a/server/routes/admin/auditLog.js
+++ b/server/routes/admin/auditLog.js
@@ -10,10 +10,6 @@ import { sendBadRequest, sendInternalError } from '../../utils/responseHelpers.j
 import { buildCsv } from '../../utils/csv.js';
 import configCache from '../../configCache.js';
 import logger from '../../utils/logger.js';
-import { promises as fs } from 'fs';
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
-import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 
 // Accept the platform.json shape exactly: false (off), true (mask),
 // or one of 'off' | 'mask' | 'drop'. Anything else is a 400 — we don't
@@ -200,20 +196,13 @@ export default function registerAdminAuditLogRoutes(app) {
         );
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
-
-      const platformContent = await fs.readFile(platformPath, 'utf8');
-      const platformConfig = JSON.parse(platformContent);
-
-      if (!platformConfig.audit) platformConfig.audit = {};
-      if (anonymizeIp !== undefined) {
-        platformConfig.audit.anonymizeIp = anonymizeIp;
-      }
-
-      await atomicWriteJSON(platformPath, platformConfig);
-      await configCache.refreshCacheEntry('config/platform.json');
+      await configCache.updatePlatformSection(platformConfig => {
+        if (!platformConfig.audit) platformConfig.audit = {};
+        if (anonymizeIp !== undefined) {
+          platformConfig.audit.anonymizeIp = anonymizeIp;
+        }
+        return platformConfig;
+      });
 
       logAudit({
         req,

--- a/server/routes/admin/browserExtension.js
+++ b/server/routes/admin/browserExtension.js
@@ -3,7 +3,6 @@ import { promises as fs } from 'fs';
 import archiver from 'archiver';
 import config from '../../config.js';
 import { getRootDir } from '../../pathUtils.js';
-import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
@@ -32,16 +31,6 @@ const SIGNING_KEY_FILE = '.browser-extension-key.pem';
 
 function signingKeyPath() {
   return join(getRootDir(), 'contents', SIGNING_KEY_FILE);
-}
-
-async function savePlatformConfig(updates) {
-  const rootDir = getRootDir();
-  const platformConfigPath = join(rootDir, 'contents', 'config', 'platform.json');
-  const existing = configCache.getPlatform() || {};
-  const merged = { ...existing, ...updates };
-  await atomicWriteJSON(platformConfigPath, merged);
-  await configCache.refreshCacheEntry('config/platform.json');
-  return merged;
 }
 
 function buildRedirectUrisFromExtensionIds(extensionIds = []) {
@@ -310,7 +299,7 @@ export default function registerAdminBrowserExtensionRoutes(app) {
         }
       };
 
-      await savePlatformConfig(updates);
+      await configCache.updatePlatformSection(cfg => ({ ...cfg, ...updates }));
 
       const baseUrl = buildPublicBaseUrl(req);
 
@@ -339,13 +328,9 @@ export default function registerAdminBrowserExtensionRoutes(app) {
    */
   app.post(buildServerPath('/api/admin/browser-extension/disable'), adminAuth, async (req, res) => {
     try {
-      const platform = configCache.getPlatform();
-
-      await savePlatformConfig({
-        browserExtension: {
-          ...(platform?.browserExtension || {}),
-          enabled: false
-        }
+      await configCache.updatePlatformSection(cfg => {
+        cfg.browserExtension = { ...(cfg.browserExtension || {}), enabled: false };
+        return cfg;
       });
 
       logger.info('Browser extension integration disabled', {
@@ -479,8 +464,9 @@ export default function registerAdminBrowserExtensionRoutes(app) {
         }
       }
 
-      await savePlatformConfig({
-        browserExtension: merged
+      await configCache.updatePlatformSection(cfg => {
+        cfg.browserExtension = merged;
+        return cfg;
       });
 
       logger.info('Browser extension integration config updated', {
@@ -562,15 +548,10 @@ export default function registerAdminBrowserExtensionRoutes(app) {
           newSigningKey
         );
 
-        await savePlatformConfig({
-          browserExtension: {
-            ...cfg,
-            signingKey: newSigningKey
-          },
-          cors: {
-            ...corsConfig,
-            origin: updatedCorsOrigin
-          }
+        await configCache.updatePlatformSection(platformCfg => {
+          platformCfg.browserExtension = { ...cfg, signingKey: newSigningKey };
+          platformCfg.cors = { ...corsConfig, origin: updatedCorsOrigin };
+          return platformCfg;
         });
 
         logger.warn('Browser extension signing key rotated', {

--- a/server/routes/admin/cors.js
+++ b/server/routes/admin/cors.js
@@ -2,11 +2,7 @@ import { adminAuth } from '../../middleware/adminAuth.js';
 import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 import configCache from '../../configCache.js';
-import { promises as fs } from 'fs';
-import { join } from 'path';
 import { buildServerPath } from '../../utils/basePath.js';
-import { getRootDir } from '../../pathUtils.js';
-import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 
 const DEFAULT_CORS_CONFIG = {
   origin: [],
@@ -128,17 +124,11 @@ export default function registerAdminCorsRoutes(app) {
         }
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
-
-      const platformContent = await fs.readFile(platformPath, 'utf8');
-      const platformConfig = JSON.parse(platformContent);
-
-      platformConfig.cors = { origin, credentials, maxAge, methods, allowedHeaders };
-
-      await atomicWriteJSON(platformPath, platformConfig);
-      await configCache.refreshCacheEntry('config/platform.json');
+      const newCorsConfig = { origin, credentials, maxAge, methods, allowedHeaders };
+      await configCache.updatePlatformSection(platformConfig => {
+        platformConfig.cors = newCorsConfig;
+        return platformConfig;
+      });
 
       logger.info('CORS configuration updated', {
         component: 'AdminCORS',
@@ -149,7 +139,7 @@ export default function registerAdminCorsRoutes(app) {
 
       res.json({
         message: 'CORS configuration updated successfully',
-        config: platformConfig.cors
+        config: newCorsConfig
       });
     } catch (error) {
       return sendInternalError(res, error, 'update CORS configuration');

--- a/server/routes/admin/logging.js
+++ b/server/routes/admin/logging.js
@@ -2,11 +2,7 @@ import { adminAuth } from '../../middleware/adminAuth.js';
 import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 import configCache from '../../configCache.js';
-import { promises as fs } from 'fs';
-import { join } from 'path';
 import { buildServerPath } from '../../utils/basePath.js';
-import { getRootDir } from '../../pathUtils.js';
-import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 
 export default function registerAdminLoggingRoutes(app) {
   /**
@@ -89,25 +85,13 @@ export default function registerAdminLoggingRoutes(app) {
 
       // Optionally persist to platform.json
       if (persist) {
-        const rootDir = getRootDir();
-        const contentsDir = process.env.CONTENTS_DIR || 'contents';
-        const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
-
-        // Read current platform config
-        const platformContent = await fs.readFile(platformPath, 'utf8');
-        const platformConfig = JSON.parse(platformContent);
-
-        // Update logging level
-        if (!platformConfig.logging) {
-          platformConfig.logging = {};
-        }
-        platformConfig.logging.level = level;
-
-        // Write back atomically
-        await atomicWriteJSON(platformPath, platformConfig);
-
-        // Refresh config cache
-        await configCache.refreshCacheEntry('config/platform.json');
+        await configCache.updatePlatformSection(platformConfig => {
+          if (!platformConfig.logging) {
+            platformConfig.logging = {};
+          }
+          platformConfig.logging.level = level;
+          return platformConfig;
+        });
 
         // Reconfigure logger to pick up any other changes
         logger.reconfigureLogger();
@@ -194,25 +178,13 @@ export default function registerAdminLoggingRoutes(app) {
     try {
       const newLoggingConfig = req.body;
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
-
-      // Read current platform config
-      const platformContent = await fs.readFile(platformPath, 'utf8');
-      const platformConfig = JSON.parse(platformContent);
-
-      // Update logging config
-      platformConfig.logging = {
-        ...platformConfig.logging,
-        ...newLoggingConfig
-      };
-
-      // Write back atomically
-      await atomicWriteJSON(platformPath, platformConfig);
-
-      // Refresh config cache
-      await configCache.refreshCacheEntry('config/platform.json');
+      const { logging: mergedLogging } = await configCache.updatePlatformSection(platformConfig => {
+        platformConfig.logging = {
+          ...platformConfig.logging,
+          ...newLoggingConfig
+        };
+        return platformConfig;
+      });
 
       // Reconfigure logger to pick up changes
       logger.reconfigureLogger();
@@ -221,7 +193,7 @@ export default function registerAdminLoggingRoutes(app) {
 
       res.json({
         success: true,
-        config: platformConfig.logging,
+        config: mergedLogging,
         message: 'Logging configuration updated successfully'
       });
     } catch (error) {

--- a/server/routes/admin/nextcloudEmbed.js
+++ b/server/routes/admin/nextcloudEmbed.js
@@ -1,6 +1,3 @@
-import { join } from 'path';
-import { getRootDir } from '../../pathUtils.js';
-import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
@@ -8,19 +5,6 @@ import { buildPublicBaseUrl } from '../../utils/publicBaseUrl.js';
 import { createOAuthClient } from '../../utils/oauthClientManager.js';
 import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
-
-async function savePlatformConfig(updates) {
-  const rootDir = getRootDir();
-  const platformConfigPath = join(rootDir, 'contents', 'config', 'platform.json');
-  // platform.json no longer stores any at-rest secrets — all integration
-  // secrets live in the central credential store (contents/config/credentials.json)
-  // referenced by `*Ref` fields — so a plain merge is safe here.
-  const existing = configCache.getPlatform() || {};
-  const merged = { ...existing, ...updates };
-  await atomicWriteJSON(platformConfigPath, merged);
-  await configCache.refreshCacheEntry('config/platform.json');
-  return merged;
-}
 
 /**
  * Validate a single `allowedHostOrigins` entry. We accept only well-formed
@@ -156,7 +140,7 @@ export default function registerAdminNextcloudEmbedRoutes(app) {
         }
       };
 
-      await savePlatformConfig(updates);
+      await configCache.updatePlatformSection(cfg => ({ ...cfg, ...updates }));
 
       logger.info('Nextcloud embed enabled', {
         component: 'AdminNextcloudEmbed',
@@ -189,13 +173,9 @@ export default function registerAdminNextcloudEmbedRoutes(app) {
    */
   app.post(buildServerPath('/api/admin/nextcloud-embed/disable'), adminAuth, async (req, res) => {
     try {
-      const platform = configCache.getPlatform();
-
-      await savePlatformConfig({
-        nextcloudEmbed: {
-          ...(platform?.nextcloudEmbed || {}),
-          enabled: false
-        }
+      await configCache.updatePlatformSection(cfg => {
+        cfg.nextcloudEmbed = { ...(cfg.nextcloudEmbed || {}), enabled: false };
+        return cfg;
       });
 
       logger.info('Nextcloud embed disabled', { component: 'AdminNextcloudEmbed' });
@@ -240,7 +220,6 @@ export default function registerAdminNextcloudEmbedRoutes(app) {
   app.put(buildServerPath('/api/admin/nextcloud-embed/config'), adminAuth, async (req, res) => {
     try {
       const { displayName, description, starterPrompts, allowedHostOrigins } = req.body;
-      const platform = configCache.getPlatform();
 
       // Accept only `{ [lang: string]: string }` objects. Any non-string locale value
       // is rejected to prevent garbage (or attacker-crafted) data from reaching the
@@ -336,11 +315,9 @@ export default function registerAdminNextcloudEmbedRoutes(app) {
         allowed.allowedHostOrigins = sanitized;
       }
 
-      await savePlatformConfig({
-        nextcloudEmbed: {
-          ...(platform?.nextcloudEmbed || {}),
-          ...allowed
-        }
+      await configCache.updatePlatformSection(cfg => {
+        cfg.nextcloudEmbed = { ...(cfg.nextcloudEmbed || {}), ...allowed };
+        return cfg;
       });
 
       logger.info('Nextcloud embed config updated', {

--- a/server/routes/admin/ssl.js
+++ b/server/routes/admin/ssl.js
@@ -2,11 +2,7 @@ import { adminAuth } from '../../middleware/adminAuth.js';
 import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 import configCache from '../../configCache.js';
-import { promises as fs } from 'fs';
-import { join } from 'path';
 import { buildServerPath } from '../../utils/basePath.js';
-import { getRootDir } from '../../pathUtils.js';
-import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 
 export default function registerAdminSSLRoutes(app) {
   /**
@@ -103,25 +99,13 @@ export default function registerAdminSSLRoutes(app) {
         }
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
-
-      // Read current platform config
-      const platformContent = await fs.readFile(platformPath, 'utf8');
-      const platformConfig = JSON.parse(platformContent);
-
-      // Update SSL configuration
-      platformConfig.ssl = {
-        ignoreInvalidCertificates,
-        domainWhitelist
-      };
-
-      // Write back atomically
-      await atomicWriteJSON(platformPath, platformConfig);
-
-      // Refresh config cache
-      await configCache.refreshCacheEntry('config/platform.json');
+      await configCache.updatePlatformSection(platformConfig => {
+        platformConfig.ssl = {
+          ignoreInvalidCertificates,
+          domainWhitelist
+        };
+        return platformConfig;
+      });
 
       logger.info('SSL configuration updated', {
         component: 'AdminSSL',

--- a/server/routes/admin/ssrf.js
+++ b/server/routes/admin/ssrf.js
@@ -2,11 +2,7 @@ import { adminAuth } from '../../middleware/adminAuth.js';
 import logger from '../../utils/logger.js';
 import { sendInternalError, sendBadRequest } from '../../utils/responseHelpers.js';
 import configCache from '../../configCache.js';
-import { promises as fs } from 'fs';
-import { join } from 'path';
 import { buildServerPath } from '../../utils/basePath.js';
-import { getRootDir } from '../../pathUtils.js';
-import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 
 export default function registerAdminSsrfRoutes(app) {
   /**
@@ -104,17 +100,10 @@ export default function registerAdminSsrfRoutes(app) {
         cleaned.push(trimmed);
       }
 
-      const rootDir = getRootDir();
-      const contentsDir = process.env.CONTENTS_DIR || 'contents';
-      const platformPath = join(rootDir, contentsDir, 'config', 'platform.json');
-
-      const platformContent = await fs.readFile(platformPath, 'utf8');
-      const platformConfig = JSON.parse(platformContent);
-
-      platformConfig.ssrf = { ...(platformConfig.ssrf || {}), allowedHosts: cleaned };
-
-      await atomicWriteJSON(platformPath, platformConfig);
-      await configCache.refreshCacheEntry('config/platform.json');
+      await configCache.updatePlatformSection(platformConfig => {
+        platformConfig.ssrf = { ...(platformConfig.ssrf || {}), allowedHosts: cleaned };
+        return platformConfig;
+      });
 
       logger.info('SSRF allowlist updated', {
         component: 'AdminSSRF',

--- a/server/routes/admin/usage.js
+++ b/server/routes/admin/usage.js
@@ -3,7 +3,6 @@ import { join } from 'path';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import { getRootDir } from '../../pathUtils.js';
-import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import config from '../../config.js';
 import { getTrackingMode, reloadConfig } from '../../usageTracker.js';
@@ -155,20 +154,11 @@ export default function registerAdminUsageRoutes(app) {
         );
       }
 
-      const rootDir = getRootDir();
-      const platformPath = join(rootDir, 'contents', 'config', 'platform.json');
-      let platform = {};
-      try {
-        const data = await fs.readFile(platformPath, 'utf8');
-        platform = JSON.parse(data);
-      } catch {
-        // Start fresh if file doesn't exist
-      }
-
-      if (!platform.features) platform.features = {};
-      platform.features.usageTrackingMode = trackingMode;
-      await atomicWriteJSON(platformPath, platform);
-      await configCache.refreshCacheEntry('config/platform.json');
+      await configCache.updatePlatformSection(platform => {
+        if (!platform.features) platform.features = {};
+        platform.features.usageTrackingMode = trackingMode;
+        return platform;
+      });
       reloadConfig();
 
       res.json({ trackingMode, message: 'Tracking mode updated successfully' });

--- a/server/tests/configCache.updatePlatformSection.test.js
+++ b/server/tests/configCache.updatePlatformSection.test.js
@@ -1,0 +1,98 @@
+/**
+ * Tests for configCache.updatePlatformSection: the shared, serialized
+ * read-modify-write helper that replaced the per-route savePlatformConfig
+ * clones and ad-hoc disk-read blocks across the admin routes.
+ */
+import { jest } from '@jest/globals';
+import { promises as fsp } from 'fs';
+import configCache from '../configCache.js';
+
+describe('configCache.updatePlatformSection', () => {
+  let diskState;
+
+  beforeEach(() => {
+    diskState = JSON.stringify({ cors: { origin: ['https://a.example'] } });
+    jest.spyOn(fsp, 'readFile').mockImplementation(async () => diskState);
+    jest.spyOn(fsp, 'writeFile').mockImplementation(async (_filePath, data) => {
+      diskState = data;
+    });
+    jest.spyOn(fsp, 'rename').mockResolvedValue(undefined);
+    jest.spyOn(configCache, 'refreshCacheEntry').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('serializes concurrent updates to different sections without clobbering', async () => {
+    const [corsResult, sslResult] = await Promise.all([
+      configCache.updatePlatformSection(cfg => {
+        cfg.cors = { origin: ['https://new.example'] };
+        return cfg;
+      }),
+      configCache.updatePlatformSection(cfg => {
+        cfg.ssl = { ignoreInvalidCertificates: true };
+        return cfg;
+      })
+    ]);
+
+    const finalOnDisk = JSON.parse(diskState);
+    expect(finalOnDisk.cors).toEqual({ origin: ['https://new.example'] });
+    expect(finalOnDisk.ssl).toEqual({ ignoreInvalidCertificates: true });
+    // Both callers see the config as it stood right after their own write,
+    // which — because writes are serialized — always includes every prior
+    // section update rather than a stale, pre-race snapshot.
+    expect(corsResult.cors).toEqual({ origin: ['https://new.example'] });
+    expect(sslResult.cors).toEqual({ origin: ['https://new.example'] });
+    expect(sslResult.ssl).toEqual({ ignoreInvalidCertificates: true });
+    expect(configCache.refreshCacheEntry).toHaveBeenCalledTimes(2);
+  });
+
+  test('defaults to {} when platform.json is missing', async () => {
+    fsp.readFile.mockImplementation(async () => {
+      throw Object.assign(new Error('no such file'), { code: 'ENOENT' });
+    });
+
+    const result = await configCache.updatePlatformSection(cfg => {
+      cfg.features = { usageTrackingMode: 'anonymous' };
+      return cfg;
+    });
+
+    expect(result).toEqual({ features: { usageTrackingMode: 'anonymous' } });
+  });
+
+  test('propagates non-ENOENT read errors instead of silently starting fresh', async () => {
+    fsp.readFile.mockImplementation(async () => {
+      throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+    });
+
+    await expect(configCache.updatePlatformSection(cfg => cfg)).rejects.toThrow(
+      'permission denied'
+    );
+  });
+
+  test('a rejected update does not stall later queued updates', async () => {
+    fsp.readFile.mockImplementationOnce(async () => {
+      throw Object.assign(new Error('boom'), { code: 'EACCES' });
+    });
+
+    await expect(configCache.updatePlatformSection(cfg => cfg)).rejects.toThrow('boom');
+
+    const result = await configCache.updatePlatformSection(cfg => {
+      cfg.ssrf = { allowedHosts: ['example.com'] };
+      return cfg;
+    });
+
+    expect(result.ssrf).toEqual({ allowedHosts: ['example.com'] });
+  });
+
+  test('supports mutators that mutate in place without returning a value', async () => {
+    const result = await configCache.updatePlatformSection(cfg => {
+      cfg.audit = { anonymizeIp: 'mask' };
+      // no return — the helper should fall back to the mutated input
+    });
+
+    expect(result.audit).toEqual({ anonymizeIp: 'mask' });
+    expect(result.cors).toEqual({ origin: ['https://a.example'] });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1757.

Eight admin route files each hand-rolled "read `platform.json` → mutate one section → atomic write → refresh cache" independently:
- `browserExtension.js` and `nextcloudEmbed.js` contained a byte-for-byte duplicated `savePlatformConfig()` that merged updates over `configCache.getPlatform()` (the **decrypted** in-memory cache) and wrote the result back to disk — which could round-trip the decrypted `speech.realtime.apiKey` / `speech.azure.subscriptionKey` secrets onto disk as plaintext.
- `cors.js`, `ssrf.js`, `ssl.js`, `usage.js`, `logging.js` (×2), and `auditLog.js` each independently read the file fresh from disk, mutated one section, and wrote it back, with inconsistent path resolution (`process.env.CONTENTS_DIR` vs. hardcoded `'contents'`).

None of these serialized against each other, so two concurrent admin saves to different sections (e.g. CORS in one tab, SSL in another) could race and silently clobber one another's write.

## Changes

- Added `configCache.updatePlatformSection(mutator)`: a single, serialized (promise-queue) helper that always reads `platform.json` fresh from disk (never the decrypted cache, so secrets are never round-tripped as plaintext), applies the mutator, atomically writes the result, and refreshes the cache entry.
- Routed all 8 files through it, deleting the two duplicated `savePlatformConfig()` clones and the 6 independent disk-read/atomic-write blocks, and removing now-unused `fs`/`path`/`atomicWriteJSON`/`getRootDir` imports where nothing else in the file needed them.
- Added `server/tests/configCache.updatePlatformSection.test.js` covering: concurrent writes to different sections no longer clobber each other, missing-file defaults to `{}`, non-ENOENT read errors propagate, a rejected update doesn't stall the queue, and mutators that mutate in place (no explicit return) still work.

No behavior/API changes — this is an internal refactor plus a race-condition fix; verified against a running dev server (see test plan) that no functional regression was introduced.

## Test plan

- [x] `server/tests/configCache.updatePlatformSection.test.js` — 5 new unit tests, all passing
- [x] `npm run lint:fix` — no new lint errors on any touched file
- [x] Verified server boots cleanly (`node server/server.js`, all cluster workers ready, no errors)
- [x] Live smoke test against a running dev server with the local admin account:
  - Fired concurrent `PUT /api/admin/cors/config` and `PUT /api/admin/ssl/config` — both persisted correctly in `platform.json` with no clobbering (the race this PR fixes)
  - Exercised `PUT /api/admin/audit-log/settings` and `PUT /api/admin/usage/meta` — both persisted correctly alongside the above


---
_Generated by [Claude Code](https://claude.ai/code/session_01PAEw8XPiS5Wjt4qe7KmN6v)_