### PR TITLE
refactor(admin): extract shared edit-page scaffold for admin resource editors

### DIFF
--- a/client/src/features/admin/hooks/useAdminResourceEditor.js
+++ b/client/src/features/admin/hooks/useAdminResourceEditor.js
@@ -1,0 +1,173 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useUnsavedChanges } from './useUnsavedChanges';
+
+/** Route-param sentinel every Admin*EditPage uses for "creating a new resource". */
+const NEW_RESOURCE_ID = 'new';
+
+/**
+ * Shared load / dirty-tracking / save orchestration for admin "edit resource" pages
+ * (AdminGroupEditPage, AdminAppEditPage, AdminModelEditPage, AdminPromptEditPage,
+ * AdminToolEditPage, AdminUserEditPage). These pages all repeat the same scaffold:
+ * branch on `resourceId === 'new'` to build a default object vs. loading the existing
+ * resource, wire up `useUnsavedChanges` for the "Unsaved Changes" confirm dialog, and
+ * save via a method/url ternary + an API call. This hook centralizes that scaffold so
+ * each page only has to supply the resource-specific pieces.
+ *
+ * Deliberately NOT handled here: navigation after save, and the `saving` UI flag.
+ * Pages differ on both (some show a toast before navigating, some navigate
+ * immediately; disabling the Save button also usually needs to wrap validation
+ * that happens before `save()` is ever called), so both stay in each page's own
+ * `handleSave`, which should call `await save()` and then `navigate(...)` itself.
+ *
+ * @param {Object} params
+ * @param {string} params.resourceId - route param identifying the resource being edited.
+ *   The sentinel value `'new'` means "creating a new resource" and skips loading.
+ * @param {(id: string) => (any | Promise<any>)} params.loadResource - fetch the existing
+ *   resource by id and resolve with the object that becomes the editable `data`. May run
+ *   additional page-specific side effects (e.g. seeding other local state) as long as it
+ *   still resolves with that object; throwing populates `error`.
+ * @param {() => (any | Promise<any>)} params.makeDefault - build the default object used
+ *   when `resourceId === 'new'`. May close over router state (e.g. `location.state`) to
+ *   pre-fill from a template.
+ * @param {(data: any, resourceId: string) => Promise<any>} params.saveResource - persist
+ *   `data`. Implements the method/url ternary + API call the page already knows about.
+ *   Whatever it returns is returned from `save()`; whatever it throws is thrown from
+ *   `save()` (and `markSaved()` is skipped in that case).
+ * @returns {{
+ *   data: any,
+ *   setData: (updater: any) => void,
+ *   initialData: any,
+ *   loading: boolean,
+ *   error: string|null,
+ *   setError: (message: string|null) => void,
+ *   isNew: boolean,
+ *   save: () => Promise<any>,
+ *   blocker: { state: 'blocked'|'unblocked', proceed: Function, reset: Function },
+ *   markSaved: () => void
+ * }}
+ *
+ * @example
+ * const { data: group, setData: setGroup, loading, error, setError, save, blocker } =
+ *   useAdminResourceEditor({
+ *     resourceId: groupId,
+ *     loadResource: async id => {
+ *       const response = await makeAdminApiCall('/admin/groups');
+ *       const groupData = response.data.groups[id];
+ *       if (!groupData) throw new Error('Group not found');
+ *       return groupData;
+ *     },
+ *     makeDefault: () => ({ id: '', name: '', description: '', enabled: true }),
+ *     saveResource: async (data, id) => {
+ *       const method = id === 'new' ? 'POST' : 'PUT';
+ *       const url = id === 'new' ? '/admin/groups' : `/admin/groups/${id}`;
+ *       await makeAdminApiCall(url, { method, body: data });
+ *     }
+ *   });
+ */
+export function useAdminResourceEditor({ resourceId, loadResource, makeDefault, saveResource }) {
+  const isNew = resourceId === NEW_RESOURCE_ID;
+
+  // Compute "new resource" defaults synchronously (not inside the effect below)
+  // so the very first render already has real `data`/`initialData` instead of
+  // `null` while `loading` is already `false` -- this mirrors how every page
+  // previously seeded a `useState` literal directly for the `resourceId === 'new'`
+  // case, and avoids handing a form component a `null` value it isn't guarding
+  // against. `useRef` (not `useState`) so this only ever runs once per mount,
+  // even though the same value is also read by two separate `useState`
+  // initializers below (calling `makeDefault` twice would, e.g., generate two
+  // different random ids for AdminUserEditPage's default user).
+  const mountDefaultsRef = useRef(undefined);
+  if (mountDefaultsRef.current === undefined) {
+    mountDefaultsRef.current = isNew ? makeDefault() : null;
+  }
+
+  const [data, setData] = useState(mountDefaultsRef.current);
+  const [initialData, setInitialData] = useState(mountDefaultsRef.current);
+  const [loading, setLoading] = useState(!isNew);
+  const [error, setError] = useState(null);
+
+  // Keep the latest callbacks in refs so the loading effect below can depend
+  // only on `resourceId` (matching what each page already did with its own
+  // `// eslint-disable-line @eslint-react/exhaustive-deps` effects) without
+  // re-running every render just because the page passed a fresh inline
+  // function this time.
+  const loadResourceRef = useRef(loadResource);
+  loadResourceRef.current = loadResource;
+  const makeDefaultRef = useRef(makeDefault);
+  makeDefaultRef.current = makeDefault;
+  const saveResourceRef = useRef(saveResource);
+  saveResourceRef.current = saveResource;
+
+  // Tracks whether the effect below is running for the very first time, so it
+  // can skip redoing the "new resource" defaults computation that
+  // `mountDefaultsRef` already handled synchronously above for the initial
+  // mount. Subsequent `resourceId` changes (e.g. switching from an existing
+  // resource to 'new', or between two different resources, without the page
+  // unmounting -- React Router keeps the component mounted across route-param
+  // changes on the same route) always recompute fresh via this effect.
+  const isFirstRunRef = useRef(true);
+
+  useEffect(() => {
+    const isFirstRun = isFirstRunRef.current;
+    isFirstRunRef.current = false;
+
+    if (isFirstRun && resourceId === NEW_RESOURCE_ID) {
+      // Already handled synchronously via mountDefaultsRef above.
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    async function run() {
+      if (resourceId === NEW_RESOURCE_ID) {
+        const defaults = await makeDefaultRef.current();
+        if (cancelled) return;
+        setData(defaults);
+        setInitialData(defaults);
+        setError(null);
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        const loaded = await loadResourceRef.current(resourceId);
+        if (cancelled) return;
+        setData(loaded);
+        setInitialData(loaded);
+        setError(null);
+      } catch (err) {
+        if (!cancelled) setError(err.message);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [resourceId]);
+
+  const { blocker, markSaved } = useUnsavedChanges(initialData, data);
+
+  const save = useCallback(async () => {
+    const result = await saveResourceRef.current(data, resourceId);
+    markSaved();
+    return result;
+  }, [data, resourceId, markSaved]);
+
+  return {
+    data,
+    setData,
+    initialData,
+    loading,
+    error,
+    setError,
+    isNew,
+    save,
+    blocker,
+    markSaved
+  };
+}

--- a/client/src/features/admin/pages/AdminAppEditPage.jsx
+++ b/client/src/features/admin/pages/AdminAppEditPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import DualModeEditor from '../../../shared/components/DualModeEditor';
@@ -8,27 +8,20 @@ import { makeAdminApiCall } from '../../../api/adminApi';
 import { fetchModels, fetchUIConfig } from '../../../api';
 import { fetchJsonSchema } from '../../../utils/schemaService';
 import ChangeHistoryDrawer from '../components/ChangeHistoryDrawer';
-import AdminBreadcrumb from '../components/AdminBreadcrumb';
-import { useUnsavedChanges } from '../hooks/useUnsavedChanges';
-import ConfirmDialog from '../../../shared/components/ConfirmDialog';
+import { useAdminResourceEditor } from '../hooks/useAdminResourceEditor';
+import AdminEditPageShell from '../../../shared/components/AdminEditPageShell';
 
 function AdminAppEditPage() {
   const { t } = useTranslation();
   const { appId } = useParams();
   const navigate = useNavigate();
-  const [app, setApp] = useState(null);
-  const [initialData, setInitialData] = useState(null);
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState(null);
   const [availableModels, setAvailableModels] = useState([]);
   const [uiConfig, setUiConfig] = useState(null);
   const [jsonSchema, setJsonSchema] = useState(null);
   const [editingMode, setEditingMode] = useState('form');
   const [validationState, setValidationState] = useState({ isValid: true, errors: [] });
   const [historyOpen, setHistoryOpen] = useState(false);
-
-  const { blocker, markSaved } = useUnsavedChanges(initialData, app);
 
   useEffect(() => {
     // Load available models, UI config, and JSON schema
@@ -65,170 +58,155 @@ function AdminAppEditPage() {
     loadJsonSchema();
   }, []);
 
-  useEffect(() => {
-    if (appId === 'new') {
-      // Initialize new app
-      const defaultApp = {
-        id: '',
-        type: 'chat',
-        order: 0,
-        name: { en: '' },
-        description: { en: '' },
-        color: '#4F46E5',
-        icon: 'chat-bubbles',
-        system: { en: '' },
-        preferredModel: undefined,
-        preferredOutputFormat: 'markdown',
-        preferredStyle: 'keep',
-        preferredTemperature: 0.7,
-        enabled: true,
-        variables: [],
-        starterPrompts: [],
-        tools: [],
-        greeting: {
-          en: {
-            title: '👋 Hello!',
-            subtitle: 'How can I help you today?'
-          },
-          de: {
-            title: '👋 Hallo!',
-            subtitle: 'Wie kann ich Ihnen heute helfen?'
-          }
+  const makeDefault = useCallback(
+    () => ({
+      id: '',
+      type: 'chat',
+      order: 0,
+      name: { en: '' },
+      description: { en: '' },
+      color: '#4F46E5',
+      icon: 'chat-bubbles',
+      system: { en: '' },
+      preferredModel: undefined,
+      preferredOutputFormat: 'markdown',
+      preferredStyle: 'keep',
+      preferredTemperature: 0.7,
+      enabled: true,
+      variables: [],
+      starterPrompts: [],
+      tools: [],
+      greeting: {
+        en: {
+          title: '👋 Hello!',
+          subtitle: 'How can I help you today?'
         },
-        allowEmptyContent: false,
-        sendChatHistory: true,
-        ephemeral: false,
-        category: 'utility',
-        inputMode: {
-          type: 'singleline',
-          rows: 5,
-          microphone: {
-            enabled: true,
-            mode: 'manual',
-            showTranscript: true
-          }
-        },
-        upload: {
+        de: {
+          title: '👋 Hallo!',
+          subtitle: 'Wie kann ich Ihnen heute helfen?'
+        }
+      },
+      allowEmptyContent: false,
+      sendChatHistory: true,
+      ephemeral: false,
+      category: 'utility',
+      inputMode: {
+        type: 'singleline',
+        rows: 5,
+        microphone: {
+          enabled: true,
+          mode: 'manual',
+          showTranscript: true
+        }
+      },
+      upload: {
+        enabled: false,
+        imageUpload: {
           enabled: false,
-          imageUpload: {
-            enabled: false,
-            resizeImages: true,
-            maxFileSizeMB: 10,
-            supportedFormats: ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']
-          },
-          fileUpload: {
-            enabled: false,
-            maxFileSizeMB: 5,
-            supportedFormats: [
-              'text/plain',
-              'text/markdown',
-              'text/csv',
-              'application/json',
-              'text/html',
-              'text/css',
-              'text/javascript',
-              'application/javascript',
-              'text/xml',
-              'message/rfc822',
-              'application/pdf',
-              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-              'application/vnd.ms-outlook',
-              'application/vnd.oasis.opendocument.text',
-              'application/vnd.oasis.opendocument.spreadsheet',
-              'application/vnd.oasis.opendocument.presentation'
-            ]
-          }
-        }
-      };
-      setApp(defaultApp);
-      setInitialData(defaultApp);
-      setLoading(false);
-    } else {
-      loadApp();
-    }
-  }, [appId]); // eslint-disable-line @eslint-react/exhaustive-deps
-
-  const loadApp = useCallback(async () => {
-    try {
-      setLoading(true);
-      const response = await makeAdminApiCall(`/admin/apps/${appId}`);
-      const data = response.data;
-
-      // Ensure all configuration sections exist with defaults
-      const appWithDefaults = {
-        ...data,
-        tools: data.tools || [],
-        greeting: data.greeting || {
-          en: {
-            title: '👋 Hello!',
-            subtitle: 'How can I help you today?'
-          },
-          de: {
-            title: '👋 Hallo!',
-            subtitle: 'Wie kann ich Ihnen heute helfen?'
-          }
+          resizeImages: true,
+          maxFileSizeMB: 10,
+          supportedFormats: ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp']
         },
-        allowEmptyContent: data.allowEmptyContent ?? false,
-        sendChatHistory: data.sendChatHistory ?? true,
-        ephemeral: data.ephemeral ?? false,
-        inputMode: {
-          type: 'singleline',
-          rows: 5,
-          microphone: {
-            enabled: true,
-            mode: 'manual',
-            showTranscript: true
-          },
-          ...(data.inputMode || {})
-        },
-        upload: {
-          enabled: data.upload?.enabled || false,
-          imageUpload: {
-            enabled: data.upload?.imageUpload?.enabled || false,
-            resizeImages: data.upload?.imageUpload?.resizeImages ?? true,
-            maxFileSizeMB: data.upload?.imageUpload?.maxFileSizeMB || 10,
-            supportedFormats: data.upload?.imageUpload?.supportedFormats || [
-              'image/jpeg',
-              'image/jpg',
-              'image/png',
-              'image/gif',
-              'image/webp'
-            ]
-          },
-          fileUpload: {
-            enabled: data.upload?.fileUpload?.enabled || false,
-            maxFileSizeMB: data.upload?.fileUpload?.maxFileSizeMB || 5,
-            supportedFormats: data.upload?.fileUpload?.supportedFormats || [
-              'text/plain',
-              'text/markdown',
-              'text/csv',
-              'application/json',
-              'text/html',
-              'text/css',
-              'text/javascript',
-              'application/javascript',
-              'text/xml',
-              'message/rfc822',
-              'application/pdf',
-              'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-              'application/vnd.ms-outlook',
-              'application/vnd.oasis.opendocument.text',
-              'application/vnd.oasis.opendocument.spreadsheet',
-              'application/vnd.oasis.opendocument.presentation'
-            ]
-          },
-          ...(data.upload || {})
+        fileUpload: {
+          enabled: false,
+          maxFileSizeMB: 5,
+          supportedFormats: [
+            'text/plain',
+            'text/markdown',
+            'text/csv',
+            'application/json',
+            'text/html',
+            'text/css',
+            'text/javascript',
+            'application/javascript',
+            'text/xml',
+            'message/rfc822',
+            'application/pdf',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'application/vnd.ms-outlook',
+            'application/vnd.oasis.opendocument.text',
+            'application/vnd.oasis.opendocument.spreadsheet',
+            'application/vnd.oasis.opendocument.presentation'
+          ]
         }
-      };
+      }
+    }),
+    []
+  );
 
-      setApp(appWithDefaults);
-      setInitialData(appWithDefaults);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  }, [appId]);
+  const loadResource = useCallback(async id => {
+    const response = await makeAdminApiCall(`/admin/apps/${id}`);
+    const data = response.data;
+
+    // Ensure all configuration sections exist with defaults
+    const appWithDefaults = {
+      ...data,
+      tools: data.tools || [],
+      greeting: data.greeting || {
+        en: {
+          title: '👋 Hello!',
+          subtitle: 'How can I help you today?'
+        },
+        de: {
+          title: '👋 Hallo!',
+          subtitle: 'Wie kann ich Ihnen heute helfen?'
+        }
+      },
+      allowEmptyContent: data.allowEmptyContent ?? false,
+      sendChatHistory: data.sendChatHistory ?? true,
+      ephemeral: data.ephemeral ?? false,
+      inputMode: {
+        type: 'singleline',
+        rows: 5,
+        microphone: {
+          enabled: true,
+          mode: 'manual',
+          showTranscript: true
+        },
+        ...(data.inputMode || {})
+      },
+      upload: {
+        enabled: data.upload?.enabled || false,
+        imageUpload: {
+          enabled: data.upload?.imageUpload?.enabled || false,
+          resizeImages: data.upload?.imageUpload?.resizeImages ?? true,
+          maxFileSizeMB: data.upload?.imageUpload?.maxFileSizeMB || 10,
+          supportedFormats: data.upload?.imageUpload?.supportedFormats || [
+            'image/jpeg',
+            'image/jpg',
+            'image/png',
+            'image/gif',
+            'image/webp'
+          ]
+        },
+        fileUpload: {
+          enabled: data.upload?.fileUpload?.enabled || false,
+          maxFileSizeMB: data.upload?.fileUpload?.maxFileSizeMB || 5,
+          supportedFormats: data.upload?.fileUpload?.supportedFormats || [
+            'text/plain',
+            'text/markdown',
+            'text/csv',
+            'application/json',
+            'text/html',
+            'text/css',
+            'text/javascript',
+            'application/javascript',
+            'text/xml',
+            'message/rfc822',
+            'application/pdf',
+            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+            'application/vnd.ms-outlook',
+            'application/vnd.oasis.opendocument.text',
+            'application/vnd.oasis.opendocument.spreadsheet',
+            'application/vnd.oasis.opendocument.presentation'
+          ]
+        },
+        ...(data.upload || {})
+      }
+    };
+
+    return appWithDefaults;
+  }, []);
 
   const cleanAppData = appData => {
     // Clean up variables - remove empty defaultValue and predefinedValues
@@ -299,6 +277,29 @@ function AdminAppEditPage() {
     return cleanedApp;
   };
 
+  const saveResource = async (value, id) => {
+    const method = id === 'new' ? 'POST' : 'PUT';
+    const url = id === 'new' ? '/admin/apps' : `/admin/apps/${id}`;
+
+    // Clean the app data before saving
+    const cleanedApp = cleanAppData(value);
+
+    await makeAdminApiCall(url, {
+      method,
+      body: cleanedApp
+    });
+  };
+
+  const {
+    data: app,
+    setData: setApp,
+    loading,
+    error,
+    setError,
+    save,
+    blocker
+  } = useAdminResourceEditor({ resourceId: appId, loadResource, makeDefault, saveResource });
+
   const handleSave = async e => {
     e.preventDefault();
 
@@ -317,18 +318,7 @@ function AdminAppEditPage() {
 
     try {
       setSaving(true);
-      const method = appId === 'new' ? 'POST' : 'PUT';
-      const url = appId === 'new' ? '/admin/apps' : `/admin/apps/${appId}`;
-
-      // Clean the app data before saving
-      const cleanedApp = cleanAppData(app);
-
-      await makeAdminApiCall(url, {
-        method,
-        body: cleanedApp
-      });
-
-      markSaved();
+      await save();
       navigate('/admin/apps');
     } catch (err) {
       setError(err.message);
@@ -348,19 +338,6 @@ function AdminAppEditPage() {
   const handleModeChange = mode => {
     setEditingMode(mode);
   };
-
-  if (loading) {
-    return (
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
-          <p className="mt-2 text-gray-600 dark:text-gray-400">
-            {t('admin.apps.loading', 'Loading...')}
-          </p>
-        </div>
-      </div>
-    );
-  }
 
   if (error) {
     return (
@@ -396,14 +373,34 @@ function AdminAppEditPage() {
   }
 
   return (
-    <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-      <AdminBreadcrumb
-        crumbs={[
-          { label: 'Admin', href: '/admin' },
-          { label: 'Apps', href: '/admin/apps' },
-          { label: appId === 'new' ? 'New App' : (app?.name?.en ?? appId) }
-        ]}
-      />
+    <AdminEditPageShell
+      loading={loading}
+      loadingFallback={
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+            <p className="mt-2 text-gray-600 dark:text-gray-400">
+              {t('admin.apps.loading', 'Loading...')}
+            </p>
+          </div>
+        </div>
+      }
+      contentClassName="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+      breadcrumbs={[
+        { label: 'Admin', href: '/admin' },
+        { label: 'Apps', href: '/admin/apps' },
+        { label: appId === 'new' ? 'New App' : (app?.name?.en ?? appId) }
+      ]}
+      extra={
+        <ChangeHistoryDrawer
+          isOpen={historyOpen}
+          onClose={() => setHistoryOpen(false)}
+          resource="app"
+          resourceId={appId}
+        />
+      }
+      blocker={blocker}
+    >
       <div className="sm:flex sm:items-center">
         <div className="sm:flex-auto">
           <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
@@ -522,25 +519,7 @@ function AdminAppEditPage() {
           </button>
         </div>
       </form>
-
-      <ChangeHistoryDrawer
-        isOpen={historyOpen}
-        onClose={() => setHistoryOpen(false)}
-        resource="app"
-        resourceId={appId}
-      />
-
-      <ConfirmDialog
-        isOpen={blocker.state === 'blocked'}
-        title="Unsaved Changes"
-        message="You have unsaved changes. Leave anyway?"
-        confirmLabel="Leave"
-        denyLabel="Stay"
-        danger={false}
-        onConfirm={() => blocker.proceed?.()}
-        onDeny={() => blocker.reset?.()}
-      />
-    </div>
+    </AdminEditPageShell>
   );
 }
 

--- a/client/src/features/admin/pages/AdminGroupEditPage.jsx
+++ b/client/src/features/admin/pages/AdminGroupEditPage.jsx
@@ -1,55 +1,80 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
-import AdminBreadcrumb from '../components/AdminBreadcrumb';
-import { useUnsavedChanges } from '../hooks/useUnsavedChanges';
-import ConfirmDialog from '../../../shared/components/ConfirmDialog';
 import DualModeEditor from '../../../shared/components/DualModeEditor';
 import GroupFormEditor from '../components/GroupFormEditor';
 import { makeAdminApiCall } from '../../../api/adminApi';
-import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import { getSchemaByType } from '../../../utils/schemaService';
+import { useAdminResourceEditor } from '../hooks/useAdminResourceEditor';
+import AdminEditPageShell, {
+  AdminSaveCancelButtons
+} from '../../../shared/components/AdminEditPageShell';
 
 function AdminGroupEditPage() {
   const { t } = useTranslation();
   const { groupId } = useParams();
   const navigate = useNavigate();
-  const [group, setGroup] = useState(null);
-  const [initialData, setInitialData] = useState(null);
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState(null);
   const [resources, setResources] = useState({ apps: [], models: [], prompts: [] });
   const [jsonSchema, setJsonSchema] = useState(null);
 
-  const { blocker, markSaved } = useUnsavedChanges(initialData, group);
+  const loadResource = useCallback(async id => {
+    const response = await makeAdminApiCall('/admin/groups');
+    const data = response.data;
+
+    const groupData = data.groups[id];
+    if (!groupData) {
+      throw new Error('Group not found');
+    }
+
+    return groupData;
+  }, []);
+
+  const makeDefault = useCallback(
+    () => ({
+      id: '',
+      name: '',
+      description: '',
+      permissions: {
+        apps: [],
+        prompts: [],
+        models: [],
+        adminAccess: false
+      },
+      mappings: [],
+      enabled: true
+    }),
+    []
+  );
+
+  const saveResource = useCallback(async (data, id) => {
+    const method = id === 'new' ? 'POST' : 'PUT';
+    const url = id === 'new' ? '/admin/groups' : `/admin/groups/${id}`;
+
+    await makeAdminApiCall(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: data
+    });
+  }, []);
+
+  const {
+    data: group,
+    setData: setGroup,
+    loading,
+    error,
+    setError,
+    save,
+    blocker
+  } = useAdminResourceEditor({ resourceId: groupId, loadResource, makeDefault, saveResource });
 
   useEffect(() => {
     loadResources();
     loadSchema();
-    if (groupId === 'new') {
-      // Initialize new group
-      const defaultGroup = {
-        id: '',
-        name: '',
-        description: '',
-        permissions: {
-          apps: [],
-          prompts: [],
-          models: [],
-          adminAccess: false
-        },
-        mappings: [],
-        enabled: true
-      };
-      setGroup(defaultGroup);
-      setInitialData(defaultGroup);
-      setLoading(false);
-    } else {
-      loadGroup();
-    }
-  }, [groupId]); // eslint-disable-line @eslint-react/exhaustive-deps
+  }, [groupId]);
 
   const loadResources = async () => {
     try {
@@ -70,26 +95,6 @@ function AdminGroupEditPage() {
     }
   };
 
-  const loadGroup = useCallback(async () => {
-    try {
-      setLoading(true);
-      const response = await makeAdminApiCall('/admin/groups');
-      const data = response.data;
-
-      const groupData = data.groups[groupId];
-      if (!groupData) {
-        throw new Error('Group not found');
-      }
-
-      setGroup(groupData);
-      setInitialData(groupData);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  }, [groupId]);
-
   const handleSave = async data => {
     if (!data) data = group;
 
@@ -100,18 +105,7 @@ function AdminGroupEditPage() {
 
     try {
       setSaving(true);
-      const method = groupId === 'new' ? 'POST' : 'PUT';
-      const url = groupId === 'new' ? '/admin/groups' : `/admin/groups/${groupId}`;
-
-      await makeAdminApiCall(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: data
-      });
-
-      markSaved();
+      await save();
       // Success - axios doesn't have response.ok, successful responses are returned directly
       navigate('/admin/groups');
     } catch (err) {
@@ -130,14 +124,6 @@ function AdminGroupEditPage() {
     e.preventDefault();
     await handleSave(group);
   };
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
-        <LoadingSpinner size="lg" />
-      </div>
-    );
-  }
 
   if (error) {
     return (
@@ -158,121 +144,94 @@ function AdminGroupEditPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <AdminBreadcrumb
-          crumbs={[
-            { label: 'Admin', href: '/admin' },
-            { label: 'Groups', href: '/admin/groups' },
-            { label: groupId === 'new' ? 'New Group' : (group?.name ?? groupId) }
-          ]}
-        />
-        <div className="mb-8">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-                {groupId === 'new'
-                  ? t('admin.groups.edit.createTitle', 'Create New Group')
-                  : t('admin.groups.edit.editTitle', 'Edit Group')}
-              </h1>
-              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                {groupId === 'new'
-                  ? t(
-                      'admin.groups.edit.createDesc',
-                      'Create a new user group with permissions and external mappings'
-                    )
-                  : t(
-                      'admin.groups.edit.editDesc',
-                      'Edit group settings, permissions, and external mappings'
-                    )}
-              </p>
-            </div>
-            <div className="flex space-x-3">
-              {groupId !== 'new' && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    const dataStr = JSON.stringify(group, null, 2);
-                    const dataUri =
-                      'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
-                    const exportFileDefaultName = `group-${group.id}.json`;
-                    const linkElement = document.createElement('a');
-                    linkElement.setAttribute('href', dataUri);
-                    linkElement.setAttribute('download', exportFileDefaultName);
-                    linkElement.click();
-                  }}
-                  className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                >
-                  <Icon name="download" className="h-4 w-4 mr-2" />
-                  {t('common.download')}
-                </button>
-              )}
+    <AdminEditPageShell
+      loading={loading}
+      outerClassName="min-h-screen bg-gray-50 dark:bg-gray-900"
+      breadcrumbs={[
+        { label: 'Admin', href: '/admin' },
+        { label: 'Groups', href: '/admin/groups' },
+        { label: groupId === 'new' ? 'New Group' : (group?.name ?? groupId) }
+      ]}
+      blocker={blocker}
+    >
+      <div className="mb-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+              {groupId === 'new'
+                ? t('admin.groups.edit.createTitle', 'Create New Group')
+                : t('admin.groups.edit.editTitle', 'Edit Group')}
+            </h1>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              {groupId === 'new'
+                ? t(
+                    'admin.groups.edit.createDesc',
+                    'Create a new user group with permissions and external mappings'
+                  )
+                : t(
+                    'admin.groups.edit.editDesc',
+                    'Edit group settings, permissions, and external mappings'
+                  )}
+            </p>
+          </div>
+          <div className="flex space-x-3">
+            {groupId !== 'new' && (
               <button
-                onClick={() => navigate('/admin/groups')}
+                type="button"
+                onClick={() => {
+                  const dataStr = JSON.stringify(group, null, 2);
+                  const dataUri =
+                    'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
+                  const exportFileDefaultName = `group-${group.id}.json`;
+                  const linkElement = document.createElement('a');
+                  linkElement.setAttribute('href', dataUri);
+                  linkElement.setAttribute('download', exportFileDefaultName);
+                  linkElement.click();
+                }}
                 className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
               >
-                <Icon name="arrow-left" className="h-4 w-4 mr-2" />
-                {t('admin.groups.edit.backToList', 'Back to Groups')}
+                <Icon name="download" className="h-4 w-4 mr-2" />
+                {t('common.download')}
               </button>
-            </div>
+            )}
+            <button
+              onClick={() => navigate('/admin/groups')}
+              className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            >
+              <Icon name="arrow-left" className="h-4 w-4 mr-2" />
+              {t('admin.groups.edit.backToList', 'Back to Groups')}
+            </button>
           </div>
         </div>
-
-        <form onSubmit={handleFormSubmit} className="space-y-8">
-          <DualModeEditor
-            value={group}
-            onChange={handleDataChange}
-            formComponent={GroupFormEditor}
-            formProps={{
-              resources,
-              jsonSchema
-            }}
-            jsonSchema={jsonSchema}
-            title={
-              groupId === 'new'
-                ? t('admin.groups.edit.createTitle', 'Create New Group')
-                : t('admin.groups.edit.editTitle', 'Edit Group')
-            }
-          />
-
-          {/* Save buttons */}
-          <div className="flex justify-end space-x-4">
-            <button
-              type="button"
-              onClick={() => navigate('/admin/groups')}
-              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-            >
-              {t('admin.groups.edit.cancel', 'Cancel')}
-            </button>
-            <button
-              type="submit"
-              disabled={saving}
-              className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
-            >
-              {saving ? (
-                <>
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2 inline-block"></div>
-                  {t('admin.groups.edit.saving', 'Saving...')}
-                </>
-              ) : (
-                t('admin.groups.edit.save', groupId === 'new' ? 'Create Group' : 'Save Group')
-              )}
-            </button>
-          </div>
-        </form>
       </div>
 
-      <ConfirmDialog
-        isOpen={blocker.state === 'blocked'}
-        title="Unsaved Changes"
-        message="You have unsaved changes. Leave anyway?"
-        confirmLabel="Leave"
-        denyLabel="Stay"
-        danger={false}
-        onConfirm={() => blocker.proceed?.()}
-        onDeny={() => blocker.reset?.()}
-      />
-    </div>
+      <form onSubmit={handleFormSubmit} className="space-y-8">
+        <DualModeEditor
+          value={group}
+          onChange={handleDataChange}
+          formComponent={GroupFormEditor}
+          formProps={{
+            resources,
+            jsonSchema
+          }}
+          jsonSchema={jsonSchema}
+          title={
+            groupId === 'new'
+              ? t('admin.groups.edit.createTitle', 'Create New Group')
+              : t('admin.groups.edit.editTitle', 'Edit Group')
+          }
+        />
+
+        {/* Save buttons */}
+        <AdminSaveCancelButtons
+          onCancel={() => navigate('/admin/groups')}
+          cancelLabel={t('admin.groups.edit.cancel', 'Cancel')}
+          saving={saving}
+          saveLabel={t('admin.groups.edit.save', groupId === 'new' ? 'Create Group' : 'Save Group')}
+          savingLabel={t('admin.groups.edit.saving', 'Saving...')}
+        />
+      </form>
+    </AdminEditPageShell>
   );
 }
 

--- a/client/src/features/admin/pages/AdminModelEditPage.jsx
+++ b/client/src/features/admin/pages/AdminModelEditPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { getLocalizedContent, DEFAULT_LANGUAGE } from '../../../utils/localizeContent';
@@ -8,9 +8,28 @@ import Icon from '../../../shared/components/Icon';
 import DualModeEditor from '../../../shared/components/DualModeEditor';
 import ModelFormEditor from '../components/ModelFormEditor';
 import ChangeHistoryDrawer from '../components/ChangeHistoryDrawer';
-import AdminBreadcrumb from '../components/AdminBreadcrumb';
-import { useUnsavedChanges } from '../hooks/useUnsavedChanges';
-import ConfirmDialog from '../../../shared/components/ConfirmDialog';
+import { useAdminResourceEditor } from '../hooks/useAdminResourceEditor';
+import AdminEditPageShell from '../../../shared/components/AdminEditPageShell';
+
+// Constants
+const API_KEY_PLACEHOLDER = '••••••••';
+
+const DEFAULT_MODEL_DATA = {
+  id: '',
+  modelId: '',
+  name: { [DEFAULT_LANGUAGE]: '' },
+  description: { [DEFAULT_LANGUAGE]: '' },
+  url: '',
+  provider: '',
+  contextWindow: '',
+  maxOutputTokens: '',
+  supportsTools: false,
+  supportsImageGeneration: false,
+  enabled: true,
+  default: false,
+  apiKey: '',
+  apiKeySet: false
+};
 
 function AdminModelEditPage() {
   const { t, i18n } = useTranslation();
@@ -20,150 +39,140 @@ function AdminModelEditPage() {
   const location = useLocation();
   const isNewModel = modelId === 'new';
 
-  // Constants
-  const API_KEY_PLACEHOLDER = '••••••••';
-
   const [historyOpen, setHistoryOpen] = useState(false);
-  const [loading, setLoading] = useState(!isNewModel);
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState(null);
   const [success, setSuccess] = useState(false);
   const [apps, setApps] = useState([]);
   const [usage, setUsage] = useState(null);
   const [jsonSchema, setJsonSchema] = useState(null);
-  const [initialData, setInitialData] = useState(null);
 
-  const [formData, setFormData] = useState({
-    id: '',
-    modelId: '',
-    name: { [DEFAULT_LANGUAGE]: '' },
-    description: { [DEFAULT_LANGUAGE]: '' },
-    url: '',
-    provider: '',
-    contextWindow: '',
-    maxOutputTokens: '',
-    supportsTools: false,
-    supportsImageGeneration: false,
-    enabled: true,
-    default: false,
-    apiKey: '',
-    apiKeySet: false
-  });
-
-  const { blocker, markSaved } = useUnsavedChanges(initialData, formData);
-
-  useEffect(() => {
-    const loadJsonSchema = async () => {
-      try {
-        const schema = await fetchJsonSchema('model');
-        setJsonSchema(schema);
-      } catch (err) {
-        console.error('Failed to load model JSON schema:', err);
-        // Continue without schema - validation will be server-side only
-      }
-    };
-
-    if (isNewModel) {
-      setLoading(false);
-    } else {
-      loadModel();
-    }
-    loadAppsUsingModel();
-    loadUsageData();
-    loadJsonSchema();
-  }, [modelId, isNewModel]); // eslint-disable-line @eslint-react/exhaustive-deps
-
-  useEffect(() => {
-    if (isNewModel && location.state?.templateModel) {
+  const makeDefault = useCallback(() => {
+    if (location.state?.templateModel) {
       const tpl = location.state.templateModel;
-      const tplData = {
+      return {
+        ...DEFAULT_MODEL_DATA,
         ...tpl,
         id: '',
         enabled: tpl.enabled !== undefined ? tpl.enabled : true,
         default: false
       };
-      setFormData(prev => ({ ...prev, ...tplData }));
-      setInitialData(tplData);
-    } else if (isNewModel && !location.state?.templateModel) {
-      setInitialData({
-        id: '',
-        modelId: '',
-        name: { [DEFAULT_LANGUAGE]: '' },
-        description: { [DEFAULT_LANGUAGE]: '' },
-        url: '',
-        provider: '',
-        contextWindow: '',
-        maxOutputTokens: '',
-        supportsTools: false,
-        supportsImageGeneration: false,
-        enabled: true,
-        default: false,
-        apiKey: '',
-        apiKeySet: false
-      });
     }
-  }, [isNewModel, location.state]);
+    return DEFAULT_MODEL_DATA;
+  }, [location.state]);
 
-  const loadModel = useCallback(async () => {
-    try {
-      setLoading(true);
-      const response = await makeAdminApiCall(`/admin/models/${modelId}`);
-      const model = response.data;
-      console.log('Model loaded:', model);
-      console.log('Model name structure:', model.name);
-      console.log('Model description structure:', model.description);
+  const loadResource = useCallback(async id => {
+    const response = await makeAdminApiCall(`/admin/models/${id}`);
+    const model = response.data;
+    console.log('Model loaded:', model);
+    console.log('Model name structure:', model.name);
+    console.log('Model description structure:', model.description);
 
-      // Ensure name and description are proper localized objects
-      const ensureLocalizedObject = value => {
-        if (!value) return { [DEFAULT_LANGUAGE]: '' };
-        if (typeof value === 'string') return { [DEFAULT_LANGUAGE]: value };
-        if (typeof value === 'object' && value !== null) return value;
-        return { [DEFAULT_LANGUAGE]: '' };
-      };
+    // Ensure name and description are proper localized objects
+    const ensureLocalizedObject = value => {
+      if (!value) return { [DEFAULT_LANGUAGE]: '' };
+      if (typeof value === 'string') return { [DEFAULT_LANGUAGE]: value };
+      if (typeof value === 'object' && value !== null) return value;
+      return { [DEFAULT_LANGUAGE]: '' };
+    };
 
-      const formDataObj = {
-        ...model, // Preserve all fields from the loaded model
-        id: model.id || '',
-        modelId: model.modelId || '',
-        name: ensureLocalizedObject(model.name),
-        description: ensureLocalizedObject(model.description),
-        url: model.url || '',
-        provider: model.provider || '',
-        contextWindow: model.contextWindow || '',
-        maxOutputTokens: model.maxOutputTokens || '',
-        supportsTools: model.supportsTools || false,
-        enabled: model.enabled !== undefined ? model.enabled : true,
-        default: model.default || false
-      };
+    const formDataObj = {
+      ...model, // Preserve all fields from the loaded model
+      id: model.id || '',
+      modelId: model.modelId || '',
+      name: ensureLocalizedObject(model.name),
+      description: ensureLocalizedObject(model.description),
+      url: model.url || '',
+      provider: model.provider || '',
+      contextWindow: model.contextWindow || '',
+      maxOutputTokens: model.maxOutputTokens || '',
+      supportsTools: model.supportsTools || false,
+      enabled: model.enabled !== undefined ? model.enabled : true,
+      default: model.default || false
+    };
 
-      // Only include optional number fields if they exist
-      if (model.concurrency !== undefined) {
-        formDataObj.concurrency = model.concurrency;
-      }
-      if (model.requestDelayMs !== undefined) {
-        formDataObj.requestDelayMs = model.requestDelayMs;
-      }
-
-      // Handle API key display - show placeholder if key is set
-      if (model.apiKeySet) {
-        formDataObj.apiKeySet = true;
-        formDataObj.apiKey = model.apiKeyMasked || API_KEY_PLACEHOLDER;
-      } else {
-        formDataObj.apiKeySet = false;
-        formDataObj.apiKey = '';
-      }
-
-      setFormData(formDataObj);
-      setInitialData(formDataObj);
-
-      console.log('Form data set with name:', ensureLocalizedObject(model.name));
-      console.log('Form data set with description:', ensureLocalizedObject(model.description));
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
+    // Only include optional number fields if they exist
+    if (model.concurrency !== undefined) {
+      formDataObj.concurrency = model.concurrency;
     }
-  }, [modelId]);
+    if (model.requestDelayMs !== undefined) {
+      formDataObj.requestDelayMs = model.requestDelayMs;
+    }
+
+    // Handle API key display - show placeholder if key is set
+    if (model.apiKeySet) {
+      formDataObj.apiKeySet = true;
+      formDataObj.apiKey = model.apiKeyMasked || API_KEY_PLACEHOLDER;
+    } else {
+      formDataObj.apiKeySet = false;
+      formDataObj.apiKey = '';
+    }
+
+    console.log('Form data set with name:', ensureLocalizedObject(model.name));
+    console.log('Form data set with description:', ensureLocalizedObject(model.description));
+
+    return formDataObj;
+  }, []);
+
+  const saveResource = async (data, id) => {
+    // Prepare the data to send
+    const dataToSend = {
+      ...data,
+      contextWindow: data.contextWindow ? parseInt(data.contextWindow) : undefined,
+      maxOutputTokens: data.maxOutputTokens ? parseInt(data.maxOutputTokens) : undefined,
+      concurrency: data.concurrency ? parseInt(data.concurrency) : undefined,
+      requestDelayMs: data.requestDelayMs ? parseInt(data.requestDelayMs) : undefined
+    };
+
+    // Handle API key:
+    // - If it's the masked placeholder and a key was previously set, keep it (backend will preserve)
+    // - If it's empty and a key was set, remove it (user wants to clear it)
+    // - If it's a new value, send it (user is setting/updating the key)
+    if (dataToSend.apiKey === API_KEY_PLACEHOLDER || dataToSend.apiKey === '') {
+      if (data.apiKeySet && dataToSend.apiKey === API_KEY_PLACEHOLDER) {
+        // Keep the placeholder so backend knows to preserve the existing key
+        dataToSend.apiKey = API_KEY_PLACEHOLDER;
+      } else if (dataToSend.apiKey === '') {
+        // Empty string - remove the field to avoid confusion
+        delete dataToSend.apiKey;
+      }
+    }
+
+    // Remove helper fields that shouldn't be sent to backend
+    delete dataToSend.apiKeySet;
+    delete dataToSend.apiKeyMasked;
+
+    // Remove empty and undefined fields (but preserve API key placeholder)
+    Object.keys(dataToSend).forEach(key => {
+      if (key === 'apiKey' && dataToSend[key] === API_KEY_PLACEHOLDER) {
+        // Keep the placeholder - it signals backend to preserve encrypted key
+        return;
+      }
+      if (dataToSend[key] === '' || dataToSend[key] === undefined) {
+        delete dataToSend[key];
+      }
+    });
+
+    const url = id === 'new' ? '/admin/models' : `/admin/models/${id}`;
+    const method = id === 'new' ? 'POST' : 'PUT';
+
+    await makeAdminApiCall(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: dataToSend
+    });
+  };
+
+  const {
+    data: formData,
+    setData: setFormData,
+    loading,
+    error,
+    setError,
+    save,
+    blocker
+  } = useAdminResourceEditor({ resourceId: modelId, loadResource, makeDefault, saveResource });
 
   const loadAppsUsingModel = useCallback(async () => {
     try {
@@ -195,6 +204,22 @@ function AdminModelEditPage() {
     }
   }, [modelId]);
 
+  useEffect(() => {
+    const loadJsonSchema = async () => {
+      try {
+        const schema = await fetchJsonSchema('model');
+        setJsonSchema(schema);
+      } catch (err) {
+        console.error('Failed to load model JSON schema:', err);
+        // Continue without schema - validation will be server-side only
+      }
+    };
+
+    loadAppsUsingModel();
+    loadUsageData();
+    loadJsonSchema();
+  }, [modelId, isNewModel]); // eslint-disable-line @eslint-react/exhaustive-deps
+
   const handleDataChange = newData => {
     setFormData(newData);
   };
@@ -204,67 +229,16 @@ function AdminModelEditPage() {
     await handleSave(formData);
   };
 
-  const handleSave = async data => {
+  const handleSave = async () => {
     try {
       setSaving(true);
       setError(null);
 
-      // Prepare the data to send
-      const dataToSend = {
-        ...data,
-        contextWindow: data.contextWindow ? parseInt(data.contextWindow) : undefined,
-        maxOutputTokens: data.maxOutputTokens ? parseInt(data.maxOutputTokens) : undefined,
-        concurrency: data.concurrency ? parseInt(data.concurrency) : undefined,
-        requestDelayMs: data.requestDelayMs ? parseInt(data.requestDelayMs) : undefined
-      };
-
-      // Handle API key:
-      // - If it's the masked placeholder and a key was previously set, keep it (backend will preserve)
-      // - If it's empty and a key was set, remove it (user wants to clear it)
-      // - If it's a new value, send it (user is setting/updating the key)
-      if (dataToSend.apiKey === API_KEY_PLACEHOLDER || dataToSend.apiKey === '') {
-        if (data.apiKeySet && dataToSend.apiKey === API_KEY_PLACEHOLDER) {
-          // Keep the placeholder so backend knows to preserve the existing key
-          dataToSend.apiKey = API_KEY_PLACEHOLDER;
-        } else if (dataToSend.apiKey === '') {
-          // Empty string - remove the field to avoid confusion
-          delete dataToSend.apiKey;
-        }
-      }
-
-      // Remove helper fields that shouldn't be sent to backend
-      delete dataToSend.apiKeySet;
-      delete dataToSend.apiKeyMasked;
-
-      // Remove empty and undefined fields (but preserve API key placeholder)
-      Object.keys(dataToSend).forEach(key => {
-        if (key === 'apiKey' && dataToSend[key] === API_KEY_PLACEHOLDER) {
-          // Keep the placeholder - it signals backend to preserve encrypted key
-          return;
-        }
-        if (dataToSend[key] === '' || dataToSend[key] === undefined) {
-          delete dataToSend[key];
-        }
-      });
-
-      const url = isNewModel ? '/admin/models' : `/admin/models/${modelId}`;
-      const method = isNewModel ? 'POST' : 'PUT';
-
-      await makeAdminApiCall(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: dataToSend
-      });
+      await save();
 
       setSuccess(true);
-      markSaved();
 
-      // Redirect after a short delay
-      setTimeout(() => {
-        navigate('/admin/models');
-      }, 1500);
+      navigate('/admin/models');
     } catch (err) {
       setError(err.message);
       throw err; // Re-throw to let DualModeEditor handle it
@@ -273,273 +247,261 @@ function AdminModelEditPage() {
     }
   };
 
-  if (loading) {
-    return (
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
-          <p className="mt-4 text-gray-600 dark:text-gray-400">{t('app.loading')}</p>
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <AdminBreadcrumb
-          crumbs={[
-            { label: 'Admin', href: '/admin' },
-            { label: 'Models', href: '/admin/models' },
-            { label: isNewModel ? 'New Model' : (formData?.name?.en ?? modelId) }
-          ]}
+    <AdminEditPageShell
+      loading={loading}
+      loadingFallback={
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-indigo-600 mx-auto"></div>
+            <p className="mt-4 text-gray-600 dark:text-gray-400">{t('app.loading')}</p>
+          </div>
+        </div>
+      }
+      outerClassName="min-h-screen bg-gray-50 dark:bg-gray-900"
+      breadcrumbs={[
+        { label: 'Admin', href: '/admin' },
+        { label: 'Models', href: '/admin/models' },
+        { label: isNewModel ? 'New Model' : (formData?.name?.en ?? modelId) }
+      ]}
+      extra={
+        <ChangeHistoryDrawer
+          isOpen={historyOpen}
+          onClose={() => setHistoryOpen(false)}
+          resource="model"
+          resourceId={modelId}
         />
-        {/* Header */}
-        <div className="mb-8">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-                {isNewModel ? t('admin.models.edit.titleNew') : t('admin.models.edit.title')}
-              </h1>
-              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                {isNewModel
-                  ? t('admin.models.edit.subtitleNew')
-                  : t('admin.models.edit.subtitle', {
-                      name: getLocalizedContent(formData.name, currentLanguage)
-                    })}
-              </p>
-            </div>
-            <div className="flex space-x-3">
-              {!isNewModel && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    const dataStr = JSON.stringify(formData, null, 2);
-                    const dataUri =
-                      'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
-                    const exportFileDefaultName = `model-${formData.id}.json`;
-                    const linkElement = document.createElement('a');
-                    linkElement.setAttribute('href', dataUri);
-                    linkElement.setAttribute('download', exportFileDefaultName);
-                    linkElement.click();
-                  }}
-                  className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                >
-                  <Icon name="download" className="h-4 w-4 mr-2" />
-                  {t('common.download')}
-                </button>
-              )}
-              {modelId !== 'new' && (
-                <button
-                  type="button"
-                  onClick={() => setHistoryOpen(true)}
-                  className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto"
-                >
-                  History
-                </button>
-              )}
+      }
+      blocker={blocker}
+    >
+      {/* Header */}
+      <div className="mb-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+              {isNewModel ? t('admin.models.edit.titleNew') : t('admin.models.edit.title')}
+            </h1>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              {isNewModel
+                ? t('admin.models.edit.subtitleNew')
+                : t('admin.models.edit.subtitle', {
+                    name: getLocalizedContent(formData.name, currentLanguage)
+                  })}
+            </p>
+          </div>
+          <div className="flex space-x-3">
+            {!isNewModel && (
               <button
-                onClick={() => navigate('/admin/models')}
+                type="button"
+                onClick={() => {
+                  const dataStr = JSON.stringify(formData, null, 2);
+                  const dataUri =
+                    'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
+                  const exportFileDefaultName = `model-${formData.id}.json`;
+                  const linkElement = document.createElement('a');
+                  linkElement.setAttribute('href', dataUri);
+                  linkElement.setAttribute('download', exportFileDefaultName);
+                  linkElement.click();
+                }}
                 className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
               >
-                <Icon name="arrow-left" className="h-4 w-4 mr-2" />
-                {t('admin.models.edit.backToModels')}
+                <Icon name="download" className="h-4 w-4 mr-2" />
+                {t('common.download')}
               </button>
+            )}
+            {modelId !== 'new' && (
+              <button
+                type="button"
+                onClick={() => setHistoryOpen(true)}
+                className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto"
+              >
+                History
+              </button>
+            )}
+            <button
+              onClick={() => navigate('/admin/models')}
+              className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            >
+              <Icon name="arrow-left" className="h-4 w-4 mr-2" />
+              {t('admin.models.edit.backToModels')}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Error display */}
+      {error && (
+        <div className="mb-6 rounded-md bg-red-50 dark:bg-red-900/30 p-4">
+          <div className="flex">
+            <div className="flex-shrink-0">
+              <Icon name="x-circle" className="h-5 w-5 text-red-400" />
+            </div>
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-red-800 dark:text-red-200">
+                {t('common.error')}
+              </h3>
+              <div className="mt-2 text-sm text-red-700 dark:text-red-300">
+                <p>{error}</p>
+              </div>
             </div>
           </div>
         </div>
+      )}
 
-        {/* Error display */}
-        {error && (
-          <div className="mb-6 rounded-md bg-red-50 dark:bg-red-900/30 p-4">
-            <div className="flex">
-              <div className="flex-shrink-0">
-                <Icon name="x-circle" className="h-5 w-5 text-red-400" />
-              </div>
-              <div className="ml-3">
-                <h3 className="text-sm font-medium text-red-800 dark:text-red-200">
-                  {t('common.error')}
-                </h3>
-                <div className="mt-2 text-sm text-red-700 dark:text-red-300">
-                  <p>{error}</p>
+      {/* Success display */}
+      {success && (
+        <div className="mb-6 rounded-md bg-green-50 dark:bg-green-900/30 p-4">
+          <div className="flex">
+            <div className="flex-shrink-0">
+              <Icon name="check-circle" className="h-5 w-5 text-green-400" />
+            </div>
+            <div className="ml-3">
+              <p className="text-sm font-medium text-green-800 dark:text-green-200">
+                {t('admin.models.edit.success', {
+                  action: isNewModel
+                    ? t('admin.models.edit.successCreated')
+                    : t('admin.models.edit.successUpdated')
+                })}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={handleFormSubmit} className="space-y-8">
+        <div className="space-y-8">
+          {/* Main Form Editor */}
+          <DualModeEditor
+            value={formData}
+            onChange={handleDataChange}
+            formComponent={ModelFormEditor}
+            formProps={{
+              isNewModel,
+              apps,
+              usage,
+              jsonSchema
+            }}
+            jsonSchema={jsonSchema}
+            title={isNewModel ? t('admin.models.edit.titleNew') : t('admin.models.edit.title')}
+          />
+
+          {/* Usage Stats and Apps List - integrated as sections */}
+          {!isNewModel && (
+            <div className="space-y-8">
+              {/* Usage Stats */}
+              <div className="bg-white dark:bg-gray-800 shadow rounded-lg">
+                <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+                  <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+                    {t('admin.models.edit.usageStats')}
+                  </h3>
                 </div>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Success display */}
-        {success && (
-          <div className="mb-6 rounded-md bg-green-50 dark:bg-green-900/30 p-4">
-            <div className="flex">
-              <div className="flex-shrink-0">
-                <Icon name="check-circle" className="h-5 w-5 text-green-400" />
-              </div>
-              <div className="ml-3">
-                <p className="text-sm font-medium text-green-800 dark:text-green-200">
-                  {t('admin.models.edit.success', {
-                    action: isNewModel
-                      ? t('admin.models.edit.successCreated')
-                      : t('admin.models.edit.successUpdated')
-                  })}
-                </p>
-              </div>
-            </div>
-          </div>
-        )}
-
-        <form onSubmit={handleFormSubmit} className="space-y-8">
-          <div className="space-y-8">
-            {/* Main Form Editor */}
-            <DualModeEditor
-              value={formData}
-              onChange={handleDataChange}
-              formComponent={ModelFormEditor}
-              formProps={{
-                isNewModel,
-                apps,
-                usage,
-                jsonSchema
-              }}
-              jsonSchema={jsonSchema}
-              title={isNewModel ? t('admin.models.edit.titleNew') : t('admin.models.edit.title')}
-            />
-
-            {/* Usage Stats and Apps List - integrated as sections */}
-            {!isNewModel && (
-              <div className="space-y-8">
-                {/* Usage Stats */}
-                <div className="bg-white dark:bg-gray-800 shadow rounded-lg">
-                  <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-                    <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                      {t('admin.models.edit.usageStats')}
-                    </h3>
-                  </div>
-                  <div className="px-6 py-4">
-                    {usage ? (
-                      <div className="grid grid-cols-2 gap-4">
-                        <div className="text-center">
-                          <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-                            {usage.messages?.toLocaleString() || 0}
-                          </div>
-                          <div className="text-sm text-gray-500 dark:text-gray-400">
-                            {t('admin.models.details.messages')}
-                          </div>
+                <div className="px-6 py-4">
+                  {usage ? (
+                    <div className="grid grid-cols-2 gap-4">
+                      <div className="text-center">
+                        <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+                          {usage.messages?.toLocaleString() || 0}
                         </div>
-                        <div className="text-center">
-                          <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-                            {usage.tokens?.toLocaleString() || 0}
-                          </div>
-                          <div className="text-sm text-gray-500 dark:text-gray-400">
-                            {t('admin.models.details.tokens')}
-                          </div>
+                        <div className="text-sm text-gray-500 dark:text-gray-400">
+                          {t('admin.models.details.messages')}
                         </div>
                       </div>
-                    ) : (
-                      <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-4">
-                        {t('admin.models.edit.noUsageData')}
-                      </p>
-                    )}
-                  </div>
+                      <div className="text-center">
+                        <div className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+                          {usage.tokens?.toLocaleString() || 0}
+                        </div>
+                        <div className="text-sm text-gray-500 dark:text-gray-400">
+                          {t('admin.models.details.tokens')}
+                        </div>
+                      </div>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-4">
+                      {t('admin.models.edit.noUsageData')}
+                    </p>
+                  )}
                 </div>
+              </div>
 
-                {/* Apps Using Model */}
-                <div className="bg-white dark:bg-gray-800 shadow rounded-lg">
-                  <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
-                    <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
-                      {t('admin.models.edit.appsUsingModel')}
-                    </h3>
-                  </div>
-                  <div className="px-6 py-4">
-                    {apps.length > 0 ? (
-                      <div className="space-y-3">
-                        {apps.map(app => (
-                          <div
-                            key={app.id}
-                            className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg"
-                          >
-                            <div className="flex items-center space-x-3">
-                              <div
-                                className="w-8 h-8 rounded-md flex items-center justify-center text-white text-xs font-bold"
-                                style={{ backgroundColor: app.color || '#6B7280' }}
-                              >
-                                <Icon name={app.icon || 'chat-bubbles'} className="w-4 h-4" />
-                              </div>
-                              <div>
-                                <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                                  {getLocalizedContent(app.name, currentLanguage)}
-                                </span>
-                                <div className="text-xs text-gray-500 dark:text-gray-400">
-                                  {app.id}
-                                </div>
+              {/* Apps Using Model */}
+              <div className="bg-white dark:bg-gray-800 shadow rounded-lg">
+                <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700">
+                  <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100">
+                    {t('admin.models.edit.appsUsingModel')}
+                  </h3>
+                </div>
+                <div className="px-6 py-4">
+                  {apps.length > 0 ? (
+                    <div className="space-y-3">
+                      {apps.map(app => (
+                        <div
+                          key={app.id}
+                          className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-700 rounded-lg"
+                        >
+                          <div className="flex items-center space-x-3">
+                            <div
+                              className="w-8 h-8 rounded-md flex items-center justify-center text-white text-xs font-bold"
+                              style={{ backgroundColor: app.color || '#6B7280' }}
+                            >
+                              <Icon name={app.icon || 'chat-bubbles'} className="w-4 h-4" />
+                            </div>
+                            <div>
+                              <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                                {getLocalizedContent(app.name, currentLanguage)}
+                              </span>
+                              <div className="text-xs text-gray-500 dark:text-gray-400">
+                                {app.id}
                               </div>
                             </div>
-                            <span
-                              className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
-                                app.enabled
-                                  ? 'bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-300'
-                                  : 'bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-300'
-                              }`}
-                            >
-                              {app.enabled
-                                ? t('admin.models.status.enabled')
-                                : t('admin.models.status.disabled')}
-                            </span>
                           </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-4">
-                        {t('admin.models.edit.noApps')}
-                      </p>
-                    )}
-                  </div>
+                          <span
+                            className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${
+                              app.enabled
+                                ? 'bg-green-100 dark:bg-green-900/50 text-green-800 dark:text-green-300'
+                                : 'bg-red-100 dark:bg-red-900/50 text-red-800 dark:text-red-300'
+                            }`}
+                          >
+                            {app.enabled
+                              ? t('admin.models.status.enabled')
+                              : t('admin.models.status.disabled')}
+                          </span>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500 dark:text-gray-400 text-center py-4">
+                      {t('admin.models.edit.noApps')}
+                    </p>
+                  )}
                 </div>
               </div>
-            )}
-          </div>
+            </div>
+          )}
+        </div>
 
-          {/* Save buttons */}
-          <div className="flex justify-end space-x-4">
-            <button
-              type="button"
-              onClick={() => navigate('/admin/models')}
-              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-            >
-              {t('common.cancel')}
-            </button>
-            <button
-              type="submit"
-              disabled={saving}
-              className="inline-flex justify-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
-            >
-              {saving
-                ? t('admin.models.edit.saving')
-                : isNewModel
-                  ? t('admin.models.edit.createModel')
-                  : t('admin.models.edit.saveChanges')}
-            </button>
-          </div>
-        </form>
-      </div>
-      <ChangeHistoryDrawer
-        isOpen={historyOpen}
-        onClose={() => setHistoryOpen(false)}
-        resource="model"
-        resourceId={modelId}
-      />
-
-      <ConfirmDialog
-        isOpen={blocker.state === 'blocked'}
-        title="Unsaved Changes"
-        message="You have unsaved changes. Leave anyway?"
-        confirmLabel="Leave"
-        denyLabel="Stay"
-        danger={false}
-        onConfirm={() => blocker.proceed?.()}
-        onDeny={() => blocker.reset?.()}
-      />
-    </div>
+        {/* Save buttons */}
+        <div className="flex justify-end space-x-4">
+          <button
+            type="button"
+            onClick={() => navigate('/admin/models')}
+            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="inline-flex justify-center px-4 py-2 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+          >
+            {saving
+              ? t('admin.models.edit.saving')
+              : isNewModel
+                ? t('admin.models.edit.createModel')
+                : t('admin.models.edit.saveChanges')}
+          </button>
+        </div>
+      </form>
+    </AdminEditPageShell>
   );
 }
 

--- a/client/src/features/admin/pages/AdminPromptEditPage.jsx
+++ b/client/src/features/admin/pages/AdminPromptEditPage.jsx
@@ -1,10 +1,7 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
-import AdminBreadcrumb from '../components/AdminBreadcrumb';
-import { useUnsavedChanges } from '../hooks/useUnsavedChanges';
-import ConfirmDialog from '../../../shared/components/ConfirmDialog';
 import {
   fetchAdminPrompts,
   createPrompt,
@@ -16,6 +13,23 @@ import { fetchJsonSchema } from '../../../utils/schemaService';
 import DualModeEditor from '../../../shared/components/DualModeEditor';
 import PromptFormEditor from '../components/PromptFormEditor';
 import ChangeHistoryDrawer from '../components/ChangeHistoryDrawer';
+import { useAdminResourceEditor } from '../hooks/useAdminResourceEditor';
+import AdminEditPageShell, {
+  AdminSaveCancelButtons
+} from '../../../shared/components/AdminEditPageShell';
+
+const DEFAULT_PROMPT_DATA = {
+  id: '',
+  name: { en: '' },
+  description: { en: '' },
+  prompt: { en: '' },
+  icon: 'clipboard',
+  enabled: true,
+  order: undefined,
+  appId: '',
+  variables: [],
+  category: 'creative'
+};
 
 function AdminPromptEditPage() {
   const { t } = useTranslation();
@@ -24,31 +38,60 @@ function AdminPromptEditPage() {
   const location = useLocation();
   const isNewPrompt = promptId === 'new';
 
-  const defaultPromptData = {
-    id: '',
-    name: { en: '' },
-    description: { en: '' },
-    prompt: { en: '' },
-    icon: 'clipboard',
-    enabled: true,
-    order: undefined,
-    appId: '',
-    variables: [],
-    category: 'creative'
-  };
-
-  const [promptData, setPromptData] = useState(defaultPromptData);
-  const [initialData, setInitialData] = useState(isNewPrompt ? defaultPromptData : null);
-
-  const [loading, setLoading] = useState(!isNewPrompt);
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState(null);
   const [apps, setApps] = useState([]);
   const [uiConfig, setUiConfig] = useState(null);
   const [jsonSchema, setJsonSchema] = useState(null);
   const [historyOpen, setHistoryOpen] = useState(false);
 
-  const { blocker, markSaved } = useUnsavedChanges(initialData, promptData);
+  const makeDefault = useCallback(() => DEFAULT_PROMPT_DATA, []);
+
+  const loadResource = useCallback(async id => {
+    const data = await fetchAdminPrompts();
+    const promptDataFromApi = data.find(p => p.id === id);
+
+    if (!promptDataFromApi) {
+      throw new Error('Prompt not found');
+    }
+
+    // Ensure proper structure for editing
+    return {
+      ...promptDataFromApi,
+      name: promptDataFromApi.name || { en: '' },
+      description: promptDataFromApi.description || { en: '' },
+      prompt: promptDataFromApi.prompt || { en: '' },
+      variables: promptDataFromApi.variables || [],
+      appId: promptDataFromApi.appId || '',
+      order: promptDataFromApi.order,
+      enabled: promptDataFromApi.enabled !== false
+    };
+  }, []);
+
+  const saveResource = async (data, id) => {
+    if (id === 'new') {
+      await createPrompt(data);
+    } else {
+      await updatePrompt(id, data);
+    }
+
+    // Clear cache to force refresh
+    clearApiCache('admin_prompts');
+    clearApiCache('prompts');
+  };
+
+  const {
+    data: promptData,
+    setData: setPromptData,
+    loading,
+    error,
+    save,
+    blocker
+  } = useAdminResourceEditor({
+    resourceId: promptId,
+    loadResource,
+    makeDefault,
+    saveResource
+  });
 
   useEffect(() => {
     if (isNewPrompt && location.state?.templatePrompt) {
@@ -60,7 +103,7 @@ function AdminPromptEditPage() {
         enabled: tpl.enabled !== false
       }));
     }
-  }, [isNewPrompt, location.state]);
+  }, [isNewPrompt, location.state, setPromptData]);
 
   useEffect(() => {
     // Load apps for the appId dropdown, UI config, and JSON schema
@@ -77,10 +120,6 @@ function AdminPromptEditPage() {
     loadApps();
     loadUIConfig();
     loadJsonSchema();
-
-    if (!isNewPrompt) {
-      loadPrompt();
-    }
   }, [promptId, isNewPrompt]); // eslint-disable-line @eslint-react/exhaustive-deps
 
   const loadApps = useCallback(async () => {
@@ -101,52 +140,10 @@ function AdminPromptEditPage() {
     }
   }, []);
 
-  const loadPrompt = useCallback(async () => {
-    try {
-      setLoading(true);
-      const data = await fetchAdminPrompts();
-      const promptDataFromApi = data.find(p => p.id === promptId);
-
-      if (!promptDataFromApi) {
-        throw new Error('Prompt not found');
-      }
-
-      // Ensure proper structure for editing
-      const processedPrompt = {
-        ...promptDataFromApi,
-        name: promptDataFromApi.name || { en: '' },
-        description: promptDataFromApi.description || { en: '' },
-        prompt: promptDataFromApi.prompt || { en: '' },
-        variables: promptDataFromApi.variables || [],
-        appId: promptDataFromApi.appId || '',
-        order: promptDataFromApi.order,
-        enabled: promptDataFromApi.enabled !== false
-      };
-
-      setPromptData(processedPrompt);
-      setInitialData(processedPrompt);
-    } catch (err) {
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  }, [promptId]);
-
-  const handleSave = async data => {
+  const handleSave = async () => {
     try {
       setSaving(true);
-
-      if (isNewPrompt) {
-        await createPrompt(data);
-      } else {
-        await updatePrompt(promptId, data);
-      }
-
-      // Clear cache to force refresh
-      clearApiCache('admin_prompts');
-      clearApiCache('prompts');
-
-      markSaved();
+      await save();
       // Redirect to prompts list
       navigate('/admin/prompts');
     } catch (err) {
@@ -163,16 +160,8 @@ function AdminPromptEditPage() {
 
   const handleFormSubmit = async e => {
     e.preventDefault();
-    await handleSave(promptData);
+    await handleSave();
   };
-
-  if (loading) {
-    return (
-      <div className="flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 dark:border-indigo-400"></div>
-      </div>
-    );
-  }
 
   if (error) {
     return (
@@ -199,134 +188,113 @@ function AdminPromptEditPage() {
   }
 
   return (
-    <div>
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <AdminBreadcrumb
-          crumbs={[
-            { label: 'Admin', href: '/admin' },
-            { label: 'Prompts', href: '/admin/prompts' },
-            { label: isNewPrompt ? 'New Prompt' : (promptData?.name?.en ?? promptId) }
-          ]}
-        />
-        <div className="mb-8">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-                {isNewPrompt
-                  ? t('admin.prompts.edit.createTitle', 'Create New Prompt')
-                  : t('admin.prompts.edit.editTitle', 'Edit Prompt')}
-              </h1>
-              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                {isNewPrompt
-                  ? t('admin.prompts.edit.createDesc', 'Create a new prompt for your iHub Apps')
-                  : t('admin.prompts.edit.editDesc', 'Edit the prompt details and configuration')}
-              </p>
-            </div>
-            <div className="flex space-x-3">
-              {!isNewPrompt && (
-                <button
-                  type="button"
-                  onClick={() => setHistoryOpen(true)}
-                  className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                >
-                  <Icon name="clock" className="h-4 w-4 mr-2" />
-                  {t('admin.prompts.edit.history', 'History')}
-                </button>
-              )}
-              {!isNewPrompt && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    const dataStr = JSON.stringify(promptData, null, 2);
-                    const dataUri =
-                      'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
-                    const exportFileDefaultName = `prompt-${promptData.id}.json`;
-                    const linkElement = document.createElement('a');
-                    linkElement.setAttribute('href', dataUri);
-                    linkElement.setAttribute('download', exportFileDefaultName);
-                    linkElement.click();
-                  }}
-                  className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                >
-                  <Icon name="download" className="h-4 w-4 mr-2" />
-                  {t('common.download')}
-                </button>
-              )}
-              <button
-                onClick={() => navigate('/admin/prompts')}
-                className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-              >
-                <Icon name="arrow-left" className="h-4 w-4 mr-2" />
-                {t('admin.prompts.edit.backToList', 'Back to Prompts')}
-              </button>
-            </div>
-          </div>
+    <AdminEditPageShell
+      loading={loading}
+      loadingFallback={
+        <div className="flex justify-center items-center h-64">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 dark:border-indigo-400"></div>
         </div>
-
-        <form onSubmit={handleFormSubmit} className="space-y-8">
-          <DualModeEditor
-            value={promptData}
-            onChange={handleDataChange}
-            formComponent={PromptFormEditor}
-            formProps={{
-              isNewPrompt,
-              apps,
-              categories: uiConfig?.promptsList?.categories?.list || [],
-              jsonSchema
-            }}
-            jsonSchema={jsonSchema}
-            title={
-              isNewPrompt
-                ? t('admin.prompts.edit.createTitle', 'Create New Prompt')
-                : t('admin.prompts.edit.editTitle', 'Edit Prompt')
-            }
-          />
-
-          {/* Save buttons */}
-          <div className="flex justify-end space-x-4">
-            <button
-              type="button"
-              onClick={() => navigate('/admin/prompts')}
-              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-            >
-              {t('admin.prompts.edit.cancel', 'Cancel')}
-            </button>
-            <button
-              type="submit"
-              disabled={saving}
-              className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
-            >
-              {saving ? (
-                <>
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2 inline-block"></div>
-                  {t('admin.prompts.edit.saving', 'Saving...')}
-                </>
-              ) : (
-                t('admin.prompts.edit.save', 'Save Prompt')
-              )}
-            </button>
-          </div>
-        </form>
-
+      }
+      breadcrumbs={[
+        { label: 'Admin', href: '/admin' },
+        { label: 'Prompts', href: '/admin/prompts' },
+        { label: isNewPrompt ? 'New Prompt' : (promptData?.name?.en ?? promptId) }
+      ]}
+      extra={
         <ChangeHistoryDrawer
           isOpen={historyOpen}
           onClose={() => setHistoryOpen(false)}
           resource="prompt"
           resourceId={promptId}
         />
+      }
+      blocker={blocker}
+    >
+      <div className="mb-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+              {isNewPrompt
+                ? t('admin.prompts.edit.createTitle', 'Create New Prompt')
+                : t('admin.prompts.edit.editTitle', 'Edit Prompt')}
+            </h1>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              {isNewPrompt
+                ? t('admin.prompts.edit.createDesc', 'Create a new prompt for your iHub Apps')
+                : t('admin.prompts.edit.editDesc', 'Edit the prompt details and configuration')}
+            </p>
+          </div>
+          <div className="flex space-x-3">
+            {!isNewPrompt && (
+              <button
+                type="button"
+                onClick={() => setHistoryOpen(true)}
+                className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              >
+                <Icon name="clock" className="h-4 w-4 mr-2" />
+                {t('admin.prompts.edit.history', 'History')}
+              </button>
+            )}
+            {!isNewPrompt && (
+              <button
+                type="button"
+                onClick={() => {
+                  const dataStr = JSON.stringify(promptData, null, 2);
+                  const dataUri =
+                    'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
+                  const exportFileDefaultName = `prompt-${promptData.id}.json`;
+                  const linkElement = document.createElement('a');
+                  linkElement.setAttribute('href', dataUri);
+                  linkElement.setAttribute('download', exportFileDefaultName);
+                  linkElement.click();
+                }}
+                className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+              >
+                <Icon name="download" className="h-4 w-4 mr-2" />
+                {t('common.download')}
+              </button>
+            )}
+            <button
+              onClick={() => navigate('/admin/prompts')}
+              className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            >
+              <Icon name="arrow-left" className="h-4 w-4 mr-2" />
+              {t('admin.prompts.edit.backToList', 'Back to Prompts')}
+            </button>
+          </div>
+        </div>
       </div>
 
-      <ConfirmDialog
-        isOpen={blocker.state === 'blocked'}
-        title="Unsaved Changes"
-        message="You have unsaved changes. Leave anyway?"
-        confirmLabel="Leave"
-        denyLabel="Stay"
-        danger={false}
-        onConfirm={() => blocker.proceed?.()}
-        onDeny={() => blocker.reset?.()}
-      />
-    </div>
+      <form onSubmit={handleFormSubmit} className="space-y-8">
+        <DualModeEditor
+          value={promptData}
+          onChange={handleDataChange}
+          formComponent={PromptFormEditor}
+          formProps={{
+            isNewPrompt,
+            apps,
+            categories: uiConfig?.promptsList?.categories?.list || [],
+            jsonSchema
+          }}
+          jsonSchema={jsonSchema}
+          title={
+            isNewPrompt
+              ? t('admin.prompts.edit.createTitle', 'Create New Prompt')
+              : t('admin.prompts.edit.editTitle', 'Edit Prompt')
+          }
+        />
+
+        {/* Save buttons */}
+        <AdminSaveCancelButtons
+          onCancel={() => navigate('/admin/prompts')}
+          cancelLabel={t('admin.prompts.edit.cancel', 'Cancel')}
+          cancelClassName="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          saving={saving}
+          saveLabel={t('admin.prompts.edit.save', 'Save Prompt')}
+          savingLabel={t('admin.prompts.edit.saving', 'Saving...')}
+        />
+      </form>
+    </AdminEditPageShell>
   );
 }
 

--- a/client/src/features/admin/pages/AdminToolEditPage.jsx
+++ b/client/src/features/admin/pages/AdminToolEditPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
@@ -6,9 +6,6 @@ import DualModeEditor from '../../../shared/components/DualModeEditor';
 import ToolFormEditor from '../components/ToolFormEditor';
 import OpenApiToolEditor from '../components/OpenApiToolEditor';
 import ChangeHistoryDrawer from '../components/ChangeHistoryDrawer';
-import AdminBreadcrumb from '../components/AdminBreadcrumb';
-import { useUnsavedChanges } from '../hooks/useUnsavedChanges';
-import ConfirmDialog from '../../../shared/components/ConfirmDialog';
 import {
   fetchAdminTools,
   createTool,
@@ -17,6 +14,25 @@ import {
   updateToolScript
 } from '../../../api/adminApi';
 import { clearApiCache } from '../../../api';
+import { useAdminResourceEditor } from '../hooks/useAdminResourceEditor';
+import AdminEditPageShell from '../../../shared/components/AdminEditPageShell';
+
+const DEFAULT_TOOL_DATA = {
+  id: '',
+  name: { en: '' },
+  description: { en: '' },
+  script: '',
+  enabled: true,
+  concurrency: 5,
+  isSpecialTool: false,
+  provider: '',
+  parameters: {
+    type: 'object',
+    properties: {},
+    required: []
+  },
+  functions: {} // Support for multi-function tools
+};
 
 function AdminToolEditPage() {
   const { t } = useTranslation();
@@ -25,34 +41,94 @@ function AdminToolEditPage() {
   const location = useLocation();
   const isNewTool = toolId === 'new';
 
-  const defaultToolData = {
-    id: '',
-    name: { en: '' },
-    description: { en: '' },
-    script: '',
-    enabled: true,
-    concurrency: 5,
-    isSpecialTool: false,
-    provider: '',
-    parameters: {
-      type: 'object',
-      properties: {},
-      required: []
-    },
-    functions: {} // Support for multi-function tools
-  };
-
-  const [toolData, setToolData] = useState(defaultToolData);
-  const [initialData, setInitialData] = useState(isNewTool ? defaultToolData : null);
-
   const [scriptContent, setScriptContent] = useState('');
-  const [loading, setLoading] = useState(!isNewTool);
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState(null);
   const [activeTab, setActiveTab] = useState('config'); // config or script
   const [historyOpen, setHistoryOpen] = useState(false);
 
-  const { blocker, markSaved } = useUnsavedChanges(initialData, toolData);
+  const makeDefault = useCallback(() => DEFAULT_TOOL_DATA, []);
+
+  const loadResource = useCallback(async id => {
+    const data = await fetchAdminTools();
+    const tool = data.find(t => t.id === id);
+
+    if (!tool) {
+      throw new Error('Tool not found');
+    }
+
+    // Ensure proper structure
+    const loadedToolData = {
+      ...tool,
+      name: tool.name || { en: '' },
+      description: tool.description || { en: '' },
+      enabled: tool.enabled !== false,
+      concurrency: tool.concurrency || 5,
+      isSpecialTool: tool.isSpecialTool || false,
+      provider: tool.provider || '',
+      parameters: tool.parameters || { type: 'object', properties: {}, required: [] },
+      functions: tool.functions || {}
+    };
+
+    // OpenAPI tools use the dedicated editor pane by default.
+    if (loadedToolData.type === 'openapi') {
+      setActiveTab('openapi');
+    }
+
+    // Load script if available
+    if (tool.script) {
+      try {
+        const scriptData = await fetchToolScript(id);
+        setScriptContent(scriptData.content || '');
+      } catch (err) {
+        console.error('Error loading script:', err);
+        setScriptContent('');
+      }
+    }
+
+    return loadedToolData;
+  }, []);
+
+  const saveResource = async (data, id) => {
+    // Validate required fields
+    if (!data.id || !data.name.en || !data.description.en) {
+      throw new Error('Please fill in all required fields (ID, Name, Description)');
+    }
+
+    // For multi-function tools, remove the parameters field as it's defined per function
+    const toolToSave = { ...data };
+    if (toolToSave.functions && Object.keys(toolToSave.functions).length > 0) {
+      // Multi-function tool - parameters are per function, not at tool level
+      delete toolToSave.parameters;
+    } else {
+      // Regular tool - remove empty functions object
+      delete toolToSave.functions;
+    }
+
+    if (id === 'new') {
+      await createTool(toolToSave);
+    } else {
+      await updateTool(id, toolToSave);
+    }
+
+    // Clear cache
+    clearApiCache('admin_tools');
+
+    // If this is a new tool and we have script content, save it
+    if (id === 'new' && scriptContent && toolToSave.script) {
+      await updateToolScript(toolToSave.id, scriptContent);
+    }
+  };
+
+  const {
+    data: toolData,
+    setData: setToolData,
+    loading,
+    error,
+    setError,
+    save,
+    markSaved,
+    blocker
+  } = useAdminResourceEditor({ resourceId: toolId, loadResource, makeDefault, saveResource });
 
   useEffect(() => {
     if (isNewTool && location.state?.templateTool) {
@@ -68,96 +144,17 @@ function AdminToolEditPage() {
           '// Script template\nexport default async function toolName(params) {\n  // Your code here\n}\n'
         );
       }
-    } else if (!isNewTool) {
-      loadTool();
     }
-  }, [toolId, isNewTool]); // eslint-disable-line @eslint-react/exhaustive-deps
-
-  const loadTool = async () => {
-    try {
-      setLoading(true);
-      setError(null);
-
-      const data = await fetchAdminTools();
-      const tool = data.find(t => t.id === toolId);
-
-      if (!tool) {
-        throw new Error('Tool not found');
-      }
-
-      // Ensure proper structure
-      const loadedToolData = {
-        ...tool,
-        name: tool.name || { en: '' },
-        description: tool.description || { en: '' },
-        enabled: tool.enabled !== false,
-        concurrency: tool.concurrency || 5,
-        isSpecialTool: tool.isSpecialTool || false,
-        provider: tool.provider || '',
-        parameters: tool.parameters || { type: 'object', properties: {}, required: [] },
-        functions: tool.functions || {}
-      };
-      setToolData(loadedToolData);
-      setInitialData(loadedToolData);
-
-      // OpenAPI tools use the dedicated editor pane by default.
-      if (loadedToolData.type === 'openapi') {
-        setActiveTab('openapi');
-      }
-
-      // Load script if available
-      if (tool.script) {
-        try {
-          const scriptData = await fetchToolScript(toolId);
-          setScriptContent(scriptData.content || '');
-        } catch (err) {
-          console.error('Error loading script:', err);
-          setScriptContent('');
-        }
-      }
-    } catch (err) {
-      console.error('Error loading tool:', err);
-      setError(err.message);
-    } finally {
-      setLoading(false);
-    }
-  };
+    // eslint-disable-next-line @eslint-react/exhaustive-deps
+  }, [isNewTool, location.state]);
 
   const handleSaveConfig = async () => {
     try {
       setSaving(true);
       setError(null);
 
-      // Validate required fields
-      if (!toolData.id || !toolData.name.en || !toolData.description.en) {
-        throw new Error('Please fill in all required fields (ID, Name, Description)');
-      }
+      await save();
 
-      // For multi-function tools, remove the parameters field as it's defined per function
-      const toolToSave = { ...toolData };
-      if (toolToSave.functions && Object.keys(toolToSave.functions).length > 0) {
-        // Multi-function tool - parameters are per function, not at tool level
-        delete toolToSave.parameters;
-      } else {
-        // Regular tool - remove empty functions object
-        delete toolToSave.functions;
-      }
-
-      if (isNewTool) {
-        await createTool(toolToSave);
-      } else {
-        await updateTool(toolId, toolToSave);
-      }
-
-      // Clear cache
-      clearApiCache('admin_tools');
-
-      // If this is a new tool and we have script content, save it
-      if (isNewTool && scriptContent && toolToSave.script) {
-        await updateToolScript(toolToSave.id, scriptContent);
-      }
-
-      markSaved();
       navigate('/admin/tools');
     } catch (err) {
       console.error('Error saving tool config:', err);
@@ -228,193 +225,252 @@ function AdminToolEditPage() {
     setActiveTab('openapi');
   };
 
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex justify-center items-center h-64">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
-      </div>
-    );
-  }
-
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <AdminBreadcrumb
-          crumbs={[
-            { label: 'Admin', href: '/admin' },
-            { label: 'Tools', href: '/admin/tools' },
-            { label: isNewTool ? 'New Tool' : (toolData?.name?.en ?? toolId) }
-          ]}
+    <AdminEditPageShell
+      loading={loading}
+      loadingFallback={
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex justify-center items-center h-64">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600"></div>
+        </div>
+      }
+      outerClassName="min-h-screen bg-gray-50 dark:bg-gray-900"
+      contentClassName="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8"
+      breadcrumbs={[
+        { label: 'Admin', href: '/admin' },
+        { label: 'Tools', href: '/admin/tools' },
+        { label: isNewTool ? 'New Tool' : (toolData?.name?.en ?? toolId) }
+      ]}
+      extra={
+        <ChangeHistoryDrawer
+          isOpen={historyOpen}
+          onClose={() => setHistoryOpen(false)}
+          resource="tool"
+          resourceId={toolId}
         />
-        <div className="md:flex md:items-center md:justify-between mb-6">
-          <div className="flex-1 min-w-0">
-            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-              {isNewTool
-                ? t('admin.tools.createNew', 'Create New Tool')
-                : t('admin.tools.editTool', 'Edit Tool')}
-            </h1>
-            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-              {isNewTool
-                ? t('admin.tools.createDescription', 'Create a new AI tool / function')
-                : t('admin.tools.editDescription', 'Edit tool configuration and script')}
-            </p>
-          </div>
-          <div className="mt-4 flex space-x-3 md:mt-0 md:ml-4">
-            {!isNewTool && (
-              <button
-                type="button"
-                onClick={() => setHistoryOpen(true)}
-                className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-              >
-                <Icon name="clock" className="h-4 w-4 mr-2" />
-                {t('admin.tools.history', 'History')}
-              </button>
-            )}
-            <button
-              onClick={() => navigate('/admin/tools')}
-              className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-            >
-              <Icon name="arrow-left" className="h-4 w-4 mr-2" />
-              {t('common.back', 'Back')}
-            </button>
-          </div>
+      }
+      blocker={blocker}
+    >
+      <div className="md:flex md:items-center md:justify-between mb-6">
+        <div className="flex-1 min-w-0">
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+            {isNewTool
+              ? t('admin.tools.createNew', 'Create New Tool')
+              : t('admin.tools.editTool', 'Edit Tool')}
+          </h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {isNewTool
+              ? t('admin.tools.createDescription', 'Create a new AI tool / function')
+              : t('admin.tools.editDescription', 'Edit tool configuration and script')}
+          </p>
         </div>
-
-        {error && (
-          <div className="mb-6 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-md p-4">
-            <div className="flex">
-              <Icon name="exclamation-triangle" className="h-5 w-5 text-red-400" />
-              <div className="ml-3">
-                <h3 className="text-sm font-medium text-red-800 dark:text-red-200">
-                  {t('common.error', 'Error')}
-                </h3>
-                <p className="mt-1 text-sm text-red-700 dark:text-red-300">{error}</p>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Tabs */}
-        <div className="border-b border-gray-200 dark:border-gray-700 mb-6">
-          <nav className="-mb-px flex space-x-8">
-            {/* The generic Configuration tab is meaningless for OpenAPI tools —
-                its content/save button already guard on `!isOpenApiTool` and
-                the OpenAPI editor owns the entire tool shape. Keep the tab
-                visible only for non-OpenAPI tools, so the "Use OpenAPI editor"
-                prompt still has a home when creating a brand-new tool. */}
-            {!isOpenApiTool && (
-              <button
-                onClick={() => setActiveTab('config')}
-                className={`${
-                  activeTab === 'config'
-                    ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
-                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
-                } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
-              >
-                <Icon name="cog" className="h-4 w-4 inline mr-2" />
-                {t('admin.tools.configTab', 'Configuration')}
-              </button>
-            )}
-            {!isNewTool && toolData.script && (
-              <button
-                onClick={() => setActiveTab('script')}
-                className={`${
-                  activeTab === 'script'
-                    ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
-                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
-                } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
-              >
-                <Icon name="code" className="h-4 w-4 inline mr-2" />
-                {t('admin.tools.scriptTab', 'Script Editor')}
-              </button>
-            )}
-            {isOpenApiTool && (
-              <button
-                onClick={() => setActiveTab('openapi')}
-                className={`${
-                  activeTab === 'openapi'
-                    ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
-                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
-                } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
-              >
-                <Icon name="globe" className="h-4 w-4 inline mr-2" />
-                {t('admin.tools.openApiTab', 'OpenAPI')}
-              </button>
-            )}
-          </nav>
-        </div>
-
-        {/* Offer creating an OpenAPI-type tool from the config tab. */}
-        {activeTab === 'config' && isNewTool && !isOpenApiTool && (
-          <div className="mb-6 rounded-md border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-900/30 p-4 flex items-center justify-between">
-            <div>
-              <p className="text-sm font-medium text-indigo-800 dark:text-indigo-200">
-                {t('admin.tools.openApiPromptTitle', 'Building an OpenAPI-backed tool?')}
-              </p>
-              <p className="text-sm text-indigo-700 dark:text-indigo-300 mt-0.5">
-                {t(
-                  'admin.tools.openApiPromptBody',
-                  'Parse an OpenAPI spec, pick an operation, and reference a stored credential — no script required.'
-                )}
-              </p>
-            </div>
+        <div className="mt-4 flex space-x-3 md:mt-0 md:ml-4">
+          {!isNewTool && (
             <button
               type="button"
-              onClick={startOpenApiTool}
-              className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700"
+              onClick={() => setHistoryOpen(true)}
+              className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
             >
-              <Icon name="globe" className="h-4 w-4 mr-2" />
-              {t('admin.tools.useOpenApi', 'Use OpenAPI editor')}
+              <Icon name="clock" className="h-4 w-4 mr-2" />
+              {t('admin.tools.history', 'History')}
             </button>
+          )}
+          <button
+            onClick={() => navigate('/admin/tools')}
+            className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >
+            <Icon name="arrow-left" className="h-4 w-4 mr-2" />
+            {t('common.back', 'Back')}
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mb-6 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-md p-4">
+          <div className="flex">
+            <Icon name="exclamation-triangle" className="h-5 w-5 text-red-400" />
+            <div className="ml-3">
+              <h3 className="text-sm font-medium text-red-800 dark:text-red-200">
+                {t('common.error', 'Error')}
+              </h3>
+              <p className="mt-1 text-sm text-red-700 dark:text-red-300">{error}</p>
+            </div>
           </div>
-        )}
+        </div>
+      )}
 
-        {/* OpenAPI Tab */}
-        {activeTab === 'openapi' && isOpenApiTool && (
-          <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
-            <OpenApiToolEditor tool={toolData} onSave={handleSaveOpenApiTool} saving={saving} />
-          </div>
-        )}
-
-        {/* Configuration Tab */}
-        {activeTab === 'config' && !isOpenApiTool && (
-          <DualModeEditor
-            value={toolData}
-            onChange={handleToolDataChange}
-            formComponent={ToolFormEditor}
-            formProps={{
-              isNewTool
-            }}
-            title={
-              isNewTool
-                ? t('admin.tools.createNew', 'Create New Tool')
-                : t('admin.tools.editTool', 'Edit Tool')
-            }
-            description={
-              isNewTool
-                ? t(
-                    'admin.tools.createDescription',
-                    'Create a new AI tool / function using the form interface or JSON editor'
-                  )
-                : t(
-                    'admin.tools.editDescription',
-                    'Edit tool configuration using the form interface or raw JSON editor'
-                  )
-            }
-          />
-        )}
-
-        {/* Save button for configuration */}
-        {activeTab === 'config' && !isOpenApiTool && (
-          <div className="mt-6 flex justify-end space-x-3">
+      {/* Tabs */}
+      <div className="border-b border-gray-200 dark:border-gray-700 mb-6">
+        <nav className="-mb-px flex space-x-8">
+          {/* The generic Configuration tab is meaningless for OpenAPI tools —
+              its content/save button already guard on `!isOpenApiTool` and
+              the OpenAPI editor owns the entire tool shape. Keep the tab
+              visible only for non-OpenAPI tools, so the "Use OpenAPI editor"
+              prompt still has a home when creating a brand-new tool. */}
+          {!isOpenApiTool && (
             <button
-              onClick={() => navigate('/admin/tools')}
+              onClick={() => setActiveTab('config')}
+              className={`${
+                activeTab === 'config'
+                  ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
+              } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
+            >
+              <Icon name="cog" className="h-4 w-4 inline mr-2" />
+              {t('admin.tools.configTab', 'Configuration')}
+            </button>
+          )}
+          {!isNewTool && toolData.script && (
+            <button
+              onClick={() => setActiveTab('script')}
+              className={`${
+                activeTab === 'script'
+                  ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
+              } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
+            >
+              <Icon name="code" className="h-4 w-4 inline mr-2" />
+              {t('admin.tools.scriptTab', 'Script Editor')}
+            </button>
+          )}
+          {isOpenApiTool && (
+            <button
+              onClick={() => setActiveTab('openapi')}
+              className={`${
+                activeTab === 'openapi'
+                  ? 'border-indigo-500 text-indigo-600 dark:text-indigo-400'
+                  : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 hover:border-gray-300 dark:hover:border-gray-600'
+              } whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm`}
+            >
+              <Icon name="globe" className="h-4 w-4 inline mr-2" />
+              {t('admin.tools.openApiTab', 'OpenAPI')}
+            </button>
+          )}
+        </nav>
+      </div>
+
+      {/* Offer creating an OpenAPI-type tool from the config tab. */}
+      {activeTab === 'config' && isNewTool && !isOpenApiTool && (
+        <div className="mb-6 rounded-md border border-indigo-200 dark:border-indigo-800 bg-indigo-50 dark:bg-indigo-900/30 p-4 flex items-center justify-between">
+          <div>
+            <p className="text-sm font-medium text-indigo-800 dark:text-indigo-200">
+              {t('admin.tools.openApiPromptTitle', 'Building an OpenAPI-backed tool?')}
+            </p>
+            <p className="text-sm text-indigo-700 dark:text-indigo-300 mt-0.5">
+              {t(
+                'admin.tools.openApiPromptBody',
+                'Parse an OpenAPI spec, pick an operation, and reference a stored credential — no script required.'
+              )}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={startOpenApiTool}
+            className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700"
+          >
+            <Icon name="globe" className="h-4 w-4 mr-2" />
+            {t('admin.tools.useOpenApi', 'Use OpenAPI editor')}
+          </button>
+        </div>
+      )}
+
+      {/* OpenAPI Tab */}
+      {activeTab === 'openapi' && isOpenApiTool && (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <OpenApiToolEditor tool={toolData} onSave={handleSaveOpenApiTool} saving={saving} />
+        </div>
+      )}
+
+      {/* Configuration Tab */}
+      {activeTab === 'config' && !isOpenApiTool && (
+        <DualModeEditor
+          value={toolData}
+          onChange={handleToolDataChange}
+          formComponent={ToolFormEditor}
+          formProps={{
+            isNewTool
+          }}
+          title={
+            isNewTool
+              ? t('admin.tools.createNew', 'Create New Tool')
+              : t('admin.tools.editTool', 'Edit Tool')
+          }
+          description={
+            isNewTool
+              ? t(
+                  'admin.tools.createDescription',
+                  'Create a new AI tool / function using the form interface or JSON editor'
+                )
+              : t(
+                  'admin.tools.editDescription',
+                  'Edit tool configuration using the form interface or raw JSON editor'
+                )
+          }
+        />
+      )}
+
+      {/* Save button for configuration */}
+      {activeTab === 'config' && !isOpenApiTool && (
+        <div className="mt-6 flex justify-end space-x-3">
+          <button
+            onClick={() => navigate('/admin/tools')}
+            className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          >
+            {t('common.cancel', 'Cancel')}
+          </button>
+          <button
+            onClick={handleSaveConfig}
+            disabled={saving}
+            className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
+          >
+            {saving ? (
+              <>
+                <Icon name="refresh" className="animate-spin h-4 w-4 mr-2" />
+                {t('common.saving', 'Saving...')}
+              </>
+            ) : (
+              <>
+                <Icon name="check" className="h-4 w-4 mr-2" />
+                {t('common.save', 'Save')}
+              </>
+            )}
+          </button>
+        </div>
+      )}
+
+      {/* Script Editor Tab */}
+      {activeTab === 'script' && !isNewTool && toolData.script && (
+        <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <div className="mb-4">
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              {t(
+                'admin.tools.scriptEditorInfo',
+                'Edit the JavaScript code for this tool. Changes will be saved to server/tools/'
+              )}{' '}
+              <code className="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded text-xs">
+                {toolData.script}
+              </code>
+            </p>
+          </div>
+
+          <div className="mb-4">
+            <textarea
+              value={scriptContent}
+              onChange={e => setScriptContent(e.target.value)}
+              rows={25}
+              className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 font-mono text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+              style={{ fontFamily: 'monospace' }}
+            />
+          </div>
+
+          <div className="flex justify-end space-x-3">
+            <button
+              onClick={() => setActiveTab('config')}
               className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
             >
               {t('common.cancel', 'Cancel')}
             </button>
             <button
-              onClick={handleSaveConfig}
+              onClick={handleSaveScript}
               disabled={saving}
               className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
             >
@@ -426,85 +482,14 @@ function AdminToolEditPage() {
               ) : (
                 <>
                   <Icon name="check" className="h-4 w-4 mr-2" />
-                  {t('common.save', 'Save')}
+                  {t('admin.tools.saveScript', 'Save Script')}
                 </>
               )}
             </button>
           </div>
-        )}
-
-        {/* Script Editor Tab */}
-        {activeTab === 'script' && !isNewTool && toolData.script && (
-          <div className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
-            <div className="mb-4">
-              <p className="text-sm text-gray-600 dark:text-gray-400">
-                {t(
-                  'admin.tools.scriptEditorInfo',
-                  'Edit the JavaScript code for this tool. Changes will be saved to server/tools/'
-                )}{' '}
-                <code className="bg-gray-100 dark:bg-gray-700 px-2 py-1 rounded text-xs">
-                  {toolData.script}
-                </code>
-              </p>
-            </div>
-
-            <div className="mb-4">
-              <textarea
-                value={scriptContent}
-                onChange={e => setScriptContent(e.target.value)}
-                rows={25}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 font-mono text-sm bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
-                style={{ fontFamily: 'monospace' }}
-              />
-            </div>
-
-            <div className="flex justify-end space-x-3">
-              <button
-                onClick={() => setActiveTab('config')}
-                className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-              >
-                {t('common.cancel', 'Cancel')}
-              </button>
-              <button
-                onClick={handleSaveScript}
-                disabled={saving}
-                className="inline-flex items-center px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
-              >
-                {saving ? (
-                  <>
-                    <Icon name="refresh" className="animate-spin h-4 w-4 mr-2" />
-                    {t('common.saving', 'Saving...')}
-                  </>
-                ) : (
-                  <>
-                    <Icon name="check" className="h-4 w-4 mr-2" />
-                    {t('admin.tools.saveScript', 'Save Script')}
-                  </>
-                )}
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-
-      <ChangeHistoryDrawer
-        isOpen={historyOpen}
-        onClose={() => setHistoryOpen(false)}
-        resource="tool"
-        resourceId={toolId}
-      />
-
-      <ConfirmDialog
-        isOpen={blocker.state === 'blocked'}
-        title="Unsaved Changes"
-        message="You have unsaved changes. Leave anyway?"
-        confirmLabel="Leave"
-        denyLabel="Stay"
-        danger={false}
-        onConfirm={() => blocker.proceed?.()}
-        onDeny={() => blocker.reset?.()}
-      />
-    </div>
+        </div>
+      )}
+    </AdminEditPageShell>
   );
 }
 

--- a/client/src/features/admin/pages/AdminUserEditPage.jsx
+++ b/client/src/features/admin/pages/AdminUserEditPage.jsx
@@ -1,83 +1,109 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
-import AdminBreadcrumb from '../components/AdminBreadcrumb';
-import { useUnsavedChanges } from '../hooks/useUnsavedChanges';
-import ConfirmDialog from '../../../shared/components/ConfirmDialog';
 import DualModeEditor from '../../../shared/components/DualModeEditor';
 import UserFormEditor from '../components/UserFormEditor';
 import { makeAdminApiCall } from '../../../api/adminApi';
-import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import { getSchemaByType } from '../../../utils/schemaService';
+import { useAdminResourceEditor } from '../hooks/useAdminResourceEditor';
+import AdminEditPageShell, {
+  AdminSaveCancelButtons
+} from '../../../shared/components/AdminEditPageShell';
+
+// Generate a unique ID for new users
+const generateUserId = () => `user_${crypto.randomUUID().replace(/-/g, '_')}`;
 
 function AdminUserEditPage() {
   const { t } = useTranslation();
   const { userId } = useParams();
   const navigate = useNavigate();
-  const [user, setUser] = useState(null);
-  const [initialData, setInitialData] = useState(null);
-  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState(null);
   const [jsonSchema, setJsonSchema] = useState(null);
   const [availableGroups, setAvailableGroups] = useState([]);
 
   const isNewUser = userId === 'new';
 
-  const { blocker, markSaved } = useUnsavedChanges(initialData, user);
+  const makeDefault = useCallback(
+    () => ({
+      id: generateUserId(),
+      username: '',
+      email: null,
+      fullName: '',
+      name: '',
+      password: '',
+      internalGroups: [],
+      authMethods: ['local'],
+      enabled: true,
+      active: true
+    }),
+    []
+  );
 
-  // Generate a unique ID for new users
-  const generateUserId = () => `user_${crypto.randomUUID().replace(/-/g, '_')}`;
+  const loadResource = useCallback(async id => {
+    const response = await makeAdminApiCall('/admin/auth/users');
+    const data = response.data;
+
+    // Find the user by ID in the users object
+    const userData = Object.values(data.users || {}).find(u => u.id === id);
+    if (!userData) {
+      throw new Error('User not found');
+    }
+
+    return { ...userData, password: '' };
+  }, []);
+
+  const saveResource = useCallback(async (data, id) => {
+    const method = id === 'new' ? 'POST' : 'PUT';
+    const url = id === 'new' ? '/admin/auth/users' : `/admin/auth/users/${id}`;
+
+    // Check if this is a local auth user (needs password)
+    const isLocalAuth =
+      !data.authMethods || data.authMethods.length === 0 || data.authMethods.includes('local');
+
+    // Prepare the data for API call
+    const apiData = {
+      username: data.username,
+      email: data.email || null,
+      name: data.fullName || data.name || '',
+      // Use internalGroups, with fallback to groups for backward compatibility
+      internalGroups: data.internalGroups || data.groups || [],
+      active: data.enabled !== false,
+      authMethods: data.authMethods || ['local']
+    };
+
+    // Only include password if it's provided
+    if (data.password) {
+      apiData.password = data.password;
+    }
+
+    // For new local auth users, ensure password is provided
+    if (id === 'new' && isLocalAuth && !data.password) {
+      throw new Error('Password is required for local authentication users');
+    }
+
+    await makeAdminApiCall(url, {
+      method,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: apiData
+    });
+  }, []);
+
+  const {
+    data: user,
+    setData: setUser,
+    loading,
+    error,
+    setError,
+    save,
+    blocker
+  } = useAdminResourceEditor({ resourceId: userId, loadResource, makeDefault, saveResource });
 
   useEffect(() => {
     loadSchema();
     loadGroups();
-
-    if (isNewUser) {
-      // Initialize new user with generated ID
-      const defaultUser = {
-        id: generateUserId(),
-        username: '',
-        email: null,
-        fullName: '',
-        name: '',
-        password: '',
-        internalGroups: [],
-        authMethods: ['local'],
-        enabled: true,
-        active: true
-      };
-      setUser(defaultUser);
-      setInitialData(defaultUser);
-      setLoading(false);
-      setError(null); // Clear any previous errors
-    } else {
-      // Call loadUser directly for existing users
-      const loadExistingUser = async () => {
-        try {
-          setLoading(true);
-          const response = await makeAdminApiCall('/admin/auth/users');
-          const data = response.data;
-
-          // Find the user by ID in the users object
-          const userData = Object.values(data.users || {}).find(u => u.id === userId);
-          if (!userData) {
-            throw new Error('User not found');
-          }
-
-          const loadedUser = { ...userData, password: '' };
-          setUser(loadedUser);
-          setInitialData(loadedUser);
-        } catch (err) {
-          setError(err.message);
-        } finally {
-          setLoading(false);
-        }
-      };
-      loadExistingUser();
-    }
-    // eslint-disable-next-line @eslint-react/exhaustive-deps
   }, [userId]);
 
   const loadSchema = async () => {
@@ -109,43 +135,7 @@ function AdminUserEditPage() {
 
     try {
       setSaving(true);
-      const method = isNewUser ? 'POST' : 'PUT';
-      const url = isNewUser ? '/admin/auth/users' : `/admin/auth/users/${userId}`;
-
-      // Check if this is a local auth user (needs password)
-      const isLocalAuth =
-        !data.authMethods || data.authMethods.length === 0 || data.authMethods.includes('local');
-
-      // Prepare the data for API call
-      const apiData = {
-        username: data.username,
-        email: data.email || null,
-        name: data.fullName || data.name || '',
-        // Use internalGroups, with fallback to groups for backward compatibility
-        internalGroups: data.internalGroups || data.groups || [],
-        active: data.enabled !== false,
-        authMethods: data.authMethods || ['local']
-      };
-
-      // Only include password if it's provided
-      if (data.password) {
-        apiData.password = data.password;
-      }
-
-      // For new local auth users, ensure password is provided
-      if (isNewUser && isLocalAuth && !data.password) {
-        throw new Error('Password is required for local authentication users');
-      }
-
-      await makeAdminApiCall(url, {
-        method,
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: apiData
-      });
-
-      markSaved();
+      await save();
       // Success - navigate back to users list
       navigate('/admin/users');
     } catch (err) {
@@ -164,14 +154,6 @@ function AdminUserEditPage() {
     e.preventDefault();
     await handleSave(user);
   };
-
-  if (loading) {
-    return (
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
-        <LoadingSpinner size="lg" />
-      </div>
-    );
-  }
 
   if (error) {
     return (
@@ -192,119 +174,92 @@ function AdminUserEditPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <AdminBreadcrumb
-          crumbs={[
-            { label: 'Admin', href: '/admin' },
-            { label: 'Users', href: '/admin/users' },
-            { label: isNewUser ? 'New User' : (user?.username ?? userId) }
-          ]}
-        />
-        <div className="mb-8">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
-                {isNewUser
-                  ? t('admin.users.edit.createTitle', 'Create New User')
-                  : t('admin.users.edit.editTitle', 'Edit User')}
-              </h1>
-              <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
-                {isNewUser
-                  ? t(
-                      'admin.users.edit.createDesc',
-                      'Create a new user account with permissions and settings'
-                    )
-                  : t('admin.users.edit.editDesc', 'Edit user account, permissions, and settings')}
-              </p>
-            </div>
-            <div className="flex space-x-3">
-              {!isNewUser && (
-                <button
-                  type="button"
-                  onClick={() => {
-                    const dataStr = JSON.stringify(user, null, 2);
-                    const dataUri =
-                      'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
-                    const exportFileDefaultName = `user-${user.username}.json`;
-                    const linkElement = document.createElement('a');
-                    linkElement.setAttribute('href', dataUri);
-                    linkElement.setAttribute('download', exportFileDefaultName);
-                    linkElement.click();
-                  }}
-                  className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-                >
-                  <Icon name="download" className="h-4 w-4 mr-2" />
-                  {t('common.download')}
-                </button>
-              )}
+    <AdminEditPageShell
+      loading={loading}
+      outerClassName="min-h-screen bg-gray-50 dark:bg-gray-900"
+      breadcrumbs={[
+        { label: 'Admin', href: '/admin' },
+        { label: 'Users', href: '/admin/users' },
+        { label: isNewUser ? 'New User' : (user?.username ?? userId) }
+      ]}
+      blocker={blocker}
+    >
+      <div className="mb-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-gray-100">
+              {isNewUser
+                ? t('admin.users.edit.createTitle', 'Create New User')
+                : t('admin.users.edit.editTitle', 'Edit User')}
+            </h1>
+            <p className="mt-1 text-sm text-gray-600 dark:text-gray-400">
+              {isNewUser
+                ? t(
+                    'admin.users.edit.createDesc',
+                    'Create a new user account with permissions and settings'
+                  )
+                : t('admin.users.edit.editDesc', 'Edit user account, permissions, and settings')}
+            </p>
+          </div>
+          <div className="flex space-x-3">
+            {!isNewUser && (
               <button
-                onClick={() => navigate('/admin/users')}
+                type="button"
+                onClick={() => {
+                  const dataStr = JSON.stringify(user, null, 2);
+                  const dataUri =
+                    'data:application/json;charset=utf-8,' + encodeURIComponent(dataStr);
+                  const exportFileDefaultName = `user-${user.username}.json`;
+                  const linkElement = document.createElement('a');
+                  linkElement.setAttribute('href', dataUri);
+                  linkElement.setAttribute('download', exportFileDefaultName);
+                  linkElement.click();
+                }}
                 className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
               >
-                <Icon name="arrow-left" className="h-4 w-4 mr-2" />
-                {t('admin.users.edit.backToList', 'Back to Users')}
+                <Icon name="download" className="h-4 w-4 mr-2" />
+                {t('common.download')}
               </button>
-            </div>
+            )}
+            <button
+              onClick={() => navigate('/admin/users')}
+              className="inline-flex items-center px-4 py-2 border border-gray-300 dark:border-gray-600 shadow-sm text-sm font-medium rounded-md text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            >
+              <Icon name="arrow-left" className="h-4 w-4 mr-2" />
+              {t('admin.users.edit.backToList', 'Back to Users')}
+            </button>
           </div>
         </div>
-
-        <form onSubmit={handleFormSubmit} className="space-y-8">
-          <DualModeEditor
-            value={user}
-            onChange={handleDataChange}
-            formComponent={UserFormEditor}
-            formProps={{
-              isNewUser,
-              jsonSchema,
-              availableGroups
-            }}
-            jsonSchema={jsonSchema}
-            title={
-              isNewUser
-                ? t('admin.users.edit.createTitle', 'Create New User')
-                : t('admin.users.edit.editTitle', 'Edit User')
-            }
-          />
-
-          {/* Save buttons */}
-          <div className="flex justify-end space-x-4">
-            <button
-              type="button"
-              onClick={() => navigate('/admin/users')}
-              className="px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-            >
-              {t('admin.users.edit.cancel', 'Cancel')}
-            </button>
-            <button
-              type="submit"
-              disabled={saving}
-              className="px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50"
-            >
-              {saving ? (
-                <>
-                  <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2 inline-block"></div>
-                  {t('admin.users.edit.saving', 'Saving...')}
-                </>
-              ) : (
-                t('admin.users.edit.save', isNewUser ? 'Create User' : 'Save User')
-              )}
-            </button>
-          </div>
-        </form>
       </div>
 
-      <ConfirmDialog
-        isOpen={blocker.state === 'blocked'}
-        title="Unsaved Changes"
-        message="You have unsaved changes. Leave anyway?"
-        confirmLabel="Leave"
-        denyLabel="Stay"
-        danger={false}
-        onConfirm={() => blocker.proceed?.()}
-        onDeny={() => blocker.reset?.()}
-      />
-    </div>
+      <form onSubmit={handleFormSubmit} className="space-y-8">
+        <DualModeEditor
+          value={user}
+          onChange={handleDataChange}
+          formComponent={UserFormEditor}
+          formProps={{
+            isNewUser,
+            jsonSchema,
+            availableGroups
+          }}
+          jsonSchema={jsonSchema}
+          title={
+            isNewUser
+              ? t('admin.users.edit.createTitle', 'Create New User')
+              : t('admin.users.edit.editTitle', 'Edit User')
+          }
+        />
+
+        {/* Save buttons */}
+        <AdminSaveCancelButtons
+          onCancel={() => navigate('/admin/users')}
+          cancelLabel={t('admin.users.edit.cancel', 'Cancel')}
+          saving={saving}
+          saveLabel={t('admin.users.edit.save', isNewUser ? 'Create User' : 'Save User')}
+          savingLabel={t('admin.users.edit.saving', 'Saving...')}
+        />
+      </form>
+    </AdminEditPageShell>
   );
 }
 

--- a/client/src/shared/components/AdminEditPageShell.jsx
+++ b/client/src/shared/components/AdminEditPageShell.jsx
@@ -1,0 +1,153 @@
+import AdminBreadcrumb from '../../features/admin/components/AdminBreadcrumb';
+import ConfirmDialog from './ConfirmDialog';
+import LoadingSpinner from './LoadingSpinner';
+
+/**
+ * Shared page chrome for admin "edit resource" pages (AdminGroupEditPage,
+ * AdminAppEditPage, AdminModelEditPage, AdminPromptEditPage, AdminToolEditPage,
+ * AdminUserEditPage). Wraps the breadcrumb, a loading state, the resource-specific
+ * form body (`children`), any extra page content that sits outside the main
+ * content column (e.g. a `ChangeHistoryDrawer`), and the "Unsaved Changes" confirm
+ * dialog driven by `blocker` (see `useAdminResourceEditor` / `useUnsavedChanges`).
+ *
+ * The wrapper `className`s are intentionally left overridable via `outerClassName`
+ * / `contentClassName` rather than hardcoded: the pages this replaces don't share
+ * identical wrapper markup (e.g. AdminAppEditPage has no `min-h-screen` outer
+ * wrapper at all, AdminToolEditPage uses `max-w-7xl` instead of `max-w-4xl`). Pass
+ * the page's existing classNames through so the rendered output doesn't change.
+ *
+ * `ConfirmDialog` is a `position: fixed` overlay, so its exact position in the DOM
+ * tree has no effect on layout - it's always rendered once here regardless of
+ * `outerClassName`.
+ *
+ * @param {Object} props
+ * @param {boolean} props.loading - when true, renders `loadingFallback` instead of
+ *   the breadcrumb + children (matches every page's original early-return spinner).
+ * @param {React.ReactNode} [props.loadingFallback] - defaults to a centered
+ *   `LoadingSpinner` in a `min-h-screen` wrapper (the AdminGroupEditPage /
+ *   AdminUserEditPage style). Pages with a different loading visual should pass
+ *   their own node here to keep pixel-identical output.
+ * @param {string} [props.outerClassName] - classes for the outermost wrapper div.
+ *   Omit (or pass `''`/`undefined`) to skip the outer wrapper entirely, e.g. for
+ *   pages whose root element IS the content column (AdminAppEditPage).
+ * @param {string} [props.contentClassName] - classes for the inner max-width
+ *   content div that holds the breadcrumb + form body. Defaults to the
+ *   `max-w-4xl` column used by most of these pages.
+ * @param {Array<{label: string, href?: string}>} props.breadcrumbs - passed
+ *   straight through to `AdminBreadcrumb`.
+ * @param {React.ReactNode} props.children - the page's form body (header,
+ *   `DualModeEditor`, save/cancel row, etc).
+ * @param {React.ReactNode} [props.extra] - rendered as a sibling after the content
+ *   div, still inside the outer wrapper when there is one (e.g. a
+ *   `ChangeHistoryDrawer`, which several pages render alongside the form).
+ * @param {{state: 'blocked'|'unblocked', proceed: Function, reset: Function}} props.blocker -
+ *   from `useAdminResourceEditor`/`useUnsavedChanges`; drives the "Unsaved Changes" dialog.
+ */
+function AdminEditPageShell({
+  loading,
+  loadingFallback,
+  outerClassName,
+  contentClassName = 'max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8',
+  breadcrumbs,
+  children,
+  extra,
+  blocker
+}) {
+  if (loading) {
+    return (
+      loadingFallback ?? (
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center">
+          <LoadingSpinner size="lg" />
+        </div>
+      )
+    );
+  }
+
+  const content = (
+    <div className={contentClassName}>
+      <AdminBreadcrumb crumbs={breadcrumbs} />
+      {children}
+    </div>
+  );
+
+  return (
+    <>
+      {outerClassName ? (
+        <div className={outerClassName}>
+          {content}
+          {extra}
+        </div>
+      ) : (
+        <>
+          {content}
+          {extra}
+        </>
+      )}
+
+      <ConfirmDialog
+        isOpen={blocker?.state === 'blocked'}
+        title="Unsaved Changes"
+        message="You have unsaved changes. Leave anyway?"
+        confirmLabel="Leave"
+        denyLabel="Stay"
+        danger={false}
+        onConfirm={() => blocker?.proceed?.()}
+        onDeny={() => blocker?.reset?.()}
+      />
+    </>
+  );
+}
+
+/**
+ * The plain-text Save/Cancel button row shared byte-for-byte by
+ * AdminGroupEditPage, AdminPromptEditPage, and AdminUserEditPage (a `type="submit"`
+ * button showing a spinner + "Saving..." label while `saving` is true, and a plain
+ * `type="button"` Cancel button next to it). AdminAppEditPage, AdminModelEditPage,
+ * and AdminToolEditPage use visually distinct button rows (icons, extra disabled
+ * conditions, tab-conditional rendering) and render their own instead of using this.
+ *
+ * `cancelClassName` / `saveClassName` default to the exact classes used by
+ * AdminGroupEditPage/AdminUserEditPage; pass an override to match small existing
+ * differences (e.g. AdminPromptEditPage's cancel button uses `dark:text-gray-200`
+ * instead of `dark:text-gray-300`).
+ *
+ * @param {Object} props
+ * @param {() => void} props.onCancel
+ * @param {React.ReactNode} props.cancelLabel
+ * @param {boolean} props.saving
+ * @param {React.ReactNode} props.saveLabel - shown when `saving` is false.
+ * @param {React.ReactNode} props.savingLabel - shown next to the spinner when `saving` is true.
+ * @param {boolean} [props.disabled=false] - additional disabled condition ORed with `saving`.
+ * @param {string} [props.cancelClassName]
+ * @param {string} [props.saveClassName]
+ */
+export function AdminSaveCancelButtons({
+  onCancel,
+  cancelLabel,
+  saving,
+  saveLabel,
+  savingLabel,
+  disabled = false,
+  cancelClassName = 'px-4 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500',
+  saveClassName = 'px-4 py-2 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 disabled:opacity-50'
+}) {
+  return (
+    <div className="flex justify-end space-x-4">
+      <button type="button" onClick={onCancel} className={cancelClassName}>
+        {cancelLabel}
+      </button>
+      <button type="submit" disabled={saving || disabled} className={saveClassName}>
+        {saving ? (
+          <>
+            <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white mr-2 inline-block"></div>
+            {savingLabel}
+          </>
+        ) : (
+          saveLabel
+        )}
+      </button>
+    </div>
+  );
+}
+
+export default AdminEditPageShell;


### PR DESCRIPTION
## Summary

Fixes #1753.

Six `Admin*EditPage` components (`AdminGroupEditPage`, `AdminAppEditPage`, `AdminModelEditPage`, `AdminPromptEditPage`, `AdminToolEditPage`, `AdminUserEditPage`) each hand-rolled the same load/save/unsaved-changes/breadcrumb scaffold with independent `handleSave` implementations. Behavior had already drifted — `AdminModelEditPage` waited 1.5s (`setTimeout`) before navigating away after a successful save, while every other page navigated immediately.

This PR extracts that shared scaffold into two new files and migrates the six Phase A pages (per the issue's own implementation plan) onto it:

- **`client/src/features/admin/hooks/useAdminResourceEditor.js`** — `useAdminResourceEditor({ resourceId, loadResource, makeDefault, saveResource })` centralizes the `resourceId === 'new'` vs. load-existing-resource branch, dirty-tracking (`useUnsavedChanges`), and the save call. Navigation after save and the `saving` UI flag are deliberately left to each page's own `handleSave`, since those differ per page.
- **`client/src/shared/components/AdminEditPageShell.jsx`** — wraps the shared breadcrumb / loading-spinner / "Unsaved Changes" `ConfirmDialog` chrome, plus an `AdminSaveCancelButtons` helper for the plain-text Save/Cancel row shared by three of the six pages. Wrapper classNames are passed through rather than hardcoded, since the six pages don't share identical outer markup.

Each page's resource-specific form body (fields, `DualModeEditor` usage, etc.) is untouched — only the duplicated scaffold around it was replaced.

**Behavior fix:** removed `AdminModelEditPage`'s undocumented 1.5s `setTimeout` before navigating away after save (traced via `git log`/`git blame` — no comment or commit message explained the delay), so it now navigates immediately like the other five pages.

Left out of scope per the issue's own plan: `AdminAgentEditPage`, `AdminOAuthClientEditPage`, `AdminPageEditPage`, `AdminAgentInboxEditPage`, and the non-`DualModeEditor` Phase B pages (`AdminProviderEditPage`, `AdminShortLinkEditPage`, `AdminSkillEditPage`, `AdminSourceEditPage`, `AdminWorkflowEditPage`) — those have structurally different editors and are recommended as follow-up work.

## Test plan

- [x] `npm run lint:fix` — 0 errors (pre-existing warnings elsewhere unrelated to this change)
- [x] `npm run format:fix` — no additional changes
- [x] `cd client && npx vite build` — succeeds
- [x] `npm run test:ui` (client jest suite) — 140/140 passing
- [ ] Manual smoke test of Group/App/Model/Prompt/Tool/User create + edit flows in a running dev server (not done in this sandbox — recommend before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ketu8dnD7GBiiwS5Gz7gMV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ketu8dnD7GBiiwS5Gz7gMV)_