### PR TITLE
fix(security): encrypt OAuth tokens with authenticated AES-256-GCM

### DIFF
--- a/server/services/TokenStorageService.js
+++ b/server/services/TokenStorageService.js
@@ -40,7 +40,14 @@ class TokenStorageService {
   async initializeEncryptionKey() {
     // Priority 1: Environment variable (allows override)
     if (process.env.TOKEN_ENCRYPTION_KEY) {
-      this.encryptionKey = process.env.TOKEN_ENCRYPTION_KEY;
+      const envKey = process.env.TOKEN_ENCRYPTION_KEY.trim();
+      if (!/^[0-9a-f]{64}$/i.test(envKey)) {
+        throw new Error(
+          'TOKEN_ENCRYPTION_KEY must be a 64-character hex string (32 bytes). ' +
+            'Generate one with: openssl rand -hex 32'
+        );
+      }
+      this.encryptionKey = envKey;
       logger.info('Using encryption key from TOKEN_ENCRYPTION_KEY environment variable', {
         component: 'TokenStorage'
       });
@@ -297,7 +304,7 @@ class TokenStorageService {
       const context = this._generateEncryptionContext(userId, serviceName);
 
       // Include context in the encryption to bind tokens to specific user/service
-      const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+      const cipher = crypto.createCipheriv(this.algorithm, key, iv);
 
       let encrypted = cipher.update(
         JSON.stringify({ ...tokens, context: context.toString('hex') }),
@@ -305,10 +312,13 @@ class TokenStorageService {
         'hex'
       );
       encrypted += cipher.final('hex');
+      const authTag = cipher.getAuthTag();
 
       return {
         encrypted,
         iv: iv.toString('hex'),
+        authTag: authTag.toString('hex'),
+        algorithm: this.algorithm,
         userId,
         serviceName,
         contextHash: context.toString('hex')
@@ -323,7 +333,14 @@ class TokenStorageService {
   }
 
   /**
-   * Decrypt token data with user and service verification
+   * Decrypt token data with user and service verification.
+   *
+   * New tokens are encrypted with authenticated AES-256-GCM (see
+   * `encryptTokens`). Tokens written before this change used
+   * unauthenticated AES-256-CBC and have no `authTag`/`algorithm`
+   * field — that legacy format is still accepted here so existing
+   * on-disk tokens keep working; they get upgraded to GCM the next
+   * time they're re-encrypted (e.g. on token refresh).
    */
   decryptTokens(encryptedData, userId, serviceName) {
     this._ensureKeyInitialized();
@@ -338,11 +355,24 @@ class TokenStorageService {
 
       const key = Buffer.from(this.encryptionKey, 'hex');
       const iv = Buffer.from(encryptedData.iv, 'hex');
+      const isGcm = encryptedData.algorithm === 'aes-256-gcm' || Boolean(encryptedData.authTag);
 
-      const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
-
-      let decrypted = decipher.update(encryptedData.encrypted, 'hex', 'utf8');
-      decrypted += decipher.final('utf8');
+      let decrypted;
+      if (isGcm) {
+        const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+        decipher.setAuthTag(Buffer.from(encryptedData.authTag, 'hex'));
+        decrypted = decipher.update(encryptedData.encrypted, 'hex', 'utf8');
+        decrypted += decipher.final('utf8');
+      } else {
+        logger.warn('Decrypting tokens stored in legacy unauthenticated AES-256-CBC format', {
+          component: 'TokenStorage',
+          userId,
+          serviceName
+        });
+        const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+        decrypted = decipher.update(encryptedData.encrypted, 'hex', 'utf8');
+        decrypted += decipher.final('utf8');
+      }
 
       const parsedData = JSON.parse(decrypted);
 

--- a/server/tests/token-storage-encryption.test.js
+++ b/server/tests/token-storage-encryption.test.js
@@ -1,0 +1,129 @@
+/**
+ * TokenStorageService encryption — unit tests.
+ *
+ * encryptTokens/decryptTokens store OAuth access/refresh tokens for
+ * Office365/GoogleDrive/Nextcloud integrations. They now use authenticated
+ * AES-256-GCM instead of unauthenticated AES-256-CBC, while still accepting
+ * the legacy CBC format so tokens written before this change keep decrypting.
+ */
+import crypto from 'crypto';
+import tokenStorage from '../services/TokenStorageService.js';
+
+const VALID_HEX_KEY = 'a'.repeat(64);
+
+describe('TokenStorageService token encryption', () => {
+  const originalKey = tokenStorage.encryptionKey;
+
+  beforeAll(() => {
+    tokenStorage.encryptionKey = VALID_HEX_KEY;
+  });
+
+  afterAll(() => {
+    tokenStorage.encryptionKey = originalKey;
+  });
+
+  test('round-trips tokens using authenticated AES-256-GCM', () => {
+    const tokens = { accessToken: 'at-1', refreshToken: 'rt-1', expiresIn: 3600 };
+    const encrypted = tokenStorage.encryptTokens(tokens, 'user-1', 'office365');
+
+    expect(encrypted.algorithm).toBe('aes-256-gcm');
+    expect(encrypted.authTag).toEqual(expect.any(String));
+
+    const decrypted = tokenStorage.decryptTokens(encrypted, 'user-1', 'office365');
+    expect(decrypted).toEqual(tokens);
+  });
+
+  test('still decrypts tokens stored in the legacy unauthenticated AES-256-CBC format', () => {
+    // Hand-build a payload the way the old encryptTokens() used to, before
+    // this fix switched to GCM, to prove old on-disk tokens keep working.
+    const key = Buffer.from(VALID_HEX_KEY, 'hex');
+    const iv = crypto.randomBytes(16);
+    const userId = 'user-legacy';
+    const serviceName = 'office365';
+    const context = crypto.createHash('sha256').update(`${userId}:${serviceName}`).digest();
+
+    const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+    const tokens = { accessToken: 'legacy-at', refreshToken: 'legacy-rt' };
+    let encrypted = cipher.update(
+      JSON.stringify({ ...tokens, context: context.toString('hex') }),
+      'utf8',
+      'hex'
+    );
+    encrypted += cipher.final('hex');
+
+    const legacyPayload = {
+      encrypted,
+      iv: iv.toString('hex'),
+      userId,
+      serviceName,
+      contextHash: context.toString('hex')
+      // no `algorithm`/`authTag` — matches what pre-fix encryptTokens() wrote
+    };
+
+    const decrypted = tokenStorage.decryptTokens(legacyPayload, userId, serviceName);
+    expect(decrypted).toEqual(tokens);
+  });
+
+  test('rejects a GCM payload whose ciphertext has been tampered with', () => {
+    const tokens = { accessToken: 'at-2', refreshToken: 'rt-2' };
+    const encrypted = tokenStorage.encryptTokens(tokens, 'user-2', 'nextcloud');
+
+    const tampered = {
+      ...encrypted,
+      encrypted:
+        encrypted.encrypted.slice(0, -2) + (encrypted.encrypted.slice(-2) === '00' ? '11' : '00')
+    };
+
+    expect(() => tokenStorage.decryptTokens(tampered, 'user-2', 'nextcloud')).toThrow(
+      'Failed to decrypt tokens'
+    );
+  });
+
+  test('rejects a GCM payload whose auth tag has been tampered with', () => {
+    const tokens = { accessToken: 'at-3', refreshToken: 'rt-3' };
+    const encrypted = tokenStorage.encryptTokens(tokens, 'user-3', 'googledrive');
+
+    const tampered = {
+      ...encrypted,
+      authTag: encrypted.authTag.slice(0, -2) + (encrypted.authTag.slice(-2) === '00' ? '11' : '00')
+    };
+
+    expect(() => tokenStorage.decryptTokens(tampered, 'user-3', 'googledrive')).toThrow(
+      'Failed to decrypt tokens'
+    );
+  });
+
+  test('rejects tokens encrypted for a different user/service context', () => {
+    const tokens = { accessToken: 'at-4' };
+    const encrypted = tokenStorage.encryptTokens(tokens, 'user-4', 'office365');
+
+    expect(() => tokenStorage.decryptTokens(encrypted, 'user-4', 'nextcloud')).toThrow(
+      'Failed to decrypt tokens'
+    );
+  });
+});
+
+describe('TokenStorageService.initializeEncryptionKey env var validation', () => {
+  const originalEnvKey = process.env.TOKEN_ENCRYPTION_KEY;
+  const originalKey = tokenStorage.encryptionKey;
+
+  afterEach(() => {
+    if (originalEnvKey === undefined) {
+      delete process.env.TOKEN_ENCRYPTION_KEY;
+    } else {
+      process.env.TOKEN_ENCRYPTION_KEY = originalEnvKey;
+    }
+    tokenStorage.encryptionKey = originalKey;
+  });
+
+  test('accepts a valid 64-character hex key', async () => {
+    process.env.TOKEN_ENCRYPTION_KEY = VALID_HEX_KEY;
+    await tokenStorage.initializeEncryptionKey();
+    expect(tokenStorage.encryptionKey).toBe(VALID_HEX_KEY);
+  });
+
+  test('throws on a malformed (non-hex/wrong-length) key instead of limping along', async () => {
+    process.env.TOKEN_ENCRYPTION_KEY = 'not-a-valid-hex-key';
+    await expect(tokenStorage.initializeEncryptionKey()).rejects.toThrow(/64-character hex string/);
+  });
+});


### PR DESCRIPTION
## Summary

- `TokenStorageService.encryptTokens`/`decryptTokens` encrypted OAuth access/refresh tokens (Office365, GoogleDrive, Nextcloud) with unauthenticated AES-256-CBC while API keys already got authenticated AES-256-GCM via `encryptString`. CBC has no integrity check, so tampered ciphertext on disk would silently decrypt to garbage instead of failing loudly.
- Switched `encryptTokens`/`decryptTokens` to AES-256-GCM (wiring up the already-declared-but-unused `this.algorithm` field), storing an `authTag`/`algorithm` alongside the existing `iv`/`contextHash`.
- `decryptTokens` still accepts the legacy CBC format (no `authTag`/`algorithm` field) so tokens already on disk keep working; they get upgraded to GCM the next time they're re-encrypted (e.g. on token refresh). A warning is logged when the legacy path is used.
- `initializeEncryptionKey()` now validates `TOKEN_ENCRYPTION_KEY` is a 64-character hex string before accepting it, failing fast at startup instead of surfacing an opaque `Invalid key length` error later during a live OAuth flow.

## Why

Follows the plan discussed in #1807: OAuth refresh tokens are the most sensitive artifact this service handles, and they were the one place still using unauthenticated encryption.

## Test plan

- [x] Added `server/tests/token-storage-encryption.test.js`: GCM round-trip, legacy-CBC-format decrypt (back-compat), tamper detection on both ciphertext and auth tag, cross-context rejection, and env-var key validation (valid/invalid).
- [x] `npm test -- tests/token-storage-encryption.test.js` — 7/7 passing.
- [x] `npx eslint`/`npx prettier --check` on touched files — clean.
- [x] Booted the dev server (`node server/server.js`) — starts cleanly, no encryption-key errors.

Fixes #1807

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VD1Kqtz2A62okhJrTYqAkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01VD1Kqtz2A62okhJrTYqAkg)_