### PR TITLE
refactor(client): extract shared useUrlParamSettings hook from AppChat/AppCanvas

### DIFF
--- a/client/src/features/apps/pages/AppChat.jsx
+++ b/client/src/features/apps/pages/AppChat.jsx
@@ -20,6 +20,7 @@ import AppShareModal from '../components/AppShareModal';
 import useAppChat from '../../chat/hooks/useAppChat';
 import useVoiceCommands from '../../voice/hooks/useVoiceCommands';
 import useAppSettings from '../../../shared/hooks/useAppSettings';
+import useUrlParamSettings from '../../../shared/hooks/useUrlParamSettings';
 import useFileUploadHandler from '../../../shared/hooks/useFileUploadHandler';
 import useMagicPrompt from '../../../shared/hooks/useMagicPrompt';
 import { useIntegrationAuth } from '../../chat/hooks/useIntegrationAuth';
@@ -233,74 +234,21 @@ function AppChat({ preloadedApp = null }) {
   const effectiveEnabledTools = toolsFeatureEnabled ? enabledTools : null;
 
   // Apply settings and variables from URL parameters once app data is loaded
-  useEffect(() => {
-    if (!app || modelsLoading) return;
-
-    const newVars = {};
-    let changed = false;
-
-    const m = searchParams.get('model');
-    if (m) {
-      setSelectedModel(m);
-      changed = true;
-    }
-    const st = searchParams.get('style');
-    if (st) {
-      setSelectedStyle(st);
-      changed = true;
-    }
-    const out = searchParams.get('outfmt');
-    if (out) {
-      setSelectedOutputFormat(out);
-      changed = true;
-    }
-    const tempParam = searchParams.get('temp');
-    if (tempParam) {
-      setTemperature(parseFloat(tempParam));
-      changed = true;
-    }
-    const hist = searchParams.get('history');
-    if (hist) {
-      setSendChatHistory(hist === 'true');
-      changed = true;
-    }
-
-    searchParams.forEach((value, key) => {
-      if (key.startsWith('var_')) {
-        newVars[key.slice(4)] = value;
-        changed = true;
-      }
-    });
-
-    if (Object.keys(newVars).length) {
-      setVariables(v => ({ ...v, ...newVars }));
-    }
-
-    if (changed) {
-      const newSearch = new URLSearchParams(searchParams);
-      [
-        'model',
-        'style',
-        'outfmt',
-        'temp',
-        'history',
-        'prefill',
-        'send',
-        ...Object.keys(newVars).map(v => `var_${v}`)
-      ].forEach(k => newSearch.delete(k));
-      navigate(`${window.location.pathname}?${newSearch.toString()}`, { replace: true });
-    }
-  }, [
+  useUrlParamSettings(
     app,
     modelsLoading,
-    navigate,
-    searchParams,
-    setSelectedModel,
-    setSelectedOutputFormat,
-    setSelectedStyle,
-    setSendChatHistory,
-    setTemperature
-  ]);
+    {
+      setSelectedModel,
+      setSelectedStyle,
+      setSelectedOutputFormat,
+      setTemperature,
+      setSendChatHistory
+    },
+    {
+      extraParamsToStrip: ['prefill', 'send'],
+      onVariables: newVars => setVariables(v => ({ ...v, ...newVars }))
+    }
+  );
 
   // State for managing parameter changes on mobile
   const [tempVariables, setTempVariables] = useState({});

--- a/client/src/features/canvas/pages/AppCanvas.jsx
+++ b/client/src/features/canvas/pages/AppCanvas.jsx
@@ -17,6 +17,7 @@ import AppShareModal from '../../apps/components/AppShareModal';
 import useAppChat from '../../chat/hooks/useAppChat';
 import useVoiceCommands from '../../voice/hooks/useVoiceCommands';
 import useAppSettings from '../../../shared/hooks/useAppSettings';
+import useUrlParamSettings from '../../../shared/hooks/useUrlParamSettings';
 import useCanvas from '../hooks/useCanvas';
 import { fetchAppDetails } from '../../../api';
 import { markdownToHtml, isMarkdown } from '../../../utils/markdownUtils';
@@ -57,68 +58,13 @@ export default function AppCanvas() {
   } = useAppSettings(appId, app);
 
   // Apply settings from query parameters once data is loaded
-  useEffect(() => {
-    if (!app || modelsLoading) return;
-
-    const newVars = {};
-    let changed = false;
-
-    const m = searchParams.get('model');
-    if (m) {
-      setSelectedModel(m);
-      changed = true;
-    }
-    const st = searchParams.get('style');
-    if (st) {
-      setSelectedStyle(st);
-      changed = true;
-    }
-    const out = searchParams.get('outfmt');
-    if (out) {
-      setSelectedOutputFormat(out);
-      changed = true;
-    }
-    const tempParam = searchParams.get('temp');
-    if (tempParam) {
-      setTemperature(parseFloat(tempParam));
-      changed = true;
-    }
-    const hist = searchParams.get('history');
-    if (hist) {
-      setSendChatHistory(hist === 'true');
-      changed = true;
-    }
-
-    searchParams.forEach((value, key) => {
-      if (key.startsWith('var_')) {
-        newVars[key.slice(4)] = value;
-        changed = true;
-      }
-    });
-
-    if (changed) {
-      const newSearch = new URLSearchParams(searchParams);
-      [
-        'model',
-        'style',
-        'outfmt',
-        'temp',
-        'history',
-        ...Object.keys(newVars).map(v => `var_${v}`)
-      ].forEach(k => newSearch.delete(k));
-      navigate(`${window.location.pathname}?${newSearch.toString()}`, { replace: true });
-    }
-  }, [
-    app,
-    modelsLoading,
-    navigate,
-    searchParams,
+  useUrlParamSettings(app, modelsLoading, {
     setSelectedModel,
-    setSelectedOutputFormat,
     setSelectedStyle,
-    setSendChatHistory,
-    setTemperature
-  ]);
+    setSelectedOutputFormat,
+    setTemperature,
+    setSendChatHistory
+  });
 
   // Canvas editor states
   const [showExportMenu, setShowExportMenu] = useState(false);

--- a/client/src/shared/hooks/useUrlParamSettings.js
+++ b/client/src/shared/hooks/useUrlParamSettings.js
@@ -1,0 +1,97 @@
+import { useEffect } from 'react';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+
+/**
+ * Applies app-settings query params (model/style/outfmt/temp/history/var_*) once
+ * app data is loaded, then strips them from the URL. Shared between AppChat and
+ * AppCanvas so the parsing/cleanup logic only needs to be fixed in one place.
+ *
+ * @param {Object} app - The loaded app configuration (effect no-ops until truthy)
+ * @param {boolean} modelsLoading - Effect no-ops while models are still loading
+ * @param {Object} setters - { setSelectedModel, setSelectedStyle, setSelectedOutputFormat, setTemperature, setSendChatHistory }
+ * @param {Object} [options]
+ * @param {string[]} [options.extraParamsToStrip] - Additional query params to remove alongside the recognized ones
+ * @param {(vars: Object) => void} [options.onVariables] - Called with parsed var_* params, keyed without the prefix
+ */
+function useUrlParamSettings(app, modelsLoading, setters, options = {}) {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const {
+    setSelectedModel,
+    setSelectedStyle,
+    setSelectedOutputFormat,
+    setTemperature,
+    setSendChatHistory
+  } = setters;
+  const { extraParamsToStrip = [], onVariables } = options;
+
+  useEffect(() => {
+    if (!app || modelsLoading) return;
+
+    const newVars = {};
+    let changed = false;
+
+    const m = searchParams.get('model');
+    if (m) {
+      setSelectedModel(m);
+      changed = true;
+    }
+    const st = searchParams.get('style');
+    if (st) {
+      setSelectedStyle(st);
+      changed = true;
+    }
+    const out = searchParams.get('outfmt');
+    if (out) {
+      setSelectedOutputFormat(out);
+      changed = true;
+    }
+    const tempParam = searchParams.get('temp');
+    if (tempParam) {
+      setTemperature(parseFloat(tempParam));
+      changed = true;
+    }
+    const hist = searchParams.get('history');
+    if (hist) {
+      setSendChatHistory(hist === 'true');
+      changed = true;
+    }
+
+    searchParams.forEach((value, key) => {
+      if (key.startsWith('var_')) {
+        newVars[key.slice(4)] = value;
+        changed = true;
+      }
+    });
+
+    if (Object.keys(newVars).length) {
+      onVariables?.(newVars);
+    }
+
+    if (changed) {
+      const newSearch = new URLSearchParams(searchParams);
+      [
+        'model',
+        'style',
+        'outfmt',
+        'temp',
+        'history',
+        ...extraParamsToStrip,
+        ...Object.keys(newVars).map(v => `var_${v}`)
+      ].forEach(k => newSearch.delete(k));
+      navigate(`${window.location.pathname}?${newSearch.toString()}`, { replace: true });
+    }
+  }, [
+    app,
+    modelsLoading,
+    navigate,
+    searchParams,
+    setSelectedModel,
+    setSelectedOutputFormat,
+    setSelectedStyle,
+    setSendChatHistory,
+    setTemperature
+  ]);
+}
+
+export default useUrlParamSettings;


### PR DESCRIPTION
## Summary
- `AppChat.jsx` and `AppCanvas.jsx` each contained an almost byte-identical `useEffect` that read `model`/`style`/`outfmt`/`temp`/`history`/`var_*` query params, applied them to app-settings state, then stripped those keys from the URL. The duplication had already drifted (AppChat additionally strips `prefill`/`send`; AppCanvas parses `var_*` params but never applies them anywhere).
- Extracted the shared logic into `client/src/shared/hooks/useUrlParamSettings.js`, a hook that takes the app/loading state, the relevant setters, and an optional `extraParamsToStrip` / `onVariables` for the two behaviors that differ between the pages.
- `AppChat.jsx` now calls the hook with `extraParamsToStrip: ['prefill', 'send']` and `onVariables` wired to `setVariables`, preserving its existing behavior.
- `AppCanvas.jsx` now calls the hook without `onVariables`, preserving its existing (pre-existing, unchanged) behavior of stripping `var_*` from the URL without applying them anywhere.
- No behavior change intended — this is a pure deduplication of existing logic into one shared hook so future fixes (e.g. `temp` validation) only need to land once.

## Test plan
- [x] `npx eslint` on the three changed files — 0 errors (only pre-existing warnings unrelated to this change)
- [x] `npx prettier --check` — clean
- [x] `cd client && npx vite build` — builds successfully
- [ ] Manual verification in a running dev server: load `/apps/:id?model=X&style=Y&temp=0.5&history=true&var_foo=bar` and confirm settings apply and the URL is cleaned; repeat for `/apps/:id/canvas?...` and for AppChat's `prefill`/`send` params

Fixes #1752


---
_Generated by [Claude Code](https://claude.ai/code/session_01LFkGB1sp7ihGJTEUPPyN18)_