### PR TITLE
refactor: consolidate localized-string extraction into shared utility

### DIFF
--- a/server/adapters/toolCalling/GenericToolCalling.js
+++ b/server/adapters/toolCalling/GenericToolCalling.js
@@ -6,6 +6,8 @@
  * conversion between provider-specific formats and a normalized generic format.
  */
 
+import { getLocalizedString } from '../../utils/localize.js';
+
 /**
  * Generic tool definition format
  * This is our normalized internal format that can represent tools for any provider
@@ -302,7 +304,7 @@ export function sanitizeSchemaForProvider(schema, provider) {
         }
         // Ensure description is a plain string (not a multilingual object)
         if (obj.description && typeof obj.description === 'object') {
-          obj.description = obj.description.en || Object.values(obj.description)[0] || '';
+          obj.description = getLocalizedString(obj.description, 'en');
         }
         delete obj.exclusiveMaximum;
         delete obj.exclusiveMinimum;

--- a/server/agents/runtime/appAsToolGateway.js
+++ b/server/agents/runtime/appAsToolGateway.js
@@ -16,6 +16,7 @@ import configCache from '../../configCache.js';
 import { isFeatureEnabled } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import ChatService from '../../services/chat/ChatService.js';
+import { getLocalizedString } from '../../utils/localize.js';
 
 const chatService = new ChatService();
 
@@ -64,10 +65,7 @@ function buildToolParameters(app) {
 
 function localizedDescription(app, language = 'en') {
   if (!app.description) return `Invoke iHub app ${app.id}.`;
-  if (typeof app.description === 'string') return app.description;
-  return (
-    app.description[language] || app.description.en || Object.values(app.description)[0] || app.id
-  );
+  return getLocalizedString(app.description, language, undefined, app.id);
 }
 
 /**
@@ -90,10 +88,7 @@ export async function getAppAsTools(appIds, language = 'en') {
     // schema rejects nested objects ("Starting an object on a scalar field").
     // Other adapters' converters also pass these straight through. Resolve
     // locale here, do NOT re-wrap as a localized object.
-    const appName =
-      typeof app.name === 'string'
-        ? app.name
-        : app.name?.[language] || app.name?.en || Object.values(app.name || {})[0] || app.id;
+    const appName = getLocalizedString(app.name, language, undefined, app.id);
     tools.push({
       id: `app__${appId}`,
       name: `App: ${appName}`,

--- a/server/configCache.js
+++ b/server/configCache.js
@@ -18,6 +18,7 @@ import ApiKeyVerifier from './utils/ApiKeyVerifier.js';
 import tokenStorageService from './services/TokenStorageService.js';
 import { SECRET_FIELDS_BY_TYPE } from './validators/credentialSchema.js';
 import logger from './utils/logger.js';
+import { getLocalizedString } from './utils/localize.js';
 
 /**
  * Resolve environment variables in a string
@@ -242,8 +243,7 @@ function expandToolFunctions(tools = []) {
         // Always extract string value from name (support both string and multilingual object)
         let toolName = tool.name;
         if (typeof toolName === 'object') {
-          // Extract from multilingual object
-          toolName = toolName.en || toolName.de || Object.values(toolName)[0] || tool.id;
+          toolName = getLocalizedString(toolName, 'en', undefined, tool.id);
         } else if (typeof toolName !== 'string') {
           // Fallback to ID if name is neither string nor object
           toolName = tool.id;

--- a/server/routes/admin/sources.js
+++ b/server/routes/admin/sources.js
@@ -21,6 +21,7 @@ import { validateIdForPath } from '../../utils/pathSecurity.js';
 import logger from '../../utils/logger.js';
 import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
+import { getLocalizedString } from '../../utils/localize.js';
 
 /**
  * Initialize source manager singleton
@@ -1553,7 +1554,7 @@ export default function registerAdminSourcesRoutes(app) {
           sourceId: id,
           dependencies: dependencies.map(dep => ({
             appId: dep.id,
-            appName: Object.values(dep.name || {})[0] || dep.id,
+            appName: getLocalizedString(dep.name, 'en', undefined, dep.id),
             type: 'app'
           }))
         });

--- a/server/services/SourceResolutionService.js
+++ b/server/services/SourceResolutionService.js
@@ -1,5 +1,6 @@
 import configCache from '../configCache.js';
 import logger from '../utils/logger.js';
+import { getLocalizedString } from '../utils/localize.js';
 
 /**
  * Source Resolution Service
@@ -143,8 +144,8 @@ class SourceResolutionService {
 
     // Convert localized fields to simple strings for app usage
     const description =
-      this.getLocalizedValue(adminSource.description, language) ||
-      this.getLocalizedValue(adminSource.name, language) ||
+      getLocalizedString(adminSource.description, language) ||
+      getLocalizedString(adminSource.name, language) ||
       adminSource.id;
 
     return {
@@ -160,23 +161,6 @@ class SourceResolutionService {
         strategy: 'static' // Admin sources are typically static
       }
     };
-  }
-
-  /**
-   * Get localized value from localized object or return string directly
-   *
-   * @param {string|object} value - Localized object or string
-   * @param {string} language - Preferred language
-   * @returns {string|null} Localized string or null
-   */
-  getLocalizedValue(value, language = 'en') {
-    if (typeof value === 'string') {
-      return value;
-    }
-    if (typeof value === 'object' && value !== null) {
-      return value[language] || value['en'] || Object.values(value)[0] || null;
-    }
-    return null;
   }
 }
 

--- a/server/services/mcp/McpServerService.js
+++ b/server/services/mcp/McpServerService.js
@@ -8,6 +8,7 @@ import { listMcpResources, readMcpResource } from './resourceAdapter.js';
 import { getVisibleToolIds, toolVisibleInSet } from './permissions.js';
 import { MCP_SCOPES } from './scopes.js';
 import logger from '../../utils/logger.js';
+import { getLocalizedString } from '../../utils/localize.js';
 
 /**
  * Builds and serves the iHub MCP gateway. Each incoming HTTP/SSE request
@@ -330,9 +331,7 @@ function toolErrorResult(message) {
 function extractText(value) {
   if (!value) return '';
   if (typeof value === 'string') return value;
-  if (typeof value === 'object') {
-    return value.en || value.de || Object.values(value)[0] || '';
-  }
+  if (typeof value === 'object') return getLocalizedString(value, 'en');
   return String(value);
 }
 

--- a/server/services/mcp/a2aHandler.js
+++ b/server/services/mcp/a2aHandler.js
@@ -6,6 +6,7 @@ import { runTool, loadConfiguredTools } from '../../toolLoader.js';
 import { getVisibleToolIds, toolVisibleInSet } from './permissions.js';
 import { isValidId } from '../../utils/pathSecurity.js';
 import logger from '../../utils/logger.js';
+import { getLocalizedString } from '../../utils/localize.js';
 
 // Tools that are surfaced as their own A2A skill kinds (apps/workflows) or
 // that wrap filesystem access (skill meta-tools) must never be invocable as
@@ -57,9 +58,7 @@ function rpcError(id, code, message, data) {
 function extractText(value) {
   if (!value) return '';
   if (typeof value === 'string') return value;
-  if (typeof value === 'object') {
-    return value.en || value.de || Object.values(value)[0] || '';
-  }
+  if (typeof value === 'object') return getLocalizedString(value, 'en');
   return String(value);
 }
 

--- a/server/services/mcp/resourceAdapter.js
+++ b/server/services/mcp/resourceAdapter.js
@@ -5,6 +5,7 @@ import { getSkillContent, validateSkillName } from '../../services/skillLoader.j
 import { isValidId } from '../../utils/pathSecurity.js';
 import { getVisibleSourceIds } from './permissions.js';
 import logger from '../../utils/logger.js';
+import { getLocalizedString } from '../../utils/localize.js';
 
 /**
  * Map iHub sources + skills onto MCP `resources/list` + `resources/read`.
@@ -24,9 +25,7 @@ import logger from '../../utils/logger.js';
 function extractText(value) {
   if (!value) return '';
   if (typeof value === 'string') return value;
-  if (typeof value === 'object') {
-    return value.en || value.de || Object.values(value)[0] || '';
-  }
+  if (typeof value === 'object') return getLocalizedString(value, 'en');
   return String(value);
 }
 

--- a/server/services/workflow/chatBridge.js
+++ b/server/services/workflow/chatBridge.js
@@ -17,6 +17,7 @@
  */
 
 import logger from '../../utils/logger.js';
+import { getLocalizedString } from '../../utils/localize.js';
 
 const PENDING_TTL_MS = 10 * 60 * 1000;
 const MAX_PENDING = 200;
@@ -89,8 +90,7 @@ export function buildReplayStepsFromState(state, workflow, language = 'en') {
   const localize = value => {
     if (value == null) return '';
     if (typeof value === 'string') return value;
-    if (typeof value === 'object')
-      return value[language] || value.en || Object.values(value)[0] || '';
+    if (typeof value === 'object') return getLocalizedString(value, language);
     return String(value);
   };
 

--- a/server/services/workflow/executors/HumanNodeExecutor.js
+++ b/server/services/workflow/executors/HumanNodeExecutor.js
@@ -17,6 +17,7 @@ import { BaseNodeExecutor } from './BaseNodeExecutor.js';
 import { v4 as uuidv4 } from 'uuid';
 import { actionTracker } from '../../../actionTracker.js';
 import configCache from '../../../configCache.js';
+import { getLocalizedString } from '../../../utils/localize.js';
 
 /**
  * Executor for human checkpoint nodes.
@@ -296,13 +297,7 @@ export class HumanNodeExecutor extends BaseNodeExecutor {
    * @private
    */
   _getLocalizedValue(value, language) {
-    if (typeof value === 'string') {
-      return value;
-    }
-    if (value && typeof value === 'object') {
-      return value[language] || value.en || Object.values(value)[0] || '';
-    }
-    return '';
+    return getLocalizedString(value, language);
   }
 
   /**

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -24,6 +24,7 @@ import configCache from '../../../configCache.js';
 import WorkflowLLMHelper from '../WorkflowLLMHelper.js';
 import { ContextSummarizer } from '../ContextSummarizer.js';
 import { dedupeCitations } from '../citationUtils.js';
+import { getLocalizedString } from '../../../utils/localize.js';
 import { estimateTokens } from '../../../usageTracker.js';
 import SourceResolutionService from '../../SourceResolutionService.js';
 import { createSourceManager } from '../../../sources/index.js';
@@ -933,13 +934,10 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
    * @private
    */
   getLocalizedValue(value, language) {
-    if (typeof value === 'string') {
-      return value;
+    if (typeof value !== 'string' && (typeof value !== 'object' || value === null)) {
+      return String(value || '');
     }
-    if (typeof value === 'object' && value !== null) {
-      return value[language] || value['en'] || Object.values(value)[0] || '';
-    }
-    return String(value || '');
+    return getLocalizedString(value, language);
   }
 
   /**

--- a/server/sources/SourceManager.js
+++ b/server/sources/SourceManager.js
@@ -6,6 +6,7 @@ import logger from '../utils/logger.js';
 import { httpFetch } from '../utils/httpConfig.js';
 import { resolveAndValidatePath } from '../utils/pathSecurity.js';
 import { recordSourceLoad } from '../telemetry/metrics.js';
+import { getLocalizedString } from '../utils/localize.js';
 
 // Global registry for source tool functions (persists across SourceManager instances)
 const globalSourceToolRegistry = new Map();
@@ -268,26 +269,15 @@ class SourceManager {
           const link = result.link || '';
 
           // Localize description
-          let description = result.description || `Content from ${result.id}`;
-          if (typeof description === 'object') {
-            description =
-              description.en || Object.values(description)[0] || `Content from ${result.id}`;
-          }
+          const description = result.description
+            ? getLocalizedString(result.description, 'en', undefined, `Content from ${result.id}`)
+            : `Content from ${result.id}`;
 
           // Get human-friendly display name
           const language = context.language || 'en';
-          let displayName = result.id; // fallback to ID if no name
-          if (result.name) {
-            if (typeof result.name === 'string') {
-              displayName = result.name;
-            } else if (typeof result.name === 'object' && result.name !== null) {
-              displayName =
-                result.name[language] ||
-                result.name.en ||
-                Object.values(result.name)[0] ||
-                result.id;
-            }
-          }
+          const displayName = result.name
+            ? getLocalizedString(result.name, language, undefined, result.id)
+            : result.id;
 
           sourceEntries.push(
             `  <source id="${result.id}" type="function" name="source_${result.id}" displayName="${displayName}" link="${link}" description="${description}"/>`
@@ -296,11 +286,9 @@ class SourceManager {
           // Prompt-based source - include directly in content (already handled in totalContent)
           // Just add metadata entry to the list
           const link = result.link || '';
-          let description = result.description || `Content from ${result.id}`;
-          if (typeof description === 'object') {
-            description =
-              description.en || Object.values(description)[0] || `Content from ${result.id}`;
-          }
+          const description = result.description
+            ? getLocalizedString(result.description, 'en', undefined, `Content from ${result.id}`)
+            : `Content from ${result.id}`;
 
           sourceEntries.push(
             `  <source id="${result.id}" type="${result.type}" link="${link}" description="${description}"/>`
@@ -347,25 +335,19 @@ class SourceManager {
 
     // Localize description
     const language = context.language || 'en';
-    let description = source.description || `Load content from ${source.type} source: ${source.id}`;
-
-    // Handle multilingual descriptions
-    if (typeof description === 'object' && description[language]) {
-      description = description[language];
-    } else if (typeof description === 'object' && description.en) {
-      description = description.en; // fallback to English
-    }
+    const description = source.description
+      ? getLocalizedString(
+          source.description,
+          language,
+          undefined,
+          `Load content from ${source.type} source: ${source.id}`
+        )
+      : `Load content from ${source.type} source: ${source.id}`;
 
     // Get human-friendly name
-    let displayName = source.id; // fallback to ID if no name
-    if (source.name) {
-      if (typeof source.name === 'string') {
-        displayName = source.name;
-      } else if (typeof source.name === 'object') {
-        displayName =
-          source.name[language] || source.name.en || Object.values(source.name)[0] || source.id;
-      }
-    }
+    const displayName = source.name
+      ? getLocalizedString(source.name, language, undefined, source.id)
+      : source.id;
 
     // Generate tool schema in generic format (will be converted by provider adapters).
     // `id` and `name` both carry the dispatch key so provider formatters that read

--- a/server/tests/localize.test.js
+++ b/server/tests/localize.test.js
@@ -1,0 +1,35 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { getLocalizedString } from '../utils/localize.js';
+
+describe('getLocalizedString', () => {
+  it('returns a plain string as-is', () => {
+    assert.strictEqual(getLocalizedString('hello', 'en'), 'hello');
+  });
+
+  it('returns the exact-language value when present', () => {
+    assert.strictEqual(getLocalizedString({ en: 'Hello', de: 'Hallo' }, 'de'), 'Hallo');
+  });
+
+  it('falls back to the given fallback language when the requested one is missing', () => {
+    assert.strictEqual(getLocalizedString({ en: 'Hello', fr: 'Bonjour' }, 'de', 'en'), 'Hello');
+  });
+
+  it('falls back to the first available string value when neither language matches', () => {
+    assert.strictEqual(getLocalizedString({ fr: 'Bonjour' }, 'de', 'en'), 'Bonjour');
+  });
+
+  it('returns the explicit fallback value when nothing is resolvable', () => {
+    assert.strictEqual(getLocalizedString(undefined, 'en', 'en', 'fallback-id'), 'fallback-id');
+    assert.strictEqual(getLocalizedString({}, 'en', 'en', 'fallback-id'), 'fallback-id');
+    assert.strictEqual(getLocalizedString(null, 'en', 'en', 'fallback-id'), 'fallback-id');
+  });
+
+  it('defaults the fallback value to an empty string', () => {
+    assert.strictEqual(getLocalizedString(undefined, 'en'), '');
+  });
+
+  it('ignores non-string values when picking the first available entry', () => {
+    assert.strictEqual(getLocalizedString({ count: 3, fr: 'Bonjour' }, 'de', 'en'), 'Bonjour');
+  });
+});

--- a/server/toolLoader.js
+++ b/server/toolLoader.js
@@ -6,6 +6,7 @@ import { isFeatureEnabled } from './featureRegistry.js';
 import { isValidId } from './utils/pathSecurity.js';
 import mcpClientManager from './services/mcp/McpClientManager.js';
 import logger from './utils/logger.js';
+import { getLocalizedString } from './utils/localize.js';
 
 /**
  * Build JSON Schema parameters from a workflow's start node inputVariables
@@ -65,7 +66,7 @@ function buildWorkflowToolParams(workflow, language = 'en') {
           description:
             typeof descriptionRaw === 'string'
               ? descriptionRaw
-              : extractLanguageValue(descriptionRaw, language)
+              : getLocalizedString(descriptionRaw, language)
         };
 
         // Enrich select types with enum values so the LLM knows valid choices
@@ -88,39 +89,6 @@ function buildWorkflowToolParams(workflow, language = 'en') {
     properties,
     required
   };
-}
-
-/**
- * Extract language-specific value from a multilingual object or return the value as-is
- * @param {any} value - Value that might be a multilingual object {en: "...", de: "..."}
- * @param {string} language - Target language (e.g., 'en', 'de')
- * @param {string} fallbackLanguage - Fallback language (default: 'en')
- * @returns {any} - Language-specific value or original value
- */
-function extractLanguageValue(value, language = 'en', fallbackLanguage = null) {
-  // Get platform default language if not provided
-  if (!fallbackLanguage) {
-    const platformConfig = configCache.getPlatform() || {};
-    fallbackLanguage = platformConfig?.defaultLanguage || 'en';
-  }
-  if (value && typeof value === 'object' && !Array.isArray(value)) {
-    // Check if this looks like a multilingual object
-    if (value[language] !== undefined) {
-      return value[language];
-    }
-    if (value[fallbackLanguage] !== undefined) {
-      return value[fallbackLanguage];
-    }
-    // If it has language keys but not the requested one, try first available
-    const availableLanguages = Object.keys(value).filter(
-      key => typeof value[key] === 'string' && key.length === 2
-    );
-    if (availableLanguages.length > 0) {
-      return value[availableLanguages[0]];
-    }
-  }
-
-  return value;
 }
 
 /**
@@ -154,7 +122,7 @@ function extractLanguageFromObject(obj, language = 'en', fallbackLanguage = null
         Object.keys(value).some(k => k.length === 2 && typeof value[k] === 'string')
       ) {
         // This is a multilingual field - an object with language codes as keys
-        result[key] = extractLanguageValue(value, language, fallbackLanguage);
+        result[key] = getLocalizedString(value, language, fallbackLanguage);
       } else {
         result[key] = extractLanguageFromObject(value, language, fallbackLanguage);
       }
@@ -413,11 +381,11 @@ export async function getToolsForApp(app, language = null, context = {}) {
         const wf = configCache.getWorkflowById(wfId);
         if (!wf || wf.enabled === false || !wf.chatIntegration?.enabled) continue;
 
-        let toolDescription = extractLanguageValue(
+        let toolDescription = getLocalizedString(
           wf.chatIntegration?.toolDescription || wf.description,
           language || 'en'
         );
-        const toolName = extractLanguageValue(wf.name, language || 'en');
+        const toolName = getLocalizedString(wf.name, language || 'en');
 
         // If the workflow has file/image input variables, hint that attached files
         // are passed automatically so the LLM knows to call this tool
@@ -468,8 +436,8 @@ export async function getToolsForApp(app, language = null, context = {}) {
 
     appTools.push({
       id: 'activate_skill',
-      name: extractLanguageValue({ en: 'Activate Skill', de: 'Skill aktivieren' }, lang),
-      description: extractLanguageValue(activateDesc, lang),
+      name: getLocalizedString({ en: 'Activate Skill', de: 'Skill aktivieren' }, lang),
+      description: getLocalizedString(activateDesc, lang),
       isInternalTool: true,
       parameters: {
         type: 'object',
@@ -485,8 +453,8 @@ export async function getToolsForApp(app, language = null, context = {}) {
 
     appTools.push({
       id: 'read_skill_resource',
-      name: extractLanguageValue({ en: 'Read Skill Resource', de: 'Skill-Ressource lesen' }, lang),
-      description: extractLanguageValue(readDesc, lang),
+      name: getLocalizedString({ en: 'Read Skill Resource', de: 'Skill-Ressource lesen' }, lang),
+      description: getLocalizedString(readDesc, lang),
       isInternalTool: true,
       parameters: {
         type: 'object',

--- a/server/tools/workflowRunner.js
+++ b/server/tools/workflowRunner.js
@@ -18,20 +18,13 @@ import { actionTracker } from '../actionTracker.js';
 import { clients } from '../sse.js';
 import configCache from '../configCache.js';
 import logger from '../utils/logger.js';
+import { getLocalizedString } from '../utils/localize.js';
 
 /** Maps chatId → { executionId, engine } for active workflow executions in chat */
 export const activeWorkflowExecutions = new Map();
 
-/**
- * Extract a plain string from a localized object or return as-is
- * @param {string|Object} value - Plain string or { en: "...", de: "..." }
- * @param {string} lang - Preferred language
- * @returns {string}
- */
 function resolveLocalized(value, lang = 'en') {
-  if (!value) return '';
-  if (typeof value === 'string') return value;
-  return value[lang] || value.en || Object.values(value)[0] || '';
+  return getLocalizedString(value, lang);
 }
 
 /**

--- a/server/utils/localize.js
+++ b/server/utils/localize.js
@@ -1,0 +1,43 @@
+/**
+ * Shared localized-string resolution.
+ *
+ * Every call site that resolves a `{en: "...", de: "..."}`-shaped value to a
+ * plain string for the current request language should go through
+ * `getLocalizedString` instead of reimplementing the fallback chain.
+ */
+
+import configCache from '../configCache.js';
+
+function resolvePlatformDefaultLanguage() {
+  try {
+    return configCache.getPlatform()?.defaultLanguage || 'en';
+  } catch {
+    return 'en';
+  }
+}
+
+/**
+ * Resolve a localized value to a plain string.
+ *
+ * Resolution order: `value[language]` → `value[fallbackLanguage]` (defaults to
+ * the platform's configured default language) → the first string-valued
+ * entry in `value` → `fallbackValue`.
+ *
+ * @param {string|Object|null|undefined} value - Plain string or localized object
+ * @param {string} [language='en'] - Preferred language code
+ * @param {string} [fallbackLanguage] - Fallback language code; defaults to the platform default language
+ * @param {string} [fallbackValue=''] - Returned when nothing resolvable is found
+ * @returns {string}
+ */
+export function getLocalizedString(value, language = 'en', fallbackLanguage, fallbackValue = '') {
+  if (typeof value === 'string') return value;
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return fallbackValue;
+
+  if (typeof value[language] === 'string') return value[language];
+
+  const resolvedFallbackLanguage = fallbackLanguage || resolvePlatformDefaultLanguage();
+  if (typeof value[resolvedFallbackLanguage] === 'string') return value[resolvedFallbackLanguage];
+
+  const firstString = Object.values(value).find(v => typeof v === 'string');
+  return firstString !== undefined ? firstString : fallbackValue;
+}

--- a/server/utils/sourceDependencyTracker.js
+++ b/server/utils/sourceDependencyTracker.js
@@ -1,5 +1,6 @@
 import configCache from '../configCache.js';
 import logger from './logger.js';
+import { getLocalizedString } from './localize.js';
 
 /**
  * Source Dependency Tracker
@@ -101,15 +102,7 @@ class SourceDependencyTracker {
    * @returns {string} Localized app name
    */
   static getAppName(app, language = 'en') {
-    if (typeof app.name === 'string') {
-      return app.name;
-    }
-
-    if (typeof app.name === 'object') {
-      return app.name[language] || app.name['en'] || Object.values(app.name)[0] || app.id;
-    }
-
-    return app.id;
+    return getLocalizedString(app.name, language, undefined, app.id);
   }
 
   /**
@@ -283,17 +276,7 @@ class SourceDependencyTracker {
    * @returns {string} Source name
    */
   static getSourceName(source, language = 'en') {
-    if (typeof source.name === 'string') {
-      return source.name;
-    }
-
-    if (typeof source.name === 'object') {
-      return (
-        source.name[language] || source.name['en'] || Object.values(source.name)[0] || source.id
-      );
-    }
-
-    return source.id;
+    return getLocalizedString(source.name, language, undefined, source.id);
   }
 
   /**


### PR DESCRIPTION
## Summary

Closes #1750.

The pattern `value[lang] || value.en || Object.values(value)[0] || fallback` for resolving a `{en: "...", de: "..."}`-shaped localized field to a plain string was reimplemented in ~15 places across the server, under several different names (`extractLanguageValue`, `getLocalizedValue`, `_getLocalizedValue`, `resolveLocalized`, `extractText`, and various inline copies) with slightly different fallback behavior at each call site.

This PR introduces a single shared `getLocalizedString(value, language, fallbackLanguage, fallbackValue)` in `server/utils/localize.js` and replaces all the named variants and inline occurrences with it.

### Files touched

- **New:** `server/utils/localize.js` (shared utility), `server/tests/localize.test.js` (unit tests)
- `server/toolLoader.js` — removed the local `extractLanguageValue`, replaced all call sites
- `server/services/SourceResolutionService.js` — removed `getLocalizedValue` method
- `server/agents/runtime/appAsToolGateway.js` — removed `localizedDescription`'s inline logic and the duplicate `appName` extraction
- `server/sources/SourceManager.js` — two duplicated description/displayName blocks
- `server/configCache.js` — inline tool-name extraction in `expandToolFunctions`
- `server/utils/sourceDependencyTracker.js` — `getAppName` / `getSourceName`
- `server/tools/workflowRunner.js` — `resolveLocalized`
- `server/services/workflow/chatBridge.js` — inline `localize` helper
- `server/services/workflow/executors/{PromptNodeExecutor,HumanNodeExecutor}.js` — swapped the private `getLocalizedValue`/`_getLocalizedValue` methods to delegate to the shared helper (deeper consolidation of these executors is tracked separately in #1748, per that issue's scope)
- `server/services/mcp/{a2aHandler,McpServerService,resourceAdapter}.js` — identical `extractText` helpers
- `server/adapters/toolCalling/GenericToolCalling.js` — Google schema description sanitization
- `server/routes/admin/sources.js` — dependency `appName` extraction

`server/agents/profile/profileWorkflowSerializer.js`'s `localizedToString`/`isLocalizedNonEmpty` was deliberately **not** folded in — it has different semantics (a fallback value used on a blank string, not just a missing key), used for runtime prompt-slot defaults.

### Behavior note

Several call sites previously hardcoded a second-choice language before falling back to "first available value" (e.g. `value.en || value.de || ...`, or in `configCache.js`'s `expandToolFunctions`, `toolName.en || toolName.de || ...`). These now fall back to the platform's configured default language instead, matching `toolLoader.js`'s existing (most complete) behavior. This only changes behavior on a platform where `defaultLanguage` is set to something other than `en`/`de`, and only for values that have neither the exact requested language nor `en` (`SourceManager.js`'s description path was the one place that also gained a genuine bug fix: it previously left the raw multilingual object in place — never actually resolving to a string — when neither the requested language nor `en` was present).

## Test plan

- [x] Added `server/tests/localize.test.js` covering string passthrough, exact-language hit, fallback-language hit, first-available-value fallback, and the fully-missing case with an explicit fallback value — all pass (`node server/tests/localize.test.js`)
- [x] Existing `server/tests/toolLoader-localization.test.js` still passes unchanged
- [x] `npx eslint` on all changed files — 0 errors (1 pre-existing, unrelated warning in `PromptNodeExecutor.js`)
- [x] `npx prettier --write` on all changed files — no changes needed
- [x] Full server Jest suite run — no new failures introduced (pre-existing failures are all `node:test`-style suites that are unrunnable under Jest by design, same as before this change)


---
_Generated by [Claude Code](https://claude.ai/code/session_011R3A7kpaUKfU7zVDykjsKD)_