### PR TITLE
refactor(workflow): consolidate path resolution and single-shot LLM boilerplate

### DIFF
--- a/server/services/workflow/DAGScheduler.js
+++ b/server/services/workflow/DAGScheduler.js
@@ -1,5 +1,6 @@
 import logger from '../../utils/logger.js';
 import { evaluateBooleanExpression } from './expressionEvaluator.js';
+import { resolveDotPath } from './pathResolver.js';
 
 /**
  * DAGScheduler handles dependency resolution and execution ordering for workflow graphs.
@@ -553,31 +554,7 @@ export class DAGScheduler {
       return undefined;
     }
 
-    const parts = path.split('.');
-    let current = context;
-
-    for (const part of parts) {
-      if (current === null || current === undefined) {
-        return undefined;
-      }
-
-      // Handle array access (e.g., "items[0]")
-      const arrayMatch = part.match(/^(\w+)\[(\d+)\]$/);
-      if (arrayMatch) {
-        const [, arrayName, indexStr] = arrayMatch;
-        const index = parseInt(indexStr, 10);
-        current = current[arrayName];
-        if (Array.isArray(current)) {
-          current = current[index];
-        } else {
-          return undefined;
-        }
-      } else {
-        current = current[part];
-      }
-    }
-
-    return current;
+    return resolveDotPath(path, context);
   }
 
   /**

--- a/server/services/workflow/WorkflowLLMHelper.js
+++ b/server/services/workflow/WorkflowLLMHelper.js
@@ -219,6 +219,63 @@ export class WorkflowLLMHelper {
   }
 
   /**
+   * Verify the API key, then execute a single non-streaming-loop LLM call and
+   * return a uniform success/error result — the "verify → call → catch"
+   * boilerplate that several node executors (query-plan, quote validator)
+   * used to hand-roll independently.
+   *
+   * Pass an already-resolved `apiKey` to skip verification (e.g. a caller
+   * that verifies once and then calls this in a loop with the same key).
+   * Only use this for genuinely single-shot calls — NOT inside a tool-use
+   * loop, which needs the raw `executeStreamingRequest` result (tool calls,
+   * finish reason, etc.) rather than this helper's collapsed `{content}`.
+   *
+   * @param {Object} params - Request parameters
+   * @param {Object} params.model - Model configuration
+   * @param {Array} params.messages - Messages to send
+   * @param {string} [params.apiKey] - Pre-verified API key; verifies via
+   *   `verifyApiKey` when omitted
+   * @param {Object} [params.options] - Request options (will be filtered)
+   * @param {string} [params.language='en'] - Language for error messages
+   * @param {string} [params.errorLabel='LLM call'] - Prefix used in the
+   *   error message on both verification and call failure
+   * @returns {Promise<{success: true, content: string, response: Object}|{success: false, error: string}>}
+   */
+  async runSingleShotLLM({
+    model,
+    messages,
+    apiKey,
+    options = {},
+    language = 'en',
+    errorLabel = 'LLM call'
+  }) {
+    let resolvedApiKey = apiKey;
+    if (!resolvedApiKey) {
+      const apiKeyResult = await this.verifyApiKey(model, language);
+      if (!apiKeyResult.success) {
+        return {
+          success: false,
+          error: apiKeyResult.error?.message || `API key verification failed for ${errorLabel}`
+        };
+      }
+      resolvedApiKey = apiKeyResult.apiKey;
+    }
+
+    try {
+      const response = await this.executeStreamingRequest({
+        model,
+        messages,
+        apiKey: resolvedApiKey,
+        options,
+        language
+      });
+      return { success: true, content: response?.content || '', response };
+    } catch (err) {
+      return { success: false, error: `${errorLabel} failed: ${err.message}` };
+    }
+  }
+
+  /**
    * Execute a streaming LLM request with proper option filtering and error handling.
    *
    * @param {Object} params - Request parameters

--- a/server/services/workflow/executors/BaseNodeExecutor.js
+++ b/server/services/workflow/executors/BaseNodeExecutor.js
@@ -13,6 +13,7 @@
 
 import logger from '../../../utils/logger.js';
 import promptService from '../../PromptService.js';
+import { resolveDotPath } from '../pathResolver.js';
 
 /**
  * Execution result returned by node executors
@@ -124,44 +125,16 @@ export class BaseNodeExecutor {
       return path;
     }
 
-    // Remove the leading '$.' and split into parts
+    // Remove the leading '$.' and resolve the remainder against the state object
     const normalizedPath = path.startsWith('$.') ? path.slice(2) : path.slice(1);
-    const parts = normalizedPath.split('.');
-
-    // Navigate through the state object
-    let current = state;
-    for (const part of parts) {
-      if (current === null || current === undefined) {
-        this.logger.debug('Variable path resolved to undefined', {
-          component: 'BaseNodeExecutor',
-          path,
-          part
-        });
-        return undefined;
-      }
-
-      // Handle array index notation (e.g., items[0])
-      const arrayMatch = part.match(/^(\w+)\[(\d+)\]$/);
-      if (arrayMatch) {
-        const [, arrayName, indexStr] = arrayMatch;
-        const index = parseInt(indexStr, 10);
-        current = current[arrayName];
-        if (Array.isArray(current)) {
-          current = current[index];
-        } else {
-          this.logger.debug('Expected array at path but found non-array', {
-            component: 'BaseNodeExecutor',
-            arrayName,
-            foundType: typeof current
-          });
-          return undefined;
-        }
-      } else {
-        current = current[part];
-      }
+    const value = resolveDotPath(normalizedPath, state);
+    if (value === undefined) {
+      this.logger.debug('Variable path resolved to undefined', {
+        component: 'BaseNodeExecutor',
+        path
+      });
     }
-
-    return current;
+    return value;
   }
 
   /**

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -22,6 +22,7 @@ import { actionTracker } from '../../../actionTracker.js';
 import { getToolsForApp, runTool, resolveNativeWebSearchProvider } from '../../../toolLoader.js';
 import configCache from '../../../configCache.js';
 import WorkflowLLMHelper from '../WorkflowLLMHelper.js';
+import { resolveDotPath } from '../pathResolver.js';
 import { ContextSummarizer } from '../ContextSummarizer.js';
 import { dedupeCitations } from '../citationUtils.js';
 import { estimateTokens } from '../../../usageTracker.js';
@@ -1113,17 +1114,7 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
    * @private
    */
   getNestedValue(path, obj) {
-    const parts = path.split('.');
-    let current = obj;
-
-    for (const part of parts) {
-      if (current === undefined || current === null) {
-        return undefined;
-      }
-      current = current[part];
-    }
-
-    return current;
+    return resolveDotPath(path, obj);
   }
 
   /**

--- a/server/services/workflow/executors/QueryPlanNodeExecutor.js
+++ b/server/services/workflow/executors/QueryPlanNodeExecutor.js
@@ -78,14 +78,6 @@ export class QueryPlanNodeExecutor extends BaseNodeExecutor {
     if (!model) {
       return this.createErrorResult('No model available for query planning', { nodeId: node.id });
     }
-    const apiKeyResult = await this.llmHelper.verifyApiKey(model, language);
-    if (!apiKeyResult.success) {
-      return this.createErrorResult(
-        apiKeyResult.error?.message || 'API key verification failed for query-plan',
-        { nodeId: node.id }
-      );
-    }
-
     const system =
       `You build search-query plans for an enterprise document index (iFinder, Elasticsearch-style query DSL). ` +
       `Given a user question and optional topic seeds, produce a plan that maximises recall over a permitted, indexed corpus. ` +
@@ -111,24 +103,20 @@ export class QueryPlanNodeExecutor extends BaseNodeExecutor {
       );
     }
 
-    let plan = null;
-    try {
-      const response = await this.llmHelper.executeStreamingRequest({
-        model,
-        messages: [
-          { role: 'system', content: system },
-          { role: 'user', content: userParts.join('\n\n') }
-        ],
-        apiKey: apiKeyResult.apiKey,
-        options: { temperature: 0.2, ...thinkingConfigToOptions(config.thinking) },
-        language
-      });
-      plan = parsePlan(response?.content || '');
-    } catch (err) {
-      return this.createErrorResult(`query-plan LLM call failed: ${err.message}`, {
-        nodeId: node.id
-      });
+    const llmResult = await this.llmHelper.runSingleShotLLM({
+      model,
+      messages: [
+        { role: 'system', content: system },
+        { role: 'user', content: userParts.join('\n\n') }
+      ],
+      options: { temperature: 0.2, ...thinkingConfigToOptions(config.thinking) },
+      language,
+      errorLabel: 'query-plan LLM call'
+    });
+    if (!llmResult.success) {
+      return this.createErrorResult(llmResult.error, { nodeId: node.id });
     }
+    const plan = parsePlan(llmResult.content);
 
     if (!plan) {
       return this.createErrorResult('query-plan: LLM returned no parseable plan', {

--- a/server/services/workflow/executors/QuoteValidatorNodeExecutor.js
+++ b/server/services/workflow/executors/QuoteValidatorNodeExecutor.js
@@ -148,23 +148,24 @@ export class QuoteValidatorNodeExecutor extends BaseNodeExecutor {
           apiKey = resolved.apiKey;
         }
 
-        try {
-          const { system, user } = buildLlmVerdictPrompt({
-            quoteText: decision.text,
-            sourceWindow: sourceText
-          });
-          const response = await this.llmHelper.executeStreamingRequest({
-            model,
-            messages: [
-              { role: 'system', content: system },
-              { role: 'user', content: user }
-            ],
-            apiKey,
-            options: { temperature: 0.1 },
-            language
-          });
+        const { system, user } = buildLlmVerdictPrompt({
+          quoteText: decision.text,
+          sourceWindow: sourceText
+        });
+        const llmResult = await this.llmHelper.runSingleShotLLM({
+          model,
+          messages: [
+            { role: 'system', content: system },
+            { role: 'user', content: user }
+          ],
+          apiKey,
+          options: { temperature: 0.1 },
+          language,
+          errorLabel: `LLM verdict for quote ${decision.index}`
+        });
+        if (llmResult.success) {
           llmCalls++;
-          const verdict = parseLlmQuoteVerdict(response?.content || '');
+          const verdict = parseLlmQuoteVerdict(llmResult.content);
           updatedRecord.quotes[decision.index] = {
             ...original,
             validated: verdict.validated,
@@ -174,7 +175,7 @@ export class QuoteValidatorNodeExecutor extends BaseNodeExecutor {
           if (verdict.validated) {
             coverage.quotesValidated = (coverage.quotesValidated || 0) + 1;
           }
-        } catch (err) {
+        } else {
           updatedRecord.quotes[decision.index] = {
             ...original,
             validated: false,
@@ -182,7 +183,7 @@ export class QuoteValidatorNodeExecutor extends BaseNodeExecutor {
           };
           updatedRecord.failures.push({
             code: 'QUOTE_LLM_ERROR',
-            message: `LLM verdict failed for quote ${decision.index}: ${err.message}`
+            message: llmResult.error
           });
         }
       }

--- a/server/services/workflow/executors/TransformNodeExecutor.js
+++ b/server/services/workflow/executors/TransformNodeExecutor.js
@@ -20,6 +20,7 @@ import { deepMerge } from '../../../utils/deepMerge.js';
 import memoryFile from '../../../agents/memory/memoryFile.js';
 import { AGENT_PROFILE_ID_PATTERN } from '../../../validators/agentProfileSchema.js';
 import { evaluateBooleanExpression } from '../expressionEvaluator.js';
+import { resolveDotPath } from '../pathResolver.js';
 
 const SECTION_HEADING_RE = /^##\s+(.+?)\s*$/;
 
@@ -635,18 +636,7 @@ export class TransformNodeExecutor extends BaseNodeExecutor {
     if (!path || typeof path !== 'string') {
       return undefined;
     }
-
-    const parts = path.split('.');
-    let current = obj;
-
-    for (const part of parts) {
-      if (current === undefined || current === null) {
-        return undefined;
-      }
-      current = current[part];
-    }
-
-    return current;
+    return resolveDotPath(path, obj);
   }
 
   /**

--- a/server/services/workflow/expressionEvaluator.js
+++ b/server/services/workflow/expressionEvaluator.js
@@ -31,6 +31,8 @@
  * @module services/workflow/expressionEvaluator
  */
 
+import { resolveDotPath } from './pathResolver.js';
+
 /* ───────────────────────── Path resolution ───────────────────────── */
 
 /**
@@ -54,20 +56,7 @@ export function resolvePath(path, state) {
     segments = ['data', 'nodeResults', rawParts[1], 'output', ...rawParts.slice(2)];
   }
 
-  let current = state;
-  for (const part of segments) {
-    if (current === null || current === undefined) return undefined;
-    const arrayMatch = part.match(/^(\w+)\[(\d+)\]$/);
-    if (arrayMatch) {
-      const [, name, idx] = arrayMatch;
-      current = current[name];
-      if (!Array.isArray(current)) return undefined;
-      current = current[Number.parseInt(idx, 10)];
-    } else {
-      current = current[part];
-    }
-  }
-  return current;
+  return resolveDotPath(segments, state);
 }
 
 /* ───────────────────────── Tokenizer ────────────────────────────── */

--- a/server/services/workflow/pathResolver.js
+++ b/server/services/workflow/pathResolver.js
@@ -1,0 +1,56 @@
+/**
+ * Shared dot-notation / bracket-array-index path resolver.
+ *
+ * Four call sites (BaseNodeExecutor.resolveVariable, DAGScheduler._getValueFromPath,
+ * TransformNodeExecutor/PromptNodeExecutor.getNestedValue, expressionEvaluator.resolvePath)
+ * used to hand-roll this traversal independently and had drifted: two of them
+ * supported `items[0]` array-index segments and two silently treated `items[0]`
+ * as a literal (always-undefined) property key. This module is the single
+ * traversal implementation; callers keep their own pre-processing (`$.`-prefix
+ * stripping, `nodeOutputs` remapping, literal-fallback semantics) and delegate
+ * the actual walk here.
+ *
+ * @module services/workflow/pathResolver
+ */
+
+const ARRAY_INDEX_RE = /^(\w+)\[(\d+)\]$/;
+
+/**
+ * Resolve a dot-notation path (optionally with `name[idx]` array-index
+ * segments) against a root object.
+ *
+ * @param {string|string[]} pathOrParts - Dot-notation path (e.g. "a.b.items[0].c")
+ *   or a pre-split array of path segments.
+ * @param {*} root - Object to traverse.
+ * @returns {*} Resolved value, or undefined if any segment is missing or a
+ *   bracketed segment doesn't resolve to an array.
+ */
+export function resolveDotPath(pathOrParts, root) {
+  let parts;
+  if (Array.isArray(pathOrParts)) {
+    parts = pathOrParts;
+  } else if (typeof pathOrParts === 'string' && pathOrParts) {
+    parts = pathOrParts.split('.');
+  } else {
+    return undefined;
+  }
+
+  let current = root;
+  for (const part of parts) {
+    if (current === null || current === undefined) {
+      return undefined;
+    }
+    const arrayMatch = part.match(ARRAY_INDEX_RE);
+    if (arrayMatch) {
+      const [, name, indexStr] = arrayMatch;
+      current = current[name];
+      if (!Array.isArray(current)) {
+        return undefined;
+      }
+      current = current[Number.parseInt(indexStr, 10)];
+    } else {
+      current = current[part];
+    }
+  }
+  return current;
+}

--- a/server/tests/pathResolver.test.js
+++ b/server/tests/pathResolver.test.js
@@ -1,0 +1,94 @@
+// Plain-node test (node server/tests/pathResolver.test.js).
+// Covers the shared resolveDotPath() used by BaseNodeExecutor.resolveVariable,
+// DAGScheduler._getValueFromPath, TransformNodeExecutor/PromptNodeExecutor's
+// getNestedValue, and expressionEvaluator.resolvePath. Before consolidation
+// these four disagreed on `items[0]` array-index support; this test asserts
+// they now behave identically through the shared resolver.
+import { resolveDotPath } from '../services/workflow/pathResolver.js';
+import { BaseNodeExecutor } from '../services/workflow/executors/BaseNodeExecutor.js';
+import { TransformNodeExecutor } from '../services/workflow/executors/TransformNodeExecutor.js';
+import { PromptNodeExecutor } from '../services/workflow/executors/PromptNodeExecutor.js';
+import { resolvePath } from '../services/workflow/expressionEvaluator.js';
+
+let failures = 0;
+function check(label, cond, detail) {
+  if (!cond) failures++;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && detail) console.log('   ' + detail);
+}
+
+function run() {
+  // --- resolveDotPath: core traversal ---
+  const obj = { a: { b: { c: 42 } }, items: [{ id: 'x' }, { id: 'y' }], list: [1, 2, 3] };
+
+  check('resolves a plain dot path', resolveDotPath('a.b.c', obj) === 42);
+  check('resolves an array-index segment', resolveDotPath('items[1].id', obj) === 'y');
+  check('returns undefined for missing path', resolveDotPath('a.missing.c', obj) === undefined);
+  check(
+    'returns undefined when bracket segment is not an array',
+    resolveDotPath('a[0]', obj) === undefined
+  );
+  check('accepts a pre-split parts array', resolveDotPath(['a', 'b', 'c'], obj) === 42);
+  check('returns undefined for empty path', resolveDotPath('', obj) === undefined);
+  check('returns undefined for non-string/array path', resolveDotPath(null, obj) === undefined);
+
+  // --- BaseNodeExecutor.resolveVariable: $-prefixed, literal fallback ---
+  const base = new BaseNodeExecutor();
+  const state = { data: { items: [{ id: 'x' }, { id: 'y' }] } };
+  check(
+    'resolveVariable returns literal for non-$ path',
+    base.resolveVariable('plain-literal', state) === 'plain-literal'
+  );
+  check(
+    'resolveVariable resolves $.data.items[1].id',
+    base.resolveVariable('$.data.items[1].id', state) === 'y'
+  );
+  check(
+    'resolveVariable returns undefined for missing $ path',
+    base.resolveVariable('$.data.missing', state) === undefined
+  );
+
+  // --- TransformNodeExecutor.getNestedValue: now supports items[0] ---
+  const transform = new TransformNodeExecutor();
+  const flatData = { items: [{ id: 'x' }, { id: 'y' }] };
+  check(
+    'TransformNodeExecutor.getNestedValue supports items[0] (previously unsupported)',
+    transform.getNestedValue('items[1].id', flatData) === 'y'
+  );
+  check(
+    'TransformNodeExecutor.getNestedValue still supports dot-numeric index (items.0.id)',
+    transform.getNestedValue('items.0.id', flatData) === 'x'
+  );
+
+  // --- PromptNodeExecutor.getNestedValue: same parity ---
+  const prompt = new PromptNodeExecutor();
+  check(
+    'PromptNodeExecutor.getNestedValue supports items[0] (previously unsupported)',
+    prompt.getNestedValue('items[1].id', flatData) === 'y'
+  );
+
+  // --- expressionEvaluator.resolvePath: $ prefix + nodeOutputs remap preserved ---
+  const exprState = {
+    data: {
+      items: [{ id: 'x' }, { id: 'y' }],
+      nodeResults: { agent1: { output: { response: 'hi' } } }
+    }
+  };
+  check(
+    'resolvePath resolves $.data.items[1].id',
+    resolvePath('$.data.items[1].id', exprState) === 'y'
+  );
+  check(
+    'resolvePath still remaps $.nodeOutputs.agent1.response',
+    resolvePath('$.nodeOutputs.agent1.response', exprState) === 'hi'
+  );
+  check(
+    'resolvePath returns undefined for a non-$ path',
+    resolvePath('data.items', exprState) === undefined
+  );
+
+  console.log(`\n${failures === 0 ? '✅ all passed' : `❌ ${failures} failed`}`);
+  process.exit(failures ? 1 : 0);
+}
+
+run();

--- a/server/tests/workflow-run-single-shot-llm.test.js
+++ b/server/tests/workflow-run-single-shot-llm.test.js
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+
+/**
+ * Tests for WorkflowLLMHelper.runSingleShotLLM — the shared "verify API key →
+ * execute a single request → return a uniform result" helper that replaced
+ * hand-rolled copies in QueryPlanNodeExecutor and QuoteValidatorNodeExecutor.
+ *
+ * Run directly: `node server/tests/workflow-run-single-shot-llm.test.js`.
+ */
+
+import { WorkflowLLMHelper } from '../services/workflow/WorkflowLLMHelper.js';
+
+let failures = 0;
+function check(label, cond, details) {
+  if (!cond) failures += 1;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && details) console.log(`   ${details}`);
+}
+
+async function run() {
+  const model = { id: 'test-model' };
+
+  {
+    // Verifies then calls, returning { success: true, content }.
+    const helper = new WorkflowLLMHelper();
+    helper.verifyApiKey = async () => ({ success: true, apiKey: 'k' });
+    let capturedApiKey = null;
+    helper.executeStreamingRequest = async ({ apiKey }) => {
+      capturedApiKey = apiKey;
+      return { content: 'hello', usage: { input_tokens: 1 } };
+    };
+    const result = await helper.runSingleShotLLM({ model, messages: [] });
+    check('success result carries content', result.success === true && result.content === 'hello');
+    check('uses the apiKey returned by verifyApiKey', capturedApiKey === 'k');
+  }
+
+  {
+    // Pre-verified apiKey skips verifyApiKey entirely (loop-reuse case).
+    const helper = new WorkflowLLMHelper();
+    let verifyCalls = 0;
+    helper.verifyApiKey = async () => {
+      verifyCalls += 1;
+      return { success: true, apiKey: 'unused' };
+    };
+    helper.executeStreamingRequest = async ({ apiKey }) => ({ content: `echo:${apiKey}` });
+    const result = await helper.runSingleShotLLM({ model, messages: [], apiKey: 'preresolved' });
+    check('skips verifyApiKey when apiKey is pre-supplied', verifyCalls === 0);
+    check('uses the pre-supplied apiKey', result.content === 'echo:preresolved');
+  }
+
+  {
+    // API key verification failure surfaces as a labeled error result, not a throw.
+    const helper = new WorkflowLLMHelper();
+    helper.verifyApiKey = async () => ({ success: false, error: null });
+    const result = await helper.runSingleShotLLM({
+      model,
+      messages: [],
+      errorLabel: 'query-plan LLM call'
+    });
+    check('failure result has success: false', result.success === false);
+    check(
+      'falls back to a labeled message when verifyApiKey has no error.message',
+      result.error === 'API key verification failed for query-plan LLM call',
+      result.error
+    );
+  }
+
+  {
+    // A thrown executeStreamingRequest error becomes a labeled error result.
+    const helper = new WorkflowLLMHelper();
+    helper.verifyApiKey = async () => ({ success: true, apiKey: 'k' });
+    helper.executeStreamingRequest = async () => {
+      throw new Error('network blip');
+    };
+    const result = await helper.runSingleShotLLM({
+      model,
+      messages: [],
+      errorLabel: 'query-plan LLM call'
+    });
+    check('call failure result has success: false', result.success === false);
+    check(
+      'call failure message matches "<label> failed: <message>"',
+      result.error === 'query-plan LLM call failed: network blip',
+      result.error
+    );
+  }
+
+  console.log(`\n${failures === 0 ? '✅ all passed' : `❌ ${failures} failed`}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+await run();


### PR DESCRIPTION
## Summary

Fixes #1748 (partially — see "Follow-up" below).

Two independent duplication clusters flagged in the issue:

**(a) Shared path resolver** — `BaseNodeExecutor.resolveVariable`, `DAGScheduler._getValueFromPath`, `TransformNodeExecutor`/`PromptNodeExecutor.getNestedValue`, and `expressionEvaluator.resolvePath` each hand-rolled the same dot-notation traversal and had already drifted: two of them supported `items[0]` array-index segments, two silently treated `items[0]` as a literal (always-undefined) property key. Added `server/services/workflow/pathResolver.js` exporting a single `resolveDotPath(pathOrParts, root)` and migrated all five call sites to delegate to it, keeping each site's own pre/post-processing (`$.`-prefix stripping, `nodeOutputs` remapping, literal fallback, debug logging) as a thin wrapper. Verified against `contents/` that no saved workflow config relies on a literal key shaped like `foo[0]`, so extending `TransformNodeExecutor`/`PromptNodeExecutor` to support array-index access is a pure bug fix, not a behavior break.

**(b) Single-shot LLM boilerplate** — added `WorkflowLLMHelper.runSingleShotLLM({ model, messages, apiKey?, options, language, errorLabel })`, a shared "verify API key (unless pre-supplied) → execute one request → return `{success, content}`/`{success:false, error}`" helper. Migrated the two node executors where the verify→call→parse pattern is cleanly self-contained: `QueryPlanNodeExecutor` and `QuoteValidatorNodeExecutor` (the latter passes its already-resolved `apiKey` to skip re-verifying inside its per-quote loop).

### Follow-up (intentionally out of scope here)

`VerifierNodeExecutor`, `PlannerNodeExecutor`, and `PromptNodeExecutor`'s LLM call sites were **not** migrated to `runSingleShotLLM` in this PR:
- `VerifierNodeExecutor` branches into a tool-loop path that bypasses `executeStreamingRequest` entirely, and its API-key verification throws rather than returning an error result.
- `PlannerNodeExecutor._generatePlan` has ~370 lines of message-building logic between its `verifyApiKey` and `executeStreamingRequest` calls.
- `PromptNodeExecutor`'s call site is inside a multi-iteration tool-use loop (`executeLLMWithTools`), genuinely not single-shot.

Migrating these without existing test coverage risked real behavior changes (error propagation semantics, verification timing relative to tool-loop branching) that deserve dedicated, reviewable follow-up PRs rather than being bundled into a mechanical consolidation.

## Test plan

- [x] New `server/tests/pathResolver.test.js` — asserts all four call sites resolve `items[0]`-style paths identically, plus core traversal edge cases (missing path, non-array bracket target, `$`-prefix/`nodeOutputs` remap parity).
- [x] New `server/tests/workflow-run-single-shot-llm.test.js` — covers verify+call success, pre-supplied-apiKey skip-verify path, API-key-failure and call-failure error messages.
- [x] Re-ran existing `server/tests/workflow-model-resolution.test.js`, `workflow-llm-retry.test.js`, `agent-phased-workflow.test.js`, `workflow-resume.test.js`, `workflowEngineSingleton.test.js` — all pass.
- [x] `npx eslint` on all touched files — clean (one pre-existing unrelated warning in `PromptNodeExecutor.js`).
- [x] `npx prettier --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cqKvuGt3g5gYPyDYw2StS


---
_Generated by [Claude Code](https://claude.ai/code/session_014cqKvuGt3g5gYPyDYw2StS)_