### PR TITLE
Fix form submission to use formRef instead of document.querySelector

### DIFF
--- a/client/src/features/apps/pages/AppChat.jsx
+++ b/client/src/features/apps/pages/AppChat.jsx
@@ -841,14 +841,7 @@ function AppChat({ preloadedApp = null }) {
     sendMessage: text => {
       setInput(text);
       setTimeout(() => {
-        const form = document.querySelector('form');
-        if (form) {
-          const submitEvent = new Event('submit', {
-            cancelable: true,
-            bubbles: true
-          });
-          form.dispatchEvent(submitEvent);
-        }
+        formRef.current?.requestSubmit();
       }, 0);
     },
     isProcessing: processing,
@@ -1182,14 +1175,7 @@ function AppChat({ preloadedApp = null }) {
     }
 
     setTimeout(() => {
-      const form = document.querySelector('form');
-      if (form) {
-        const submitEvent = new Event('submit', {
-          cancelable: true,
-          bubbles: true
-        });
-        form.dispatchEvent(submitEvent);
-      }
+      formRef.current?.requestSubmit();
     }, 0);
   };
 


### PR DESCRIPTION
## Summary
- `sendMessage` (imperative handle) and `handleResendMessage` in `AppChat.jsx` looked up the form via `document.querySelector('form')` — the first `<form>` in the whole document — instead of using the component's own `formRef`, which is already used elsewhere in the same file.
- In layouts with more than one form on the page (e.g. embedded/widget contexts), this could target the wrong form and either no-op or submit unrelated inputs.
- Replaced both `document.querySelector('form')` + manual `submit` event dispatch blocks with `formRef.current?.requestSubmit()`, matching the pattern already used elsewhere in the component (e.g. `formRef.current.requestSubmit()` at the other call site).

## Test plan
- [ ] Manually send a message via voice command / resend in a page with multiple forms and confirm the chat form submits correctly
- [ ] Confirm required-field validation still behaves as expected (`requestSubmit()` triggers native constraint validation, unlike a raw `submit` event dispatch)

Fixes #1732

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015HwMC4ajvZWRfWfVU4bSza

---
_Generated by [Claude Code](https://claude.ai/code/session_015HwMC4ajvZWRfWfVU4bSza)_