### PR TITLE
fix: centralize permission-enhancement/anonymous-principal logic in global middleware

### DIFF
--- a/server/middleware/setup.js
+++ b/server/middleware/setup.js
@@ -10,7 +10,7 @@ import jwtAuthMiddleware from './jwtAuth.js';
 import ldapAuthMiddleware from './ldapAuth.js';
 import { teamsAuthMiddleware } from './teamsAuth.js';
 import ntlmAuthMiddleware from './ntlmAuth.js';
-import { enhanceUserWithPermissions } from '../utils/authorization.js';
+import { enhanceUserWithPermissions, isAnonymousAccessAllowed } from '../utils/authorization.js';
 import { createRateLimiters } from './rateLimiting.js';
 import { buildApiPath, buildServerPath } from '../utils/basePath.js';
 import config from '../config.js';
@@ -630,23 +630,21 @@ export function setupMiddleware(app, platformConfig = {}) {
     next();
   });
 
-  // Enhance user with permissions after authentication.
+  // Enhance user with permissions after authentication, synthesizing an
+  // anonymous principal when no user is authenticated but anonymous access is
+  // allowed. Centralized here so every route sees a fully-enhanced req.user
+  // (real or anonymous) without having to remember to do it itself — a
+  // per-route copy of this logic was missing in the chat routes and caused an
+  // anonymous app-access bypass.
   // Read platform config from configCache per-request so that admin saves and
   // IHUB_PLATFORM__* overrides take effect without a server restart.
   app.use((req, res, next) => {
+    const livePlatform = configCache.getPlatform() || platformConfig;
+    const authConfig = livePlatform.auth || {};
     if (req.user && !req.user.permissions) {
-      const livePlatform = configCache.getPlatform() || platformConfig;
-      const authConfig = livePlatform.auth || {};
       req.user = enhanceUserWithPermissions(req.user, authConfig, livePlatform);
-
-      // logger.info('🔍 User permissions enhanced:', {
-      //   userId: req.user.id,
-      //   groups: req.user.groups,
-      //   hasPermissions: !!req.user.permissions,
-      //   appsCount: req.user.permissions?.apps?.size || 0,
-      //   modelsCount: req.user.permissions?.models?.size || 0,
-      //   isAdmin: req.user.isAdmin
-      // });
+    } else if (!req.user && isAnonymousAccessAllowed(livePlatform)) {
+      req.user = enhanceUserWithPermissions(null, authConfig, livePlatform);
     }
     next();
   });

--- a/server/routes/chat/dataRoutes.js
+++ b/server/routes/chat/dataRoutes.js
@@ -1,8 +1,7 @@
 import configCache from '../../configCache.js';
 import {
   filterResourcesByPermissions,
-  isAnonymousAccessAllowed,
-  enhanceUserWithPermissions
+  isAnonymousAccessAllowed
 } from '../../utils/authorization.js';
 import { authRequired } from '../../middleware/authRequired.js';
 import { getAppVersion } from '../../utils/versionHelper.js';
@@ -382,18 +381,6 @@ export default function registerDataRoutes(app) {
             'load prompts configuration',
             new Error('prompts is null')
           );
-        }
-
-        // Force permission enhancement if not already done
-        if (req.user && !req.user.permissions) {
-          const authConfig = platformConfig.auth || {};
-          req.user = enhanceUserWithPermissions(req.user, authConfig, platformConfig);
-        }
-
-        // Create anonymous user if none exists and anonymous access is allowed
-        if (!req.user && isAnonymousAccessAllowed(platformConfig)) {
-          const authConfig = platformConfig.auth || {};
-          req.user = enhanceUserWithPermissions(null, authConfig, platformConfig);
         }
 
         // Apply group-based filtering if user is authenticated

--- a/server/routes/generalRoutes.js
+++ b/server/routes/generalRoutes.js
@@ -1,5 +1,4 @@
 import configCache from '../configCache.js';
-import { enhanceUserWithPermissions, isAnonymousAccessAllowed } from '../utils/authorization.js';
 import { authRequired, appAccessRequired } from '../middleware/authRequired.js';
 import { buildServerPath, getRelativeRequestPath } from '../utils/basePath.js';
 import {
@@ -163,17 +162,6 @@ export default function registerGeneralRoutes(app, { getLocalizedError }) {
   app.get(buildServerPath('/api/apps'), authRequired, async (req, res) => {
     try {
       const platformConfig = configCache.getPlatform() || {};
-      const authConfig = platformConfig.auth || {};
-
-      // Force permission enhancement if not already done
-      if (req.user && !req.user.permissions) {
-        req.user = enhanceUserWithPermissions(req.user, authConfig, platformConfig);
-      }
-
-      // Create anonymous user if none exists and anonymous access is allowed
-      if (!req.user && isAnonymousAccessAllowed(platformConfig)) {
-        req.user = enhanceUserWithPermissions(null, authConfig, platformConfig);
-      }
 
       // Use centralized method to get filtered apps with user-specific ETag
       const { data: apps, etag: userSpecificEtag } = await configCache.getAppsForUser(

--- a/server/routes/integrations/googledrive.js
+++ b/server/routes/integrations/googledrive.js
@@ -5,6 +5,7 @@ import express from 'express';
 import crypto from 'crypto';
 import GoogleDriveService from '../../services/integrations/GoogleDriveService.js';
 import { authOptional, authRequired } from '../../middleware/authRequired.js';
+import { hasAuthenticatedUser } from '../../utils/authorization.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import rateLimit from 'express-rate-limit';
@@ -78,7 +79,7 @@ router.get('/auth', authRequired, googleDriveAuthLimiter, async (req, res) => {
     // it does NOT guarantee req.user.id is truthy. Refuse to start an
     // OAuth flow without a real user id — otherwise tokens would land
     // under a shared sentinel key and could be read by another caller.
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -250,7 +251,7 @@ router.get('/:providerId/callback', authOptional, async (req, res) => {
  */
 router.get('/status', authRequired, googleDriveApiLimiter, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -308,7 +309,7 @@ router.get('/status', authRequired, googleDriveApiLimiter, async (req, res) => {
  */
 router.post('/disconnect', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -346,7 +347,7 @@ router.post('/disconnect', authRequired, async (req, res) => {
  */
 router.get('/sources', authRequired, googleDriveApiLimiter, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -406,7 +407,7 @@ router.get('/sources', authRequired, googleDriveApiLimiter, async (req, res) => 
  */
 router.get('/drives/:source', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -471,7 +472,7 @@ router.get('/drives/:source', authRequired, async (req, res) => {
  */
 router.get('/items', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -525,7 +526,7 @@ router.get('/items', authRequired, async (req, res) => {
  */
 router.get('/download', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 

--- a/server/routes/integrations/jira.js
+++ b/server/routes/integrations/jira.js
@@ -5,6 +5,7 @@ import express from 'express';
 import crypto from 'crypto';
 import JiraService from '../../services/integrations/JiraService.js';
 import { authOptional, authRequired } from '../../middleware/authRequired.js';
+import { hasAuthenticatedUser } from '../../utils/authorization.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import {
@@ -46,7 +47,7 @@ router.get('/auth', authRequired, async (req, res) => {
     // it does NOT guarantee req.user.id is truthy. Refuse to start an
     // OAuth flow without a real user id — otherwise tokens would land
     // under a shared sentinel key and could be read by another caller.
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -198,7 +199,7 @@ router.get('/callback', authOptional, async (req, res) => {
  */
 router.get('/status', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -255,7 +256,7 @@ router.get('/status', authRequired, async (req, res) => {
  */
 router.post('/disconnect', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -284,7 +285,7 @@ router.post('/disconnect', authRequired, async (req, res) => {
  */
 router.post('/refresh', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -339,7 +340,7 @@ router.get('/attachment/:attachmentId', authRequired, async (req, res) => {
     const { attachmentId } = req.params;
     const { download } = req.query;
 
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -380,7 +381,7 @@ router.get('/attachment/:attachmentId', authRequired, async (req, res) => {
  */
 router.get('/test', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 

--- a/server/routes/integrations/nextcloud.js
+++ b/server/routes/integrations/nextcloud.js
@@ -5,6 +5,7 @@ import express from 'express';
 import crypto from 'crypto';
 import NextcloudService from '../../services/integrations/NextcloudService.js';
 import { authOptional, authRequired } from '../../middleware/authRequired.js';
+import { hasAuthenticatedUser } from '../../utils/authorization.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import rateLimit from 'express-rate-limit';
@@ -64,7 +65,7 @@ router.get('/auth', authRequired, nextcloudAuthLimiter, async (req, res) => {
     // it does NOT guarantee req.user.id is truthy. Refuse to start an
     // OAuth flow without a real user id — otherwise tokens would land
     // under a shared sentinel key and could be read by another caller.
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -212,7 +213,7 @@ router.get('/:providerId/callback', authOptional, async (req, res) => {
  */
 router.get('/status', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -283,7 +284,7 @@ router.get('/status', authRequired, async (req, res) => {
  */
 router.post('/disconnect', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -326,7 +327,7 @@ router.post('/disconnect', authRequired, async (req, res) => {
  */
 router.get('/sources', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -354,7 +355,7 @@ router.get('/sources', authRequired, async (req, res) => {
  */
 router.get('/drives/:source', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -412,7 +413,7 @@ router.get('/drives/:source', authRequired, async (req, res) => {
  */
 router.get('/items', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -453,7 +454,7 @@ router.get('/items', authRequired, async (req, res) => {
  */
 router.get('/download', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 

--- a/server/routes/integrations/office365.js
+++ b/server/routes/integrations/office365.js
@@ -5,6 +5,7 @@ import express from 'express';
 import crypto from 'crypto';
 import Office365Service from '../../services/integrations/Office365Service.js';
 import { authOptional, authRequired } from '../../middleware/authRequired.js';
+import { hasAuthenticatedUser } from '../../utils/authorization.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import rateLimit from 'express-rate-limit';
@@ -74,7 +75,7 @@ router.get('/auth', authRequired, office365AuthLimiter, async (req, res) => {
     // it does NOT guarantee req.user.id is truthy. Refuse to start an
     // OAuth flow without a real user id — otherwise tokens would land
     // under a shared sentinel key and could be read by another caller.
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -256,7 +257,7 @@ router.get('/:providerId/callback', authOptional, async (req, res) => {
  */
 router.get('/status', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -318,7 +319,7 @@ router.get('/status', authRequired, async (req, res) => {
  */
 router.post('/disconnect', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -356,7 +357,7 @@ router.post('/disconnect', authRequired, async (req, res) => {
  */
 router.get('/sources', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -402,7 +403,7 @@ router.get('/sources', authRequired, async (req, res) => {
  */
 router.get('/drives/:source', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -449,7 +450,7 @@ router.get('/drives/:source', authRequired, async (req, res) => {
  */
 router.get('/items', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 
@@ -499,7 +500,7 @@ router.get('/items', authRequired, async (req, res) => {
  */
 router.get('/download', authRequired, async (req, res) => {
   try {
-    if (!req.user?.id) {
+    if (!hasAuthenticatedUser(req)) {
       return sendAuthRequired(res);
     }
 

--- a/server/routes/modelRoutes.js
+++ b/server/routes/modelRoutes.js
@@ -1,5 +1,4 @@
 import configCache from '../configCache.js';
-import { isAnonymousAccessAllowed, enhanceUserWithPermissions } from '../utils/authorization.js';
 import { authRequired, modelAccessRequired } from '../middleware/authRequired.js';
 import {
   sendFailedOperationError,
@@ -91,17 +90,6 @@ export default function registerModelRoutes(app, { getLocalizedError }) {
   app.get(buildServerPath('/api/models'), authRequired, async (req, res) => {
     try {
       const platformConfig = configCache.getPlatform() || {};
-      const authConfig = platformConfig.auth || {};
-
-      // Force permission enhancement if not already done
-      if (req.user && !req.user.permissions) {
-        req.user = enhanceUserWithPermissions(req.user, authConfig, platformConfig);
-      }
-
-      // Create anonymous user if none exists and anonymous access is allowed
-      if (!req.user && isAnonymousAccessAllowed(platformConfig)) {
-        req.user = enhanceUserWithPermissions(null, authConfig, platformConfig);
-      }
 
       // Use centralized method to get filtered models with user-specific ETag
       const { data: models, etag: userSpecificEtag } = await configCache.getModelsForUser(

--- a/server/routes/skillRoutes.js
+++ b/server/routes/skillRoutes.js
@@ -1,6 +1,5 @@
 import { authRequired } from '../middleware/authRequired.js';
 import configCache from '../configCache.js';
-import { isAnonymousAccessAllowed, enhanceUserWithPermissions } from '../utils/authorization.js';
 import { buildServerPath } from '../utils/basePath.js';
 import { getSkillContent, getSkillResource } from '../services/skillLoader.js';
 import { validateIdForPath } from '../utils/pathSecurity.js';
@@ -18,15 +17,6 @@ export default function registerSkillRoutes(app) {
     async (req, res) => {
       try {
         const platformConfig = configCache.getPlatform() || {};
-        const authConfig = platformConfig.auth || {};
-
-        if (req.user && !req.user.permissions) {
-          req.user = enhanceUserWithPermissions(req.user, authConfig, platformConfig);
-        }
-
-        if (!req.user && isAnonymousAccessAllowed(platformConfig)) {
-          req.user = enhanceUserWithPermissions(null, authConfig, platformConfig);
-        }
 
         const { data: skills, etag } = await configCache.getSkillsForUser(req.user, platformConfig);
 
@@ -61,11 +51,6 @@ export default function registerSkillRoutes(app) {
         if (!validateIdForPath(req.params.name, 'skill', res)) return;
 
         const platformConfig = configCache.getPlatform() || {};
-        const authConfig = platformConfig.auth || {};
-
-        if (req.user && !req.user.permissions) {
-          req.user = enhanceUserWithPermissions(req.user, authConfig, platformConfig);
-        }
 
         const { data: skills } = await configCache.getSkillsForUser(req.user, platformConfig);
         const skill = skills.find(s => s.name === req.params.name);
@@ -94,11 +79,6 @@ export default function registerSkillRoutes(app) {
         if (!validateIdForPath(req.params.name, 'skill', res)) return;
 
         const platformConfig = configCache.getPlatform() || {};
-        const authConfig = platformConfig.auth || {};
-
-        if (req.user && !req.user.permissions) {
-          req.user = enhanceUserWithPermissions(req.user, authConfig, platformConfig);
-        }
 
         // Verify user has access to this skill
         const { data: skills } = await configCache.getSkillsForUser(req.user, platformConfig);
@@ -144,11 +124,6 @@ export default function registerSkillRoutes(app) {
         }
 
         const platformConfig = configCache.getPlatform() || {};
-        const authConfig = platformConfig.auth || {};
-
-        if (req.user && !req.user.permissions) {
-          req.user = enhanceUserWithPermissions(req.user, authConfig, platformConfig);
-        }
 
         // Verify user has access to this skill
         const { data: skills } = await configCache.getSkillsForUser(req.user, platformConfig);

--- a/server/routes/toolRoutes.js
+++ b/server/routes/toolRoutes.js
@@ -4,7 +4,6 @@ import { authRequired } from '../middleware/authRequired.js';
 import validate from '../validators/validate.js';
 import { runToolSchema } from '../validators/index.js';
 import configCache from '../configCache.js';
-import { isAnonymousAccessAllowed, enhanceUserWithPermissions } from '../utils/authorization.js';
 import { buildServerPath } from '../utils/basePath.js';
 import { validateIdForPath } from '../utils/pathSecurity.js';
 import { requireFeature } from '../featureRegistry.js';
@@ -18,17 +17,6 @@ export default function registerToolRoutes(app) {
     async (req, res) => {
       try {
         const platformConfig = configCache.getPlatform() || {};
-        const authConfig = platformConfig.auth || {};
-
-        // Force permission enhancement if not already done
-        if (req.user && !req.user.permissions) {
-          req.user = enhanceUserWithPermissions(req.user, authConfig, platformConfig);
-        }
-
-        // Create anonymous user if none exists and anonymous access is allowed
-        if (!req.user && isAnonymousAccessAllowed(platformConfig)) {
-          req.user = enhanceUserWithPermissions(null, authConfig, platformConfig);
-        }
 
         // Get user language from query parameters or platform default
         const defaultLang = platformConfig?.defaultLanguage || 'en';

--- a/server/utils/authorization.js
+++ b/server/utils/authorization.js
@@ -510,6 +510,19 @@ export function isAnonymousAccessAllowed(platform) {
 }
 
 /**
+ * Check whether a request carries a genuinely authenticated (non-anonymous) user.
+ * `req.user` is always populated with an `{ id: 'anonymous', ... }` principal when
+ * anonymous access is enabled, so a plain `!req.user?.id` check no longer detects
+ * "not logged in" — callers that must refuse anonymous callers (e.g. OAuth flows
+ * keyed by user id) need this instead.
+ * @param {Object} req - Express request object
+ * @returns {boolean} True if req.user is a real, authenticated user
+ */
+export function hasAuthenticatedUser(req) {
+  return Boolean(req.user?.id) && req.user.id !== 'anonymous';
+}
+
+/**
  * Get default groups for anonymous users
  * @param {Object} platform - Platform configuration
  * @returns {string[]} Default group names


### PR DESCRIPTION
## Summary

- The same ~8-line "enhance permissions, or synthesize an anonymous principal" block was copy-pasted across `generalRoutes.js`, `modelRoutes.js`, `dataRoutes.js`, `toolRoutes.js`, and `skillRoutes.js` (4 occurrences there). It was missing entirely from the chat routes' prompts handler, which is what previously caused an anonymous app-access bypass.
- Moved this logic into the existing global middleware in `server/middleware/setup.js` so every request gets a fully-enhanced `req.user` (real or synthesized anonymous principal) before any route handler runs — it can no longer be forgotten in a new endpoint. Deleted all 8 per-route copies (~85 lines).
- Because `req.user` is now **always** populated when anonymous access is enabled, audited the codebase for code that relied on `req.user` being falsy/undefined to mean "not authenticated". Found that the Jira/Office365/GoogleDrive/Nextcloud OAuth integration routes (27 call sites total) used `!req.user?.id` for exactly that purpose — to refuse starting an OAuth flow for an anonymous caller (their own comment: *"otherwise tokens would land under a shared sentinel key and could be read by another caller"*). The middleware change would have silently reopened that gap, so added a shared `hasAuthenticatedUser(req)` helper in `server/utils/authorization.js` (excludes the anonymous sentinel id) and switched all 27 sites to use it.

## Why

Duplicated, easy-to-forget security-relevant boilerplate is exactly how the original anonymous-access bug happened. Centralizing it removes the whole class of "someone adds a new permission-filtered route and forgets the anonymous branch" bugs.

## Testing

- `npx eslint` and `npx prettier --check` on all changed files — clean.
- The repo's `server/tests/authentication-security.test.js` / `admin-endpoints-security.test.js` / `group-handling.test.js` are unfortunately not wired into `tests/config/jest.config.js`'s `testMatch` and fail to even parse under the current Jest config (unrelated, pre-existing issue — `node-fetch` ESM import chokes the transform), so they could not be run as-is.
- Verified the core behavior change manually: booted `setupMiddleware` in an isolated Express app with `anonymousAuth.enabled: true` and confirmed an unauthenticated request now receives a fully-enhanced `req.user` with `id: 'anonymous'` and populated `permissions`, and that the new `hasAuthenticatedUser()` helper correctly returns `false` for it (so the OAuth integration routes correctly reject it).

Fixes #1745


---
_Generated by [Claude Code](https://claude.ai/code/session_0134yrWJESP6ac1LqF9o2ma5)_