### PR TITLE
Deduplicate the four OAuth integration route files into a shared factory

### DIFF
--- a/server/routes/integrations/googledrive.js
+++ b/server/routes/integrations/googledrive.js
@@ -7,7 +7,12 @@ import { authRequired } from '../../middleware/authRequired.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import rateLimit from 'express-rate-limit';
-import { sendInternalError, sendAuthRequired, sendBadRequest, sendErrorResponse } from '../../utils/responseHelpers.js';
+import {
+  sendInternalError,
+  sendAuthRequired,
+  sendBadRequest,
+  sendErrorResponse
+} from '../../utils/responseHelpers.js';
 import { buildContentDisposition } from '../../utils/safeContentDisposition.js';
 import { createOAuthIntegrationRouter } from './oauthIntegrationFactory.js';
 
@@ -55,7 +60,8 @@ createOAuthIntegrationRouter(router, {
   exchangeCodeForTokens: ({ providerId, code, codeVerifier, req }) =>
     GoogleDriveService.exchangeCodeForTokens(providerId, code, codeVerifier, req),
   storeUserTokens: (userId, tokens) => GoogleDriveService.storeUserTokens(userId, tokens),
-  isUserAuthenticated: (userId, providerId) => GoogleDriveService.isUserAuthenticated(userId, providerId),
+  isUserAuthenticated: (userId, providerId) =>
+    GoogleDriveService.isUserAuthenticated(userId, providerId),
   getUserInfo: (userId, providerId) => GoogleDriveService.getUserInfo(userId, providerId),
   getTokenExpirationInfo: (userId, providerId) =>
     GoogleDriveService.getTokenExpirationInfo(userId, providerId),

--- a/server/routes/integrations/googledrive.js
+++ b/server/routes/integrations/googledrive.js
@@ -2,20 +2,14 @@
 // Handles OAuth2 PKCE flow for Google Workspace file access authentication
 
 import express from 'express';
-import crypto from 'crypto';
 import GoogleDriveService from '../../services/integrations/GoogleDriveService.js';
-import { authOptional, authRequired } from '../../middleware/authRequired.js';
+import { authRequired } from '../../middleware/authRequired.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import rateLimit from 'express-rate-limit';
-import {
-  sendInternalError,
-  sendAuthRequired,
-  sendBadRequest,
-  sendErrorResponse
-} from '../../utils/responseHelpers.js';
-import { isValidReturnUrl } from '../../utils/oauthReturnUrl.js';
+import { sendInternalError, sendAuthRequired, sendBadRequest, sendErrorResponse } from '../../utils/responseHelpers.js';
 import { buildContentDisposition } from '../../utils/safeContentDisposition.js';
+import { createOAuthIntegrationRouter } from './oauthIntegrationFactory.js';
 
 const router = express.Router();
 
@@ -49,295 +43,28 @@ const googleDriveApiLimiter = rateLimit({
   legacyHeaders: false
 });
 
-/**
- * Initiate Google Drive OAuth2 flow
- * GET /api/integrations/googledrive/auth?providerId=xxx
- */
-router.get('/auth', authRequired, googleDriveAuthLimiter, async (req, res) => {
-  try {
-    const { providerId, returnUrl } = req.query;
-
-    if (!providerId) {
-      return sendBadRequest(res, 'providerId query parameter is required');
-    }
-
-    logger.debug('Google Drive Auth Debug:', {
-      component: 'Google Drive',
-      hasUser: !!req.user,
-      userId: req.user?.id,
-      providerId,
-      returnUrl,
-      hasSession: !!req.session
-    });
-
-    if (!req.session) {
-      return sendErrorResponse(res, 500, 'Session not available');
-    }
-
-    // authRequired only rejects missing `req.user` or anonymous users;
-    // it does NOT guarantee req.user.id is truthy. Refuse to start an
-    // OAuth flow without a real user id — otherwise tokens would land
-    // under a shared sentinel key and could be read by another caller.
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    // Generate state for CSRF protection
-    const state = crypto.randomBytes(32).toString('hex');
-
-    // Generate PKCE parameters
-    const codeVerifier = crypto.randomBytes(32).toString('base64url');
-
-    // Validate returnUrl to prevent open redirects
-    const validatedReturnUrl = isValidReturnUrl(returnUrl, req)
-      ? returnUrl
-      : '/settings/integrations';
-
-    // Store OAuth parameters in session with provider-specific key
-    const sessionKey = `oauth_googledrive_${providerId}`;
-    req.session[sessionKey] = {
-      state,
-      codeVerifier,
-      providerId,
-      userId: req.user.id,
-      returnUrl: validatedReturnUrl,
-      timestamp: Date.now()
-    };
-
-    // Generate authorization URL
-    const authUrl = GoogleDriveService.generateAuthUrl(providerId, state, codeVerifier, req);
-
-    logger.info('Initiating Google Drive OAuth', {
-      component: 'Google Drive',
-      userId: req.user?.id,
-      providerId
-    });
-
-    res.redirect(authUrl);
-  } catch (error) {
-    return sendInternalError(res, error, 'initiate Google Drive OAuth');
-  }
-});
-
-/**
- * Handle Google Drive OAuth callback (provider-specific)
- * GET /api/integrations/googledrive/:providerId/callback
- */
-router.get('/:providerId/callback', authOptional, async (req, res) => {
-  try {
-    const { code, state, error: oauthError } = req.query;
-    const { providerId } = req.params;
-
-    if (oauthError) {
-      logger.error('Google Drive OAuth error:', {
-        component: 'Google Drive',
-        error: oauthError,
-        providerId
-      });
-      return res.redirect('/settings/integrations?googledrive_error=oauth_failed');
-    }
-
-    // Some IdP edge cases (consent denied without `error`, or a manual
-    // hit on the callback URL) can land here with no `code`. Surface a
-    // stable error code instead of throwing inside `exchangeCodeForTokens`
-    // and leaking the raw error into the redirect URL.
-    if (!code) {
-      logger.error('Google Drive OAuth callback missing code', {
-        component: 'Google Drive',
-        providerId
-      });
-      return res.redirect('/settings/integrations?googledrive_error=missing_code');
-    }
-
-    if (!req.session) {
-      logger.error('No session available for Google Drive OAuth callback', {
-        component: 'Google Drive',
-        providerId
-      });
-      return res.redirect('/settings/integrations?googledrive_error=no_session');
-    }
-
-    // Validate state parameter
-    const sessionKey = `oauth_googledrive_${providerId}`;
-    const storedAuth = req.session[sessionKey];
-
-    const returnUrl = storedAuth?.returnUrl || '/settings/integrations';
-    const separator = returnUrl.includes('?') ? '&' : '?';
-
-    if (!storedAuth || storedAuth.state !== state) {
-      logger.error('Invalid Google Drive OAuth state parameter', {
-        component: 'Google Drive',
-        providerId
-      });
-      return res.redirect(`${returnUrl}${separator}googledrive_error=invalid_state`);
-    }
-
-    if (storedAuth.providerId !== providerId) {
-      logger.error('Provider ID mismatch in Google Drive OAuth callback', {
-        component: 'Google Drive',
-        urlProviderId: providerId,
-        sessionProviderId: storedAuth.providerId
-      });
-      return res.redirect(`${returnUrl}${separator}googledrive_error=provider_mismatch`);
-    }
-
-    // Check session timeout (15 minutes)
-    if (Date.now() - storedAuth.timestamp > 15 * 60 * 1000) {
-      logger.error('Google Drive OAuth session expired', {
-        component: 'Google Drive',
-        providerId
-      });
-      return res.redirect(`${returnUrl}${separator}googledrive_error=session_expired`);
-    }
-
-    // Exchange authorization code for tokens
-    const tokens = await GoogleDriveService.exchangeCodeForTokens(
-      storedAuth.providerId,
-      code,
-      storedAuth.codeVerifier,
-      req
-    );
-
-    if (!tokens.refreshToken) {
-      logger.error('No refresh token received from Google Drive OAuth.', {
-        component: 'Google Drive',
-        providerId
-      });
-      logger.warn(
-        'Storing tokens WITHOUT refresh capability - user will need to reconnect periodically',
-        { component: 'Google Drive' }
-      );
-    }
-
-    // Store encrypted tokens for user
-    await GoogleDriveService.storeUserTokens(storedAuth.userId, tokens);
-
-    // Clear session data
-    delete req.session[sessionKey];
-
-    logger.info('Google Drive OAuth completed', {
-      component: 'Google Drive',
-      userId: storedAuth.userId,
-      providerId: storedAuth.providerId
-    });
-
-    res.redirect(`${returnUrl}${separator}googledrive_connected=true`);
-  } catch (error) {
-    logger.error('Error handling Google Drive OAuth callback:', {
-      component: 'Google Drive',
-      error: error.message,
-      providerId: req.params.providerId
-    });
-
-    let catchReturnUrl = '/settings/integrations';
-    if (req.session) {
-      const catchKey = `oauth_googledrive_${req.params.providerId}`;
-      catchReturnUrl = req.session[catchKey]?.returnUrl || catchReturnUrl;
-      delete req.session[catchKey];
-    }
-
-    const catchSeparator = catchReturnUrl.includes('?') ? '&' : '?';
-    // Use a stable error code rather than echoing `error.message` —
-    // some upstream errors interpolate user-influenced strings, and
-    // we don't want those landing in the redirect URL.
-    res.redirect(`${catchReturnUrl}${catchSeparator}googledrive_error=callback_failed`);
-  }
-});
-
-/**
- * Get Google Drive connection status for current user
- * GET /api/integrations/googledrive/status
- */
-router.get('/status', authRequired, googleDriveApiLimiter, async (req, res) => {
-  try {
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    const providerId = typeof req.query.providerId === 'string' ? req.query.providerId : undefined;
-
-    const isAuthenticated = await GoogleDriveService.isUserAuthenticated(req.user.id, providerId);
-
-    if (!isAuthenticated) {
-      return res.json({
-        connected: false,
-        message: 'Google Drive account not connected'
-      });
-    }
-
-    const userInfo = await GoogleDriveService.getUserInfo(req.user.id, providerId);
-    const tokenInfo = await GoogleDriveService.getTokenExpirationInfo(req.user.id, providerId);
-
-    res.json({
-      connected: true,
-      userInfo: {
-        displayName: userInfo.displayName,
-        mail: userInfo.mail,
-        picture: userInfo.picture
-      },
-      tokenInfo: {
-        expiresAt: tokenInfo.expiresAt,
-        minutesUntilExpiry: tokenInfo.minutesUntilExpiry,
-        isExpiring: tokenInfo.isExpiring,
-        isExpired: tokenInfo.isExpired
-      },
-      message: tokenInfo.isExpiring
-        ? 'Google Drive account connected (tokens expiring soon)'
-        : 'Google Drive account connected successfully'
-    });
-  } catch (error) {
-    logger.error('Error getting Google Drive status:', {
-      component: 'Google Drive',
-      error: error.message
-    });
-
-    if (error.message.includes('authentication required')) {
-      return res.json({
-        connected: false,
-        message: 'Google Drive authentication expired'
-      });
-    }
-
-    return sendInternalError(res, error, 'get Google Drive status');
-  }
-});
-
-/**
- * Disconnect Google Drive account
- * POST /api/integrations/googledrive/disconnect
- */
-router.post('/disconnect', authRequired, async (req, res) => {
-  try {
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    const providerId =
-      (typeof req.query.providerId === 'string' && req.query.providerId) ||
-      (typeof req.body?.providerId === 'string' && req.body.providerId) ||
-      undefined;
-
-    const success = await GoogleDriveService.deleteUserTokens(req.user.id, providerId);
-
-    if (success) {
-      logger.info('Google Drive disconnected', {
-        component: 'Google Drive',
-        userId: req.user.id,
-        providerId
-      });
-      res.json({
-        success: true,
-        message: 'Google Drive account disconnected successfully'
-      });
-    } else {
-      res.json({
-        success: false,
-        message: 'No Google Drive connection found to disconnect'
-      });
-    }
-  } catch (error) {
-    return sendInternalError(res, error, 'disconnect Google Drive');
-  }
+createOAuthIntegrationRouter(router, {
+  providerKey: 'googledrive',
+  displayName: 'Google Drive',
+  requiresProviderId: true,
+  usesPkce: true,
+  authLimiter: googleDriveAuthLimiter,
+  statusLimiter: googleDriveApiLimiter,
+  buildAuthUrl: ({ providerId, state, codeVerifier, req }) =>
+    GoogleDriveService.generateAuthUrl(providerId, state, codeVerifier, req),
+  exchangeCodeForTokens: ({ providerId, code, codeVerifier, req }) =>
+    GoogleDriveService.exchangeCodeForTokens(providerId, code, codeVerifier, req),
+  storeUserTokens: (userId, tokens) => GoogleDriveService.storeUserTokens(userId, tokens),
+  isUserAuthenticated: (userId, providerId) => GoogleDriveService.isUserAuthenticated(userId, providerId),
+  getUserInfo: (userId, providerId) => GoogleDriveService.getUserInfo(userId, providerId),
+  getTokenExpirationInfo: (userId, providerId) =>
+    GoogleDriveService.getTokenExpirationInfo(userId, providerId),
+  deleteUserTokens: (userId, providerId) => GoogleDriveService.deleteUserTokens(userId, providerId),
+  formatUserInfo: userInfo => ({
+    displayName: userInfo.displayName,
+    mail: userInfo.mail,
+    picture: userInfo.picture
+  })
 });
 
 /**

--- a/server/routes/integrations/jira.js
+++ b/server/routes/integrations/jira.js
@@ -2,280 +2,61 @@
 // Handles OAuth2 PKCE flow for JIRA authentication
 
 import express from 'express';
-import crypto from 'crypto';
 import JiraService from '../../services/integrations/JiraService.js';
-import { authOptional, authRequired } from '../../middleware/authRequired.js';
+import { authRequired } from '../../middleware/authRequired.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
-import {
-  sendInternalError,
-  sendAuthRequired,
-  sendErrorResponse
-} from '../../utils/responseHelpers.js';
-import { isValidReturnUrl } from '../../utils/oauthReturnUrl.js';
+import rateLimit from 'express-rate-limit';
+import { sendInternalError, sendAuthRequired, sendErrorResponse } from '../../utils/responseHelpers.js';
+import { createOAuthIntegrationRouter } from './oauthIntegrationFactory.js';
 
 const router = express.Router();
 
 // Gate all Jira routes behind the integrations feature flag
 router.use(requireFeature('integrations'));
 
-/**
- * Initiate JIRA OAuth2 flow for Atlassian Cloud
- * GET /api/integrations/jira/auth
- */
-router.get('/auth', authRequired, async (req, res) => {
-  try {
-    const { returnUrl } = req.query;
-
-    logger.debug('🔍 JIRA Auth Debug:', {
-      hasUser: !!req.user,
-      userId: req.user?.id,
-      userGroups: req.user?.groups,
-      returnUrl,
-      hasSession: !!req.session,
-      cookies: Object.keys(req.cookies || {}),
-      authHeader: req.headers.authorization ? 'present' : 'missing'
-    });
-
-    // Check if session is available
-    if (!req.session) {
-      return sendErrorResponse(res, 500, 'Session not available');
-    }
-
-    // authRequired only rejects missing `req.user` or anonymous users;
-    // it does NOT guarantee req.user.id is truthy. Refuse to start an
-    // OAuth flow without a real user id — otherwise tokens would land
-    // under a shared sentinel key and could be read by another caller.
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    // Generate state for CSRF protection
-    const state = crypto.randomBytes(32).toString('hex');
-
-    // Generate PKCE parameters (may be ignored by Atlassian Cloud)
-    const codeVerifier = crypto.randomBytes(32).toString('base64url');
-
-    // Validate returnUrl to reject `javascript:`, `data:`, off-host
-    // redirects, and protocol-relative URLs that would leak the flow
-    // off-site after the callback finishes.
-    const validatedReturnUrl = isValidReturnUrl(returnUrl, req)
-      ? returnUrl
-      : '/settings/integrations';
-
-    // Store OAuth parameters in session with a consistent key
-    // Using oauth_jira key for consistency with Office 365 pattern
-    const sessionKey = 'oauth_jira';
-    req.session[sessionKey] = {
-      state,
-      codeVerifier,
-      userId: req.user.id,
-      returnUrl: validatedReturnUrl,
-      timestamp: Date.now()
-    };
-
-    // Generate authorization URL for Atlassian Cloud
-    const authUrl = JiraService.generateAuthUrl(state, codeVerifier);
-
-    logger.info('Initiating JIRA OAuth', { component: 'Jira', userId: req.user?.id, authUrl });
-
-    // Redirect to Atlassian OAuth consent screen
-    res.redirect(authUrl);
-  } catch (error) {
-    return sendInternalError(res, error, 'initiate JIRA OAuth');
-  }
+// Rate limiter for JIRA OAuth initiation to prevent abuse/DoS. Jira
+// previously had no rate limiter on `/auth` unlike the other three OAuth
+// integrations — bringing it in line with Office 365/Google Drive/Nextcloud
+// as part of consolidating this into the shared factory.
+const jiraAuthLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  standardHeaders: true,
+  legacyHeaders: false
 });
 
-/**
- * Handle JIRA OAuth callback
- * GET /api/integrations/jira/callback
- */
-router.get('/callback', authOptional, async (req, res) => {
-  try {
-    const { code, state, error } = req.query;
-
-    // Use consistent session key
-    const sessionKey = 'oauth_jira';
-    const storedAuth = req.session?.[sessionKey];
-
-    // Get return URL early for error redirects
-    const returnUrl = storedAuth?.returnUrl || '/settings/integrations';
-    const separator = returnUrl.includes('?') ? '&' : '?';
-
-    // Check for OAuth errors
-    if (error) {
-      logger.error('JIRA OAuth error', { component: 'Jira', oauthError: error });
-      // Stable error code rather than echoing the upstream error string.
-      return res.redirect(`${returnUrl}${separator}jira_error=oauth_failed`);
-    }
-
-    // Surface a stable error code if the IdP returned no `code`
-    // rather than failing inside `exchangeCodeForTokens`.
-    if (!code) {
-      logger.error('JIRA OAuth callback missing code', { component: 'Jira' });
-      return res.redirect(`${returnUrl}${separator}jira_error=missing_code`);
-    }
-
-    // Check if session is available
-    if (!req.session) {
-      logger.error('No session available for JIRA OAuth callback', { component: 'Jira' });
-      return res.redirect(`${returnUrl}${separator}jira_error=no_session`);
-    }
-
-    // Validate state parameter
-    if (!storedAuth || storedAuth.state !== state) {
-      logger.error('Invalid JIRA OAuth state parameter', { component: 'Jira' });
-      return res.redirect(`${returnUrl}${separator}jira_error=invalid_state`);
-    }
-
-    // Check session timeout (15 minutes)
-    if (Date.now() - storedAuth.timestamp > 15 * 60 * 1000) {
-      logger.error('JIRA OAuth session expired', { component: 'Jira' });
-      return res.redirect(`${returnUrl}${separator}jira_error=session_expired`);
-    }
-
-    // Exchange authorization code for tokens
-    const tokens = await JiraService.exchangeCodeForTokens(code, storedAuth.codeVerifier);
-
-    // Verify we received a refresh token (required for long-term access)
-    if (!tokens.refreshToken) {
-      logger.error(
-        'CRITICAL: No refresh token received from JIRA OAuth - user will need to re-authenticate when access token expires',
-        {
-          component: 'Jira',
-          causes: [
-            'JIRA app does not support offline access',
-            'User denied offline_access scope',
-            'Atlassian OAuth server configuration issue'
-          ]
-        }
-      );
-
-      // Still store the tokens but with a clear warning in logs
-      logger.warn(
-        'Storing tokens WITHOUT refresh capability - user will need to reconnect every hour',
-        { component: 'Jira' }
-      );
-    }
-
-    // Store encrypted tokens for user
-    await JiraService.storeUserTokens(storedAuth.userId, tokens);
-
-    // Clear session data using the consistent key
-    delete req.session[sessionKey];
-
-    logger.info('JIRA OAuth completed', {
-      component: 'Jira',
-      userId: storedAuth.userId,
-      returnUrl
-    });
-
-    // Redirect back to the original page with success
-    res.redirect(`${returnUrl}${separator}jira_connected=true`);
-  } catch (error) {
-    logger.error('Error handling JIRA OAuth callback', { component: 'Jira', error });
-
-    // Get return URL from session (default to /settings/integrations)
-    const sessionKey = 'oauth_jira';
-    const returnUrl = req.session?.[sessionKey]?.returnUrl || '/settings/integrations';
-
-    // Clear session data on error
-    if (req.session && req.session[sessionKey]) {
-      delete req.session[sessionKey];
-    }
-
-    const separator = returnUrl.includes('?') ? '&' : '?';
-    // Use a stable error code rather than echoing `error.message` —
-    // some upstream errors interpolate user-influenced strings, and
-    // we don't want those landing in the redirect URL.
-    res.redirect(`${returnUrl}${separator}jira_error=callback_failed`);
-  }
-});
-
-/**
- * Get JIRA connection status for current user
- * GET /api/integrations/jira/status
- */
-router.get('/status', authRequired, async (req, res) => {
-  try {
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    const isAuthenticated = await JiraService.isUserAuthenticated(req.user.id);
-
-    if (!isAuthenticated) {
-      return res.json({
-        connected: false,
-        message: 'JIRA account not connected'
-      });
-    }
-
-    // Get user info from JIRA
-    const userInfo = await JiraService.getUserInfo(req.user.id);
-
-    // Get token expiration info
-    const tokenInfo = await JiraService.getTokenExpirationInfo(req.user.id);
-
-    res.json({
-      connected: true,
-      userInfo: {
-        displayName: userInfo.displayName,
-        emailAddress: userInfo.emailAddress,
-        accountType: userInfo.accountType,
-        active: userInfo.active
-      },
-      tokenInfo: {
-        expiresAt: tokenInfo.expiresAt,
-        minutesUntilExpiry: tokenInfo.minutesUntilExpiry,
-        isExpiring: tokenInfo.isExpiring,
-        isExpired: tokenInfo.isExpired
-      },
-      message: tokenInfo.isExpiring
-        ? 'JIRA account connected (tokens expiring soon)'
-        : 'JIRA account connected successfully'
-    });
-  } catch (error) {
-    logger.error('Error getting JIRA status', { component: 'Jira', error });
-
-    if (error.message.includes('authentication required')) {
-      return res.json({
-        connected: false,
-        message: 'JIRA authentication expired'
-      });
-    }
-
-    return sendInternalError(res, error, 'get JIRA status');
-  }
-});
-
-/**
- * Disconnect JIRA account
- * POST /api/integrations/jira/disconnect
- */
-router.post('/disconnect', authRequired, async (req, res) => {
-  try {
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    const success = await JiraService.deleteUserTokens(req.user.id);
-
-    if (success) {
-      logger.info('JIRA disconnected', { component: 'Jira', userId: req.user.id });
-      res.json({
-        success: true,
-        message: 'JIRA account disconnected successfully'
-      });
-    } else {
-      res.json({
-        success: false,
-        message: 'No JIRA connection found to disconnect'
-      });
-    }
-  } catch (error) {
-    return sendInternalError(res, error, 'disconnect JIRA');
-  }
+createOAuthIntegrationRouter(router, {
+  providerKey: 'jira',
+  displayName: 'JIRA',
+  requiresProviderId: false,
+  usesPkce: true,
+  authLimiter: jiraAuthLimiter,
+  buildAuthUrl: ({ state, codeVerifier }) => JiraService.generateAuthUrl(state, codeVerifier),
+  exchangeCodeForTokens: ({ code, codeVerifier }) => JiraService.exchangeCodeForTokens(code, codeVerifier),
+  storeUserTokens: (userId, tokens) => JiraService.storeUserTokens(userId, tokens),
+  isUserAuthenticated: userId => JiraService.isUserAuthenticated(userId),
+  getUserInfo: userId => JiraService.getUserInfo(userId),
+  getTokenExpirationInfo: userId => JiraService.getTokenExpirationInfo(userId),
+  deleteUserTokens: userId => JiraService.deleteUserTokens(userId),
+  formatUserInfo: userInfo => ({
+    displayName: userInfo.displayName,
+    emailAddress: userInfo.emailAddress,
+    accountType: userInfo.accountType,
+    active: userInfo.active
+  }),
+  logMissingRefreshToken: () =>
+    logger.error(
+      'CRITICAL: No refresh token received from JIRA OAuth - user will need to re-authenticate when access token expires',
+      {
+        component: 'JIRA',
+        causes: [
+          'JIRA app does not support offline access',
+          'User denied offline_access scope',
+          'Atlassian OAuth server configuration issue'
+        ]
+      }
+    )
 });
 
 /**

--- a/server/routes/integrations/jira.js
+++ b/server/routes/integrations/jira.js
@@ -7,7 +7,11 @@ import { authRequired } from '../../middleware/authRequired.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import rateLimit from 'express-rate-limit';
-import { sendInternalError, sendAuthRequired, sendErrorResponse } from '../../utils/responseHelpers.js';
+import {
+  sendInternalError,
+  sendAuthRequired,
+  sendErrorResponse
+} from '../../utils/responseHelpers.js';
 import { createOAuthIntegrationRouter } from './oauthIntegrationFactory.js';
 
 const router = express.Router();
@@ -33,7 +37,8 @@ createOAuthIntegrationRouter(router, {
   usesPkce: true,
   authLimiter: jiraAuthLimiter,
   buildAuthUrl: ({ state, codeVerifier }) => JiraService.generateAuthUrl(state, codeVerifier),
-  exchangeCodeForTokens: ({ code, codeVerifier }) => JiraService.exchangeCodeForTokens(code, codeVerifier),
+  exchangeCodeForTokens: ({ code, codeVerifier }) =>
+    JiraService.exchangeCodeForTokens(code, codeVerifier),
   storeUserTokens: (userId, tokens) => JiraService.storeUserTokens(userId, tokens),
   isUserAuthenticated: userId => JiraService.isUserAuthenticated(userId),
   getUserInfo: userId => JiraService.getUserInfo(userId),

--- a/server/routes/integrations/nextcloud.js
+++ b/server/routes/integrations/nextcloud.js
@@ -2,20 +2,14 @@
 // Handles OAuth2 flow for Nextcloud file access authentication.
 
 import express from 'express';
-import crypto from 'crypto';
 import NextcloudService from '../../services/integrations/NextcloudService.js';
-import { authOptional, authRequired } from '../../middleware/authRequired.js';
+import { authRequired } from '../../middleware/authRequired.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import rateLimit from 'express-rate-limit';
-import {
-  sendInternalError,
-  sendAuthRequired,
-  sendBadRequest,
-  sendErrorResponse
-} from '../../utils/responseHelpers.js';
-import { isValidReturnUrl } from '../../utils/oauthReturnUrl.js';
+import { sendInternalError, sendAuthRequired, sendBadRequest, sendErrorResponse } from '../../utils/responseHelpers.js';
 import { buildContentDisposition } from '../../utils/safeContentDisposition.js';
+import { createOAuthIntegrationRouter } from './oauthIntegrationFactory.js';
 
 const router = express.Router();
 
@@ -44,276 +38,28 @@ const nextcloudAuthLimiter = rateLimit({
   legacyHeaders: false
 });
 
-/**
- * Initiate Nextcloud OAuth2 flow
- * GET /api/integrations/nextcloud/auth?providerId=xxx
- */
-router.get('/auth', authRequired, nextcloudAuthLimiter, async (req, res) => {
-  try {
-    const { providerId, returnUrl } = req.query;
-
-    if (!providerId) {
-      return sendBadRequest(res, 'providerId query parameter is required');
-    }
-
-    if (!req.session) {
-      return sendErrorResponse(res, 500, 'Session not available');
-    }
-
-    // authRequired only rejects missing `req.user` or anonymous users;
-    // it does NOT guarantee req.user.id is truthy. Refuse to start an
-    // OAuth flow without a real user id — otherwise tokens would land
-    // under a shared sentinel key and could be read by another caller.
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    const state = crypto.randomBytes(32).toString('hex');
-    const validatedReturnUrl = isValidReturnUrl(returnUrl, req)
-      ? returnUrl
-      : '/settings/integrations';
-
-    const sessionKey = `oauth_nextcloud_${providerId}`;
-    req.session[sessionKey] = {
-      state,
-      providerId,
-      userId: req.user.id,
-      returnUrl: validatedReturnUrl,
-      timestamp: Date.now()
-    };
-
-    const authUrl = NextcloudService.generateAuthUrl(providerId, state, req);
-
-    logger.info('Initiating Nextcloud OAuth', {
-      component: 'Nextcloud',
-      userId: req.user?.id,
-      providerId
-    });
-
-    res.redirect(authUrl);
-  } catch (error) {
-    return sendInternalError(res, error, 'initiate Nextcloud OAuth');
-  }
-});
-
-/**
- * Handle Nextcloud OAuth callback (provider-specific)
- * GET /api/integrations/nextcloud/:providerId/callback
- */
-router.get('/:providerId/callback', authOptional, async (req, res) => {
-  try {
-    const { code, state, error: oauthError } = req.query;
-    const { providerId } = req.params;
-
-    if (oauthError) {
-      logger.error('Nextcloud OAuth error', {
-        component: 'Nextcloud',
-        error: oauthError,
-        providerId
-      });
-      return res.redirect('/settings/integrations?nextcloud_error=oauth_failed');
-    }
-
-    // Some IdP edge cases (consent denied without `error`, or a manual
-    // hit on the callback URL) can land here with no `code`. Surface a
-    // stable error code instead of throwing inside `exchangeCodeForTokens`
-    // and leaking the raw error into the redirect URL.
-    if (!code) {
-      logger.error('Nextcloud OAuth callback missing code', {
-        component: 'Nextcloud',
-        providerId
-      });
-      return res.redirect('/settings/integrations?nextcloud_error=missing_code');
-    }
-
-    if (!req.session) {
-      logger.error('No session available for Nextcloud OAuth callback', {
-        component: 'Nextcloud',
-        providerId
-      });
-      return res.redirect('/settings/integrations?nextcloud_error=no_session');
-    }
-
-    const sessionKey = `oauth_nextcloud_${providerId}`;
-    const storedAuth = req.session[sessionKey];
-
-    const returnUrl = storedAuth?.returnUrl || '/settings/integrations';
-    const separator = returnUrl.includes('?') ? '&' : '?';
-
-    if (!storedAuth || storedAuth.state !== state) {
-      logger.error('Invalid Nextcloud OAuth state parameter', {
-        component: 'Nextcloud',
-        providerId
-      });
-      return res.redirect(`${returnUrl}${separator}nextcloud_error=invalid_state`);
-    }
-
-    if (storedAuth.providerId !== providerId) {
-      logger.error('Provider ID mismatch in Nextcloud OAuth callback', {
-        component: 'Nextcloud',
-        urlProviderId: providerId,
-        sessionProviderId: storedAuth.providerId
-      });
-      return res.redirect(`${returnUrl}${separator}nextcloud_error=provider_mismatch`);
-    }
-
-    // 15-minute session timeout for the OAuth handshake
-    if (Date.now() - storedAuth.timestamp > 15 * 60 * 1000) {
-      logger.error('Nextcloud OAuth session expired', {
-        component: 'Nextcloud',
-        providerId
-      });
-      return res.redirect(`${returnUrl}${separator}nextcloud_error=session_expired`);
-    }
-
-    const tokens = await NextcloudService.exchangeCodeForTokens(storedAuth.providerId, code, req);
-
-    if (!tokens.refreshToken) {
-      logger.warn(
-        'Storing Nextcloud tokens WITHOUT refresh capability - user will need to reconnect periodically',
-        { component: 'Nextcloud', providerId }
-      );
-    }
-
-    await NextcloudService.storeUserTokens(storedAuth.userId, tokens);
-    delete req.session[sessionKey];
-
-    logger.info('Nextcloud OAuth completed', {
-      component: 'Nextcloud',
-      userId: storedAuth.userId,
-      providerId: storedAuth.providerId
-    });
-
-    res.redirect(`${returnUrl}${separator}nextcloud_connected=true`);
-  } catch (error) {
-    logger.error('Error handling Nextcloud OAuth callback', {
-      component: 'Nextcloud',
-      error: error.message,
-      providerId: req.params.providerId
-    });
-
-    let catchReturnUrl = '/settings/integrations';
-    if (req.session) {
-      const catchKey = `oauth_nextcloud_${req.params.providerId}`;
-      catchReturnUrl = req.session[catchKey]?.returnUrl || catchReturnUrl;
-      delete req.session[catchKey];
-    }
-    const catchSeparator = catchReturnUrl.includes('?') ? '&' : '?';
-    // Use a stable error code rather than echoing `error.message` —
-    // some upstream errors interpolate user-influenced strings, and
-    // we don't want those landing in the redirect URL.
-    res.redirect(`${catchReturnUrl}${catchSeparator}nextcloud_error=callback_failed`);
-  }
-});
-
-/**
- * Get Nextcloud connection status for current user
- * GET /api/integrations/nextcloud/status
- */
-router.get('/status', authRequired, async (req, res) => {
-  try {
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    const providerId = typeof req.query.providerId === 'string' ? req.query.providerId : undefined;
-
-    const isAuthenticated = await NextcloudService.isUserAuthenticated(req.user.id, providerId);
-
-    if (!isAuthenticated) {
-      return res.json({
-        connected: false,
-        message: 'Nextcloud account not connected'
-      });
-    }
-
-    let userInfo = null;
-    try {
-      userInfo = await NextcloudService.getUserInfo(req.user.id, providerId);
-    } catch (userInfoError) {
-      logger.warn('Nextcloud connected but user info lookup failed', {
-        component: 'Nextcloud',
-        userId: req.user.id,
-        providerId,
-        error: userInfoError.message
-      });
-    }
-    const tokenInfo = await NextcloudService.getTokenExpirationInfo(req.user.id, providerId);
-
-    res.json({
-      connected: true,
-      userInfo: userInfo
-        ? {
-            displayName: userInfo.displayName,
-            email: userInfo.email,
-            userPrincipalName: userInfo.id,
-            serverUrl: userInfo.serverUrl
-          }
-        : null,
-      tokenInfo: {
-        expiresAt: tokenInfo.expiresAt,
-        minutesUntilExpiry: tokenInfo.minutesUntilExpiry,
-        isExpiring: tokenInfo.isExpiring,
-        isExpired: tokenInfo.isExpired
-      },
-      message: tokenInfo.isExpiring
-        ? 'Nextcloud account connected (tokens expiring soon)'
-        : 'Nextcloud account connected successfully'
-    });
-  } catch (error) {
-    logger.error('Error getting Nextcloud status', {
-      component: 'Nextcloud',
-      error: error.message
-    });
-
-    if (error.message.includes('authentication required')) {
-      return res.json({
-        connected: false,
-        message: 'Nextcloud authentication expired'
-      });
-    }
-
-    return sendInternalError(res, error, 'get Nextcloud status');
-  }
-});
-
-/**
- * Disconnect Nextcloud account
- * POST /api/integrations/nextcloud/disconnect
- */
-router.post('/disconnect', authRequired, async (req, res) => {
-  try {
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    // Accept providerId from either query (legacy clients) or JSON body.
-    const providerId =
-      (typeof req.query.providerId === 'string' && req.query.providerId) ||
-      (typeof req.body?.providerId === 'string' && req.body.providerId) ||
-      undefined;
-
-    const success = await NextcloudService.deleteUserTokens(req.user.id, providerId);
-
-    if (success) {
-      logger.info('Nextcloud disconnected', {
-        component: 'Nextcloud',
-        userId: req.user.id,
-        providerId
-      });
-      res.json({
-        success: true,
-        message: 'Nextcloud account disconnected successfully'
-      });
-    } else {
-      res.json({
-        success: false,
-        message: 'No Nextcloud connection found to disconnect'
-      });
-    }
-  } catch (error) {
-    return sendInternalError(res, error, 'disconnect Nextcloud');
-  }
+createOAuthIntegrationRouter(router, {
+  providerKey: 'nextcloud',
+  displayName: 'Nextcloud',
+  requiresProviderId: true,
+  usesPkce: false,
+  authLimiter: nextcloudAuthLimiter,
+  tolerateUserInfoFailure: true,
+  buildAuthUrl: ({ providerId, state, req }) => NextcloudService.generateAuthUrl(providerId, state, req),
+  exchangeCodeForTokens: ({ providerId, code, req }) =>
+    NextcloudService.exchangeCodeForTokens(providerId, code, req),
+  storeUserTokens: (userId, tokens) => NextcloudService.storeUserTokens(userId, tokens),
+  isUserAuthenticated: (userId, providerId) => NextcloudService.isUserAuthenticated(userId, providerId),
+  getUserInfo: (userId, providerId) => NextcloudService.getUserInfo(userId, providerId),
+  getTokenExpirationInfo: (userId, providerId) =>
+    NextcloudService.getTokenExpirationInfo(userId, providerId),
+  deleteUserTokens: (userId, providerId) => NextcloudService.deleteUserTokens(userId, providerId),
+  formatUserInfo: userInfo => ({
+    displayName: userInfo.displayName,
+    email: userInfo.email,
+    userPrincipalName: userInfo.id,
+    serverUrl: userInfo.serverUrl
+  })
 });
 
 /**

--- a/server/routes/integrations/nextcloud.js
+++ b/server/routes/integrations/nextcloud.js
@@ -7,7 +7,12 @@ import { authRequired } from '../../middleware/authRequired.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import rateLimit from 'express-rate-limit';
-import { sendInternalError, sendAuthRequired, sendBadRequest, sendErrorResponse } from '../../utils/responseHelpers.js';
+import {
+  sendInternalError,
+  sendAuthRequired,
+  sendBadRequest,
+  sendErrorResponse
+} from '../../utils/responseHelpers.js';
 import { buildContentDisposition } from '../../utils/safeContentDisposition.js';
 import { createOAuthIntegrationRouter } from './oauthIntegrationFactory.js';
 
@@ -45,11 +50,13 @@ createOAuthIntegrationRouter(router, {
   usesPkce: false,
   authLimiter: nextcloudAuthLimiter,
   tolerateUserInfoFailure: true,
-  buildAuthUrl: ({ providerId, state, req }) => NextcloudService.generateAuthUrl(providerId, state, req),
+  buildAuthUrl: ({ providerId, state, req }) =>
+    NextcloudService.generateAuthUrl(providerId, state, req),
   exchangeCodeForTokens: ({ providerId, code, req }) =>
     NextcloudService.exchangeCodeForTokens(providerId, code, req),
   storeUserTokens: (userId, tokens) => NextcloudService.storeUserTokens(userId, tokens),
-  isUserAuthenticated: (userId, providerId) => NextcloudService.isUserAuthenticated(userId, providerId),
+  isUserAuthenticated: (userId, providerId) =>
+    NextcloudService.isUserAuthenticated(userId, providerId),
   getUserInfo: (userId, providerId) => NextcloudService.getUserInfo(userId, providerId),
   getTokenExpirationInfo: (userId, providerId) =>
     NextcloudService.getTokenExpirationInfo(userId, providerId),

--- a/server/routes/integrations/oauthIntegrationFactory.js
+++ b/server/routes/integrations/oauthIntegrationFactory.js
@@ -137,189 +137,212 @@ export function createOAuthIntegrationRouter(
    * GET /api/integrations/<providerKey>/:providerId/callback (multi-provider)
    * GET /api/integrations/<providerKey>/callback (single-provider)
    */
-  router.get(requiresProviderId ? '/:providerId/callback' : '/callback', authOptional, async (req, res) => {
-    const providerId = requiresProviderId ? req.params.providerId : undefined;
-    try {
-      const { code, state, error: oauthError } = req.query;
+  router.get(
+    requiresProviderId ? '/:providerId/callback' : '/callback',
+    authOptional,
+    async (req, res) => {
+      const providerId = requiresProviderId ? req.params.providerId : undefined;
+      try {
+        const { code, state, error: oauthError } = req.query;
 
-      const sessionKey = sessionKeyFor(providerId);
-      const storedAuth = req.session?.[sessionKey];
-      const returnUrl = storedAuth?.returnUrl || '/settings/integrations';
-      const separator = returnUrl.includes('?') ? '&' : '?';
+        const sessionKey = sessionKeyFor(providerId);
+        const storedAuth = req.session?.[sessionKey];
+        const returnUrl = storedAuth?.returnUrl || '/settings/integrations';
+        const separator = returnUrl.includes('?') ? '&' : '?';
 
-      if (oauthError) {
-        logger.error(`${displayName} OAuth error`, { component: displayName, error: oauthError, providerId });
-        // Redirect with a generic error code to avoid exposing raw error details in the URL
-        return res.redirect(`${returnUrl}${separator}${providerKey}_error=oauth_failed`);
-      }
+        if (oauthError) {
+          logger.error(`${displayName} OAuth error`, {
+            component: displayName,
+            error: oauthError,
+            providerId
+          });
+          // Redirect with a generic error code to avoid exposing raw error details in the URL
+          return res.redirect(`${returnUrl}${separator}${providerKey}_error=oauth_failed`);
+        }
 
-      // Some IdP edge cases (consent denied without `error`, or a manual
-      // hit on the callback URL) can land here with no `code`. Surface a
-      // stable error code instead of throwing inside `exchangeCodeForTokens`
-      // and leaking the raw error into the redirect URL.
-      if (!code) {
-        logger.error(`${displayName} OAuth callback missing code`, { component: displayName, providerId });
-        return res.redirect(`${returnUrl}${separator}${providerKey}_error=missing_code`);
-      }
-
-      if (!req.session) {
-        logger.error(`No session available for ${displayName} OAuth callback`, {
-          component: displayName,
-          providerId
-        });
-        return res.redirect(`${returnUrl}${separator}${providerKey}_error=no_session`);
-      }
-
-      if (!storedAuth || storedAuth.state !== state) {
-        logger.error(`Invalid ${displayName} OAuth state parameter`, { component: displayName, providerId });
-        return res.redirect(`${returnUrl}${separator}${providerKey}_error=invalid_state`);
-      }
-
-      if (requiresProviderId && storedAuth.providerId !== providerId) {
-        logger.error(`Provider ID mismatch in ${displayName} OAuth callback`, {
-          component: displayName,
-          urlProviderId: providerId,
-          sessionProviderId: storedAuth.providerId
-        });
-        return res.redirect(`${returnUrl}${separator}${providerKey}_error=provider_mismatch`);
-      }
-
-      // Check session timeout
-      if (Date.now() - storedAuth.timestamp > SESSION_TIMEOUT_MS) {
-        logger.error(`${displayName} OAuth session expired`, { component: displayName, providerId });
-        return res.redirect(`${returnUrl}${separator}${providerKey}_error=session_expired`);
-      }
-
-      // Exchange authorization code for tokens
-      const tokens = await exchangeCodeForTokens({
-        providerId: storedAuth.providerId,
-        code,
-        codeVerifier: storedAuth.codeVerifier,
-        req
-      });
-
-      // Verify we received a refresh token
-      if (!tokens.refreshToken) {
-        if (logMissingRefreshToken) {
-          logMissingRefreshToken(providerId);
-        } else {
-          logger.error(`No refresh token received from ${displayName} OAuth.`, {
+        // Some IdP edge cases (consent denied without `error`, or a manual
+        // hit on the callback URL) can land here with no `code`. Surface a
+        // stable error code instead of throwing inside `exchangeCodeForTokens`
+        // and leaking the raw error into the redirect URL.
+        if (!code) {
+          logger.error(`${displayName} OAuth callback missing code`, {
             component: displayName,
             providerId
           });
+          return res.redirect(`${returnUrl}${separator}${providerKey}_error=missing_code`);
         }
-        logger.warn(
-          'Storing tokens WITHOUT refresh capability - user will need to reconnect periodically',
-          { component: displayName, providerId }
-        );
+
+        if (!req.session) {
+          logger.error(`No session available for ${displayName} OAuth callback`, {
+            component: displayName,
+            providerId
+          });
+          return res.redirect(`${returnUrl}${separator}${providerKey}_error=no_session`);
+        }
+
+        if (!storedAuth || storedAuth.state !== state) {
+          logger.error(`Invalid ${displayName} OAuth state parameter`, {
+            component: displayName,
+            providerId
+          });
+          return res.redirect(`${returnUrl}${separator}${providerKey}_error=invalid_state`);
+        }
+
+        if (requiresProviderId && storedAuth.providerId !== providerId) {
+          logger.error(`Provider ID mismatch in ${displayName} OAuth callback`, {
+            component: displayName,
+            urlProviderId: providerId,
+            sessionProviderId: storedAuth.providerId
+          });
+          return res.redirect(`${returnUrl}${separator}${providerKey}_error=provider_mismatch`);
+        }
+
+        // Check session timeout
+        if (Date.now() - storedAuth.timestamp > SESSION_TIMEOUT_MS) {
+          logger.error(`${displayName} OAuth session expired`, {
+            component: displayName,
+            providerId
+          });
+          return res.redirect(`${returnUrl}${separator}${providerKey}_error=session_expired`);
+        }
+
+        // Exchange authorization code for tokens
+        const tokens = await exchangeCodeForTokens({
+          providerId: storedAuth.providerId,
+          code,
+          codeVerifier: storedAuth.codeVerifier,
+          req
+        });
+
+        // Verify we received a refresh token
+        if (!tokens.refreshToken) {
+          if (logMissingRefreshToken) {
+            logMissingRefreshToken(providerId);
+          } else {
+            logger.error(`No refresh token received from ${displayName} OAuth.`, {
+              component: displayName,
+              providerId
+            });
+          }
+          logger.warn(
+            'Storing tokens WITHOUT refresh capability - user will need to reconnect periodically',
+            { component: displayName, providerId }
+          );
+        }
+
+        // Store encrypted tokens for user
+        await storeUserTokens(storedAuth.userId, tokens);
+
+        // Clear session data
+        delete req.session[sessionKey];
+
+        logger.info(`${displayName} OAuth completed`, {
+          component: displayName,
+          userId: storedAuth.userId,
+          providerId: storedAuth.providerId
+        });
+
+        // Redirect back to the original page with success
+        res.redirect(`${returnUrl}${separator}${providerKey}_connected=true`);
+      } catch (error) {
+        logger.error(`Error handling ${displayName} OAuth callback`, {
+          component: displayName,
+          error: error.message,
+          providerId
+        });
+
+        // Try to get returnUrl from session before clearing
+        let catchReturnUrl = '/settings/integrations';
+        if (req.session) {
+          const catchKey = sessionKeyFor(providerId);
+          catchReturnUrl = req.session[catchKey]?.returnUrl || catchReturnUrl;
+          delete req.session[catchKey];
+        }
+
+        const catchSeparator = catchReturnUrl.includes('?') ? '&' : '?';
+        // Use a stable error code rather than echoing `error.message` —
+        // some upstream errors interpolate user-influenced strings, and
+        // we don't want those landing in the redirect URL.
+        res.redirect(`${catchReturnUrl}${catchSeparator}${providerKey}_error=callback_failed`);
       }
-
-      // Store encrypted tokens for user
-      await storeUserTokens(storedAuth.userId, tokens);
-
-      // Clear session data
-      delete req.session[sessionKey];
-
-      logger.info(`${displayName} OAuth completed`, {
-        component: displayName,
-        userId: storedAuth.userId,
-        providerId: storedAuth.providerId
-      });
-
-      // Redirect back to the original page with success
-      res.redirect(`${returnUrl}${separator}${providerKey}_connected=true`);
-    } catch (error) {
-      logger.error(`Error handling ${displayName} OAuth callback`, {
-        component: displayName,
-        error: error.message,
-        providerId
-      });
-
-      // Try to get returnUrl from session before clearing
-      let catchReturnUrl = '/settings/integrations';
-      if (req.session) {
-        const catchKey = sessionKeyFor(providerId);
-        catchReturnUrl = req.session[catchKey]?.returnUrl || catchReturnUrl;
-        delete req.session[catchKey];
-      }
-
-      const catchSeparator = catchReturnUrl.includes('?') ? '&' : '?';
-      // Use a stable error code rather than echoing `error.message` —
-      // some upstream errors interpolate user-influenced strings, and
-      // we don't want those landing in the redirect URL.
-      res.redirect(`${catchReturnUrl}${catchSeparator}${providerKey}_error=callback_failed`);
     }
-  });
+  );
 
   /**
    * Get connection status for the current user.
    * GET /api/integrations/<providerKey>/status
    */
-  router.get('/status', authRequired, ...(statusLimiter ? [statusLimiter] : []), async (req, res) => {
-    try {
-      if (!req.user?.id) {
-        return sendAuthRequired(res);
-      }
-
-      const providerId = typeof req.query.providerId === 'string' ? req.query.providerId : undefined;
-
-      const isAuthenticated = await isUserAuthenticated(req.user.id, providerId);
-
-      if (!isAuthenticated) {
-        return res.json({
-          connected: false,
-          message: `${displayName} account not connected`
-        });
-      }
-
-      let userInfo;
-      if (tolerateUserInfoFailure) {
-        try {
-          userInfo = await getUserInfo(req.user.id, providerId);
-        } catch (userInfoError) {
-          logger.warn(`${displayName} connected but user info lookup failed`, {
-            component: displayName,
-            userId: req.user.id,
-            providerId,
-            error: userInfoError.message
-          });
-          userInfo = null;
+  router.get(
+    '/status',
+    authRequired,
+    ...(statusLimiter ? [statusLimiter] : []),
+    async (req, res) => {
+      try {
+        if (!req.user?.id) {
+          return sendAuthRequired(res);
         }
-      } else {
-        userInfo = await getUserInfo(req.user.id, providerId);
-      }
 
-      const tokenInfo = await getTokenExpirationInfo(req.user.id, providerId);
+        const providerId =
+          typeof req.query.providerId === 'string' ? req.query.providerId : undefined;
 
-      res.json({
-        connected: true,
-        userInfo: userInfo ? formatUserInfo(userInfo) : null,
-        tokenInfo: {
-          expiresAt: tokenInfo.expiresAt,
-          minutesUntilExpiry: tokenInfo.minutesUntilExpiry,
-          isExpiring: tokenInfo.isExpiring,
-          isExpired: tokenInfo.isExpired
-        },
-        message: tokenInfo.isExpiring
-          ? `${displayName} account connected (tokens expiring soon)`
-          : `${displayName} account connected successfully`
-      });
-    } catch (error) {
-      logger.error(`Error getting ${displayName} status`, {
-        component: displayName,
-        error: error.message
-      });
+        const isAuthenticated = await isUserAuthenticated(req.user.id, providerId);
 
-      if (error.message.includes('authentication required')) {
-        return res.json({
-          connected: false,
-          message: `${displayName} authentication expired`
+        if (!isAuthenticated) {
+          return res.json({
+            connected: false,
+            message: `${displayName} account not connected`
+          });
+        }
+
+        let userInfo;
+        if (tolerateUserInfoFailure) {
+          try {
+            userInfo = await getUserInfo(req.user.id, providerId);
+          } catch (userInfoError) {
+            logger.warn(`${displayName} connected but user info lookup failed`, {
+              component: displayName,
+              userId: req.user.id,
+              providerId,
+              error: userInfoError.message
+            });
+            userInfo = null;
+          }
+        } else {
+          userInfo = await getUserInfo(req.user.id, providerId);
+        }
+
+        const tokenInfo = await getTokenExpirationInfo(req.user.id, providerId);
+
+        res.json({
+          connected: true,
+          userInfo: userInfo ? formatUserInfo(userInfo) : null,
+          tokenInfo: {
+            expiresAt: tokenInfo.expiresAt,
+            minutesUntilExpiry: tokenInfo.minutesUntilExpiry,
+            isExpiring: tokenInfo.isExpiring,
+            isExpired: tokenInfo.isExpired
+          },
+          message: tokenInfo.isExpiring
+            ? `${displayName} account connected (tokens expiring soon)`
+            : `${displayName} account connected successfully`
         });
-      }
+      } catch (error) {
+        logger.error(`Error getting ${displayName} status`, {
+          component: displayName,
+          error: error.message
+        });
 
-      return sendInternalError(res, error, `get ${displayName} status`);
+        if (error.message.includes('authentication required')) {
+          return res.json({
+            connected: false,
+            message: `${displayName} authentication expired`
+          });
+        }
+
+        return sendInternalError(res, error, `get ${displayName} status`);
+      }
     }
-  });
+  );
 
   /**
    * Disconnect the integration for the current user.

--- a/server/routes/integrations/oauthIntegrationFactory.js
+++ b/server/routes/integrations/oauthIntegrationFactory.js
@@ -143,7 +143,7 @@ export function createOAuthIntegrationRouter(
     async (req, res) => {
       const providerId = requiresProviderId ? req.params.providerId : undefined;
       try {
-        const { code, state, error: oauthError } = req.query;
+        const { code, state, error: oauthError } = req.query; // lgtm[js/sensitive-get-query] -- OAuth authorization code and state delivered via callback redirect by design (RFC 6749)
 
         const sessionKey = sessionKeyFor(providerId);
         const storedAuth = req.session?.[sessionKey];

--- a/server/routes/integrations/oauthIntegrationFactory.js
+++ b/server/routes/integrations/oauthIntegrationFactory.js
@@ -1,0 +1,364 @@
+// Shared OAuth2 integration route factory.
+//
+// office365.js, googledrive.js, nextcloud.js and jira.js each implement the
+// same auth -> callback -> status -> disconnect OAuth2 (+PKCE) flow with
+// only the provider service, PKCE usage, and multi- vs single-provider
+// routing as real differences. This factory registers those four routes
+// directly on the router passed in; each provider file supplies the small
+// adapter functions below and keeps its own provider-specific routes
+// (sources/drives/items/download/etc.) on the same router.
+
+import crypto from 'crypto';
+import { authOptional, authRequired } from '../../middleware/authRequired.js';
+import logger from '../../utils/logger.js';
+import {
+  sendInternalError,
+  sendAuthRequired,
+  sendBadRequest,
+  sendErrorResponse
+} from '../../utils/responseHelpers.js';
+import { isValidReturnUrl } from '../../utils/oauthReturnUrl.js';
+
+const SESSION_TIMEOUT_MS = 15 * 60 * 1000;
+
+/**
+ * @param {import('express').Router} router - router to register the shared OAuth routes on
+ * @param {object} config
+ * @param {string} config.providerKey - route/session/query-param slug, e.g. 'office365'
+ * @param {string} config.displayName - human-readable name used in logs/messages, e.g. 'Office 365'
+ * @param {boolean} config.requiresProviderId - true for multi-provider integrations (office365/googledrive/nextcloud), false for single-provider ones (jira)
+ * @param {boolean} config.usesPkce - whether to generate/forward a PKCE code verifier
+ * @param {(ctx: {providerId, state, codeVerifier, req}) => string} config.buildAuthUrl
+ * @param {(ctx: {providerId, code, codeVerifier, req}) => Promise<{refreshToken?: string}>} config.exchangeCodeForTokens
+ * @param {(userId, tokens) => Promise<void>} config.storeUserTokens
+ * @param {(userId, providerId) => Promise<boolean>} config.isUserAuthenticated
+ * @param {(userId, providerId) => Promise<object>} config.getUserInfo
+ * @param {(userId, providerId) => Promise<object>} config.getTokenExpirationInfo
+ * @param {(userId, providerId) => Promise<boolean>} config.deleteUserTokens
+ * @param {(userInfo: object) => object} config.formatUserInfo - shapes the `/status` userInfo payload
+ * @param {boolean} [config.tolerateUserInfoFailure] - if true, a failed getUserInfo on `/status` is logged and reported as `userInfo: null` instead of failing the request (Nextcloud)
+ * @param {import('express').RequestHandler} [config.authLimiter] - rate limiter applied to `/auth`
+ * @param {import('express').RequestHandler} [config.statusLimiter] - optional extra rate limiter applied to `/status`
+ * @param {(providerId: string|undefined) => void} [config.logMissingRefreshToken] - custom log when no refresh token is returned
+ */
+export function createOAuthIntegrationRouter(
+  router,
+  {
+    providerKey,
+    displayName,
+    requiresProviderId,
+    usesPkce,
+    buildAuthUrl,
+    exchangeCodeForTokens,
+    storeUserTokens,
+    isUserAuthenticated,
+    getUserInfo,
+    getTokenExpirationInfo,
+    deleteUserTokens,
+    formatUserInfo,
+    tolerateUserInfoFailure = false,
+    authLimiter,
+    statusLimiter,
+    logMissingRefreshToken
+  }
+) {
+  const sessionKeyFor = providerId =>
+    requiresProviderId ? `oauth_${providerKey}_${providerId}` : `oauth_${providerKey}`;
+
+  const authMiddleware = [authRequired, ...(authLimiter ? [authLimiter] : [])];
+
+  /**
+   * Initiate the OAuth2 flow.
+   * GET /api/integrations/<providerKey>/auth?providerId=xxx
+   */
+  router.get('/auth', ...authMiddleware, async (req, res) => {
+    try {
+      const { providerId, returnUrl } = req.query;
+
+      if (requiresProviderId && !providerId) {
+        return sendBadRequest(res, 'providerId query parameter is required');
+      }
+
+      logger.debug(`${displayName} Auth Debug:`, {
+        component: displayName,
+        hasUser: !!req.user,
+        userId: req.user?.id,
+        providerId,
+        returnUrl,
+        hasSession: !!req.session
+      });
+
+      if (!req.session) {
+        return sendErrorResponse(res, 500, 'Session not available');
+      }
+
+      // authRequired only rejects missing `req.user` or anonymous users;
+      // it does NOT guarantee req.user.id is truthy. Refuse to start an
+      // OAuth flow without a real user id — otherwise tokens would land
+      // under a shared sentinel key and could be read by another caller.
+      if (!req.user?.id) {
+        return sendAuthRequired(res);
+      }
+
+      const state = crypto.randomBytes(32).toString('hex');
+      const codeVerifier = usesPkce ? crypto.randomBytes(32).toString('base64url') : undefined;
+
+      // Validate returnUrl to prevent open redirects
+      const validatedReturnUrl = isValidReturnUrl(returnUrl, req)
+        ? returnUrl
+        : '/settings/integrations';
+
+      const sessionKey = sessionKeyFor(providerId);
+      req.session[sessionKey] = {
+        state,
+        codeVerifier,
+        providerId,
+        userId: req.user.id,
+        returnUrl: validatedReturnUrl,
+        timestamp: Date.now()
+      };
+
+      const authUrl = buildAuthUrl({ providerId, state, codeVerifier, req });
+
+      logger.info(`Initiating ${displayName} OAuth`, {
+        component: displayName,
+        userId: req.user?.id,
+        providerId
+      });
+
+      res.redirect(authUrl);
+    } catch (error) {
+      return sendInternalError(res, error, `initiate ${displayName} OAuth`);
+    }
+  });
+
+  /**
+   * Handle the OAuth2 callback.
+   * GET /api/integrations/<providerKey>/:providerId/callback (multi-provider)
+   * GET /api/integrations/<providerKey>/callback (single-provider)
+   */
+  router.get(requiresProviderId ? '/:providerId/callback' : '/callback', authOptional, async (req, res) => {
+    const providerId = requiresProviderId ? req.params.providerId : undefined;
+    try {
+      const { code, state, error: oauthError } = req.query;
+
+      const sessionKey = sessionKeyFor(providerId);
+      const storedAuth = req.session?.[sessionKey];
+      const returnUrl = storedAuth?.returnUrl || '/settings/integrations';
+      const separator = returnUrl.includes('?') ? '&' : '?';
+
+      if (oauthError) {
+        logger.error(`${displayName} OAuth error`, { component: displayName, error: oauthError, providerId });
+        // Redirect with a generic error code to avoid exposing raw error details in the URL
+        return res.redirect(`${returnUrl}${separator}${providerKey}_error=oauth_failed`);
+      }
+
+      // Some IdP edge cases (consent denied without `error`, or a manual
+      // hit on the callback URL) can land here with no `code`. Surface a
+      // stable error code instead of throwing inside `exchangeCodeForTokens`
+      // and leaking the raw error into the redirect URL.
+      if (!code) {
+        logger.error(`${displayName} OAuth callback missing code`, { component: displayName, providerId });
+        return res.redirect(`${returnUrl}${separator}${providerKey}_error=missing_code`);
+      }
+
+      if (!req.session) {
+        logger.error(`No session available for ${displayName} OAuth callback`, {
+          component: displayName,
+          providerId
+        });
+        return res.redirect(`${returnUrl}${separator}${providerKey}_error=no_session`);
+      }
+
+      if (!storedAuth || storedAuth.state !== state) {
+        logger.error(`Invalid ${displayName} OAuth state parameter`, { component: displayName, providerId });
+        return res.redirect(`${returnUrl}${separator}${providerKey}_error=invalid_state`);
+      }
+
+      if (requiresProviderId && storedAuth.providerId !== providerId) {
+        logger.error(`Provider ID mismatch in ${displayName} OAuth callback`, {
+          component: displayName,
+          urlProviderId: providerId,
+          sessionProviderId: storedAuth.providerId
+        });
+        return res.redirect(`${returnUrl}${separator}${providerKey}_error=provider_mismatch`);
+      }
+
+      // Check session timeout
+      if (Date.now() - storedAuth.timestamp > SESSION_TIMEOUT_MS) {
+        logger.error(`${displayName} OAuth session expired`, { component: displayName, providerId });
+        return res.redirect(`${returnUrl}${separator}${providerKey}_error=session_expired`);
+      }
+
+      // Exchange authorization code for tokens
+      const tokens = await exchangeCodeForTokens({
+        providerId: storedAuth.providerId,
+        code,
+        codeVerifier: storedAuth.codeVerifier,
+        req
+      });
+
+      // Verify we received a refresh token
+      if (!tokens.refreshToken) {
+        if (logMissingRefreshToken) {
+          logMissingRefreshToken(providerId);
+        } else {
+          logger.error(`No refresh token received from ${displayName} OAuth.`, {
+            component: displayName,
+            providerId
+          });
+        }
+        logger.warn(
+          'Storing tokens WITHOUT refresh capability - user will need to reconnect periodically',
+          { component: displayName, providerId }
+        );
+      }
+
+      // Store encrypted tokens for user
+      await storeUserTokens(storedAuth.userId, tokens);
+
+      // Clear session data
+      delete req.session[sessionKey];
+
+      logger.info(`${displayName} OAuth completed`, {
+        component: displayName,
+        userId: storedAuth.userId,
+        providerId: storedAuth.providerId
+      });
+
+      // Redirect back to the original page with success
+      res.redirect(`${returnUrl}${separator}${providerKey}_connected=true`);
+    } catch (error) {
+      logger.error(`Error handling ${displayName} OAuth callback`, {
+        component: displayName,
+        error: error.message,
+        providerId
+      });
+
+      // Try to get returnUrl from session before clearing
+      let catchReturnUrl = '/settings/integrations';
+      if (req.session) {
+        const catchKey = sessionKeyFor(providerId);
+        catchReturnUrl = req.session[catchKey]?.returnUrl || catchReturnUrl;
+        delete req.session[catchKey];
+      }
+
+      const catchSeparator = catchReturnUrl.includes('?') ? '&' : '?';
+      // Use a stable error code rather than echoing `error.message` —
+      // some upstream errors interpolate user-influenced strings, and
+      // we don't want those landing in the redirect URL.
+      res.redirect(`${catchReturnUrl}${catchSeparator}${providerKey}_error=callback_failed`);
+    }
+  });
+
+  /**
+   * Get connection status for the current user.
+   * GET /api/integrations/<providerKey>/status
+   */
+  router.get('/status', authRequired, ...(statusLimiter ? [statusLimiter] : []), async (req, res) => {
+    try {
+      if (!req.user?.id) {
+        return sendAuthRequired(res);
+      }
+
+      const providerId = typeof req.query.providerId === 'string' ? req.query.providerId : undefined;
+
+      const isAuthenticated = await isUserAuthenticated(req.user.id, providerId);
+
+      if (!isAuthenticated) {
+        return res.json({
+          connected: false,
+          message: `${displayName} account not connected`
+        });
+      }
+
+      let userInfo;
+      if (tolerateUserInfoFailure) {
+        try {
+          userInfo = await getUserInfo(req.user.id, providerId);
+        } catch (userInfoError) {
+          logger.warn(`${displayName} connected but user info lookup failed`, {
+            component: displayName,
+            userId: req.user.id,
+            providerId,
+            error: userInfoError.message
+          });
+          userInfo = null;
+        }
+      } else {
+        userInfo = await getUserInfo(req.user.id, providerId);
+      }
+
+      const tokenInfo = await getTokenExpirationInfo(req.user.id, providerId);
+
+      res.json({
+        connected: true,
+        userInfo: userInfo ? formatUserInfo(userInfo) : null,
+        tokenInfo: {
+          expiresAt: tokenInfo.expiresAt,
+          minutesUntilExpiry: tokenInfo.minutesUntilExpiry,
+          isExpiring: tokenInfo.isExpiring,
+          isExpired: tokenInfo.isExpired
+        },
+        message: tokenInfo.isExpiring
+          ? `${displayName} account connected (tokens expiring soon)`
+          : `${displayName} account connected successfully`
+      });
+    } catch (error) {
+      logger.error(`Error getting ${displayName} status`, {
+        component: displayName,
+        error: error.message
+      });
+
+      if (error.message.includes('authentication required')) {
+        return res.json({
+          connected: false,
+          message: `${displayName} authentication expired`
+        });
+      }
+
+      return sendInternalError(res, error, `get ${displayName} status`);
+    }
+  });
+
+  /**
+   * Disconnect the integration for the current user.
+   * POST /api/integrations/<providerKey>/disconnect
+   */
+  router.post('/disconnect', authRequired, async (req, res) => {
+    try {
+      if (!req.user?.id) {
+        return sendAuthRequired(res);
+      }
+
+      const providerId = requiresProviderId
+        ? (typeof req.query.providerId === 'string' && req.query.providerId) ||
+          (typeof req.body?.providerId === 'string' && req.body.providerId) ||
+          undefined
+        : undefined;
+
+      const success = await deleteUserTokens(req.user.id, providerId);
+
+      if (success) {
+        logger.info(`${displayName} disconnected`, {
+          component: displayName,
+          userId: req.user.id,
+          providerId
+        });
+        res.json({
+          success: true,
+          message: `${displayName} account disconnected successfully`
+        });
+      } else {
+        res.json({
+          success: false,
+          message: `No ${displayName} connection found to disconnect`
+        });
+      }
+    } catch (error) {
+      return sendInternalError(res, error, `disconnect ${displayName}`);
+    }
+  });
+
+  return router;
+}

--- a/server/routes/integrations/office365.js
+++ b/server/routes/integrations/office365.js
@@ -2,20 +2,14 @@
 // Handles OAuth2 PKCE flow for Microsoft 365 file access authentication
 
 import express from 'express';
-import crypto from 'crypto';
 import Office365Service from '../../services/integrations/Office365Service.js';
-import { authOptional, authRequired } from '../../middleware/authRequired.js';
+import { authRequired } from '../../middleware/authRequired.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import rateLimit from 'express-rate-limit';
-import {
-  sendInternalError,
-  sendAuthRequired,
-  sendBadRequest,
-  sendErrorResponse
-} from '../../utils/responseHelpers.js';
-import { isValidReturnUrl } from '../../utils/oauthReturnUrl.js';
+import { sendInternalError, sendAuthRequired, sendBadRequest, sendErrorResponse } from '../../utils/responseHelpers.js';
 import { buildContentDisposition } from '../../utils/safeContentDisposition.js';
+import { createOAuthIntegrationRouter } from './oauthIntegrationFactory.js';
 
 const router = express.Router();
 
@@ -44,310 +38,28 @@ const office365AuthLimiter = rateLimit({
   legacyHeaders: false
 });
 
-/**
- * Initiate Office 365 OAuth2 flow for Microsoft 365
- * GET /api/integrations/office365/auth?providerId=xxx
- */
-router.get('/auth', authRequired, office365AuthLimiter, async (req, res) => {
-  try {
-    const { providerId, returnUrl } = req.query;
-
-    if (!providerId) {
-      return sendBadRequest(res, 'providerId query parameter is required');
-    }
-
-    logger.debug('🔍 Office 365 Auth Debug:', {
-      component: 'Office 365',
-      hasUser: !!req.user,
-      userId: req.user?.id,
-      providerId,
-      returnUrl,
-      hasSession: !!req.session
-    });
-
-    // Check if session is available
-    if (!req.session) {
-      return sendErrorResponse(res, 500, 'Session not available');
-    }
-
-    // authRequired only rejects missing `req.user` or anonymous users;
-    // it does NOT guarantee req.user.id is truthy. Refuse to start an
-    // OAuth flow without a real user id — otherwise tokens would land
-    // under a shared sentinel key and could be read by another caller.
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    // Generate state for CSRF protection
-    const state = crypto.randomBytes(32).toString('hex');
-
-    // Generate PKCE parameters
-    const codeVerifier = crypto.randomBytes(32).toString('base64url');
-
-    // Validate returnUrl to prevent open redirects
-    const validatedReturnUrl = isValidReturnUrl(returnUrl, req)
-      ? returnUrl
-      : '/settings/integrations';
-
-    // Store OAuth parameters in session with provider-specific key
-    // This allows multiple Office 365 providers to have concurrent OAuth flows
-    const sessionKey = `oauth_office365_${providerId}`;
-    req.session[sessionKey] = {
-      state,
-      codeVerifier,
-      providerId,
-      userId: req.user.id,
-      returnUrl: validatedReturnUrl,
-      timestamp: Date.now()
-    };
-
-    // Generate authorization URL (pass request for auto-detection)
-    const authUrl = Office365Service.generateAuthUrl(providerId, state, codeVerifier, req);
-
-    logger.info('Initiating Office 365 OAuth', {
-      component: 'Office 365',
-      userId: req.user?.id,
-      providerId
-    });
-
-    // Redirect to Microsoft OAuth consent screen
-    res.redirect(authUrl);
-  } catch (error) {
-    return sendInternalError(res, error, 'initiate Office 365 OAuth');
-  }
-});
-
-/**
- * Handle Office 365 OAuth callback (provider-specific)
- * GET /api/integrations/office365/:providerId/callback
- */
-router.get('/:providerId/callback', authOptional, async (req, res) => {
-  try {
-    const { code, state, error: oauthError } = req.query;
-    const { providerId } = req.params;
-
-    // Check for OAuth errors
-    if (oauthError) {
-      logger.error('❌ Office 365 OAuth error:', {
-        component: 'Office 365',
-        error: oauthError,
-        providerId
-      });
-      // Redirect with a generic error code to avoid exposing raw error details in the URL
-      return res.redirect('/settings/integrations?office365_error=oauth_failed');
-    }
-
-    // Some IdP edge cases (consent denied without `error`, or a manual
-    // hit on the callback URL) can land here with no `code`. Surface a
-    // stable error code instead of throwing inside `exchangeCodeForTokens`
-    // and leaking the raw error into the redirect URL.
-    if (!code) {
-      logger.error('❌ Office 365 OAuth callback missing code', {
-        component: 'Office 365',
-        providerId
-      });
-      return res.redirect('/settings/integrations?office365_error=missing_code');
-    }
-
-    // Check if session is available
-    if (!req.session) {
-      logger.error('❌ No session available for Office 365 OAuth callback', {
-        component: 'Office 365',
-        providerId
-      });
-      return res.redirect('/settings/integrations?office365_error=no_session');
-    }
-
-    // Validate state parameter
-    const sessionKey = `oauth_office365_${providerId}`;
-    const storedAuth = req.session[sessionKey];
-
-    // Extract returnUrl early for use in all redirects
-    const returnUrl = storedAuth?.returnUrl || '/settings/integrations';
-    const separator = returnUrl.includes('?') ? '&' : '?';
-
-    if (!storedAuth || storedAuth.state !== state) {
-      logger.error('❌ Invalid Office 365 OAuth state parameter', {
-        component: 'Office 365',
-        providerId
-      });
-      return res.redirect(`${returnUrl}${separator}office365_error=invalid_state`);
-    }
-
-    // Verify providerId matches
-    if (storedAuth.providerId !== providerId) {
-      logger.error('❌ Provider ID mismatch in Office 365 OAuth callback', {
-        component: 'Office 365',
-        urlProviderId: providerId,
-        sessionProviderId: storedAuth.providerId
-      });
-      return res.redirect(`${returnUrl}${separator}office365_error=provider_mismatch`);
-    }
-
-    // Check session timeout (15 minutes)
-    if (Date.now() - storedAuth.timestamp > 15 * 60 * 1000) {
-      logger.error('❌ Office 365 OAuth session expired', {
-        component: 'Office 365',
-        providerId
-      });
-      return res.redirect(`${returnUrl}${separator}office365_error=session_expired`);
-    }
-
-    // Exchange authorization code for tokens (pass request for auto-detection)
-    const tokens = await Office365Service.exchangeCodeForTokens(
-      storedAuth.providerId,
-      code,
-      storedAuth.codeVerifier,
-      req
-    );
-
-    // Verify we received a refresh token
-    if (!tokens.refreshToken) {
-      logger.error('❌ CRITICAL: No refresh token received from Office 365 OAuth.', {
-        component: 'Office 365',
-        providerId
-      });
-      logger.warn(
-        '⚠️ Storing tokens WITHOUT refresh capability - user will need to reconnect periodically',
-        { component: 'Office 365' }
-      );
-    }
-
-    // Store encrypted tokens for user
-    await Office365Service.storeUserTokens(storedAuth.userId, tokens);
-
-    // Clear session data
-    delete req.session[sessionKey];
-
-    logger.info('Office 365 OAuth completed', {
-      component: 'Office 365',
-      userId: storedAuth.userId,
-      providerId: storedAuth.providerId
-    });
-
-    // Redirect back to the original page with success
-    res.redirect(`${returnUrl}${separator}office365_connected=true`);
-  } catch (error) {
-    logger.error('❌ Error handling Office 365 OAuth callback:', {
-      component: 'Office 365',
-      error: error.message,
-      providerId: req.params.providerId
-    });
-
-    // Try to get returnUrl from session before clearing
-    let catchReturnUrl = '/settings/integrations';
-    if (req.session) {
-      const catchKey = `oauth_office365_${req.params.providerId}`;
-      catchReturnUrl = req.session[catchKey]?.returnUrl || catchReturnUrl;
-      delete req.session[catchKey];
-    }
-
-    const catchSeparator = catchReturnUrl.includes('?') ? '&' : '?';
-    // Use a stable error code rather than echoing `error.message` —
-    // some upstream errors interpolate user-influenced strings, and
-    // we don't want those landing in the redirect URL.
-    res.redirect(`${catchReturnUrl}${catchSeparator}office365_error=callback_failed`);
-  }
-});
-
-/**
- * Get Office 365 connection status for current user
- * GET /api/integrations/office365/status
- */
-router.get('/status', authRequired, async (req, res) => {
-  try {
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    const providerId = typeof req.query.providerId === 'string' ? req.query.providerId : undefined;
-
-    const isAuthenticated = await Office365Service.isUserAuthenticated(req.user.id, providerId);
-
-    if (!isAuthenticated) {
-      return res.json({
-        connected: false,
-        message: 'Office 365 account not connected'
-      });
-    }
-
-    // Get user info from Microsoft
-    const userInfo = await Office365Service.getUserInfo(req.user.id, providerId);
-
-    // Get token expiration info
-    const tokenInfo = await Office365Service.getTokenExpirationInfo(req.user.id, providerId);
-
-    res.json({
-      connected: true,
-      userInfo: {
-        displayName: userInfo.displayName,
-        mail: userInfo.mail,
-        userPrincipalName: userInfo.userPrincipalName,
-        jobTitle: userInfo.jobTitle
-      },
-      tokenInfo: {
-        expiresAt: tokenInfo.expiresAt,
-        minutesUntilExpiry: tokenInfo.minutesUntilExpiry,
-        isExpiring: tokenInfo.isExpiring,
-        isExpired: tokenInfo.isExpired
-      },
-      message: tokenInfo.isExpiring
-        ? 'Office 365 account connected (tokens expiring soon)'
-        : 'Office 365 account connected successfully'
-    });
-  } catch (error) {
-    logger.error('❌ Error getting Office 365 status:', {
-      component: 'Office 365',
-      error: error.message
-    });
-
-    if (error.message.includes('authentication required')) {
-      return res.json({
-        connected: false,
-        message: 'Office 365 authentication expired'
-      });
-    }
-
-    return sendInternalError(res, error, 'get Office 365 status');
-  }
-});
-
-/**
- * Disconnect Office 365 account
- * POST /api/integrations/office365/disconnect
- */
-router.post('/disconnect', authRequired, async (req, res) => {
-  try {
-    if (!req.user?.id) {
-      return sendAuthRequired(res);
-    }
-
-    const providerId =
-      (typeof req.query.providerId === 'string' && req.query.providerId) ||
-      (typeof req.body?.providerId === 'string' && req.body.providerId) ||
-      undefined;
-
-    const success = await Office365Service.deleteUserTokens(req.user.id, providerId);
-
-    if (success) {
-      logger.info('Office 365 disconnected', {
-        component: 'Office 365',
-        userId: req.user.id,
-        providerId
-      });
-      res.json({
-        success: true,
-        message: 'Office 365 account disconnected successfully'
-      });
-    } else {
-      res.json({
-        success: false,
-        message: 'No Office 365 connection found to disconnect'
-      });
-    }
-  } catch (error) {
-    return sendInternalError(res, error, 'disconnect Office 365');
-  }
+createOAuthIntegrationRouter(router, {
+  providerKey: 'office365',
+  displayName: 'Office 365',
+  requiresProviderId: true,
+  usesPkce: true,
+  authLimiter: office365AuthLimiter,
+  buildAuthUrl: ({ providerId, state, codeVerifier, req }) =>
+    Office365Service.generateAuthUrl(providerId, state, codeVerifier, req),
+  exchangeCodeForTokens: ({ providerId, code, codeVerifier, req }) =>
+    Office365Service.exchangeCodeForTokens(providerId, code, codeVerifier, req),
+  storeUserTokens: (userId, tokens) => Office365Service.storeUserTokens(userId, tokens),
+  isUserAuthenticated: (userId, providerId) => Office365Service.isUserAuthenticated(userId, providerId),
+  getUserInfo: (userId, providerId) => Office365Service.getUserInfo(userId, providerId),
+  getTokenExpirationInfo: (userId, providerId) =>
+    Office365Service.getTokenExpirationInfo(userId, providerId),
+  deleteUserTokens: (userId, providerId) => Office365Service.deleteUserTokens(userId, providerId),
+  formatUserInfo: userInfo => ({
+    displayName: userInfo.displayName,
+    mail: userInfo.mail,
+    userPrincipalName: userInfo.userPrincipalName,
+    jobTitle: userInfo.jobTitle
+  })
 });
 
 /**

--- a/server/routes/integrations/office365.js
+++ b/server/routes/integrations/office365.js
@@ -7,7 +7,12 @@ import { authRequired } from '../../middleware/authRequired.js';
 import { requireFeature } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
 import rateLimit from 'express-rate-limit';
-import { sendInternalError, sendAuthRequired, sendBadRequest, sendErrorResponse } from '../../utils/responseHelpers.js';
+import {
+  sendInternalError,
+  sendAuthRequired,
+  sendBadRequest,
+  sendErrorResponse
+} from '../../utils/responseHelpers.js';
 import { buildContentDisposition } from '../../utils/safeContentDisposition.js';
 import { createOAuthIntegrationRouter } from './oauthIntegrationFactory.js';
 
@@ -49,7 +54,8 @@ createOAuthIntegrationRouter(router, {
   exchangeCodeForTokens: ({ providerId, code, codeVerifier, req }) =>
     Office365Service.exchangeCodeForTokens(providerId, code, codeVerifier, req),
   storeUserTokens: (userId, tokens) => Office365Service.storeUserTokens(userId, tokens),
-  isUserAuthenticated: (userId, providerId) => Office365Service.isUserAuthenticated(userId, providerId),
+  isUserAuthenticated: (userId, providerId) =>
+    Office365Service.isUserAuthenticated(userId, providerId),
   getUserInfo: (userId, providerId) => Office365Service.getUserInfo(userId, providerId),
   getTokenExpirationInfo: (userId, providerId) =>
     Office365Service.getTokenExpirationInfo(userId, providerId),


### PR DESCRIPTION
## Summary

Closes #1746.

`office365.js`, `googledrive.js`, `nextcloud.js` and `jira.js` each hand-rolled the same `/auth` → `/:providerId/callback` → `/status` → `/disconnect` OAuth2(+PKCE) flow (session state/CSRF handling, 15-minute timeout, stable `_error=` redirect codes, token exchange/storage). Every OAuth fix or hardening change had to be applied by hand in 3-4 places and had already drifted between providers.

- Added `server/routes/integrations/oauthIntegrationFactory.js` exporting `createOAuthIntegrationRouter(router, config)`, which registers the four shared routes directly on the router passed in (so route introspection/tests that walk `router.stack` keep working unchanged).
- Each provider file now calls the factory with its own config (`providerKey`, `displayName`, whether it's multi-provider (`requiresProviderId`), PKCE usage, provider-service adapter callbacks for `buildAuthUrl`/`exchangeCodeForTokens` since those signatures differ per service, `formatUserInfo` for the `/status` payload shape, and rate limiters) and keeps only its provider-specific routes (`/sources`, `/drives/:source`, `/items`, `/download`, Jira's `/refresh`/`/attachment/:id`/`/test`) unchanged.
- Removes ~1150 lines of duplicated route logic.

The Office 365 "deprecated legacy callback" mentioned in the original issue no longer exists in the codebase (confirmed via grep before starting), so there was nothing to remove there.

### Intentional behavior changes (called out per the issue's implementation plan)
- Jira's `/auth` now has the same 10 req/min rate limiter the other three providers already had — it was previously unprotected.
- All four providers now redirect early OAuth-error/missing-code callback failures to the user's actual stored `returnUrl` (when a session exists) instead of a hardcoded `/settings/integrations` default, matching Jira's existing (more correct) behavior. The other three previously only used the stored `returnUrl` starting from the state-mismatch check onward.
- Error logs consistently use `error.message` instead of occasionally logging the raw `Error` object.

No route paths, request/response shapes, or session storage keys changed.

## Test plan
- [x] `node --check` on all modified/new files
- [x] `server/tests/office365-callback-routes.test.js`, `office365-callback-url-autodetect.test.js`, `oauthReturnUrl.test.js`, `oauth-authz-code-permission-filter.test.js`, `office365-scope-build.test.js`, `nextcloud-service.test.js`, `auditLogger.test.js` — all pass (the pre-existing, unrelated `office365-old-token-migration.test.js` failure was verified to also fail on `main` before this change; it exercises `Office365Service` scope-detection logic untouched here)
- [x] Started the server locally (`WORKERS=1`) and confirmed it boots without route-registration errors
- [x] Manually hit `/auth` (401 without session), `/status`/`/disconnect` (401 without auth), and `/callback` (302 redirect on invalid state) for all four providers to confirm behavior parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01P8YbswWR2si7UbMrCtHTzs)_