### PR TITLE
fix(security): escape appName, watermark text, and settings in chat export HTML

### DIFF
--- a/client/src/api/endpoints/apps.js
+++ b/client/src/api/endpoints/apps.js
@@ -287,15 +287,15 @@ const generatePDFHTML = (
     <div class="metadata">
       <h3>Chat Settings</h3>
       <div class="metadata-grid">
-        ${settings.model ? `<div><strong>Model:</strong> ${settings.model}</div>` : ''}
+        ${settings.model ? `<div><strong>Model:</strong> ${escapeHtml(settings.model)}</div>` : ''}
         ${settings.temperature !== undefined ? `<div><strong>Temperature:</strong> ${settings.temperature}</div>` : ''}
-        ${settings.style ? `<div><strong>Style:</strong> ${settings.style}</div>` : ''}
-        ${settings.outputFormat ? `<div><strong>Output Format:</strong> ${settings.outputFormat}</div>` : ''}
+        ${settings.style ? `<div><strong>Style:</strong> ${escapeHtml(settings.style)}</div>` : ''}
+        ${settings.outputFormat ? `<div><strong>Output Format:</strong> ${escapeHtml(settings.outputFormat)}</div>` : ''}
         ${
           settings.variables && Object.keys(settings.variables).length > 0
             ? `
           <div><strong>Variables:</strong> ${Object.entries(settings.variables)
-            .map(([k, v]) => `${k}: ${v}`)
+            .map(([k, v]) => `${escapeHtml(k)}: ${escapeHtml(v)}`)
             .join(', ')}</div>
         `
             : ''
@@ -321,7 +321,7 @@ const generatePDFHTML = (
   <div class="container">
     <header class="header">
       <h1>${escapeHtml(docTitle)}</h1>
-      ${appName ? `<h2>${appName}</h2>` : ''}
+      ${appName ? `<h2>${escapeHtml(appName)}</h2>` : ''}
       <p class="export-date">Exported on ${new Date().toLocaleString()}</p>
     </header>
     
@@ -331,7 +331,7 @@ const generatePDFHTML = (
       ${messagesHTML}
     </main>
     
-    ${watermark.text ? `<div class="watermark">${watermark.text}</div>` : ''}
+    ${watermark.text ? `<div class="watermark">${escapeHtml(watermark.text)}</div>` : ''}
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Fixes #1739.

`generatePDFHTML` (used by PDF export, print, and `exportChatToHTML`) already escaped the attacker-controlled chat title via `escapeHtml()`, but interpolated `appName`, `watermark.text`, and `settings.model`/`style`/`outputFormat`/`variables` into the export document without escaping. `settings.variables` are user-supplied form inputs that can be pre-filled via shared short links, so a crafted link could inject markup that executes in the app's own origin when the document is printed via the same-origin `iframe.srcdoc` (`printHtmlDocument`), or gets written to disk unescaped by `exportChatToHTML`.

- Wrapped `appName`, `watermark.text`, `settings.model`, `settings.style`, `settings.outputFormat`, and every `settings.variables` key/value with the existing `escapeHtml()` helper in `generatePDFHTML` — mirroring the pattern already used for `docTitle`.
- `settings.temperature` is numeric and doesn't need escaping.
- No server-side changes; this is entirely client-side export/print code (`client/src/api/endpoints/apps.js`).
- Confirmed both `exportChatToPDF` and `exportChatToHTML` (via `generateHTML`) route through the same `generatePDFHTML`, so this single fix covers PDF export, print, and HTML export/download.

## Test plan

- [x] Verified with a standalone script that `escapeHtml()` neutralizes `<script>`/`onerror` payloads injected via `appName`, `watermark.text`, and `settings.variables` keys/values, while leaving normal text unaffected.
- [x] Confirmed via `prettier --write` that formatting is unchanged (matches project style).
- [x] Syntax-checked the modified file.
- [ ] CI (lint/build) — could not run locally in this environment (dependencies not installed); please confirm CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013vvas8Pm53SzuerXPxDQem

---
_Generated by [Claude Code](https://claude.ai/code/session_013vvas8Pm53SzuerXPxDQem)_