### PR TITLE
Extract shared OAuthIntegrationBase from GoogleDrive/Office365/Nextcloud services

### DIFF
--- a/server/services/integrations/GoogleDriveService.js
+++ b/server/services/integrations/GoogleDriveService.js
@@ -1,11 +1,9 @@
 import 'dotenv/config';
 import crypto from 'crypto';
-import tokenStorage from '../TokenStorageService.js';
 import { httpFetch } from '../../utils/httpConfig.js';
 import logger from '../../utils/logger.js';
-import configCache from '../../configCache.js';
-import credentialService from '../CredentialService.js';
 import { readBoundedBody, MAX_DOWNLOAD_BYTES } from '../../utils/boundedBodyReader.js';
+import OAuthIntegrationBase from './OAuthIntegrationBase.js';
 
 /**
  * Google Drive export MIME type mappings for Google Workspace documents
@@ -34,9 +32,13 @@ const GOOGLE_EXPORT_MIME_TYPES = {
  * Google Drive Service for Google Workspace file access integration
  * Provides OAuth 2.0 authentication with PKCE, secure token storage, and Google Drive API access
  */
-class GoogleDriveService {
+class GoogleDriveService extends OAuthIntegrationBase {
   constructor() {
-    this.serviceName = 'googledrive';
+    super({
+      serviceName: 'googledrive',
+      displayName: 'Google Drive',
+      componentName: 'Google Drive'
+    });
 
     // Google OAuth2 endpoints
     this.authBaseUrl = 'https://accounts.google.com/o/oauth2/v2/auth';
@@ -48,59 +50,16 @@ class GoogleDriveService {
   }
 
   /**
-   * Build callback URL from request
-   * @param {Object} req - Express request object
-   * @param {string} providerId - Provider ID to include in callback URL
-   * @returns {string} Full callback URL
-   */
-  _buildCallbackUrl(req, providerId) {
-    const protocol = req.get('x-forwarded-proto') || req.protocol || 'https';
-    const host = req.get('x-forwarded-host') || req.get('host');
-
-    if (!host) {
-      throw new Error('Unable to determine host for callback URL');
-    }
-
-    return `${protocol}://${host}/api/integrations/${this.serviceName}/${providerId}/callback`;
-  }
-
-  /**
    * Get Google Drive provider configuration
    * @param {string} providerId - The provider ID from cloud storage config
    * @returns {Object} Provider configuration
    */
   _getProviderConfig(providerId) {
-    if (!configCache || typeof configCache.get !== 'function') {
-      throw new Error('Platform configuration cache is not initialized');
-    }
-
-    const platformConfig = configCache.getPlatform();
-    const cloudStorage = platformConfig?.cloudStorage;
-
-    if (!cloudStorage?.enabled) {
-      throw new Error('Cloud storage is not enabled');
-    }
-
-    const provider = cloudStorage.providers?.find(
-      p => p.id === providerId && p.type === 'googledrive' && p.enabled !== false
-    );
-
-    if (!provider) {
-      throw new Error(`Google Drive provider '${providerId}' not found or not enabled`);
-    }
-
-    if (!provider.clientId || !provider.clientSecretRef) {
-      throw new Error(
-        `Google Drive provider '${providerId}' missing required configuration (clientId, clientSecretRef)`
-      );
-    }
-
-    // Resolve the client secret from the central credential store so
-    // downstream code works with the plaintext value inline on the provider.
-    return {
-      ...provider,
-      clientSecret: credentialService.resolveSecret(provider.clientSecretRef)
-    };
+    return super._getProviderConfig(providerId, {
+      type: 'googledrive',
+      requiredFields: ['clientId', 'clientSecretRef'],
+      secretFields: ['clientSecretRef']
+    });
   }
 
   /**
@@ -114,24 +73,12 @@ class GoogleDriveService {
   generateAuthUrl(providerId, state, codeVerifier, req = null) {
     const provider = this._getProviderConfig(providerId);
     const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
-
-    let redirectUri = provider.redirectUri || process.env.GOOGLEDRIVE_OAUTH_REDIRECT_URI;
-
-    if (!redirectUri && req) {
-      redirectUri = this._buildCallbackUrl(req, providerId);
-      logger.info('Auto-detected Google Drive callback URL from request', {
-        component: 'Google Drive',
-        redirectUri
-      });
-    }
-
-    if (!redirectUri) {
-      redirectUri = `${process.env.SERVER_URL || 'http://localhost:3000'}/api/integrations/${this.serviceName}/${providerId}/callback`;
-      logger.warn('Using fallback localhost URL for Google Drive callback', {
-        component: 'Google Drive',
-        redirectUri
-      });
-    }
+    const redirectUri = this._resolveRedirectUri(
+      provider,
+      providerId,
+      'GOOGLEDRIVE_OAUTH_REDIRECT_URI',
+      req
+    );
 
     // Google Drive API scopes
     const scopes = [
@@ -166,24 +113,12 @@ class GoogleDriveService {
   async exchangeCodeForTokens(providerId, authCode, codeVerifier, req = null) {
     try {
       const provider = this._getProviderConfig(providerId);
-
-      let redirectUri = provider.redirectUri || process.env.GOOGLEDRIVE_OAUTH_REDIRECT_URI;
-
-      if (!redirectUri && req) {
-        redirectUri = this._buildCallbackUrl(req, providerId);
-        logger.info('Auto-detected Google Drive callback URL for token exchange', {
-          component: 'Google Drive',
-          redirectUri
-        });
-      }
-
-      if (!redirectUri) {
-        redirectUri = `${process.env.SERVER_URL || 'http://localhost:3000'}/api/integrations/${this.serviceName}/${providerId}/callback`;
-        logger.warn('Using fallback localhost URL for Google Drive token exchange', {
-          component: 'Google Drive',
-          redirectUri
-        });
-      }
+      const redirectUri = this._resolveRedirectUri(
+        provider,
+        providerId,
+        'GOOGLEDRIVE_OAUTH_REDIRECT_URI',
+        req
+      );
 
       const tokenData = new URLSearchParams({
         client_id: provider.clientId,
@@ -307,129 +242,6 @@ class GoogleDriveService {
   }
 
   /**
-   * Store encrypted user tokens
-   * @param {string} userId - User ID
-   * @param {Object} tokens - Tokens to store
-   */
-  async storeUserTokens(userId, tokens) {
-    try {
-      if (!tokens.refreshToken) {
-        logger.warn('No refresh token - user will need to reconnect when access token expires', {
-          component: 'Google Drive'
-        });
-      }
-
-      await tokenStorage.storeUserTokens(userId, this.serviceName, tokens, tokens.providerId);
-      logger.info('Google Drive tokens stored for user', {
-        component: 'Google Drive',
-        userId,
-        providerId: tokens.providerId
-      });
-      return true;
-    } catch (error) {
-      logger.error('Error storing user tokens', {
-        component: 'Google Drive',
-        error
-      });
-      throw new Error('Failed to store user tokens');
-    }
-  }
-
-  /**
-   * Retrieve and decrypt user tokens with automatic refresh if expired
-   * @param {string} userId - User ID
-   * @param {string} [providerId] - Provider ID
-   * @returns {Promise<Object>} Decrypted tokens
-   */
-  async getUserTokens(userId, providerId) {
-    try {
-      let tokens = await tokenStorage.getUserTokens(userId, this.serviceName, providerId);
-
-      const expired = await tokenStorage.areTokensExpired(userId, this.serviceName, providerId);
-
-      if (expired) {
-        logger.info('Tokens expired for user, attempting refresh', {
-          component: 'Google Drive',
-          userId
-        });
-
-        try {
-          if (!tokens.refreshToken) {
-            logger.error('No refresh token available for user', {
-              component: 'Google Drive',
-              userId
-            });
-            throw new Error(
-              'No refresh token available - user needs to reconnect Google Drive account'
-            );
-          }
-
-          const refreshedTokens = await this.refreshAccessToken(
-            tokens.providerId,
-            tokens.refreshToken
-          );
-
-          await this.storeUserTokens(userId, refreshedTokens);
-          logger.info('Successfully refreshed Google Drive tokens for user', {
-            component: 'Google Drive',
-            userId
-          });
-          return refreshedTokens;
-        } catch (refreshError) {
-          logger.error('Failed to refresh tokens for user', {
-            component: 'Google Drive',
-            userId,
-            error: refreshError
-          });
-
-          await this.deleteUserTokens(userId, providerId);
-          throw new Error('Google Drive authentication expired. Please reconnect your account.');
-        }
-      }
-
-      return tokens;
-    } catch (error) {
-      if (
-        error.message.includes('not authenticated') ||
-        error.message.includes('authentication expired')
-      ) {
-        throw error;
-      }
-      logger.error('Error retrieving user tokens', {
-        component: 'Google Drive',
-        error
-      });
-      throw new Error('Failed to retrieve user tokens');
-    }
-  }
-
-  /**
-   * Delete user tokens (disconnect)
-   * @param {string} userId - User ID
-   * @param {string} [providerId] - Provider ID
-   * @returns {Promise<boolean>} Success status
-   */
-  async deleteUserTokens(userId, providerId) {
-    try {
-      const result = await tokenStorage.deleteUserTokens(userId, this.serviceName, providerId);
-      if (result) {
-        logger.info('Google Drive tokens deleted for user', {
-          component: 'Google Drive',
-          userId,
-          providerId
-        });
-      }
-      return result;
-    } catch (error) {
-      logger.error('Error deleting user tokens', {
-        component: 'Google Drive',
-        error
-      });
-      return false;
-    }
-  }
-
-  /**
    * Make authenticated Google API request
    * @param {string} endpoint - API endpoint
    * @param {string} method - HTTP method
@@ -440,116 +252,15 @@ class GoogleDriveService {
    * @returns {Promise<Object>} API response
    */
   async makeApiRequest(endpoint, method = 'GET', data = null, userId, providerId, retryCount = 0) {
-    const maxRetries = 1;
-
-    try {
-      const tokens = await this.getUserTokens(userId, providerId);
-
-      const url = endpoint.startsWith('http') ? endpoint : `${this.driveApiUrl}${endpoint}`;
-
-      const fetchOptions = {
-        method,
-        headers: {
-          Authorization: `Bearer ${tokens.accessToken}`,
-          Accept: 'application/json'
-        }
-      };
-
-      if (data && (method === 'POST' || method === 'PUT' || method === 'PATCH')) {
-        fetchOptions.headers['Content-Type'] = 'application/json';
-        fetchOptions.body = JSON.stringify(data);
-      }
-
-      const response = await httpFetch(url, fetchOptions);
-
-      if (!response.ok) {
-        if (response.status === 401 && retryCount < maxRetries) {
-          logger.info('Received 401, attempting token refresh and retry', {
-            component: 'Google Drive',
-            attempt: retryCount + 1,
-            maxAttempts: maxRetries + 1
-          });
-
-          try {
-            const expiredTokens = await tokenStorage.getUserTokens(
-              userId,
-              this.serviceName,
-              providerId
-            );
-
-            if (!expiredTokens.refreshToken) {
-              throw new Error('No refresh token available');
-            }
-
-            const refreshedTokens = await this.refreshAccessToken(
-              expiredTokens.providerId,
-              expiredTokens.refreshToken
-            );
-
-            await this.storeUserTokens(userId, refreshedTokens);
-
-            return await this.makeApiRequest(
-              endpoint,
-              method,
-              data,
-              userId,
-              providerId,
-              retryCount + 1
-            );
-          } catch (refreshError) {
-            logger.error('Forced token refresh failed', {
-              component: 'Google Drive',
-              error: refreshError
-            });
-
-            await this.deleteUserTokens(userId, providerId);
-            throw new Error('Google Drive authentication expired. Please reconnect your account.');
-          }
-        } else if (response.status === 401) {
-          throw new Error('Google Drive authentication required. Please reconnect your account.');
-        } else if (response.status === 429) {
-          const retryAfter = response.headers.get('retry-after') || 'unknown';
-          logger.warn('Rate limit exceeded', {
-            component: 'Google Drive',
-            retryAfter,
-            endpoint
-          });
-          throw new Error('Google Drive API rate limit exceeded. Please try again in a moment.');
-        }
-
-        const errorData = await response.json().catch(() => ({}));
-        if (response.status === 404) {
-          logger.debug('Google Drive API returned 404 (not found)', {
-            component: 'Google Drive',
-            endpoint,
-            errorMessage: errorData?.error?.message || 'Resource not found'
-          });
-          throw new Error(
-            `Google Drive API error: ${errorData?.error?.message || 'Resource not found'}`
-          );
-        }
-
-        logger.error('Google Drive API request failed', {
-          component: 'Google Drive',
-          error: errorData
-        });
-        throw new Error(
-          `Google Drive API error: ${errorData?.error?.message || response.statusText}`
-        );
-      }
-
-      if (response.status === 204) return null;
-      return await response.json();
-    } catch (error) {
-      if (error.message.includes('Google Drive')) {
-        throw error;
-      }
-      logger.error('Google Drive API request failed', {
-        component: 'Google Drive',
-        error
-      });
-      throw new Error(`Google Drive API error: ${error.message}`);
-    }
+    return this._makeApiRequestWithRetry(
+      this.driveApiUrl,
+      endpoint,
+      method,
+      data,
+      userId,
+      providerId,
+      retryCount
+    );
   }
 
   /**
@@ -595,34 +306,6 @@ class GoogleDriveService {
         error
       });
       throw error;
-    }
-  }
-
-  /**
-   * Get token expiration info for monitoring
-   * @param {string} userId - User ID
-   * @returns {Promise<Object>} Token metadata
-   */
-  async getTokenExpirationInfo(userId, providerId) {
-    try {
-      const metadata = await tokenStorage.getTokenMetadata(userId, this.serviceName, providerId);
-      const now = new Date();
-      const expiresAt = new Date(metadata.expiresAt);
-      const minutesUntilExpiry = Math.floor((expiresAt - now) / (1000 * 60));
-
-      return {
-        expiresAt: metadata.expiresAt,
-        minutesUntilExpiry,
-        isExpiring: minutesUntilExpiry <= 10,
-        isExpired: metadata.expired
-      };
-    } catch (error) {
-      return {
-        expiresAt: null,
-        minutesUntilExpiry: 0,
-        isExpiring: true,
-        isExpired: true
-      };
     }
   }
 

--- a/server/services/integrations/NextcloudService.js
+++ b/server/services/integrations/NextcloudService.js
@@ -1,11 +1,8 @@
 import 'dotenv/config';
-import tokenStorage from '../TokenStorageService.js';
 import { httpFetch } from '../../utils/httpConfig.js';
-import { getForwardedProto, getForwardedHost } from '../../utils/publicBaseUrl.js';
 import logger from '../../utils/logger.js';
-import configCache from '../../configCache.js';
-import credentialService from '../CredentialService.js';
 import { readBoundedBody, MAX_DOWNLOAD_BYTES } from '../../utils/boundedBodyReader.js';
+import OAuthIntegrationBase from './OAuthIntegrationBase.js';
 
 /**
  * Nextcloud Service for Nextcloud file access integration.
@@ -26,27 +23,24 @@ import { readBoundedBody, MAX_DOWNLOAD_BYTES } from '../../utils/boundedBodyRead
  *     the user's session, same as the other cloud storage providers).
  *   - Nextcloud rotates refresh tokens on every refresh, so callers must
  *     persist the new refresh token returned by `refreshAccessToken`.
+ *   - WebDAV PROPFIND / OCS calls below don't go through the shared
+ *     Graph/Drive-style `makeApiRequest` wrapper (unlike Google
+ *     Drive/Office 365) since the response shape (XML) and verbs
+ *     (PROPFIND) are fundamentally different from those JSON REST APIs.
  */
 // PROPFIND responses are small XML directory listings — a tighter cap
 // than the download budget defends against malicious or misconfigured
 // servers without affecting healthy responses.
 const MAX_PROPFIND_BYTES = 10 * 1024 * 1024; // 10 MiB
 
-class NextcloudService {
+class NextcloudService extends OAuthIntegrationBase {
   constructor() {
-    this.serviceName = 'nextcloud';
+    super({
+      serviceName: 'nextcloud',
+      displayName: 'Nextcloud',
+      componentName: 'NextcloudService'
+    });
     logger.info('NextcloudService initialized', { component: 'NextcloudService' });
-  }
-
-  _buildCallbackUrl(req, providerId) {
-    const protocol = getForwardedProto(req);
-    const host = getForwardedHost(req);
-
-    if (!host) {
-      throw new Error('Unable to determine host for callback URL');
-    }
-
-    return `${protocol}://${host}/api/integrations/${this.serviceName}/${providerId}/callback`;
   }
 
   _normalizeServerUrl(serverUrl) {
@@ -55,60 +49,15 @@ class NextcloudService {
   }
 
   _getProviderConfig(providerId) {
-    if (!configCache || typeof configCache.get !== 'function') {
-      throw new Error('Platform configuration cache is not initialized');
-    }
-
-    const platformConfig = configCache.getPlatform();
-    const cloudStorage = platformConfig?.cloudStorage;
-
-    if (!cloudStorage?.enabled) {
-      throw new Error('Cloud storage is not enabled');
-    }
-
-    const provider = cloudStorage.providers?.find(
-      p => p.id === providerId && p.type === 'nextcloud' && p.enabled !== false
-    );
-
-    if (!provider) {
-      throw new Error(`Nextcloud provider '${providerId}' not found or not enabled`);
-    }
-
-    if (!provider.serverUrl || !provider.clientId || !provider.clientSecretRef) {
-      throw new Error(
-        `Nextcloud provider '${providerId}' missing required configuration (serverUrl, clientId, clientSecretRef)`
-      );
-    }
-
-    // Resolve the client secret from the central credential store so
-    // downstream code works with the plaintext value inline on the provider.
-    return {
-      ...provider,
-      serverUrl: this._normalizeServerUrl(provider.serverUrl),
-      clientSecret: credentialService.resolveSecret(provider.clientSecretRef)
-    };
-  }
-
-  _resolveRedirectUri(provider, providerId, req) {
-    let redirectUri = provider.redirectUri || process.env.NEXTCLOUD_OAUTH_REDIRECT_URI;
-
-    if (!redirectUri && req) {
-      redirectUri = this._buildCallbackUrl(req, providerId);
-      logger.info('Auto-detected Nextcloud callback URL from request', {
-        component: 'NextcloudService',
-        redirectUri
-      });
-    }
-
-    if (!redirectUri) {
-      redirectUri = `${process.env.SERVER_URL || 'http://localhost:3000'}/api/integrations/${this.serviceName}/${providerId}/callback`;
-      logger.warn('Using fallback localhost URL for Nextcloud callback', {
-        component: 'NextcloudService',
-        redirectUri
-      });
-    }
-
-    return redirectUri;
+    return super._getProviderConfig(providerId, {
+      type: 'nextcloud',
+      requiredFields: ['serverUrl', 'clientId', 'clientSecretRef'],
+      secretFields: ['clientSecretRef'],
+      postProcess: provider => ({
+        ...provider,
+        serverUrl: this._normalizeServerUrl(provider.serverUrl)
+      })
+    });
   }
 
   /**
@@ -118,7 +67,12 @@ class NextcloudService {
    */
   generateAuthUrl(providerId, state, req = null) {
     const provider = this._getProviderConfig(providerId);
-    const redirectUri = this._resolveRedirectUri(provider, providerId, req);
+    const redirectUri = this._resolveRedirectUri(
+      provider,
+      providerId,
+      'NEXTCLOUD_OAUTH_REDIRECT_URI',
+      req
+    );
 
     const params = new URLSearchParams({
       client_id: provider.clientId,
@@ -133,7 +87,12 @@ class NextcloudService {
   async exchangeCodeForTokens(providerId, authCode, req = null) {
     try {
       const provider = this._getProviderConfig(providerId);
-      const redirectUri = this._resolveRedirectUri(provider, providerId, req);
+      const redirectUri = this._resolveRedirectUri(
+        provider,
+        providerId,
+        'NEXTCLOUD_OAUTH_REDIRECT_URI',
+        req
+      );
       const tokenUrl = `${provider.serverUrl}/apps/oauth2/api/v1/token`;
 
       const tokenData = new URLSearchParams({
@@ -252,136 +211,18 @@ class NextcloudService {
     }
   }
 
-  async storeUserTokens(userId, tokens) {
-    try {
-      if (!tokens.refreshToken) {
-        logger.warn(
-          'No Nextcloud refresh token - user will need to reconnect when access token expires',
-          { component: 'NextcloudService' }
-        );
-      }
-
-      // tokens.providerId is the source of truth — it was set by the
-      // OAuth exchange. Pass it explicitly so the storage layer scopes
-      // the file as `<userId>__<providerId>.json`.
-      await tokenStorage.storeUserTokens(userId, this.serviceName, tokens, tokens.providerId);
-      logger.info('Nextcloud tokens stored for user', {
-        component: 'NextcloudService',
-        userId,
-        providerId: tokens.providerId
-      });
-      return true;
-    } catch (error) {
-      logger.error('Error storing Nextcloud user tokens', {
-        component: 'NextcloudService',
-        error
-      });
-      throw new Error('Failed to store user tokens');
+  /**
+   * Preserve the cached Nextcloud username if the refresh response omitted it.
+   */
+  _afterTokenRefresh(refreshedTokens, previousTokens) {
+    if (!refreshedTokens.nextcloudUserId && previousTokens.nextcloudUserId) {
+      refreshedTokens.nextcloudUserId = previousTokens.nextcloudUserId;
     }
+    return refreshedTokens;
   }
 
-  async getUserTokens(userId, providerId) {
-    try {
-      const tokens = await tokenStorage.getUserTokens(userId, this.serviceName, providerId);
-      const expired = await tokenStorage.areTokensExpired(userId, this.serviceName, providerId);
-
-      if (!expired) return tokens;
-
-      logger.info('Nextcloud tokens expired, attempting refresh', {
-        component: 'NextcloudService',
-        userId,
-        providerId
-      });
-
-      try {
-        if (!tokens.refreshToken) {
-          throw new Error('No refresh token available - user needs to reconnect Nextcloud account');
-        }
-
-        const refreshedTokens = await this.refreshAccessToken(
-          tokens.providerId,
-          tokens.refreshToken
-        );
-
-        // Preserve the cached username if the refresh response omitted it
-        if (!refreshedTokens.nextcloudUserId && tokens.nextcloudUserId) {
-          refreshedTokens.nextcloudUserId = tokens.nextcloudUserId;
-        }
-
-        await this.storeUserTokens(userId, refreshedTokens);
-        logger.info('Successfully refreshed and stored Nextcloud tokens for user', {
-          component: 'NextcloudService',
-          userId,
-          providerId
-        });
-        return refreshedTokens;
-      } catch (refreshError) {
-        logger.error('Failed to refresh Nextcloud tokens for user', {
-          component: 'NextcloudService',
-          userId,
-          providerId,
-          error: refreshError
-        });
-        await this.deleteUserTokens(userId, providerId);
-        throw new Error('Nextcloud authentication expired. Please reconnect your account.');
-      }
-    } catch (error) {
-      if (
-        error.message.includes('not authenticated') ||
-        error.message.includes('authentication expired') ||
-        error.message.includes('needs to reconnect')
-      ) {
-        throw error;
-      }
-      logger.error('Error retrieving Nextcloud user tokens', {
-        component: 'NextcloudService',
-        error
-      });
-      throw new Error('Failed to retrieve user tokens');
-    }
-  }
-
-  async deleteUserTokens(userId, providerId) {
-    try {
-      const result = await tokenStorage.deleteUserTokens(userId, this.serviceName, providerId);
-      if (result) {
-        logger.info('Nextcloud tokens deleted for user', {
-          component: 'NextcloudService',
-          userId,
-          providerId
-        });
-      }
-      return result;
-    } catch (error) {
-      logger.error('Error deleting Nextcloud user tokens', {
-        component: 'NextcloudService',
-        error
-      });
-      return false;
-    }
-  }
-
-  async getTokenExpirationInfo(userId, providerId) {
-    try {
-      const metadata = await tokenStorage.getTokenMetadata(userId, this.serviceName, providerId);
-      const now = new Date();
-      const expiresAt = new Date(metadata.expiresAt);
-      const minutesUntilExpiry = Math.floor((expiresAt - now) / (1000 * 60));
-
-      return {
-        expiresAt: metadata.expiresAt,
-        minutesUntilExpiry,
-        isExpiring: minutesUntilExpiry <= 10,
-        isExpired: metadata.expired
-      };
-    } catch {
-      return {
-        expiresAt: null,
-        minutesUntilExpiry: 0,
-        isExpiring: true,
-        isExpired: true
-      };
-    }
+  _isPassthroughTokenError(error) {
+    return super._isPassthroughTokenError(error) || error.message.includes('needs to reconnect');
   }
 
   /**

--- a/server/services/integrations/OAuthIntegrationBase.js
+++ b/server/services/integrations/OAuthIntegrationBase.js
@@ -1,0 +1,454 @@
+import tokenStorage from '../TokenStorageService.js';
+import { httpFetch } from '../../utils/httpConfig.js';
+import { getForwardedProto, getForwardedHost } from '../../utils/publicBaseUrl.js';
+import logger from '../../utils/logger.js';
+import configCache from '../../configCache.js';
+import credentialService from '../CredentialService.js';
+
+/**
+ * Shared OAuth 2.0 token-lifecycle implementation for cloud storage
+ * integrations (Google Drive, Office 365, Nextcloud, ...).
+ *
+ * Subclasses supply provider-specific pieces (auth URL, token exchange,
+ * refresh endpoint/params, API base URL) and get callback-URL resolution,
+ * provider-config loading, token store/refresh/expiry handling, and the
+ * 401-retry-once API request wrapper for free.
+ */
+class OAuthIntegrationBase {
+  constructor({ serviceName, displayName, componentName }) {
+    this.serviceName = serviceName;
+    this.displayName = displayName;
+    this.componentName = componentName || displayName;
+  }
+
+  /**
+   * Build callback URL from request, honoring X-Forwarded-* proxy chains.
+   * @param {Object} req - Express request object
+   * @param {string} providerId - Provider ID to include in callback URL
+   * @returns {string} Full callback URL
+   */
+  _buildCallbackUrl(req, providerId) {
+    const protocol = getForwardedProto(req);
+    const host = getForwardedHost(req);
+
+    if (!host) {
+      throw new Error('Unable to determine host for callback URL');
+    }
+
+    return `${protocol}://${host}/api/integrations/${this.serviceName}/${providerId}/callback`;
+  }
+
+  /**
+   * Resolve the OAuth redirect URI: explicit provider config, then an
+   * env var, then auto-detection from the request, then a localhost
+   * fallback (development).
+   * @param {Object} provider - Resolved provider configuration
+   * @param {string} providerId - Provider ID
+   * @param {string} envVarName - Environment variable holding a fixed redirect URI
+   * @param {Object} [req] - Express request object (optional, for auto-detection)
+   * @returns {string} Redirect URI
+   */
+  _resolveRedirectUri(provider, providerId, envVarName, req = null) {
+    let redirectUri = provider.redirectUri || process.env[envVarName];
+
+    if (!redirectUri && req) {
+      redirectUri = this._buildCallbackUrl(req, providerId);
+      logger.info(`Auto-detected ${this.displayName} callback URL from request`, {
+        component: this.componentName,
+        redirectUri
+      });
+    }
+
+    if (!redirectUri) {
+      redirectUri = `${process.env.SERVER_URL || 'http://localhost:3000'}/api/integrations/${this.serviceName}/${providerId}/callback`;
+      logger.warn(`Using fallback localhost URL for ${this.displayName} callback`, {
+        component: this.componentName,
+        redirectUri
+      });
+    }
+
+    return redirectUri;
+  }
+
+  /**
+   * Load and validate a provider's configuration from cloudStorage.providers,
+   * resolving secret-reference fields through the credential service.
+   * @param {string} providerId - The provider ID from cloud storage config
+   * @param {Object} options
+   * @param {string} options.type - Provider type discriminator (e.g. 'googledrive')
+   * @param {string[]} [options.requiredFields] - Fields that must be present on the provider
+   * @param {string[]} [options.secretFields] - Ref fields to resolve (e.g. 'clientSecretRef' -> 'clientSecret')
+   * @param {Function} [options.postProcess] - Optional (provider) => provider transform
+   * @returns {Object} Provider configuration with secrets resolved
+   */
+  _getProviderConfig(
+    providerId,
+    { type, requiredFields = [], secretFields = [], postProcess } = {}
+  ) {
+    if (!configCache || typeof configCache.get !== 'function') {
+      throw new Error('Platform configuration cache is not initialized');
+    }
+
+    const platformConfig = configCache.getPlatform();
+    const cloudStorage = platformConfig?.cloudStorage;
+
+    if (!cloudStorage?.enabled) {
+      throw new Error('Cloud storage is not enabled');
+    }
+
+    const provider = cloudStorage.providers?.find(
+      p => p.id === providerId && p.type === type && p.enabled !== false
+    );
+
+    if (!provider) {
+      throw new Error(`${this.displayName} provider '${providerId}' not found or not enabled`);
+    }
+
+    const missingFields = requiredFields.filter(field => !provider[field]);
+    if (missingFields.length > 0) {
+      throw new Error(
+        `${this.displayName} provider '${providerId}' missing required configuration (${requiredFields.join(', ')})`
+      );
+    }
+
+    const resolved = { ...provider };
+    for (const refField of secretFields) {
+      const targetField = refField.replace(/Ref$/, '');
+      resolved[targetField] = credentialService.resolveSecret(provider[refField]);
+    }
+
+    return postProcess ? postProcess(resolved) || resolved : resolved;
+  }
+
+  /**
+   * Store encrypted user tokens.
+   * @param {string} userId - User ID
+   * @param {Object} tokens - Tokens to store
+   */
+  async storeUserTokens(userId, tokens) {
+    try {
+      if (!tokens.refreshToken) {
+        logger.warn('No refresh token - user will need to reconnect when access token expires', {
+          component: this.componentName
+        });
+      }
+
+      await tokenStorage.storeUserTokens(userId, this.serviceName, tokens, tokens.providerId);
+      logger.info(`${this.displayName} tokens stored for user`, {
+        component: this.componentName,
+        userId,
+        providerId: tokens.providerId
+      });
+      return true;
+    } catch (error) {
+      logger.error('Error storing user tokens', {
+        component: this.componentName,
+        error
+      });
+      throw new Error('Failed to store user tokens');
+    }
+  }
+
+  /**
+   * Hook for subclasses to adjust freshly refreshed tokens before they're
+   * stored (e.g. carrying forward a cached value the refresh response
+   * omitted). Default is a no-op.
+   * @param {Object} refreshedTokens
+   * @param {Object} _previousTokens
+   * @returns {Object} refreshedTokens (mutated or replaced)
+   */
+  _afterTokenRefresh(refreshedTokens, _previousTokens) {
+    return refreshedTokens;
+  }
+
+  /**
+   * Hook determining whether an error from the outer getUserTokens() try
+   * block should be re-thrown as-is rather than wrapped as a generic
+   * 'Failed to retrieve user tokens'. Subclasses may extend this.
+   * @param {Error} error
+   * @returns {boolean}
+   */
+  _isPassthroughTokenError(error) {
+    return (
+      error.message.includes('not authenticated') ||
+      error.message.includes('authentication expired')
+    );
+  }
+
+  /**
+   * Retrieve and decrypt user tokens with automatic refresh if expired.
+   * @param {string} userId - User ID
+   * @param {string} [providerId] - Provider ID
+   * @returns {Promise<Object>} Decrypted tokens
+   */
+  async getUserTokens(userId, providerId) {
+    try {
+      const tokens = await tokenStorage.getUserTokens(userId, this.serviceName, providerId);
+      const expired = await tokenStorage.areTokensExpired(userId, this.serviceName, providerId);
+
+      if (!expired) {
+        return tokens;
+      }
+
+      logger.info('Tokens expired for user, attempting refresh', {
+        component: this.componentName,
+        userId
+      });
+
+      try {
+        if (!tokens.refreshToken) {
+          logger.error('No refresh token available for user', {
+            component: this.componentName,
+            userId
+          });
+          throw new Error(
+            `No refresh token available - user needs to reconnect ${this.displayName} account`
+          );
+        }
+
+        let refreshedTokens = await this.refreshAccessToken(tokens.providerId, tokens.refreshToken);
+        refreshedTokens = this._afterTokenRefresh(refreshedTokens, tokens);
+
+        await this.storeUserTokens(userId, refreshedTokens);
+        logger.info(`Successfully refreshed and stored ${this.displayName} tokens for user`, {
+          component: this.componentName,
+          userId
+        });
+        return refreshedTokens;
+      } catch (refreshError) {
+        logger.error('Failed to refresh tokens for user', {
+          component: this.componentName,
+          userId,
+          error: refreshError
+        });
+
+        await this.deleteUserTokens(userId, providerId);
+        throw new Error(
+          `${this.displayName} authentication expired. Please reconnect your account.`
+        );
+      }
+    } catch (error) {
+      if (this._isPassthroughTokenError(error)) {
+        throw error;
+      }
+      logger.error('Error retrieving user tokens', {
+        component: this.componentName,
+        error
+      });
+      throw new Error('Failed to retrieve user tokens');
+    }
+  }
+
+  /**
+   * Delete user tokens (disconnect).
+   * @param {string} userId - User ID
+   * @param {string} [providerId] - Provider ID
+   * @returns {Promise<boolean>} Success status
+   */
+  async deleteUserTokens(userId, providerId) {
+    try {
+      const result = await tokenStorage.deleteUserTokens(userId, this.serviceName, providerId);
+      if (result) {
+        logger.info(`${this.displayName} tokens deleted for user`, {
+          component: this.componentName,
+          userId,
+          providerId
+        });
+      }
+      return result;
+    } catch (error) {
+      logger.error('Error deleting user tokens', {
+        component: this.componentName,
+        error
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Get token expiration info for monitoring.
+   * @param {string} userId - User ID
+   * @param {string} [providerId] - Provider ID
+   * @returns {Promise<Object>} Token metadata
+   */
+  async getTokenExpirationInfo(userId, providerId) {
+    try {
+      const metadata = await tokenStorage.getTokenMetadata(userId, this.serviceName, providerId);
+      const now = new Date();
+      const expiresAt = new Date(metadata.expiresAt);
+      const minutesUntilExpiry = Math.floor((expiresAt - now) / (1000 * 60));
+
+      return {
+        expiresAt: metadata.expiresAt,
+        minutesUntilExpiry,
+        isExpiring: minutesUntilExpiry <= 10,
+        isExpired: metadata.expired
+      };
+    } catch {
+      return {
+        expiresAt: null,
+        minutesUntilExpiry: 0,
+        isExpiring: true,
+        isExpired: true
+      };
+    }
+  }
+
+  /**
+   * Build headers for an authenticated API request. Subclasses override
+   * to always include Content-Type (Office 365) vs. only on write methods
+   * with a body (Google Drive default here).
+   * @param {Object} tokens
+   * @param {string} method
+   * @param {boolean} hasBody
+   * @returns {Object} headers
+   */
+  _buildApiRequestHeaders(tokens, method, hasBody) {
+    const headers = {
+      Authorization: `Bearer ${tokens.accessToken}`,
+      Accept: 'application/json'
+    };
+    if (hasBody) {
+      headers['Content-Type'] = 'application/json';
+    }
+    return headers;
+  }
+
+  /**
+   * Make an authenticated API request against the given base URL, with a
+   * single automatic token-refresh retry on 401.
+   * @param {string} apiBaseUrl - Base URL to prefix onto relative endpoints
+   * @param {string} endpoint - API endpoint (absolute or relative to apiBaseUrl)
+   * @param {string} method - HTTP method
+   * @param {Object|null} data - Request body
+   * @param {string} userId - User ID
+   * @param {string} [providerId] - Provider ID
+   * @param {number} retryCount - Current retry count
+   * @returns {Promise<Object>} API response
+   */
+  async _makeApiRequestWithRetry(
+    apiBaseUrl,
+    endpoint,
+    method = 'GET',
+    data = null,
+    userId,
+    providerId,
+    retryCount = 0
+  ) {
+    const maxRetries = 1;
+
+    try {
+      const tokens = await this.getUserTokens(userId, providerId);
+      const url = endpoint.startsWith('http') ? endpoint : `${apiBaseUrl}${endpoint}`;
+      const hasBody = !!data && ['POST', 'PUT', 'PATCH'].includes(method);
+
+      const fetchOptions = {
+        method,
+        headers: this._buildApiRequestHeaders(tokens, method, hasBody)
+      };
+
+      if (hasBody) {
+        fetchOptions.body = JSON.stringify(data);
+      }
+
+      const response = await httpFetch(url, fetchOptions);
+
+      if (!response.ok) {
+        if (response.status === 401 && retryCount < maxRetries) {
+          logger.info('Received 401, attempting token refresh and retry', {
+            component: this.componentName,
+            attempt: retryCount + 1,
+            maxAttempts: maxRetries + 1
+          });
+
+          try {
+            const expiredTokens = await tokenStorage.getUserTokens(
+              userId,
+              this.serviceName,
+              providerId
+            );
+
+            if (!expiredTokens.refreshToken) {
+              throw new Error('No refresh token available');
+            }
+
+            const refreshedTokens = await this.refreshAccessToken(
+              expiredTokens.providerId,
+              expiredTokens.refreshToken
+            );
+
+            await this.storeUserTokens(userId, refreshedTokens);
+
+            return await this._makeApiRequestWithRetry(
+              apiBaseUrl,
+              endpoint,
+              method,
+              data,
+              userId,
+              providerId,
+              retryCount + 1
+            );
+          } catch (refreshError) {
+            logger.error('Forced token refresh failed', {
+              component: this.componentName,
+              error: refreshError
+            });
+
+            await this.deleteUserTokens(userId, providerId);
+            throw new Error(
+              `${this.displayName} authentication expired. Please reconnect your account.`
+            );
+          }
+        } else if (response.status === 401) {
+          throw new Error(
+            `${this.displayName} authentication required. Please reconnect your account.`
+          );
+        } else if (response.status === 429) {
+          const retryAfter = response.headers.get('retry-after') || 'unknown';
+          logger.warn('Rate limit exceeded', {
+            component: this.componentName,
+            retryAfter,
+            endpoint
+          });
+          throw new Error(
+            `${this.displayName} API rate limit exceeded. Please try again in a moment.`
+          );
+        }
+
+        const errorData = await response.json().catch(() => ({}));
+        if (response.status === 404) {
+          logger.debug(`${this.displayName} API returned 404 (not found)`, {
+            component: this.componentName,
+            endpoint,
+            errorMessage: errorData?.error?.message || 'Resource not found'
+          });
+          throw new Error(
+            `${this.displayName} API error: ${errorData?.error?.message || 'Resource not found'}`
+          );
+        }
+
+        logger.error(`${this.displayName} API request failed`, {
+          component: this.componentName,
+          error: errorData
+        });
+        throw new Error(
+          `${this.displayName} API error: ${errorData?.error?.message || response.statusText}`
+        );
+      }
+
+      if (response.status === 204) return null;
+      return await response.json();
+    } catch (error) {
+      if (error.message.includes(this.displayName) || error.message.includes('authentication')) {
+        throw error;
+      }
+      logger.error(`${this.displayName} API request failed`, {
+        component: this.componentName,
+        error
+      });
+      throw new Error(`${this.displayName} API error: ${error.message}`);
+    }
+  }
+}
+
+export default OAuthIntegrationBase;

--- a/server/services/integrations/Office365Service.js
+++ b/server/services/integrations/Office365Service.js
@@ -1,20 +1,21 @@
 import 'dotenv/config';
 import crypto from 'crypto';
-import tokenStorage from '../TokenStorageService.js';
 import { httpFetch } from '../../utils/httpConfig.js';
-import { getForwardedProto, getForwardedHost } from '../../utils/publicBaseUrl.js';
 import logger from '../../utils/logger.js';
-import configCache from '../../configCache.js';
-import credentialService from '../CredentialService.js';
 import { readBoundedBody, MAX_DOWNLOAD_BYTES } from '../../utils/boundedBodyReader.js';
+import OAuthIntegrationBase from './OAuthIntegrationBase.js';
 
 /**
  * Office 365 Service for Microsoft 365 file access integration
  * Provides OAuth 2.0 authentication with PKCE, secure token storage, and Microsoft Graph API access
  */
-class Office365Service {
+class Office365Service extends OAuthIntegrationBase {
   constructor() {
-    this.serviceName = 'office365';
+    super({
+      serviceName: 'office365',
+      displayName: 'Office 365',
+      componentName: 'Office365Service'
+    });
 
     // Microsoft Identity Platform endpoints
     this.authBaseUrl = 'https://login.microsoftonline.com';
@@ -24,65 +25,16 @@ class Office365Service {
   }
 
   /**
-   * Build callback URL from request
-   * @param {Object} req - Express request object
-   * @param {string} providerId - Provider ID to include in callback URL
-   * @returns {string} Full callback URL
-   */
-  _buildCallbackUrl(req, providerId) {
-    // Resolve protocol + host with proxy-chain awareness (multi-value
-    // X-Forwarded-* lists are reduced to the leftmost / most-trusted
-    // value in publicBaseUrl.js).
-    const protocol = getForwardedProto(req);
-    const host = getForwardedHost(req);
-
-    if (!host) {
-      throw new Error('Unable to determine host for callback URL');
-    }
-
-    // Build full callback URL with provider ID
-    // Note: serviceName is included in the route mount point (/api/integrations/office365)
-    return `${protocol}://${host}/api/integrations/${this.serviceName}/${providerId}/callback`;
-  }
-
-  /**
    * Get Office 365 provider configuration
    * @param {string} providerId - The provider ID from cloud storage config
    * @returns {Object} Provider configuration
    */
   _getProviderConfig(providerId) {
-    if (!configCache || typeof configCache.get !== 'function') {
-      throw new Error('Platform configuration cache is not initialized');
-    }
-
-    const platformConfig = configCache.getPlatform();
-    const cloudStorage = platformConfig?.cloudStorage;
-
-    if (!cloudStorage?.enabled) {
-      throw new Error('Cloud storage is not enabled');
-    }
-
-    const provider = cloudStorage.providers?.find(
-      p => p.id === providerId && p.type === 'office365' && p.enabled !== false
-    );
-
-    if (!provider) {
-      throw new Error(`Office 365 provider '${providerId}' not found or not enabled`);
-    }
-
-    if (!provider.tenantIdRef || !provider.clientId || !provider.clientSecretRef) {
-      throw new Error(
-        `Office 365 provider '${providerId}' missing required configuration (tenantIdRef, clientId, clientSecretRef)`
-      );
-    }
-
-    // Resolve secrets from the central credential store so downstream code
-    // works with plaintext tenantId/clientSecret values inline on the provider.
-    return {
-      ...provider,
-      tenantId: credentialService.resolveSecret(provider.tenantIdRef),
-      clientSecret: credentialService.resolveSecret(provider.clientSecretRef)
-    };
+    return super._getProviderConfig(providerId, {
+      type: 'office365',
+      requiredFields: ['tenantIdRef', 'clientId', 'clientSecretRef'],
+      secretFields: ['tenantIdRef', 'clientSecretRef']
+    });
   }
 
   /**
@@ -146,27 +98,12 @@ class Office365Service {
   generateAuthUrl(providerId, state, codeVerifier, req = null) {
     const provider = this._getProviderConfig(providerId);
     const codeChallenge = crypto.createHash('sha256').update(codeVerifier).digest('base64url');
-
-    // Use the provider's redirect URI, environment variable, auto-detected URL, or fallback to localhost
-    let redirectUri = provider.redirectUri || process.env.OFFICE365_OAUTH_REDIRECT_URI;
-
-    if (!redirectUri && req) {
-      // Auto-detect from request if not configured
-      redirectUri = this._buildCallbackUrl(req, providerId);
-      logger.info('Auto-detected Office 365 callback URL from request', {
-        component: 'Office365Service',
-        redirectUri
-      });
-    }
-
-    if (!redirectUri) {
-      // Final fallback to localhost (development)
-      redirectUri = `${process.env.SERVER_URL || 'http://localhost:3000'}/api/integrations/${this.serviceName}/${providerId}/callback`;
-      logger.warn('Using fallback localhost URL for Office 365 callback', {
-        component: 'Office365Service',
-        redirectUri
-      });
-    }
+    const redirectUri = this._resolveRedirectUri(
+      provider,
+      providerId,
+      'OFFICE365_OAUTH_REDIRECT_URI',
+      req
+    );
 
     const authUrl = `${this.authBaseUrl}/${provider.tenantId}/oauth2/v2.0/authorize`;
 
@@ -206,27 +143,12 @@ class Office365Service {
     try {
       const provider = this._getProviderConfig(providerId);
       const tokenUrl = `${this.authBaseUrl}/${provider.tenantId}/oauth2/v2.0/token`;
-
-      // Use the provider's redirect URI, environment variable, auto-detected URL, or fallback to localhost
-      let redirectUri = provider.redirectUri || process.env.OFFICE365_OAUTH_REDIRECT_URI;
-
-      if (!redirectUri && req) {
-        // Auto-detect from request if not configured
-        redirectUri = this._buildCallbackUrl(req, providerId);
-        logger.info('Auto-detected Office 365 callback URL from request for token exchange', {
-          component: 'Office365Service',
-          redirectUri
-        });
-      }
-
-      if (!redirectUri) {
-        // Final fallback to localhost (development)
-        redirectUri = `${process.env.SERVER_URL || 'http://localhost:3000'}/api/integrations/${this.serviceName}/${providerId}/callback`;
-        logger.warn('Using fallback localhost URL for Office 365 token exchange', {
-          component: 'Office365Service',
-          redirectUri
-        });
-      }
+      const redirectUri = this._resolveRedirectUri(
+        provider,
+        providerId,
+        'OFFICE365_OAUTH_REDIRECT_URI',
+        req
+      );
 
       const tokenData = new URLSearchParams({
         client_id: provider.clientId,
@@ -352,150 +274,28 @@ class Office365Service {
   }
 
   /**
-   * Store encrypted user tokens
-   * @param {string} userId - User ID
-   * @param {Object} tokens - Tokens to store
+   * Office 365 also treats a 'permissions have been updated' error as a
+   * pass-through condition (surfaced by the outer getUserTokens() catch).
+   * @param {Error} error
+   * @returns {boolean}
    */
-  async storeUserTokens(userId, tokens) {
-    try {
-      if (!tokens.refreshToken) {
-        logger.warn('No refresh token - user will need to reconnect when access token expires', {
-          component: 'Office365Service'
-        });
-      }
-
-      await tokenStorage.storeUserTokens(userId, this.serviceName, tokens, tokens.providerId);
-      logger.info('Office 365 tokens stored for user', {
-        component: 'Office365Service',
-        userId,
-        providerId: tokens.providerId
-      });
-      return true;
-    } catch (error) {
-      logger.error('Error storing user tokens', {
-        component: 'Office365Service',
-        error
-      });
-      throw new Error('Failed to store user tokens');
-    }
+  _isPassthroughTokenError(error) {
+    return (
+      super._isPassthroughTokenError(error) ||
+      error.message.includes('permissions have been updated')
+    );
   }
 
   /**
-   * Retrieve and decrypt user tokens with automatic refresh if expired
-   * @param {string} userId - User ID
-   * @param {string} [providerId] - Provider ID (omit for legacy single-slot lookup)
-   * @returns {Promise<Object>} Decrypted tokens
+   * Microsoft Graph always expects Content-Type: application/json, even
+   * for GET requests without a body.
    */
-  async getUserTokens(userId, providerId) {
-    try {
-      // First, get the tokens to check their scope
-      let tokens = await tokenStorage.getUserTokens(userId, this.serviceName, providerId);
-
-      // Check if tokens have old scopes that require admin consent (Group.Read.All, ChannelSettings.Read.All)
-      // These tokens need to be invalidated so user can re-authenticate with new scopes
-      if (
-        tokens.scope &&
-        (tokens.scope.includes('Group.Read.All') ||
-          tokens.scope.includes('ChannelSettings.Read.All'))
-      ) {
-        logger.warn(
-          'Detected old Office 365 token with admin-consent scope, invalidating to force re-authentication',
-          {
-            component: 'Office365Service',
-            userId,
-            oldScope: tokens.scope
-          }
-        );
-      }
-
-      // Check if tokens are expired
-      const expired = await tokenStorage.areTokensExpired(userId, this.serviceName, providerId);
-
-      if (expired) {
-        logger.info('Tokens expired, attempting refresh', {
-          component: 'Office365Service',
-          userId
-        });
-
-        try {
-          if (!tokens.refreshToken) {
-            logger.error('No refresh token available for user', {
-              component: 'Office365Service',
-              userId
-            });
-            throw new Error(
-              'No refresh token available - user needs to reconnect Office 365 account'
-            );
-          }
-
-          const refreshedTokens = await this.refreshAccessToken(
-            tokens.providerId,
-            tokens.refreshToken
-          );
-
-          // Store the refreshed tokens
-          await this.storeUserTokens(userId, refreshedTokens);
-          logger.info('Successfully refreshed and stored Office 365 tokens for user', {
-            component: 'Office365Service',
-            userId
-          });
-          return refreshedTokens;
-        } catch (refreshError) {
-          logger.error('Failed to refresh tokens for user', {
-            component: 'Office365Service',
-            userId,
-            error: refreshError
-          });
-
-          // If refresh fails, delete the invalid tokens so user can reconnect
-          await this.deleteUserTokens(userId, providerId);
-
-          throw new Error('Office 365 authentication expired. Please reconnect your account.');
-        }
-      }
-
-      return tokens;
-    } catch (error) {
-      // Don't wrap specific error messages - pass them through
-      if (
-        error.message.includes('not authenticated') ||
-        error.message.includes('permissions have been updated') ||
-        error.message.includes('authentication expired')
-      ) {
-        throw error;
-      }
-      logger.error('Error retrieving user tokens', {
-        component: 'Office365Service',
-        error
-      });
-      throw new Error('Failed to retrieve user tokens');
-    }
-  }
-
-  /**
-   * Delete user tokens (disconnect)
-   * @param {string} userId - User ID
-   * @param {string} [providerId] - Provider ID (omit for legacy single-slot delete)
-   * @returns {Promise<boolean>} Success status
-   */
-  async deleteUserTokens(userId, providerId) {
-    try {
-      const result = await tokenStorage.deleteUserTokens(userId, this.serviceName, providerId);
-      if (result) {
-        logger.info('Office 365 tokens deleted for user', {
-          component: 'Office365Service',
-          userId,
-          providerId
-        });
-      }
-      return result;
-    } catch (error) {
-      logger.error('Error deleting user tokens', {
-        component: 'Office365Service',
-        error
-      });
-      return false;
-    }
+  _buildApiRequestHeaders(tokens) {
+    return {
+      Authorization: `Bearer ${tokens.accessToken}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json'
+    };
   }
 
   /**
@@ -509,129 +309,15 @@ class Office365Service {
    * @returns {Promise<Object>} API response
    */
   async makeApiRequest(endpoint, method = 'GET', data = null, userId, providerId, retryCount = 0) {
-    const maxRetries = 1; // Allow one retry for token refresh
-
-    try {
-      const tokens = await this.getUserTokens(userId, providerId);
-
-      const url = endpoint.startsWith('http') ? endpoint : `${this.graphApiUrl}${endpoint}`;
-
-      const fetchOptions = {
-        method,
-        headers: {
-          Authorization: `Bearer ${tokens.accessToken}`,
-          Accept: 'application/json',
-          'Content-Type': 'application/json'
-        }
-      };
-
-      if (data && (method === 'POST' || method === 'PUT' || method === 'PATCH')) {
-        fetchOptions.body = JSON.stringify(data);
-      }
-
-      const response = await httpFetch(url, fetchOptions);
-
-      if (!response.ok) {
-        if (response.status === 401 && retryCount < maxRetries) {
-          logger.info('Received 401 error, attempting to force token refresh and retry', {
-            component: 'Office365Service',
-            attempt: retryCount + 1,
-            maxAttempts: maxRetries + 1
-          });
-
-          try {
-            // Force refresh tokens
-            const expiredTokens = await tokenStorage.getUserTokens(
-              userId,
-              this.serviceName,
-              providerId
-            );
-
-            if (!expiredTokens.refreshToken) {
-              throw new Error('No refresh token available');
-            }
-
-            const refreshedTokens = await this.refreshAccessToken(
-              expiredTokens.providerId,
-              expiredTokens.refreshToken
-            );
-
-            await this.storeUserTokens(userId, refreshedTokens);
-
-            logger.info('Forced token refresh successful for user', {
-              component: 'Office365Service',
-              userId,
-              providerId
-            });
-
-            // Retry the request with fresh tokens
-            return await this.makeApiRequest(
-              endpoint,
-              method,
-              data,
-              userId,
-              providerId,
-              retryCount + 1
-            );
-          } catch (refreshError) {
-            logger.error('Forced token refresh failed', {
-              component: 'Office365Service',
-              error: refreshError
-            });
-
-            // Clean up invalid tokens
-            await this.deleteUserTokens(userId, providerId);
-            throw new Error('Office 365 authentication expired. Please reconnect your account.');
-          }
-        } else if (response.status === 401) {
-          throw new Error('Office 365 authentication required. Please reconnect your account.');
-        } else if (response.status === 429) {
-          // Rate limit exceeded - log and throw
-          const retryAfter = response.headers.get('retry-after') || 'unknown';
-          logger.warn('Rate limit exceeded', {
-            component: 'Office365Service',
-            retryAfter,
-            endpoint
-          });
-          throw new Error('Office 365 API rate limit exceeded. Please try again in a moment.');
-        }
-
-        // Log 404 errors as debug (expected for Teams without SharePoint sites, etc.)
-        const errorData = await response.json().catch(() => ({}));
-        if (response.status === 404) {
-          logger.debug('Office 365 API returned 404', {
-            component: 'Office365Service',
-            endpoint,
-            error: errorData?.error?.message || 'Resource not found'
-          });
-          throw new Error(
-            `Office 365 API error: ${errorData?.error?.message || 'Resource not found'}`
-          );
-        }
-
-        // Log other errors as error
-        logger.error('Office 365 API request failed', {
-          component: 'Office365Service',
-          error: errorData
-        });
-        throw new Error(
-          `Office 365 API error: ${errorData?.error?.message || response.statusText}`
-        );
-      }
-
-      if (response.status === 204) return null;
-      return await response.json();
-    } catch (error) {
-      // Re-throw known errors
-      if (error.message.includes('Office 365') || error.message.includes('authentication')) {
-        throw error;
-      }
-      logger.error('Office 365 API request failed', {
-        component: 'Office365Service',
-        error
-      });
-      throw new Error(`Office 365 API error: ${error.message}`);
-    }
+    return this._makeApiRequestWithRetry(
+      this.graphApiUrl,
+      endpoint,
+      method,
+      data,
+      userId,
+      providerId,
+      retryCount
+    );
   }
 
   /**
@@ -688,34 +374,6 @@ class Office365Service {
         error
       });
       throw error;
-    }
-  }
-
-  /**
-   * Get token expiration info for monitoring
-   * @param {string} userId - User ID
-   * @returns {Promise<Object>} Token metadata
-   */
-  async getTokenExpirationInfo(userId, providerId) {
-    try {
-      const metadata = await tokenStorage.getTokenMetadata(userId, this.serviceName, providerId);
-      const now = new Date();
-      const expiresAt = new Date(metadata.expiresAt);
-      const minutesUntilExpiry = Math.floor((expiresAt - now) / (1000 * 60));
-
-      return {
-        expiresAt: metadata.expiresAt,
-        minutesUntilExpiry,
-        isExpiring: minutesUntilExpiry <= 10, // Consider expiring if less than 10 minutes
-        isExpired: metadata.expired
-      };
-    } catch (error) {
-      return {
-        expiresAt: null,
-        minutesUntilExpiry: 0,
-        isExpiring: true,
-        isExpired: true
-      };
     }
   }
 
@@ -963,7 +621,7 @@ class Office365Service {
           logger.warn('Could not load drives for site', {
             component: 'Office365Service',
             siteName: site.displayName,
-            error: e
+            error
           });
         }
       }


### PR DESCRIPTION
## Summary

- `GoogleDriveService`, `Office365Service`, and `NextcloudService` each hand-rolled an identical OAuth token-lifecycle: callback-URL building, provider-config resolution (`configCache` lookup + `credentialService.resolveSecret`), the redirect-URI fallback chain (explicit config → env var → auto-detect from request → localhost), token store/refresh/expiry-refresh/delete, and (for Google Drive/Office 365) a 401-retry-once API request wrapper.
- Extracted that shared lifecycle into `server/services/integrations/OAuthIntegrationBase.js`, a base class the three services now `extends`. Each service keeps only its actual provider-specific logic: auth-URL construction, token exchange/refresh endpoints and params, and (Nextcloud) the WebDAV/OCS calls, which intentionally still bypass the shared API-request wrapper since their response shape (XML/WebDAV) differs fundamentally from the JSON REST APIs.
- Public method signatures (`generateAuthUrl`, `exchangeCodeForTokens`, `getUserTokens`, `makeApiRequest`, `_getProviderConfig(providerId)`, etc.) are unchanged, so `server/routes/integrations/{office365,googledrive,nextcloud}.js` needed no changes.

Also fixes two divergence bugs the duplication had already produced:
- `Office365Service.listSharePointDrives`'s catch block logged `error: e` (an undefined variable) instead of the caught `error`, so it threw a `ReferenceError` inside its own error handler whenever a followed-site drive lookup failed, masking the real error.
- `GoogleDriveService._buildCallbackUrl` read `X-Forwarded-Proto`/`X-Forwarded-Host` directly instead of going through `getForwardedProto`/`getForwardedHost` (which collapse multi-value proxy-chain headers to the trusted value) — the hardening already applied to Office 365 and Nextcloud. It now shares the same base-class implementation.

Removed Office 365's dead "invalidate old admin-consent scopes" block, which logged a warning about legacy `Group.Read.All`/`ChannelSettings.Read.All` scopes but never actually invalidated anything (no behavior change — it was diagnostic-only).

Net: `GoogleDriveService` (943 → ~630 lines), `Office365Service` (1124 → ~780), `NextcloudService` (723 → ~560), plus one new ~450-line shared base class.

Fixes #1742

## Test plan

- [x] `npx eslint` on the four changed/new files — 0 errors, 0 warnings
- [x] `npx prettier --check` — passes
- [x] Verified `server/tests/office365-callback-url-autodetect.test.js`, `server/tests/office365-scope-build.test.js`, and `server/tests/nextcloud-service.test.js` still pass identically before/after the refactor (these aren't wired into the Jest/CI runner today, but I ran them manually with `node`)
- [x] Confirmed `server/tests/office365-old-token-migration.test.js` fails identically before and after (it was already asserting throw-behavior for the dead scope-invalidation block that never actually threw — a pre-existing gap, not a regression from this change)
- [x] Booted the server locally (`node server/server.js`, clustered) and confirmed `GoogleDriveService`/`Office365Service`/`NextcloudService` initialize cleanly in every worker with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hce1M1kX6UUEAVpSpyLiCr

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hce1M1kX6UUEAVpSpyLiCr)_