### PR TITLE
fix(security): restrict docker-ci.yml comment trigger to trusted authors

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -41,25 +41,33 @@ jobs:
         id: check
         env:
           COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
         run: |
           should_run=false
-          
+
           # Always run on releases
           if [[ "${{ github.event_name }}" == "release" ]]; then
             should_run=true
           fi
-          
+
           # Always run on manual workflow dispatch
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             should_run=true
           fi
-          
+
           # Check for comment trigger with proper escaping
+          # GHSA-f79p-xmmr-m7xg: only trusted associations may trigger a build,
+          # since issue_comment always runs against the default branch and
+          # this workflow has packages: write.
           if [[ "${{ github.event_name }}" == "issue_comment" ]]; then
             # Use environment variable to safely handle multi-line comments
             echo "$COMMENT_BODY" > comment_body.txt
             if grep -q "@build docker images" comment_body.txt; then
-              should_run=true
+              if [[ "$COMMENT_AUTHOR_ASSOCIATION" =~ ^(OWNER|MEMBER|COLLABORATOR)$ ]]; then
+                should_run=true
+              else
+                echo "Comment matched trigger phrase but author association '$COMMENT_AUTHOR_ASSOCIATION' is not trusted. Skipping."
+              fi
             fi
             rm -f comment_body.txt
           fi
@@ -132,7 +140,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
           labels: |
             org.opencontainers.image.title=iHub Apps
             org.opencontainers.image.description=iHub Applications Platform


### PR DESCRIPTION
## Summary

`docker-ci.yml`'s `issue_comment` trigger built and pushed a Docker image to GHCR — including overwriting the public `:latest` tag — whenever any comment on any issue or PR contained the string `@build docker images`, with no check on who posted it. Since `issue_comment` events always run against the default branch, any GitHub user who can comment could force a build of unreleased `main` and push it as `ghcr.io/.../ihub-apps:latest`, which is what most consumers pull — a live supply-chain risk requiring no write access, just a comment box.

`summary.yml` already documents this class of risk (GHSA-f79p-xmmr-m7xg) with an author-association guard, but that guard was left commented out rather than applied.

## Changes

- `.github/workflows/docker-ci.yml`: gate the `issue_comment` trigger path in the `check-trigger` job on `github.event.comment.author_association`, only allowing `OWNER`, `MEMBER`, or `COLLABORATOR` to trigger a build via comment. Rejected attempts are logged for visibility.
- `.github/workflows/docker-ci.yml`: restrict the `latest` image tag to `release` events only (`type=raw,value=latest,enable=${{ github.event_name == 'release' }}`), so a comment-triggered or manual `workflow_dispatch` build of `main` can no longer silently become the image most users pull.

## Test plan

- [x] Validated the modified workflow YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Confirm in Actions logs that a comment from a non-member account with the trigger phrase is skipped with the new log message
- [ ] Confirm a `release` event still builds and tags `:latest` as before

Fixes #1738

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A6gmDJAD1kh8yoa8jFaH1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01A6gmDJAD1kh8yoa8jFaH1q)_