### PR TITLE
fix(auth): reject JWTs for OIDC/LDAP/Teams/NTLM users deleted after token issuance

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,15 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Deleting an SSO User Now Revokes Access Immediately
+
+Deleting a user who signed in via OIDC, LDAP, Microsoft Teams, or NTLM now immediately invalidates
+their existing session token, matching the behavior already in place for local (username/password)
+accounts. Previously, only local-account deletions took effect right away — a deleted SSO user
+could keep using their app with a valid token until it expired (up to the configured session
+timeout).
+
+- Any request presenting a token for a user no longer found in the user database is now rejected
+  with a 401, for every authentication mode.
+- No admin action is required — the fix takes effect automatically on upgrade.

--- a/server/middleware/jwtAuth.js
+++ b/server/middleware/jwtAuth.js
@@ -429,7 +429,18 @@ export default function jwtAuthMiddleware(req, res, next) {
           );
         }
 
-        if (userRecord && !isUserActive(userRecord)) {
+        if (!userRecord) {
+          logger.warn('JWT Auth token rejected: OIDC user not found', {
+            component: 'JwtAuth',
+            userId
+          });
+          return res.status(401).json({
+            error: 'invalid_token',
+            error_description: 'User account no longer exists'
+          });
+        }
+
+        if (!isUserActive(userRecord)) {
           logger.warn('JWT Auth token rejected: OIDC user account disabled', {
             component: 'JwtAuth',
             userId: userRecord.id
@@ -440,7 +451,6 @@ export default function jwtAuthMiddleware(req, res, next) {
           });
         }
 
-        // User either doesn't exist (not yet persisted) or is active
         user = {
           id: decoded.sub || decoded.username,
           username: decoded.username || decoded.preferred_username || decoded.sub,
@@ -485,7 +495,18 @@ export default function jwtAuthMiddleware(req, res, next) {
           );
         }
 
-        if (userRecord && !isUserActive(userRecord)) {
+        if (!userRecord) {
+          logger.warn('JWT Auth token rejected: LDAP user not found', {
+            component: 'JwtAuth',
+            userId
+          });
+          return res.status(401).json({
+            error: 'invalid_token',
+            error_description: 'User account no longer exists'
+          });
+        }
+
+        if (!isUserActive(userRecord)) {
           logger.warn('JWT Auth token rejected: LDAP user account disabled', {
             component: 'JwtAuth',
             userId: userRecord.id
@@ -532,7 +553,18 @@ export default function jwtAuthMiddleware(req, res, next) {
           );
         }
 
-        if (userRecord && !isUserActive(userRecord)) {
+        if (!userRecord) {
+          logger.warn('JWT Auth token rejected: Teams user not found', {
+            component: 'JwtAuth',
+            userId
+          });
+          return res.status(401).json({
+            error: 'invalid_token',
+            error_description: 'User account no longer exists'
+          });
+        }
+
+        if (!isUserActive(userRecord)) {
           logger.warn('JWT Auth token rejected: Teams user account disabled', {
             component: 'JwtAuth',
             userId: userRecord.id
@@ -581,7 +613,18 @@ export default function jwtAuthMiddleware(req, res, next) {
           );
         }
 
-        if (userRecord && !isUserActive(userRecord)) {
+        if (!userRecord) {
+          logger.warn('JWT Auth token rejected: NTLM user not found', {
+            component: 'JwtAuth',
+            userId
+          });
+          return res.status(401).json({
+            error: 'invalid_token',
+            error_description: 'User account no longer exists'
+          });
+        }
+
+        if (!isUserActive(userRecord)) {
           logger.warn('JWT Auth token rejected: NTLM user account disabled', {
             component: 'JwtAuth',
             userId: userRecord.id

--- a/server/tests/jwt-user-validation.test.js
+++ b/server/tests/jwt-user-validation.test.js
@@ -57,6 +57,94 @@ const mockTestUsersConfig = {
       internalGroups: ['users'],
       createdAt: '2025-01-01T00:00:00.000Z',
       updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_active_oidc: {
+      id: 'user_active_oidc',
+      username: 'oidcactive',
+      email: 'oidc-active@example.com',
+      name: 'Active OIDC User',
+      active: true,
+      authMethods: ['oidc'],
+      internalGroups: ['users'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_disabled_oidc: {
+      id: 'user_disabled_oidc',
+      username: 'oidcdisabled',
+      email: 'oidc-disabled@example.com',
+      name: 'Disabled OIDC User',
+      active: false,
+      authMethods: ['oidc'],
+      internalGroups: ['users'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_active_ldap: {
+      id: 'user_active_ldap',
+      username: 'ldapactive',
+      email: 'ldap-active@example.com',
+      name: 'Active LDAP User',
+      active: true,
+      authMethods: ['ldap'],
+      internalGroups: ['users'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_disabled_ldap: {
+      id: 'user_disabled_ldap',
+      username: 'ldapdisabled',
+      email: 'ldap-disabled@example.com',
+      name: 'Disabled LDAP User',
+      active: false,
+      authMethods: ['ldap'],
+      internalGroups: ['users'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_active_teams: {
+      id: 'user_active_teams',
+      username: 'teamsactive',
+      email: 'teams-active@example.com',
+      name: 'Active Teams User',
+      active: true,
+      authMethods: ['teams'],
+      internalGroups: ['users'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_disabled_teams: {
+      id: 'user_disabled_teams',
+      username: 'teamsdisabled',
+      email: 'teams-disabled@example.com',
+      name: 'Disabled Teams User',
+      active: false,
+      authMethods: ['teams'],
+      internalGroups: ['users'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_active_ntlm: {
+      id: 'user_active_ntlm',
+      username: 'ntlmactive',
+      email: 'ntlm-active@example.com',
+      name: 'Active NTLM User',
+      active: true,
+      authMethods: ['ntlm'],
+      internalGroups: ['users'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_disabled_ntlm: {
+      id: 'user_disabled_ntlm',
+      username: 'ntlmdisabled',
+      email: 'ntlm-disabled@example.com',
+      name: 'Disabled NTLM User',
+      active: false,
+      authMethods: ['ntlm'],
+      internalGroups: ['users'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
     }
   },
   metadata: {
@@ -195,6 +283,84 @@ describe('JWT User Validation Security Tests', () => {
           expiresIn: '7d',
           issuer: 'ihub-apps'
         }
+      );
+
+      const response = await request(app)
+        .get('/api/test/protected')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('invalid_token');
+      expect(response.body.error_description).toBe('User account no longer exists');
+    });
+  });
+
+  describe.each([
+    { authMode: 'oidc', activeId: 'user_active_oidc', disabledId: 'user_disabled_oidc' },
+    { authMode: 'ldap', activeId: 'user_active_ldap', disabledId: 'user_disabled_ldap' },
+    { authMode: 'teams', activeId: 'user_active_teams', disabledId: 'user_disabled_teams' },
+    { authMode: 'ntlm', activeId: 'user_active_ntlm', disabledId: 'user_disabled_ntlm' }
+  ])('$authMode JWT Validation (external auth mode)', ({ authMode, activeId, disabledId }) => {
+    test('should allow access with valid JWT for active user', async () => {
+      const token = jwt.sign(
+        {
+          sub: activeId,
+          id: activeId,
+          username: activeId,
+          name: 'Active User',
+          email: `${activeId}@example.com`,
+          groups: ['users'],
+          authMode
+        },
+        TEST_JWT_SECRET,
+        { expiresIn: '7d', issuer: 'ihub-apps' }
+      );
+
+      const response = await request(app)
+        .get('/api/test/protected')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.user.id).toBe(activeId);
+    });
+
+    test('should reject JWT for disabled user with 403', async () => {
+      const token = jwt.sign(
+        {
+          sub: disabledId,
+          id: disabledId,
+          username: disabledId,
+          name: 'Disabled User',
+          email: `${disabledId}@example.com`,
+          groups: ['users'],
+          authMode
+        },
+        TEST_JWT_SECRET,
+        { expiresIn: '7d', issuer: 'ihub-apps' }
+      );
+
+      const response = await request(app)
+        .get('/api/test/protected')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(403);
+      expect(response.body.error).toBe('access_denied');
+      expect(response.body.error_description).toBe('User account has been disabled');
+    });
+
+    test('should reject JWT with 401 when the user record is missing (deleted after issuance)', async () => {
+      const token = jwt.sign(
+        {
+          sub: `${authMode}_deleted_user`,
+          id: `${authMode}_deleted_user`,
+          username: `${authMode}_deleted_user`,
+          name: 'Deleted User',
+          email: 'no-such-user@example.com',
+          groups: ['users'],
+          authMode
+        },
+        TEST_JWT_SECRET,
+        { expiresIn: '7d', issuer: 'ihub-apps' }
       );
 
       const response = await request(app)

--- a/server/tests/manual-test-jwt-validation.js
+++ b/server/tests/manual-test-jwt-validation.js
@@ -248,7 +248,7 @@ const oidcToken = jwt.sign(
 console.log(`  ✓ Generated OIDC JWT for testing`);
 console.log(`  🔍 Note: OIDC users are now validated against users database`);
 console.log(`  - If user exists and is disabled: returns 403`);
-console.log(`  - If user doesn't exist yet: allows (not persisted on first login)`);
+console.log(`  - If user record is missing (deleted after token issuance): returns 401`);
 
 // Test 9: Simulate LDAP user validation
 console.log('\n📋 Test 9: Simulate JWT validation for LDAP users');
@@ -268,7 +268,8 @@ const ldapToken = jwt.sign(
 );
 
 console.log(`  ✓ Generated LDAP JWT for testing`);
-console.log(`  🔍 Note: LDAP users are now validated if persisted to users database`);
+console.log(`  🔍 Note: LDAP users are now validated against users database`);
+console.log(`  - If user record is missing (deleted after token issuance): returns 401`);
 
 // Test 10: Simulate Teams user validation
 console.log('\n📋 Test 10: Simulate JWT validation for Teams users');
@@ -290,21 +291,25 @@ const teamsToken = jwt.sign(
 
 console.log(`  ✓ Generated Teams JWT for testing`);
 console.log(`  🔍 Note: Teams users are now validated against users database`);
+console.log(`  - If user record is missing (deleted after token issuance): returns 401`);
 
 console.log('\n' + '='.repeat(60));
 console.log('\n✅ Manual JWT validation security test completed!\n');
 console.log('Summary:');
 console.log('- The jwtAuth.js middleware now validates ALL auth modes against the database');
-console.log('- Local, OIDC, LDAP, and Teams users are validated for active status');
-console.log('- Deleted users will receive 401 "User account no longer exists" (local only)');
+console.log(
+  '- Local, OIDC, LDAP, Teams, and NTLM users are validated for existence + active status'
+);
+console.log('- Deleted users will receive 401 "User account no longer exists"');
 console.log('- Disabled users will receive 403 "User account has been disabled"');
 console.log('- Database errors will receive 503 "Service unavailable" (prevents bypass)');
 console.log('- This prevents disabled/deleted users from using valid JWT tokens\n');
 console.log('Auth Modes Covered:');
 console.log('- ✅ Local: Full validation (existence + active status)');
-console.log('- ✅ OIDC: Active status validation if user persisted');
-console.log('- ✅ LDAP: Active status validation if user persisted');
-console.log('- ✅ Teams: Active status validation if user persisted');
+console.log('- ✅ OIDC: Full validation (existence + active status)');
+console.log('- ✅ LDAP: Full validation (existence + active status)');
+console.log('- ✅ Teams: Full validation (existence + active status)');
+console.log('- ✅ NTLM: Full validation (existence + active status)');
 console.log('\nSecurity Improvement:');
 console.log('- If the user database cannot be loaded, authentication is REJECTED');
 console.log('- This prevents authentication bypass when the database is unavailable');


### PR DESCRIPTION
## Summary

- `jwtAuth.js` only rejected a missing user record for **local** auth (`if (!userRecord) return 401`). For **OIDC/LDAP/Teams/NTLM** the check was `if (userRecord && !isUserActive(userRecord))`, which has no `else` branch for a missing record — the request fell through and was authenticated purely from the still-valid signed token.
- Since all four external providers persist the user to `users.json` **synchronously, before the JWT is issued** (verified in `oidcAuth.js`, `ldapAuth.js`, `ntlmAuth.js`), a missing record at request time can only mean the account was deleted (or, for one NTLM code path, that persistence failed) after the token was minted — not a "not yet persisted" race.
- Each of the four branches (`oidc`, `ldap`, `teams`, `ntlm` in `server/middleware/jwtAuth.js`) now rejects with `401 invalid_token` when the user record is missing, before the existing `403` disabled-account check — making external auth modes symmetric with local auth's revocation behavior.
- `oauth_authorization_code` was intentionally left out of scope: it wasn't in the reported evidence and represents a delegated/API-client principal rather than a directly admin-managed user.

## Why

Deleting/offboarding a local user revokes access immediately; deleting an OIDC/LDAP/Teams/NTLM user did not — the user kept full access until their token expired (default session timeout, admin-configurable higher). An admin relying on user deletion as an access-revocation control had no way to know the deleted account was still usable.

## Testing

- Added `jwt-user-validation.test.js` coverage for all four external auth modes (active/disabled/missing-record) mirroring the existing local-auth test cases.
- Manually verified the fix end-to-end (all 12 new scenarios: active/disabled/missing-record × oidc/ldap/teams/ntlm) via a standalone script exercising the real `jwtAuthMiddleware` with mocked `configCache`/`users.json` data — confirms 401 for missing records, 403 for disabled, and unaffected pass-through for active users.
- Note: this repo's `server/tests/*.test.js` suite (this file and 3 others using `jest.mock`) currently fails to run under the project's `server/jest.config.js` (`transform: {}`, native ESM) with `ReferenceError: jest is not defined` / a non-functional `jest.mock` under native ESM — a pre-existing test-infrastructure gap unrelated to this change, and out of scope to fix here.
- Updated `manual-test-jwt-validation.js`'s commentary, which described the old fail-open behavior as intentional ("not yet persisted on first login: allows").
- Added a changelog entry under `docs/releases/5.5.0/features.md`.

Fixes #1736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013Je6LeVErREq2RxSvU64k6

---
_Generated by [Claude Code](https://claude.ai/code/session_013Je6LeVErREq2RxSvU64k6)_