### PR TITLE
fix: enforce user model permissions in chat flow (#1734)

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,17 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Chat Requests Now Enforce Per-User Model Permissions
+
+The model allowlist configured for a user's group (**Admin → Groups → Models**) is now enforced on
+every chat request, closing a gap where it previously only affected which models appeared in the
+app's model picker.
+
+- Requesting a model outside your group's allowed models now returns a clear "not permitted" error
+  instead of silently succeeding.
+- Automatic model selection (when no model is explicitly chosen) now only considers models both the
+  app and the user's group permit, instead of every model the app allows.
+- No admin action is required — groups that already restrict `models` to specific IDs are now fully
+  enforced for chat, matching the behavior already used by the model list and the OpenAI-compatible
+  API endpoints.

--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -811,12 +811,14 @@ export default function registerSessionRoutes(
               .status(
                 prep.error.code === 'APP_NOT_FOUND' || prep.error.code === 'MODEL_NOT_FOUND'
                   ? 404
-                  : prep.error.code === 'noModelsAvailable' ||
-                      prep.error.code === 'noCompatibleModels' ||
-                      prep.error.code === 'noModelIdProvided' ||
-                      prep.error.code === 'noModelsForUser'
-                    ? 400
-                    : 500
+                  : prep.error.code === 'modelAccessDeniedForUser'
+                    ? 403
+                    : prep.error.code === 'noModelsAvailable' ||
+                        prep.error.code === 'noCompatibleModels' ||
+                        prep.error.code === 'noModelIdProvided' ||
+                        prep.error.code === 'noModelsForUser'
+                      ? 400
+                      : 500
               )
               .json({ error: errMsg, code: prep.error.code });
           }

--- a/server/services/chat/RequestBuilder.js
+++ b/server/services/chat/RequestBuilder.js
@@ -3,6 +3,7 @@ import { createCompletionRequest } from '../../adapters/index.js';
 import { getToolsForApp, resolveAppNativeWebSearch } from '../../toolLoader.js';
 import ErrorHandler from '../../utils/ErrorHandler.js';
 import ApiKeyVerifier from '../../utils/ApiKeyVerifier.js';
+import { filterResourcesByPermissions } from '../../utils/authorization.js';
 import logger from '../../utils/logger.js';
 
 function preprocessMessagesWithFileData(messages) {
@@ -147,6 +148,21 @@ function filterModelsForApp(models, app) {
   return availableModels;
 }
 
+/**
+ * Narrow a model list down to what the requesting user's group permissions
+ * allow. Apps only express what they support; user.permissions.models is the
+ * separate, group-driven allowlist enforced everywhere else (/api/models,
+ * the OpenAI-compatible proxy) and must also bound chat model resolution.
+ * @param {Array} models - Models already filtered for app requirements
+ * @param {Object} user - Authenticated/anonymous principal, may be undefined
+ * @returns {Array} Models the user is permitted to use
+ */
+function filterModelsForUser(models, user) {
+  if (!user?.permissions) return models;
+  const allowedModels = user.permissions.models || new Set();
+  return filterResourcesByPermissions(models, allowedModels);
+}
+
 class RequestBuilder {
   constructor() {
     this.errorHandler = new ErrorHandler();
@@ -199,17 +215,36 @@ class RequestBuilder {
         return { success: false, error };
       }
 
+      // A caller who explicitly names a model outside their group's model
+      // allowlist gets a clear 403, not a silent substitution further down.
+      // This mirrors the enforcement already applied to /api/models and the
+      // OpenAI-compatible proxy (server/routes/openaiProxy.js).
+      if (modelId && user?.permissions) {
+        const allowedModels = user.permissions.models || new Set();
+        const requestedModelExists = models.some(m => m.id === modelId);
+        if (requestedModelExists && !allowedModels.has('*') && !allowedModels.has(modelId)) {
+          const error = new Error(
+            `You don't have permission to use the model '${modelId}'. Please contact your administrator to request access.`
+          );
+          error.code = 'modelAccessDeniedForUser';
+          return { success: false, error };
+        }
+      }
+
       // Filter models based on app requirements (allowedModels, tools, settings.model.filter)
       const filteredModels = filterModelsForApp(models, app);
+      // Then narrow to what the requesting user's group permissions allow.
+      const permittedModels = filterModelsForUser(filteredModels, user);
       logger.info('Filtered compatible models for app', {
         component: 'RequestBuilder',
         appId: app.id,
         filteredCount: filteredModels.length,
+        permittedCount: permittedModels.length,
         totalCount: models.length
       });
 
       // Check if no models are available at all
-      if (filteredModels.length === 0) {
+      if (permittedModels.length === 0) {
         // Determine the most appropriate error message
         let errorCode;
 
@@ -218,10 +253,13 @@ class RequestBuilder {
           errorCode = 'noModelsAvailable';
         }
         // If models exist but none passed the app-specific filters
-        else if (app.allowedModels || app.tools || app.settings?.model?.filter) {
+        else if (
+          filteredModels.length === 0 &&
+          (app.allowedModels || app.tools || app.settings?.model?.filter)
+        ) {
           errorCode = 'noCompatibleModels';
         }
-        // Otherwise, likely a permissions issue
+        // Otherwise, the app permits models this user's group does not
         else {
           errorCode = 'noModelsForUser';
         }
@@ -237,8 +275,8 @@ class RequestBuilder {
         return { success: false, error };
       }
 
-      // Find the default model from filtered models, or fall back to global default
-      const defaultModelFromFiltered = filteredModels.find(m => m.default)?.id;
+      // Find the default model from the permitted list, or fall back to global default
+      const defaultModelFromFiltered = permittedModels.find(m => m.default)?.id;
       const globalDefaultModel = models.find(m => m.default)?.id;
       const defaultModel = defaultModelFromFiltered || globalDefaultModel;
 
@@ -251,23 +289,23 @@ class RequestBuilder {
           component: 'RequestBuilder',
           appId: app.id
         });
-        // Use the first available model from filtered list as last resort
-        if (filteredModels.length > 0) {
-          resolvedModelId = filteredModels[0].id;
+        // Use the first available model from the permitted list as last resort
+        if (permittedModels.length > 0) {
+          resolvedModelId = permittedModels[0].id;
           logger.info('Using first available model as fallback', {
             component: 'RequestBuilder',
             resolvedModelId
           });
         } else {
-          // This shouldn't happen since we checked filteredModels.length above, but handle it anyway
+          // This shouldn't happen since we checked permittedModels.length above, but handle it anyway
           const error = new Error('No model ID provided and no default model available.');
           error.code = 'noModelIdProvided';
           return { success: false, error };
         }
       }
 
-      // Check if the resolved model is in the filtered list
-      const isModelInFilteredList = filteredModels.some(m => m.id === resolvedModelId);
+      // Check if the resolved model is in the permitted list
+      const isModelInFilteredList = permittedModels.some(m => m.id === resolvedModelId);
 
       if (!isModelInFilteredList) {
         logger.info('Model not compatible with app requirements, searching for fallback', {
@@ -279,15 +317,15 @@ class RequestBuilder {
         // Try to find a compatible fallback model
         let fallbackModel = null;
 
-        // 1. Try app's preferred model if it's in the filtered list
-        if (app.preferredModel && filteredModels.some(m => m.id === app.preferredModel)) {
+        // 1. Try app's preferred model if it's in the permitted list
+        if (app.preferredModel && permittedModels.some(m => m.id === app.preferredModel)) {
           fallbackModel = app.preferredModel;
           logger.info("Using app's preferred model as fallback", {
             component: 'RequestBuilder',
             fallbackModel
           });
         }
-        // 2. Try default model from filtered list
+        // 2. Try default model from the permitted list
         else if (defaultModelFromFiltered) {
           fallbackModel = defaultModelFromFiltered;
           logger.info('Using default model from filtered list as fallback', {
@@ -295,9 +333,9 @@ class RequestBuilder {
             fallbackModel
           });
         }
-        // 3. Try first available model from filtered list
-        else if (filteredModels.length > 0) {
-          fallbackModel = filteredModels[0].id;
+        // 3. Try first available model from the permitted list
+        else if (permittedModels.length > 0) {
+          fallbackModel = permittedModels[0].id;
           logger.info('Using first available compatible model as fallback', {
             component: 'RequestBuilder',
             fallbackModel

--- a/server/tests/model-permission-enforcement.test.js
+++ b/server/tests/model-permission-enforcement.test.js
@@ -1,0 +1,139 @@
+/**
+ * Regression tests for issue #1734: the chat flow (RequestBuilder.prepareChatRequest)
+ * must enforce user/group model-level permissions (user.permissions.models), not just
+ * app-level model constraints (allowedModels, tool support, settings.model.filter).
+ *
+ * Before this fix, filterModelsForApp only considered app requirements, so a user whose
+ * group restricted them to e.g. 'cheap-model' could still invoke 'expensive-model'
+ * through any app that permitted it, inconsistent with /api/models and the
+ * OpenAI-compatible proxy which both enforce user.permissions.models.
+ *
+ * Note: The repo's source is native ESM, so this file uses `jest.unstable_mockModule` +
+ * dynamic imports rather than the CommonJS-only `jest.mock` API. Run with
+ * `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+
+const mockApps = [
+  {
+    id: 'general-app',
+    name: { en: 'General App' },
+    system: { en: 'You are a helpful assistant.' }
+  }
+];
+
+const mockModels = [
+  { id: 'cheap-model', provider: 'iassistant-conversation', default: true },
+  { id: 'expensive-model', provider: 'iassistant-conversation' }
+];
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: {
+    getApps: () => ({ data: mockApps }),
+    getModels: () => ({ data: mockModels }),
+    getPlatform: () => ({ data: {} })
+  }
+}));
+
+jest.unstable_mockModule('../adapters/index.js', () => ({
+  createCompletionRequest: async () => ({ url: 'http://example.test', method: 'POST', body: {} })
+}));
+
+jest.unstable_mockModule('../toolLoader.js', () => ({
+  getToolsForApp: async () => [],
+  resolveAppNativeWebSearch: () => false
+}));
+
+const { default: RequestBuilder } = await import('../services/chat/RequestBuilder.js');
+
+const identityTemplateProcessor = async messages => messages;
+
+function userWithModels(modelIds) {
+  return {
+    id: 'restricted-user',
+    groups: ['restricted'],
+    permissions: { models: new Set(modelIds) }
+  };
+}
+
+function baseRequest(overrides) {
+  return {
+    appId: 'general-app',
+    messages: [{ role: 'user', content: 'hi' }],
+    language: 'en',
+    processMessageTemplates: identityTemplateProcessor,
+    res: null,
+    clientRes: null,
+    chatId: 'chat-test',
+    ...overrides
+  };
+}
+
+describe('RequestBuilder model permission enforcement (issue #1734)', () => {
+  let builder;
+
+  beforeEach(() => {
+    builder = new RequestBuilder();
+  });
+
+  test('rejects an explicitly requested model outside the user allowlist', async () => {
+    const result = await builder.prepareChatRequest(
+      baseRequest({
+        modelId: 'expensive-model',
+        user: userWithModels(['cheap-model'])
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe('modelAccessDeniedForUser');
+  });
+
+  test('default resolution never falls back to a model outside the permitted set', async () => {
+    const result = await builder.prepareChatRequest(
+      baseRequest({
+        modelId: undefined,
+        user: userWithModels(['cheap-model'])
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data.model.id).toBe('cheap-model');
+  });
+
+  test('surfaces noModelsForUser when the app-permitted and user-permitted sets do not intersect', async () => {
+    const result = await builder.prepareChatRequest(
+      baseRequest({
+        modelId: undefined,
+        user: userWithModels(['some-other-model'])
+      })
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.error.code).toBe('noModelsForUser');
+  });
+
+  test("wildcard ('*') permission is unaffected", async () => {
+    const result = await builder.prepareChatRequest(
+      baseRequest({
+        modelId: 'expensive-model',
+        user: userWithModels(['*'])
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data.model.id).toBe('expensive-model');
+  });
+
+  test('requests without a user/permissions object are unaffected (e.g. internal callers)', async () => {
+    const result = await builder.prepareChatRequest(
+      baseRequest({
+        modelId: 'expensive-model',
+        user: undefined
+      })
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.data.model.id).toBe('expensive-model');
+  });
+});

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -539,6 +539,7 @@
     "networkError": "Netzwerkfehler bei der Verbindung zur {provider} API für Modell {model}: {error}. Überprüfen Sie Ihre Netzwerkverbindung und Proxy-Konfiguration.",
     "unauthorized": "Ungültiger API-Schlüssel",
     "modelAccessDenied": "API-Schlüssel darf dieses Modell nicht verwenden",
+    "modelAccessDeniedForUser": "Sie haben keine Berechtigung, dieses KI-Modell zu verwenden. Bitte wenden Sie sich an Ihren Administrator, um Zugriff anzufordern.",
     "noModelsAvailable": "Für diese Anwendung sind keine KI-Modelle verfügbar. Bitte wenden Sie sich an Ihren Administrator, um Modelle und Berechtigungen zu konfigurieren.",
     "noCompatibleModels": "Keine kompatiblen KI-Modelle für diese Anwendung gefunden. Die Anwendung erfordert spezifische Modellfunktionen, die nicht verfügbar sind. Bitte wenden Sie sich an Ihren Administrator.",
     "noModelIdProvided": "Kein Modell ausgewählt. Bitte wählen Sie ein KI-Modell, um fortzufahren.",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1972,6 +1972,7 @@
     "networkError": "Network error connecting to {provider} API for model {model}: {error}. Check your network connection and proxy configuration.",
     "unauthorized": "Invalid API key",
     "modelAccessDenied": "API key is not allowed to use this model",
+    "modelAccessDeniedForUser": "You don't have permission to use this AI model. Please contact your administrator to request access.",
     "noModelsAvailable": "No AI models are available for this app. Please contact your administrator to configure models and permissions.",
     "noCompatibleModels": "No compatible AI models found for this app. The app requires specific model features that are not available. Please contact your administrator.",
     "noModelIdProvided": "No model selected. Please select an AI model to continue.",


### PR DESCRIPTION
## Summary

Fixes #1734.

`RequestBuilder.prepareChatRequest` (the code path behind `POST /api/apps/:appId/chat/:chatId`) resolved and validated the chat model purely against app-level constraints (`allowedModels`, tool support, `settings.model.filter`) and never consulted `req.user.permissions.models`. A user in a group whose `models` allowlist excluded an expensive/restricted model could still invoke it through any app that permitted it — inconsistent with `/api/models` and the OpenAI-compatible proxy (`/api/inference/v1/*`), which both already enforce `permissions.models`.

- Added `filterModelsForUser`, which narrows the app-filtered model list down to the user's group-permitted models (reusing the existing `filterResourcesByPermissions` helper from `utils/authorization.js`).
- If the caller explicitly requests a `modelId` that exists but is outside the user's allowlist, the request now fails fast with a new `modelAccessDeniedForUser` error code (mapped to HTTP 403), instead of silently falling back to a different, permitted model.
- Default/fallback model resolution (no explicit `modelId`, app's `preferredModel`, global default, first-available fallback) now only considers the intersection of app-permitted and user-permitted models.
- If that intersection is empty, the existing `noModelsForUser` error path is used, matching prior behavior when nothing is resolvable.
- Added new `modelAccessDeniedForUser` i18n strings (en/de).
- Added a changelog entry under `docs/releases/5.5.0/features.md`.

## Test plan

- [x] New regression test suite `server/tests/model-permission-enforcement.test.js` (Jest) covering:
  - explicit request for a model outside the user's allowlist → rejected with `modelAccessDeniedForUser`
  - default resolution never falls back to a model outside the permitted set
  - empty intersection between app-permitted and user-permitted models → `noModelsForUser`
  - wildcard (`*`) permission unaffected
  - requests without a `user`/`permissions` object (internal callers) unaffected
- [x] `npx eslint` and `npx prettier --check` on all changed files — clean
- [x] Ran the full test file with `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/model-permission-enforcement.test.js` — all 5 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7vgTCxnS7ZyMrexReSPAV


---
_Generated by [Claude Code](https://claude.ai/code/session_01S7vgTCxnS7ZyMrexReSPAV)_