### PR TITLE
fix: stop caching 5xx error placeholders and replaying them as data

### DIFF
--- a/client/src/api/utils/requestHandler.js
+++ b/client/src/api/utils/requestHandler.js
@@ -127,17 +127,6 @@ export const handleApiResponse = async (
           url: error.config?.url
         });
 
-        // For 5xx server errors, store a minimal placeholder in cache with shorter TTL
-        // to prevent overwhelming the server with retries on error
-        if (error.response?.status >= 500 && cacheKey) {
-          const errorPlaceholder = {
-            error: enhancedError.message,
-            isErrorPlaceholder: true,
-            status: enhancedError.status
-          };
-          cache.set(cacheKey, errorPlaceholder, DEFAULT_CACHE_TTL.SHORT);
-        }
-
         throw enhancedError;
       } finally {
         // Always clear the pending request reference when done

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -461,6 +461,16 @@ field) and the multimodal audio-upload path (which sends audio to a chat LLM).
 **Before using:** add or enable a transcription model under **Admin → Models** (model type
 "Transcription"), set its realtime URL, then enable transcription on the desired app.
 
+## Transient Server Errors No Longer Get Cached and Replayed as Data
+
+A single transient server error (for example a brief hiccup loading styles or UI configuration)
+could previously get cached client-side and served back as if it were successful data for up to a
+minute, causing affected screens to crash or render blank instead of showing an error or retrying.
+
+- Failed requests are no longer written into the client-side response cache; a retry after a
+  transient error always fetches fresh data instead of replaying the earlier failure.
+- No configuration or admin action required.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/tests/unit/client/request-handler-5xx-cache.test.jsx
+++ b/tests/unit/client/request-handler-5xx-cache.test.jsx
@@ -1,0 +1,80 @@
+/**
+ * Regression test for issue #1731: a 5xx response used to be written into the
+ * request cache as an error placeholder, and the cache-hit path had no
+ * isErrorPlaceholder check, so the placeholder object was returned as if it
+ * were successful data for up to a minute. handleApiResponse must never
+ * cache a failed response, and a cache miss must always trigger a fresh
+ * apiCall.
+ */
+
+// client.js and utils/cache.js both read import.meta.env at module scope,
+// which the CommonJS jest transform can't evaluate. Mock them so the test
+// exercises requestHandler.js's real logic without loading those modules.
+jest.mock('../../../client/src/api/client', () => ({
+  API_REQUEST_TIMEOUT: 30000
+}));
+
+jest.mock('../../../client/src/utils/cache', () => {
+  const mockStore = new Map();
+  return {
+    __esModule: true,
+    default: {
+      get: jest.fn(key => (mockStore.has(key) ? mockStore.get(key) : null)),
+      set: jest.fn((key, value) => {
+        mockStore.set(key, value);
+        return value;
+      }),
+      __mockStore: mockStore
+    },
+    DEFAULT_CACHE_TTL: { SHORT: 60 * 1000, MEDIUM: 5 * 60 * 1000 }
+  };
+});
+
+const { handleApiResponse } = require('../../../client/src/api/utils/requestHandler');
+const cache = require('../../../client/src/utils/cache').default;
+
+beforeEach(() => {
+  cache.__mockStore.clear();
+  jest.clearAllMocks();
+});
+
+function serverError() {
+  const error = new Error('Internal Server Error');
+  error.response = { status: 500, data: { error: 'Internal Server Error' } };
+  return error;
+}
+
+test('a 5xx failure rejects and is not written into the cache', async () => {
+  const apiCall = jest.fn().mockRejectedValue(serverError());
+
+  await expect(handleApiResponse(apiCall, 'test-key')).rejects.toMatchObject({
+    status: 500
+  });
+
+  expect(cache.__mockStore.has('test-key')).toBe(false);
+});
+
+test('a cache miss after a prior 5xx triggers a fresh apiCall instead of replaying the error', async () => {
+  const apiCall = jest
+    .fn()
+    .mockRejectedValueOnce(serverError())
+    .mockResolvedValueOnce({ status: 200, data: { ok: true } });
+
+  await expect(handleApiResponse(apiCall, 'test-key')).rejects.toMatchObject({ status: 500 });
+
+  const result = await handleApiResponse(apiCall, 'test-key');
+
+  expect(apiCall).toHaveBeenCalledTimes(2);
+  expect(result).toEqual({ ok: true });
+});
+
+test('a successful response is cached and served without re-invoking apiCall', async () => {
+  const apiCall = jest.fn().mockResolvedValue({ status: 200, data: { ok: true } });
+
+  const first = await handleApiResponse(apiCall, 'test-key');
+  const second = await handleApiResponse(apiCall, 'test-key');
+
+  expect(apiCall).toHaveBeenCalledTimes(1);
+  expect(first).toEqual({ ok: true });
+  expect(second).toEqual({ ok: true });
+});


### PR DESCRIPTION
## Summary

Fixes #1731.

`handleApiResponse` in `client/src/api/utils/requestHandler.js` wrote a `{ error, isErrorPlaceholder: true, status }` object into the response cache on any 5xx response, under the same `cacheKey` used for real data. The cache-hit read path (`cachedData.data !== undefined ? cachedData.data : cachedData`) had no `isErrorPlaceholder` check, so that placeholder object was served back as if it were a successful response for up to 60 seconds (`DEFAULT_CACHE_TTL.SHORT`). No caller anywhere checked the flag (confirmed via `grep -rn isErrorPlaceholder client/` — only the definition itself matched), so components expecting arrays/objects (e.g. from `/styles` or `/configs/ui`) would crash or render blank after a single transient server error.

- Removed the 5xx error-placeholder cache write entirely (the recommended fix from the issue). The existing `pendingRequests` deduplication map already collapses concurrent identical in-flight requests, so this doesn't reopen a request-storm risk.
- Added `tests/unit/client/request-handler-5xx-cache.test.jsx`, which verifies:
  - a 5xx failure rejects and is never written to the cache
  - a cache miss following a prior 5xx triggers a fresh `apiCall` instead of replaying the stored error
  - a genuinely successful response is still cached and served without re-invoking `apiCall`
- Added a changelog entry under `docs/releases/5.5.0/features.md`.

## Test plan

- [x] `npx jest --config tests/config/jest.config.js tests/unit/client/request-handler-5xx-cache.test.jsx` — new test passes against the fix, and fails against the pre-fix code (verified by temporarily reverting the fix).
- [x] `npx jest --config tests/config/jest.config.js tests/unit/client` — full client unit suite (143 tests) passes.
- [x] `npx eslint client/src/api/utils/requestHandler.js` — clean.
- [x] `npx prettier --check` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KRRj7iMzD4VqHV2Y1XrEou

---
_Generated by [Claude Code](https://claude.ai/code/session_01KRRj7iMzD4VqHV2Y1XrEou)_