### PR TITLE
fix: reconcile plan on all WorkflowEngine terminal-failure paths

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -461,6 +461,17 @@ field) and the multimodal audio-upload path (which sends audio to a chat LLM).
 **Before using:** add or enable a transcription model under **Admin → Models** (model type
 "Transcription"), set its realtime URL, then enable transcription on the desired app.
 
+## Agent Workflow Tasks No Longer Stay Stuck "In Progress" After a Timeout or Iteration-Limit Failure
+
+Agent workflow runs that failed because they ran out of time (`maxExecutionTime`) or hit the
+internal iteration cap previously left their last task showing as still running in the execution
+view, even though the run itself had already stopped. Runs that fail via the normal node-error path
+were already handled correctly.
+
+- Any task still marked "in progress" or "open" when a run ends is now always flipped to
+  "cancelled," regardless of which failure path ended the run.
+- No configuration or admin action required.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/server/services/workflow/WorkflowEngine.js
+++ b/server/services/workflow/WorkflowEngine.js
@@ -556,6 +556,10 @@ export class WorkflowEngine {
             executionId
           });
 
+          // Same plan reconciliation as the success/error paths: a run that
+          // dies by wall-clock timeout shouldn't leave a task spinning either.
+          await this._reconcilePlanOnTerminal(executionId, state);
+
           await this.stateManager.update(executionId, {
             status: WorkflowStatus.FAILED,
             completedAt: new Date().toISOString()
@@ -801,6 +805,10 @@ export class WorkflowEngine {
           maxIterations: MAX_EXECUTION_ITERATIONS
         });
 
+        // Same plan reconciliation as the other terminal paths: a run that
+        // dies by hitting the iteration cap shouldn't leave a task spinning.
+        await this._reconcilePlanOnTerminal(executionId);
+
         await this.stateManager.update(executionId, {
           status: WorkflowStatus.FAILED
         });
@@ -824,6 +832,10 @@ export class WorkflowEngine {
         executionId,
         error
       });
+
+      // Same plan reconciliation as the other terminal paths: a run that
+      // dies with an unexpected error shouldn't leave a task spinning either.
+      await this._reconcilePlanOnTerminal(executionId);
 
       await this.stateManager.update(executionId, {
         status: WorkflowStatus.FAILED

--- a/server/tests/workflow-terminal-plan-reconciliation.test.js
+++ b/server/tests/workflow-terminal-plan-reconciliation.test.js
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+/**
+ * Regression tests for GH #1729: _runExecutionLoop must reconcile the living
+ * plan (cancel leftover in_progress/open tasks) on EVERY terminal-failure
+ * exit, not just the node-error and success paths. Covers the three branches
+ * that previously skipped it: the maxExecutionTime deadline, the
+ * MAX_EXECUTION_ITERATIONS cap, and the outer fatal-error catch.
+ *
+ * Run directly: `node server/tests/workflow-terminal-plan-reconciliation.test.js`.
+ */
+
+import os from 'os';
+import path from 'path';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { WorkflowEngine } from '../services/workflow/WorkflowEngine.js';
+import { StateManager } from '../services/workflow/StateManager.js';
+
+let failures = 0;
+function check(label, cond, details) {
+  if (!cond) failures += 1;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && details) console.log(`   ${details}`);
+}
+
+function seedState(stateDir, executionId, state) {
+  mkdirSync(path.join(stateDir, executionId), { recursive: true });
+  writeFileSync(
+    path.join(stateDir, executionId, 'latest.json'),
+    JSON.stringify({
+      executionId,
+      workflowId: state.workflowId || 'wf1',
+      status: state.status || 'running',
+      currentNodes: state.currentNodes || [],
+      completedNodes: state.completedNodes || [],
+      failedNodes: [],
+      checkpoints: [],
+      history: [],
+      errors: [],
+      data: state.data || {}
+    }),
+    'utf8'
+  );
+}
+
+function newEngine() {
+  const stateDir = mkdtempSync(path.join(os.tmpdir(), 'ihub-terminal-reconcile-'));
+  const sm = new StateManager({ stateDir });
+  return { engine: new WorkflowEngine({ stateManager: sm }), sm, stateDir };
+}
+
+const taskQueueWithOpenTask = [
+  { id: 't1', title: 'Step 1', status: 'in_progress' },
+  { id: 't2', title: 'Step 2', status: 'done' }
+];
+
+function reconciledStatuses(state) {
+  return Object.fromEntries((state.data._taskQueue || []).map(t => [t.id, t.status]));
+}
+
+async function run() {
+  console.log('🧪 deadline (maxExecutionTime) failure reconciles the plan\n');
+  {
+    const { engine, sm, stateDir } = newEngine();
+    const execId = 'wf-exec-deadline-1';
+    seedState(stateDir, execId, {
+      currentNodes: ['a'],
+      data: {
+        _executionDeadline: Date.now() - 1000,
+        _taskQueue: taskQueueWithOpenTask
+      }
+    });
+    // Preload into StateManager's in-memory map (update() requires this).
+    await sm.get(execId);
+
+    const def = {
+      id: 'wf1',
+      config: {},
+      nodes: [{ id: 'a', type: 'noop' }],
+      edges: []
+    };
+    await engine._runExecutionLoop(def, execId, {}, new AbortController().signal);
+
+    const after = await sm.get(execId);
+    const byId = reconciledStatuses(after);
+    check('status is failed', after.status === 'failed', after.status);
+    check('in_progress task cancelled', byId.t1 === 'cancelled', JSON.stringify(byId));
+    check('already-done task untouched', byId.t2 === 'done', JSON.stringify(byId));
+    check(
+      'error code recorded',
+      after.errors?.some(e => e.code === 'MAX_EXECUTION_TIME_EXCEEDED'),
+      JSON.stringify(after.errors)
+    );
+  }
+
+  console.log('\n🧪 fatal error in the execution loop reconciles the plan\n');
+  {
+    const { engine, sm, stateDir } = newEngine();
+    const execId = 'wf-exec-fatal-1';
+    seedState(stateDir, execId, {
+      currentNodes: ['a'],
+      data: { _taskQueue: taskQueueWithOpenTask }
+    });
+    await sm.get(execId);
+
+    // Force the try block to throw so control reaches the outer catch,
+    // without needing a real scheduler/node-execution setup.
+    engine.scheduler.getExecutableNodes = () => {
+      throw new Error('boom');
+    };
+
+    const def = {
+      id: 'wf1',
+      config: {},
+      nodes: [{ id: 'a', type: 'noop' }],
+      edges: []
+    };
+    await engine._runExecutionLoop(def, execId, {}, new AbortController().signal);
+
+    const after = await sm.get(execId);
+    const byId = reconciledStatuses(after);
+    check('status is failed', after.status === 'failed', after.status);
+    check('in_progress task cancelled', byId.t1 === 'cancelled', JSON.stringify(byId));
+    check(
+      'error message recorded',
+      after.errors?.some(e => e.message === 'boom'),
+      JSON.stringify(after.errors)
+    );
+  }
+
+  console.log('\n🧪 MAX_EXECUTION_ITERATIONS cap reconciles the plan\n');
+  {
+    const { engine, sm, stateDir } = newEngine();
+    const execId = 'wf-exec-max-iter-1';
+    seedState(stateDir, execId, {
+      currentNodes: ['a'],
+      // Seed 'a' as already-completed so the self-loop edge (source: a,
+      // target: a) is satisfied on the very first readiness check too —
+      // otherwise the first iteration deadlocks waiting on its own back-edge.
+      completedNodes: ['a'],
+      data: { _taskQueue: taskQueueWithOpenTask }
+    });
+    await sm.get(execId);
+
+    // Self-looping single node: getExecutableNodes stays ready forever
+    // (allowCycles defaults true), so the real loop runs until it trips the
+    // 10000-iteration cap. Stub executeNode to skip real node dispatch while
+    // still driving the state transitions _runExecutionLoop depends on.
+    engine.executeNode = async (node, _workflow, executionId) => {
+      await sm.markNodeCompleted(executionId, node.id, {});
+      return {};
+    };
+
+    const def = {
+      id: 'wf1',
+      config: {},
+      nodes: [{ id: 'a', type: 'noop' }],
+      edges: [{ source: 'a', target: 'a' }]
+    };
+    await engine._runExecutionLoop(def, execId, {}, new AbortController().signal);
+
+    const after = await sm.get(execId);
+    const byId = reconciledStatuses(after);
+    check('status is failed', after.status === 'failed', after.status);
+    check('in_progress task cancelled', byId.t1 === 'cancelled', JSON.stringify(byId));
+    check(
+      'error code recorded',
+      after.errors?.some(e => e.code === 'MAX_ITERATIONS_EXCEEDED'),
+      JSON.stringify(after.errors)
+    );
+  }
+
+  console.log(`\n${failures === 0 ? '✅ all passed' : `❌ ${failures} failed`}`);
+  process.exit(failures ? 1 : 0);
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes #1729.

`_reconcilePlanOnTerminal` (which flips any leftover `in_progress`/`open` tasks to `cancelled` so a finished run never shows a perpetually-spinning task) was only invoked from the success path (`_completeWorkflow`) and the node-error path (`_handleNodeError`). Two other terminal transitions in `_runExecutionLoop` skipped it entirely:

- The `maxExecutionTime` deadline branch
- The `MAX_EXECUTION_ITERATIONS` cap branch

Runs that died via wall-clock timeout or the iteration cap therefore rendered with tasks stuck spinning in the UI — the exact bug reconciliation exists to prevent, just via a different exit path.

While in there, I also added the same call to the outer fatal-error `catch` block in `_runExecutionLoop`, since it has the identical shape (sets `status: FAILED` without reconciling first) and is the same bug class — flagged as an open question in the issue's implementation-plan comment.

## Changes

- `server/services/workflow/WorkflowEngine.js`: added `await this._reconcilePlanOnTerminal(...)` to the deadline branch, the max-iterations branch, and the fatal-error catch block.
- `server/tests/workflow-terminal-plan-reconciliation.test.js`: new regression tests exercising all three branches against the real `_runExecutionLoop` (not reimplemented), verifying leftover `in_progress` tasks are cancelled and the correct error code is recorded on each failure path.
- `docs/releases/5.5.0/features.md`: changelog entry.

## Test plan

- [x] New test `node server/tests/workflow-terminal-plan-reconciliation.test.js` passes (deadline, fatal-error, and max-iterations branches all reconcile the plan correctly).
- [x] Existing `node server/tests/agent-plan-reconciliation.test.js` and `node server/tests/workflow-resume.test.js` still pass.
- [x] `npx eslint` and `npx prettier --check` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTS3unpHUGXoo28DfzzsRz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTS3unpHUGXoo28DfzzsRz)_