### PR TITLE
Fix prompt template substitution to escape regex keys and $-patterns

### DIFF
--- a/server/services/PromptService.js
+++ b/server/services/PromptService.js
@@ -16,6 +16,28 @@ import logger from '../utils/logger.js';
 const promptKnowledgeSources = new Map();
 
 /**
+ * Escape regex metacharacters so arbitrary keys can be used inside `new RegExp(...)`
+ * @param {string} str
+ * @returns {string}
+ */
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Replace all `{{key}}` occurrences in text with value, treating both the key and the
+ * value as literal text (key is regex-escaped, value is passed via a function replacer
+ * so `$&`, `$1`, etc. in the value are never reinterpreted by String.replace)
+ * @param {string} text
+ * @param {string} key
+ * @param {string} value
+ * @returns {string}
+ */
+function replaceTemplateVar(text, key, value) {
+  return text.replace(new RegExp(`\\{\\{${escapeRegExp(key)}\\}\\}`, 'g'), () => value);
+}
+
+/**
  * Service for handling prompt processing and template resolution
  */
 class PromptService {
@@ -114,11 +136,7 @@ class PromptService {
       // Replace variables in platform_context with their resolved values
       for (const [key, value] of Object.entries(globalPromptVars)) {
         if (value !== null && value !== undefined && value !== '') {
-          const strValue = String(value);
-          platformContext = platformContext.replace(
-            new RegExp(`\\{\\{${key}\\}\\}`, 'g'),
-            strValue
-          );
+          platformContext = replaceTemplateVar(platformContext, key, String(value));
         }
       }
     }
@@ -194,10 +212,7 @@ class PromptService {
         if (variables && Object.keys(variables).length > 0) {
           for (const [key, value] of Object.entries(variables)) {
             const strValue = typeof value === 'string' ? value : String(value || '');
-            processedContent = processedContent.replace(
-              new RegExp(`\\{\\{${key}\\}\\}`, 'g'),
-              strValue
-            );
+            processedContent = replaceTemplateVar(processedContent, key, strValue);
           }
         }
         // Ensure user content is always included: if template is empty or doesn't contain {{content}},
@@ -238,10 +253,7 @@ class PromptService {
       ) {
         for (const [key, value] of Object.entries(globalPromptVariables)) {
           const strValue = typeof value === 'string' ? value : String(value || '');
-          processedContent = processedContent.replace(
-            new RegExp(`\\{\\{${key}\\}\\}`, 'g'),
-            strValue
-          );
+          processedContent = replaceTemplateVar(processedContent, key, strValue);
         }
       }
       const processedMsg = { role: msg.role, content: processedContent };
@@ -269,7 +281,7 @@ class PromptService {
           if (typeof value === 'function' || (typeof value === 'object' && value !== null))
             continue;
           const strValue = String(value || '');
-          systemPrompt = systemPrompt.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), strValue);
+          systemPrompt = replaceTemplateVar(systemPrompt, key, strValue);
         }
       }
 
@@ -328,11 +340,11 @@ class PromptService {
           const hasSourcePlaceholder = systemPrompt.includes('{{source}}');
 
           if (hasSourcesPlaceholder) {
-            systemPrompt = systemPrompt.replace('{{sources}}', sourceContent || '');
+            systemPrompt = systemPrompt.replace('{{sources}}', () => sourceContent || '');
           }
           // Also support legacy {{source}} template
           if (hasSourcePlaceholder) {
-            systemPrompt = systemPrompt.replace('{{source}}', sourceContent || '');
+            systemPrompt = systemPrompt.replace('{{source}}', () => sourceContent || '');
           }
 
           // If no placeholder was found but we have source content, append it automatically

--- a/server/tests/promptService.test.js
+++ b/server/tests/promptService.test.js
@@ -234,6 +234,110 @@ async function testStringPromptTemplate() {
   logger.info('✓ String prompt template test passed');
 }
 
+// Test 7: Variable key with regex metacharacters should not throw and should substitute correctly
+async function testVariableKeyWithRegexMetacharacters() {
+  const messages = [
+    {
+      role: 'user',
+      content: '',
+      promptTemplate: { en: 'Value: {{foo(bar)}}' },
+      variables: { 'foo(bar)': 'baz' }
+    }
+  ];
+
+  const app = {
+    system: { en: 'You are a helpful assistant' }
+  };
+
+  const result = await PromptService.processMessageTemplates(
+    messages,
+    app,
+    null,
+    null,
+    'en',
+    null,
+    null,
+    null,
+    null
+  );
+
+  assert.strictEqual(result.length, 2, 'Should have 2 messages');
+  assert.strictEqual(
+    result[1].content,
+    'Value: baz',
+    'Variable key with regex metacharacters should substitute without throwing'
+  );
+
+  logger.info('✓ Variable key with regex metacharacters test passed');
+}
+
+// Test 8: Content with $-patterns should be substituted literally, not interpreted
+async function testContentWithDollarPatterns() {
+  const messages = [
+    {
+      role: 'user',
+      content: "Price is $& and $1 and $` and $'",
+      promptTemplate: { en: 'Echo: {{content}}' },
+      variables: {}
+    }
+  ];
+
+  const app = {
+    system: { en: 'You are a helpful assistant' }
+  };
+
+  const result = await PromptService.processMessageTemplates(
+    messages,
+    app,
+    null,
+    null,
+    'en',
+    null,
+    null,
+    null,
+    null
+  );
+
+  assert.strictEqual(result.length, 2, 'Should have 2 messages');
+  assert.strictEqual(
+    result[1].content,
+    "Echo: Price is $& and $1 and $` and $'",
+    '$-patterns in content should be preserved literally, not treated as replacement patterns'
+  );
+
+  logger.info('✓ Content with $-patterns test passed');
+}
+
+// Test 9: System prompt variable substitution should not interpret $-patterns in the value
+async function testSystemPromptWithDollarPatternVariable() {
+  const messages = [{ role: 'user', content: 'Hi', variables: { location: '$100 & change' } }];
+
+  const app = {
+    system: { en: 'Location: {{location}}' }
+  };
+
+  const result = await PromptService.processMessageTemplates(
+    messages,
+    app,
+    null,
+    null,
+    'en',
+    null,
+    null,
+    null,
+    null
+  );
+
+  const systemMessage = result.find(msg => msg.role === 'system');
+  assert.strictEqual(
+    systemMessage.content,
+    'Location: $100 & change',
+    'System prompt should substitute $-pattern values literally'
+  );
+
+  logger.info('✓ System prompt with $-pattern variable test passed');
+}
+
 // Run all tests
 async function runTests() {
   try {
@@ -243,6 +347,9 @@ async function runTests() {
     await testPromptTemplateWithVariablesAndContent();
     await testEmptyContentWithVariables();
     await testStringPromptTemplate();
+    await testVariableKeyWithRegexMetacharacters();
+    await testContentWithDollarPatterns();
+    await testSystemPromptWithDollarPatternVariable();
 
     logger.info('\n✅ All PromptService tests passed!');
   } catch (error) {


### PR DESCRIPTION
## Summary

Fixes #1728.

`PromptService.processMessageTemplates` (and `resolveGlobalPromptVariables`) built `RegExp` objects directly from unescaped, potentially client-supplied variable keys, and passed raw string values as the *replacement* argument to `String.replace`. This had two consequences:

- A variable key containing regex metacharacters (e.g. `foo(bar)`) threw a `SyntaxError`, failing the entire chat request.
- Any value containing `$&`, `` $` ``, `$'`, `$1`, etc. (e.g. a user's chat message substituted into `{{content}}`, or `{{sources}}` content) was silently corrupted, since those sequences are special to `String.replace`'s replacement-string syntax.

## Changes

- Added two module-level helpers in `server/services/PromptService.js`: `escapeRegExp(str)` and `replaceTemplateVar(text, key, value)` — the latter escapes the key before building the `RegExp` and uses a function replacer (`() => value`) so replacement values are never reinterpreted as `$`-patterns.
- Replaced all five ad-hoc substitution call sites (`resolveGlobalPromptVariables` platform context, template `{{content}}`/variables, non-template message variables, system prompt variables, and `{{sources}}`/`{{source}}`) with calls to the shared helper.
- Added regression tests to `server/tests/promptService.test.js` covering: a variable key with regex metacharacters, `$`-patterns in user content substituted via `{{content}}`, and `$`-patterns in a variable substituted into the system prompt.

## Test plan

- [x] `node server/tests/promptService.test.js` — all 9 tests pass (6 existing + 3 new)
- [x] `npx eslint server/services/PromptService.js server/tests/promptService.test.js` — no new warnings/errors
- [x] `npx prettier --check` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSRt71aesHrT9zmauHgf5L


---
_Generated by [Claude Code](https://claude.ai/code/session_01LSRt71aesHrT9zmauHgf5L)_