### PR TITLE
fix(workflow): don't let node retries consume the cycle-guard budget

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,16 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Workflow Node Retries No Longer Count Against the Loop-Protection Limit
+
+A workflow node configured with automatic retries (`node.execution.retries`) could previously fail
+the whole run with a misleading "exceeded maximum iterations" error, even though it never actually
+looped. Retries were sharing the same counter used to detect genuine infinite loop-backs, so a node
+retried a few times could exhaust that budget on its own.
+
+- Retry attempts no longer advance the loop-protection counter; only a node that is genuinely
+  re-executed as part of a workflow loop counts toward `maxIterations`.
+- Loop protection itself is unchanged — a workflow with a real infinite loop still fails with the
+  same error and limit as before.
+- No configuration or admin action required.

--- a/server/services/workflow/WorkflowEngine.js
+++ b/server/services/workflow/WorkflowEngine.js
@@ -648,7 +648,7 @@ export class WorkflowEngine {
 
             while (true) {
               try {
-                result = await this.executeNode(node, workflow, executionId, options);
+                result = await this.executeNode(node, workflow, executionId, options, attempt > 0);
                 break; // Success - exit retry loop
               } catch (executeError) {
                 attempt++;
@@ -858,6 +858,8 @@ export class WorkflowEngine {
    * @param {Object} workflow - The workflow definition
    * @param {string} executionId - The execution identifier
    * @param {Object} options - Execution options
+   * @param {boolean} isRetryAttempt - Whether this call is a retry of an already-counted
+   *   iteration (skips bumping the cycle-guard counter so retries don't consume loop budget)
    * @returns {Promise<*>} The node execution result
    *
    * @example
@@ -868,7 +870,7 @@ export class WorkflowEngine {
    *   { timeout: 30000 }
    * );
    */
-  async executeNode(node, workflow, executionId, options = {}) {
+  async executeNode(node, workflow, executionId, options = {}, isRetryAttempt = false) {
     const { id: nodeId, type: nodeType, config } = node;
 
     logger.info('Executing node', { component: 'WorkflowEngine', executionId, nodeId, nodeType });
@@ -905,9 +907,13 @@ export class WorkflowEngine {
     // 4. Get current state for context
     const state = await this.stateManager.get(executionId);
 
-    // 5. Track node iteration count (for cycle/loop protection)
+    // 5. Track node iteration count (for cycle/loop protection).
+    // Retries of an already-counted attempt reuse that iteration instead of bumping it —
+    // this counter guards against infinite loop-backs, not against configured node retries.
     const nodeIterations = state.data?._nodeIterations || {};
-    const currentIteration = (nodeIterations[nodeId] || 0) + 1;
+    const currentIteration = isRetryAttempt
+      ? nodeIterations[nodeId] || 1
+      : (nodeIterations[nodeId] || 0) + 1;
     const maxIterations = workflow.config?.maxIterations || 10;
 
     if (currentIteration > maxIterations) {
@@ -926,14 +932,16 @@ export class WorkflowEngine {
     const nodeInvocations = Object.keys(state.data?.nodeResults || {}).length + 1;
     const totalNodes = workflow.nodes.filter(n => n.type !== 'start' && n.type !== 'end').length;
 
-    // Update iteration count and step counters in state
+    // Update iteration count and step counters in state (retries don't re-persist the counter)
     await this.stateManager.update(executionId, {
       data: {
         ...state.data,
-        _nodeIterations: {
-          ...nodeIterations,
-          [nodeId]: currentIteration
-        },
+        _nodeIterations: isRetryAttempt
+          ? nodeIterations
+          : {
+              ...nodeIterations,
+              [nodeId]: currentIteration
+            },
         _currentStep: nodeInvocations,
         _currentNodeIteration: currentIteration,
         _totalNodes: totalNodes

--- a/server/tests/services/workflow/WorkflowEngine.executeNode.test.js
+++ b/server/tests/services/workflow/WorkflowEngine.executeNode.test.js
@@ -1,0 +1,93 @@
+/**
+ * WorkflowEngine.executeNode cycle-guard tests.
+ *
+ * Covers issue #1730: the `_nodeIterations` counter guards against infinite
+ * loop-backs (a node id being scheduled again and again), not against
+ * `node.execution.retries` re-invoking the same logical attempt. A retry
+ * attempt (isRetryAttempt=true) must reuse the already-recorded iteration
+ * instead of bumping it, so retries don't silently consume the loop budget.
+ */
+
+import { jest } from '@jest/globals';
+import { WorkflowEngine } from '../../../services/workflow/WorkflowEngine.js';
+
+function createEngine({ nodeIterations = {} } = {}) {
+  const state = {
+    data: {
+      _nodeIterations: { ...nodeIterations },
+      nodeResults: {}
+    }
+  };
+
+  const stateManager = {
+    get: jest.fn(async () => state),
+    update: jest.fn(async (_executionId, { data }) => {
+      state.data = data;
+    }),
+    markNodeCompleted: jest.fn(async () => {}),
+    addStep: jest.fn(async () => {})
+  };
+
+  const engine = new WorkflowEngine({ stateManager, scheduler: {} });
+  engine.registerExecutor('noop', { execute: async () => ({ status: 'success', output: 'ok' }) });
+
+  return { engine, stateManager, state };
+}
+
+const workflow = { nodes: [], config: { maxIterations: 3 } };
+const node = { id: 'node-1', type: 'noop', config: {} };
+
+describe('WorkflowEngine.executeNode cycle guard', () => {
+  test('a first attempt increments and persists _nodeIterations', async () => {
+    const { engine, state } = createEngine();
+
+    await engine.executeNode(node, workflow, 'exec-1', {});
+
+    expect(state.data._nodeIterations['node-1']).toBe(1);
+  });
+
+  test('a retry attempt reuses the recorded iteration instead of bumping it', async () => {
+    const { engine, state } = createEngine({ nodeIterations: { 'node-1': 1 } });
+
+    await engine.executeNode(node, workflow, 'exec-1', {}, true);
+
+    expect(state.data._nodeIterations['node-1']).toBe(1);
+  });
+
+  test('retries never trip MAX_NODE_ITERATIONS_EXCEEDED on their own', async () => {
+    const { engine } = createEngine({ nodeIterations: { 'node-1': 1 } });
+
+    // Simulate several retries of the same logical attempt (e.g. node.execution.retries: 5) —
+    // none of them should advance the cycle-guard counter or exceed maxIterations: 3.
+    await expect(engine.executeNode(node, workflow, 'exec-1', {}, true)).resolves.toMatchObject({
+      status: 'success'
+    });
+    await expect(engine.executeNode(node, workflow, 'exec-1', {}, true)).resolves.toMatchObject({
+      status: 'success'
+    });
+    await expect(engine.executeNode(node, workflow, 'exec-1', {}, true)).resolves.toMatchObject({
+      status: 'success'
+    });
+  });
+
+  test('a genuine loop-back (non-retry) still trips MAX_NODE_ITERATIONS_EXCEEDED', async () => {
+    const { engine } = createEngine({ nodeIterations: { 'node-1': 3 } });
+
+    await expect(engine.executeNode(node, workflow, 'exec-1', {})).rejects.toMatchObject({
+      code: 'MAX_NODE_ITERATIONS_EXCEEDED',
+      nodeId: 'node-1'
+    });
+  });
+
+  test('result carries the reused iteration number on a retry', async () => {
+    const { engine, stateManager } = createEngine({ nodeIterations: { 'node-1': 2 } });
+
+    await engine.executeNode(node, workflow, 'exec-1', {}, true);
+
+    expect(stateManager.markNodeCompleted).toHaveBeenCalledWith(
+      'exec-1',
+      'node-1',
+      expect.objectContaining({ iteration: 2 })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1730.

`WorkflowEngine.executeNode()` incremented `state.data._nodeIterations[nodeId]` — the counter that
guards against genuine infinite loop-backs — on **every** call, including retries of the same
logical attempt driven by the retry loop in `_runExecutionLoop`. With `node.execution.retries`
configured and the default `maxIterations: 10`, a handful of retries could silently exhaust the
cycle-guard budget and fail the whole run with `MAX_NODE_ITERATIONS_EXCEEDED`, even though the node
never actually looped.

- `executeNode()` now accepts a 5th parameter, `isRetryAttempt` (default `false`).
- The retry loop in `_runExecutionLoop` now calls `executeNode(node, workflow, executionId, options, attempt > 0)`.
- When `isRetryAttempt` is `true`, the cycle guard reuses the already-recorded iteration for that
  node instead of incrementing/re-persisting `_nodeIterations` — so retries no longer advance the
  loop-protection counter.
- Genuine loop-back executions (`isRetryAttempt: false`, the normal path) are unaffected: the
  counter still increments and `MAX_NODE_ITERATIONS_EXCEEDED` still fires at `maxIterations` exactly
  as before.

## Changes

- `server/services/workflow/WorkflowEngine.js`: pass through `isRetryAttempt` from the retry loop,
  gate the `_nodeIterations` increment/persist and the `MAX_NODE_ITERATIONS_EXCEEDED` accounting on
  it.
- `server/tests/services/workflow/WorkflowEngine.executeNode.test.js` (new): unit tests covering
  first-attempt increment, retry-attempt reuse, repeated retries not tripping the cap, a genuine
  loop-back still tripping the cap, and the result carrying the reused iteration number.
- `docs/releases/5.5.0/features.md`: changelog entry.

## Test plan

- [x] New unit tests pass: `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/services/workflow/WorkflowEngine.executeNode.test.js`
- [x] Existing `server/tests/services/workflow` suite still passes (one unrelated pre-existing
      failure in `WebhookTrigger.test.js` — a `jest.mock` module-resolution error present on `main`
      before this change too, confirmed via `git stash`).
- [x] `eslint`/`prettier` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Lty1EYr3dscz299Yivv5f


---
_Generated by [Claude Code](https://claude.ai/code/session_012Lty1EYr3dscz299Yivv5f)_