### PR TITLE
fix: stop InMemorySink actionTracker listener leak on non-tools app-as-tool calls

### DIFF
--- a/server/services/chat/ChatService.js
+++ b/server/services/chat/ChatService.js
@@ -84,7 +84,6 @@ class ChatService {
         variables
       });
       if (!prepResult.success) {
-        sink.stopListening();
         return {
           status: 'error',
           error: prepResult.error,
@@ -166,7 +165,6 @@ class ChatService {
       }
       return result;
     } catch (error) {
-      sink.stopListening();
       logger.error('invokeAppInternal failed', {
         component: 'ChatService',
         appId,
@@ -179,6 +177,11 @@ class ChatService {
         finalMessage: null,
         toolCalls: []
       };
+    } finally {
+      // Defense-in-depth: sink.getResult() already releases the listener on
+      // every exit path it controls, but this also covers callers that throw
+      // before getResult() is reached (e.g. prepareChatRequest/processChat*).
+      sink.stopListening();
     }
   }
 }

--- a/server/services/chat/streamSink/InMemorySink.js
+++ b/server/services/chat/streamSink/InMemorySink.js
@@ -160,49 +160,55 @@ export class InMemorySink {
    * Wait for the chat to finish and return the assembled result.
    */
   async getResult({ timeoutMs = DEFAULT_TIMEOUT_MS } = {}) {
-    // If we have a non-streaming JSON body (NonStreamingHandler path), return it directly.
-    if (this.jsonBody && !this.chatId) {
-      return this._assembleNonStreamingResult();
-    }
+    try {
+      // If we have a non-streaming JSON body (NonStreamingHandler path), return it directly.
+      if (this.jsonBody && !this.chatId) {
+        return this._assembleNonStreamingResult();
+      }
 
-    // If we already have a JSON body and no SSE traffic, prefer the JSON body.
-    if (this.jsonBody && this.chunks.length === 0 && !this.done) {
-      return this._assembleNonStreamingResult();
-    }
+      // If we already have a JSON body and no SSE traffic, prefer the JSON body.
+      if (this.jsonBody && this.chunks.length === 0 && !this.done) {
+        return this._assembleNonStreamingResult();
+      }
 
-    // Otherwise wait for streaming completion.
-    if (this._donePromise) {
-      await Promise.race([
-        this._donePromise,
-        new Promise((_, reject) =>
-          setTimeout(
-            () => reject(new Error(`InMemorySink timed out after ${timeoutMs}ms`)),
-            timeoutMs
+      // Otherwise wait for streaming completion.
+      if (this._donePromise) {
+        await Promise.race([
+          this._donePromise,
+          new Promise((_, reject) =>
+            setTimeout(
+              () => reject(new Error(`InMemorySink timed out after ${timeoutMs}ms`)),
+              timeoutMs
+            )
           )
-        )
-      ]);
-    }
-    this.stopListening();
+        ]);
+      }
 
-    if (this.errorPayload) {
+      if (this.errorPayload) {
+        return {
+          status: 'error',
+          error: this.errorPayload,
+          finalMessage: null,
+          toolCalls: this.toolCalls
+        };
+      }
+
+      const finalContent = this.chunks.join('');
       return {
-        status: 'error',
-        error: this.errorPayload,
-        finalMessage: null,
-        toolCalls: this.toolCalls
+        status: 'ok',
+        statusCode: this.statusCode,
+        finalMessage: { role: 'assistant', content: finalContent },
+        toolCalls: this.toolCalls,
+        citations: this.citations,
+        usage: this.usage,
+        finishReason: this.finishReason
       };
+    } finally {
+      // Every exit path above (early return or timeout) must release the
+      // actionTracker listener — it's a process-wide singleton, so a leaked
+      // listener here accumulates for the life of the server.
+      this.stopListening();
     }
-
-    const finalContent = this.chunks.join('');
-    return {
-      status: 'ok',
-      statusCode: this.statusCode,
-      finalMessage: { role: 'assistant', content: finalContent },
-      toolCalls: this.toolCalls,
-      citations: this.citations,
-      usage: this.usage,
-      finishReason: this.finishReason
-    };
   }
 
   _assembleNonStreamingResult() {

--- a/server/tests/inmemory-sink-listener-leak.test.js
+++ b/server/tests/inmemory-sink-listener-leak.test.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+/**
+ * Regression test for the InMemorySink `fire-sse` listener leak.
+ *
+ * `actionTracker` is a process-wide singleton EventEmitter. `getResult()` used
+ * to skip `stopListening()` on the non-streaming (tool-less app) success path,
+ * so every invocation left a listener registered forever. This asserts every
+ * `getResult()` exit path releases the listener.
+ *
+ * Run directly: `node server/tests/inmemory-sink-listener-leak.test.js`.
+ */
+
+import { InMemorySink } from '../services/chat/streamSink/InMemorySink.js';
+import { actionTracker } from '../actionTracker.js';
+
+let failures = 0;
+function check(label, cond, details) {
+  if (!cond) failures += 1;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && details) console.log(`   ${details}`);
+}
+
+async function run() {
+  const baseline = actionTracker.listenerCount('fire-sse');
+
+  console.log('🧪 InMemorySink — non-streaming success path releases the listener\n');
+  {
+    const sink = new InMemorySink({ chatId: 'leak-test-nonstreaming' });
+    sink.startListening();
+    check('listener registered by startListening', sink._listener !== null);
+    check(
+      'listener count bumped by one',
+      actionTracker.listenerCount('fire-sse') === baseline + 1
+    );
+
+    // Simulate the res-shim path (NonStreamingHandler writes the final
+    // response directly): no `fire-sse` traffic is ever emitted for this
+    // chatId, so getResult() must take the early-return JSON-body branch.
+    sink.json({ choices: [{ message: { content: 'hi' } }] });
+    const result = await sink.getResult({ timeoutMs: 1_000 });
+
+    check('result assembled from the JSON body', result.finalMessage?.content === 'hi');
+    check('listener cleared after getResult()', sink._listener === null);
+    check(
+      'listener count back to baseline',
+      actionTracker.listenerCount('fire-sse') === baseline,
+      `expected ${baseline}, got ${actionTracker.listenerCount('fire-sse')}`
+    );
+  }
+
+  console.log('\n🧪 InMemorySink — streaming success path still releases the listener\n');
+  {
+    const sink = new InMemorySink({ chatId: 'leak-test-streaming' });
+    sink.startListening();
+    actionTracker.emit('fire-sse', {
+      event: 'chunk',
+      chatId: 'leak-test-streaming',
+      content: 'hello'
+    });
+    actionTracker.emit('fire-sse', { event: 'done', chatId: 'leak-test-streaming' });
+    await sink.getResult({ timeoutMs: 1_000 });
+
+    check('listener cleared after streaming completion', sink._listener === null);
+    check(
+      'listener count back to baseline',
+      actionTracker.listenerCount('fire-sse') === baseline,
+      `expected ${baseline}, got ${actionTracker.listenerCount('fire-sse')}`
+    );
+  }
+
+  console.log('\n🧪 InMemorySink — timeout path still releases the listener\n');
+  {
+    const sink = new InMemorySink({ chatId: 'leak-test-timeout' });
+    sink.startListening();
+    // Nothing is ever emitted for this chatId, so getResult() must hit the
+    // timeout branch rather than hanging — the `finally` must still run.
+    let threw = false;
+    try {
+      await sink.getResult({ timeoutMs: 50 });
+    } catch {
+      threw = true;
+    }
+    check('getResult() rejects on timeout', threw);
+    check('listener cleared after timeout', sink._listener === null);
+    check(
+      'listener count back to baseline',
+      actionTracker.listenerCount('fire-sse') === baseline,
+      `expected ${baseline}, got ${actionTracker.listenerCount('fire-sse')}`
+    );
+  }
+
+  console.log(`\n${failures === 0 ? '🎉 All tests passed.' : `❌ ${failures} failure(s).`}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+run().catch(err => {
+  console.error('Test harness error:', err);
+  process.exit(1);
+});

--- a/server/tests/inmemory-sink-listener-leak.test.js
+++ b/server/tests/inmemory-sink-listener-leak.test.js
@@ -29,10 +29,7 @@ async function run() {
     const sink = new InMemorySink({ chatId: 'leak-test-nonstreaming' });
     sink.startListening();
     check('listener registered by startListening', sink._listener !== null);
-    check(
-      'listener count bumped by one',
-      actionTracker.listenerCount('fire-sse') === baseline + 1
-    );
+    check('listener count bumped by one', actionTracker.listenerCount('fire-sse') === baseline + 1);
 
     // Simulate the res-shim path (NonStreamingHandler writes the final
     // response directly): no `fire-sse` traffic is ever emitted for this


### PR DESCRIPTION
## Summary

Fixes #1726.

`InMemorySink.getResult()` had an early-return branch for the non-streaming (tool-less) App-as-tool success path that returned before reaching `this.stopListening()`. Since `actionTracker` is a process-wide singleton `EventEmitter`, every successful tool-less App-as-tool invocation left a `fire-sse` listener registered forever — growing heap (each closure retains the `InMemorySink` instance) and eventual `MaxListenersExceededWarning` noise under sustained agent traffic.

- `server/services/chat/streamSink/InMemorySink.js`: wrap `getResult()`'s body in `try/finally` so **every** exit path (both early-return JSON-body branches, normal streaming completion, and the timeout branch) calls `stopListening()`. This removes the need for the previous `this.stopListening()` call placed only after the streaming-wait, since it's now hoisted into the `finally`.
- `server/services/chat/ChatService.js`: `invokeAppInternal` now releases the sink in a `finally` block instead of only in the `catch`, so a throw before `sink.getResult()` is reached (e.g. from `prepareChatRequest`) is also covered. Removed the now-redundant explicit `sink.stopListening()` calls at the two return sites.
- Added `server/tests/inmemory-sink-listener-leak.test.js`, following the existing `inmemory-sink-overflow.test.js` pattern (plain Node script, no test framework), asserting `actionTracker.listenerCount('fire-sse')` returns to baseline after the non-streaming success path, the streaming success path, and the timeout path.

## Test plan

- [x] `node server/tests/inmemory-sink-listener-leak.test.js` — new regression test, all assertions pass
- [x] `node server/tests/inmemory-sink-overflow.test.js` — existing sink tests still pass (no regression)
- [x] `npx eslint` on the three changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01PhHaFrHvkrD16DVX7uffBh)_