### PR TITLE
fix: OpenAI Responses non-streaming parsers dropped tool calls (flat function_call shape)

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,13 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Tool Calls No Longer Silently Dropped for GPT-5 / Responses API Models
+
+Apps using a GPT-5 or other OpenAI Responses API model with tools enabled could silently lose tool
+calls whenever the model answered via the non-streaming path — the model appeared to simply stop
+instead of calling the tool, with no error shown.
+
+- The non-streaming response parser now reads the actual (flat) shape of a `function_call` output
+  item instead of a nested shape that never existed on that API path.
+- No configuration or admin action is required — the fix takes effect automatically on upgrade.

--- a/server/adapters/openai-responses.js
+++ b/server/adapters/openai-responses.js
@@ -308,14 +308,14 @@ class OpenAIResponsesAdapterClass extends BaseAdapter {
                 result.content.push(contentItem.text);
               }
             }
-          } else if (item.type === 'function_call' && item.function) {
-            // Handle function calls
+          } else if (item.type === 'function_call') {
+            // Handle function calls (flat shape: { type, call_id, name, arguments })
             result.tool_calls.push({
-              id: item.id,
+              id: item.call_id || item.id,
               type: 'function',
               function: {
-                name: item.function.name,
-                arguments: item.function.arguments
+                name: item.name,
+                arguments: item.arguments
               }
             });
           }

--- a/server/adapters/toolCalling/OpenAIResponsesConverter.js
+++ b/server/adapters/toolCalling/OpenAIResponsesConverter.js
@@ -440,14 +440,14 @@ export async function convertOpenaiResponsesResponseToGeneric(data, _streamId = 
             }
           }
         }
-        // Handle function calls
-        else if (item.type === 'function_call' && item.function) {
+        // Handle function calls (flat shape: { type, call_id, name, arguments })
+        else if (item.type === 'function_call') {
           toolCalls.push({
-            id: item.id,
+            id: item.call_id || item.id,
             type: 'function',
             function: {
-              name: item.function.name,
-              arguments: item.function.arguments
+              name: item.name,
+              arguments: item.arguments
             }
           });
         }

--- a/server/tests/openaiResponsesAdapter.test.js
+++ b/server/tests/openaiResponsesAdapter.test.js
@@ -128,7 +128,7 @@ const nonStreamingResponse = JSON.stringify({
   status: 'completed'
 });
 
-const result = OpenAIResponsesAdapter.processResponseBuffer(nonStreamingResponse);
+const result = await OpenAIResponsesAdapter.processResponseBuffer(nonStreamingResponse);
 assert.strictEqual(result.content.length, 1, 'Should have one content item');
 assert.strictEqual(
   result.content[0],
@@ -147,20 +147,20 @@ const toolCallResponse = JSON.stringify({
   object: 'response',
   output: [
     {
-      id: 'call_123',
+      id: 'fc_123',
+      call_id: 'call_123',
       type: 'function_call',
-      function: {
-        name: 'get_weather',
-        arguments: '{"location":"San Francisco"}'
-      }
+      name: 'get_weather',
+      arguments: '{"location":"San Francisco"}'
     }
   ],
   status: 'completed'
 });
 
-const result2 = OpenAIResponsesAdapter.processResponseBuffer(toolCallResponse);
+const result2 = await OpenAIResponsesAdapter.processResponseBuffer(toolCallResponse);
 assert.strictEqual(result2.tool_calls.length, 1, 'Should have one tool call');
 assert.strictEqual(result2.tool_calls[0].function.name, 'get_weather', 'Tool name should match');
+assert.strictEqual(result2.tool_calls[0].id, 'call_123', 'call_id should take precedence over id');
 assert.strictEqual(result2.complete, true, 'Response should be complete');
 
 logger.info('✓ Test 5 passed: Tool calls processed correctly');


### PR DESCRIPTION
## Summary

Fixes #1723.

Non-streaming `output` items from the OpenAI Responses API of type `function_call` are flat:
`{ type: 'function_call', id, call_id, name, arguments }`. Both `processResponseBuffer` in the
adapter and the converter's non-streaming branch guarded on `item.type === 'function_call' && item.function`
and read `item.function.name` / `item.function.arguments` — properties that never exist on this
shape — so tool calls in any non-streaming Responses payload were silently discarded (the model
appeared to just stop). The already-correct streaming branch (`response.output_item.done`) reads
the flat fields, proving the two paths were written against different assumptions about the API.

- `server/adapters/openai-responses.js`: read `item.name` / `item.arguments` directly, and prefer
  `item.call_id` over `item.id` for the tool-call id, mirroring the correct streaming handler.
- `server/adapters/toolCalling/OpenAIResponsesConverter.js`: same fix in the non-streaming branch
  of `convertOpenaiResponsesResponseToGeneric`.
- `server/tests/openaiResponsesAdapter.test.js`: the "Tool calls processing" test fixture asserted
  against the same wrong nested shape (so it was passing *because* it exercised the bug). Updated
  the fixture to the real flat shape, added an assertion that `call_id` wins over `id`, and added
  the missing `await` on `processResponseBuffer()` calls (the method is `async`; without `await`
  the assertions were silently operating on unresolved Promises).

## Test plan

- [x] `node server/tests/openaiResponsesAdapter.test.js` — all 5 tests pass, including the updated
      tool-call fixture and the new `call_id`-precedence assertion.
- [x] `npx eslint` on the three changed source/test files — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U9qhyBPg3naMKdjpwQygZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01U9qhyBPg3naMKdjpwQygZ1)_