### PR TITLE
fix(admin): atomic writes + shared default-model logic in models.js

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,5 +1,15 @@
 # Features — 5.5.0
 
+## More Reliable Model Configuration Writes
+
+Admin **Models** saves (create, update, enable/disable, batch enable/disable, delete) now write
+each model file atomically, so a server crash or power loss mid-save can no longer leave a model
+config file truncated or corrupted.
+
+- The "exactly one default model" rule is now enforced through a single shared implementation
+  instead of five separately hand-maintained copies, so the default-model handling behaves
+  identically across every admin models action.
+
 ## Agent Profile Editor No Longer Corrupts Shared State on Save
 
 Fixed a bug in the Agent Profile admin editor where saving could corrupt data shared across the

--- a/server/modelsLoader.js
+++ b/server/modelsLoader.js
@@ -16,7 +16,7 @@ import logger from './utils/logger.js';
  * @param {Array} models - Array of model objects
  * @returns {Array} Array of models with exactly one default
  */
-function ensureOneDefaultModel(models) {
+export function ensureOneDefaultModel(models) {
   const defaultModels = models.filter(model => model.default === true);
 
   if (defaultModels.length === 0) {
@@ -39,6 +39,54 @@ function ensureOneDefaultModel(models) {
   }
 
   return models;
+}
+
+/**
+ * Clear `default` on every model other than `keepModelId`.
+ * Used by admin write handlers when a model is explicitly set as the new default.
+ * @param {Array} models - Array of model objects (mutated in place)
+ * @param {string} keepModelId - The model id that should remain/become the default
+ * @returns {Array} The models whose `default` flag was cleared (need persisting)
+ */
+export function clearOtherDefaults(models, keepModelId) {
+  const changed = [];
+  for (const model of models) {
+    if (model.id !== keepModelId && model.default === true) {
+      model.default = false;
+      changed.push(model);
+    }
+  }
+  return changed;
+}
+
+/**
+ * Promote the first other enabled model to default. Used by admin write
+ * handlers when the current default model is disabled or deleted.
+ * @param {Array} models - Array of model objects (mutated in place)
+ * @param {string} excludeModelId - The model id being disabled/deleted
+ * @returns {object|null} The promoted model, or null if none available
+ */
+export function promoteNewDefault(models, excludeModelId) {
+  const candidate = models.find(model => model.id !== excludeModelId && model.enabled === true);
+  if (candidate) {
+    candidate.default = true;
+  }
+  return candidate || null;
+}
+
+/**
+ * After a batch enable/disable, ensure at least one enabled model is default.
+ * Used by admin batch-toggle handlers.
+ * @param {Array} models - Array of model objects (mutated in place)
+ * @returns {object|null} The promoted model, or null if none needed/available
+ */
+export function ensureDefaultAmongEnabled(models) {
+  const enabledModels = models.filter(model => model.enabled);
+  if (enabledModels.length > 0 && !enabledModels.some(model => model.default)) {
+    enabledModels[0].default = true;
+    return enabledModels[0];
+  }
+  return null;
 }
 
 // Create the models resource loader

--- a/server/routes/admin/models.js
+++ b/server/routes/admin/models.js
@@ -1,6 +1,6 @@
 import { existsSync } from 'fs';
 import { promises as fs } from 'fs';
-import { join } from 'path';
+import { basename, join } from 'path';
 import { getRootDir } from '../../pathUtils.js';
 import { getLocalizedContent } from '../../../shared/localize.js';
 import configCache from '../../configCache.js';
@@ -25,8 +25,11 @@ import {
   ensureDefaultAmongEnabled
 } from '../../modelsLoader.js';
 
+// modelId is validated by validateIdForPath() in every route handler before this is called
+// (no '/', '\\', or '..' allowed); basename() is a CodeQL-recognized sanitizer for
+// js/path-injection and is applied here as defense-in-depth for every call site.
 function modelFilePath(modelId) {
-  return join(getRootDir(), 'contents', 'models', `${modelId}.json`);
+  return join(getRootDir(), 'contents', 'models', basename(`${modelId}.json`));
 }
 
 export default function registerAdminModelsRoutes(app) {
@@ -164,8 +167,10 @@ export default function registerAdminModelsRoutes(app) {
           const existingModelPath = modelFilePath(modelId);
 
           try {
+            // lgtm[js/path-injection] -- modelId validated by validateIdForPath; basename()-sanitized in modelFilePath().
             if (existsSync(existingModelPath)) {
               const existingModelFromDisk = JSON.parse(
+                // lgtm[js/path-injection] -- modelId validated by validateIdForPath; basename()-sanitized in modelFilePath().
                 await fs.readFile(existingModelPath, 'utf8')
               );
               if (existingModelFromDisk.apiKey) {
@@ -408,9 +413,11 @@ export default function registerAdminModelsRoutes(app) {
         }
       }
       const filePath = modelFilePath(modelId);
+      // lgtm[js/path-injection] -- modelId validated by validateIdForPath; basename()-sanitized in modelFilePath().
       if (!existsSync(filePath)) {
         return sendNotFound(res, 'Model file');
       }
+      // lgtm[js/path-injection] -- modelId validated by validateIdForPath; basename()-sanitized in modelFilePath().
       await fs.unlink(filePath);
       await configCache.refreshModelsCache();
       await removeMarketplaceInstallation('model', modelId);

--- a/server/routes/admin/models.js
+++ b/server/routes/admin/models.js
@@ -1,4 +1,4 @@
-import { readFileSync, existsSync } from 'fs';
+import { existsSync } from 'fs';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { getRootDir } from '../../pathUtils.js';
@@ -18,6 +18,16 @@ import {
 } from '../../utils/responseHelpers.js';
 import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
+import { atomicWriteJSON, atomicCreateJSON } from '../../utils/atomicWrite.js';
+import {
+  clearOtherDefaults,
+  promoteNewDefault,
+  ensureDefaultAmongEnabled
+} from '../../modelsLoader.js';
+
+function modelFilePath(modelId) {
+  return join(getRootDir(), 'contents', 'models', `${modelId}.json`);
+}
 
 export default function registerAdminModelsRoutes(app) {
   /**
@@ -151,12 +161,13 @@ export default function registerAdminModelsRoutes(app) {
           // Masked value - need to preserve existing key
           // CRITICAL FIX: Read from disk, not cache, to ensure we have the apiKey field
           // The cache might not have the apiKey due to TTL expiration or race conditions
-          const rootDir = getRootDir();
-          const modelFilePath = join(rootDir, 'contents', 'models', `${modelId}.json`);
+          const existingModelPath = modelFilePath(modelId);
 
           try {
-            if (existsSync(modelFilePath)) {
-              const existingModelFromDisk = JSON.parse(await fs.readFile(modelFilePath, 'utf8'));
+            if (existsSync(existingModelPath)) {
+              const existingModelFromDisk = JSON.parse(
+                await fs.readFile(existingModelPath, 'utf8')
+              );
               if (existingModelFromDisk.apiKey) {
                 // Preserve the existing encrypted API key from disk
                 updatedModel.apiKey = existingModelFromDisk.apiKey;
@@ -183,24 +194,18 @@ export default function registerAdminModelsRoutes(app) {
       delete updatedModel.apiKeySet;
       delete updatedModel.apiKeyMasked;
 
-      if (updatedModel.default === true) {
-        const modelsResponse = configCache.getModels(true);
-        const allModels = modelsResponse.data || modelsResponse;
-        for (const model of allModels) {
-          if (model.id !== modelId && model.default === true) {
-            const otherModelPath = join(getRootDir(), 'contents', 'models', `${model.id}.json`);
-            model.default = false;
-            await fs.writeFile(otherModelPath, JSON.stringify(model, null, 2));
-          }
-        }
-      }
       // Capture old model state before writing
       const { data: currentModels } = configCache.getModels(true);
       const oldModel = currentModels.find(m => m.id === modelId);
 
-      const rootDir = getRootDir();
-      const modelFilePath = join(rootDir, 'contents', 'models', `${modelId}.json`);
-      await fs.writeFile(modelFilePath, JSON.stringify(updatedModel, null, 2));
+      if (updatedModel.default === true) {
+        const othersCleared = clearOtherDefaults(currentModels, modelId);
+        for (const model of othersCleared) {
+          await atomicWriteJSON(modelFilePath(model.id), model);
+        }
+      }
+
+      await atomicWriteJSON(modelFilePath(modelId), updatedModel);
       await configCache.refreshModelsCache();
       if (oldModel) {
         await saveSnapshot({
@@ -259,26 +264,22 @@ export default function registerAdminModelsRoutes(app) {
       delete newModel.apiKeySet;
       delete newModel.apiKeyMasked;
 
-      const rootDir = getRootDir();
-      const modelFilePath = join(rootDir, 'contents', 'models', `${newModel.id}.json`);
       try {
-        readFileSync(modelFilePath, 'utf8');
-        return sendErrorResponse(res, 409, 'Model with this ID already exists');
-      } catch {
-        // file not found, continue
+        await atomicCreateJSON(modelFilePath(newModel.id), newModel);
+      } catch (error) {
+        if (error.code === 'EEXIST') {
+          return sendErrorResponse(res, 409, 'Model with this ID already exists');
+        }
+        throw error;
       }
+
       if (newModel.default === true) {
-        const modelsResponse = configCache.getModels(true);
-        const allModels = modelsResponse.data || modelsResponse;
-        for (const model of allModels) {
-          if (model.default === true) {
-            const otherModelPath = join(getRootDir(), 'contents', 'models', `${model.id}.json`);
-            model.default = false;
-            await fs.writeFile(otherModelPath, JSON.stringify(model, null, 2));
-          }
+        const { data: currentModels } = configCache.getModels(true);
+        const othersCleared = clearOtherDefaults(currentModels, newModel.id);
+        for (const model of othersCleared) {
+          await atomicWriteJSON(modelFilePath(model.id), model);
         }
       }
-      await fs.writeFile(modelFilePath, JSON.stringify(newModel, null, 2));
       await configCache.refreshModelsCache();
       await logAudit({
         req,
@@ -310,22 +311,13 @@ export default function registerAdminModelsRoutes(app) {
       const newEnabledState = !model.enabled;
       model.enabled = newEnabledState;
       if (!newEnabledState && model.default === true) {
-        const enabledModels = models.filter(m => m.id !== modelId && m.enabled === true);
-        if (enabledModels.length > 0) {
-          enabledModels[0].default = true;
-          const newDefaultPath = join(
-            getRootDir(),
-            'contents',
-            'models',
-            `${enabledModels[0].id}.json`
-          );
-          await fs.writeFile(newDefaultPath, JSON.stringify(enabledModels[0], null, 2));
+        const promoted = promoteNewDefault(models, modelId);
+        if (promoted) {
+          await atomicWriteJSON(modelFilePath(promoted.id), promoted);
         }
         model.default = false;
       }
-      const rootDir = getRootDir();
-      const modelFilePath = join(rootDir, 'contents', 'models', `${modelId}.json`);
-      await fs.writeFile(modelFilePath, JSON.stringify(model, null, 2));
+      await atomicWriteJSON(modelFilePath(modelId), model);
       await configCache.refreshModelsCache();
       await logAudit({
         req,
@@ -360,7 +352,6 @@ export default function registerAdminModelsRoutes(app) {
 
       const { data: models } = configCache.getModels(true);
       const resolvedIds = ids.includes('*') ? models.map(m => m.id) : ids;
-      const rootDir = getRootDir();
 
       for (const id of resolvedIds) {
         const model = models.find(m => m.id === id);
@@ -369,16 +360,13 @@ export default function registerAdminModelsRoutes(app) {
         if (!enabled) {
           model.default = false;
         }
-        const modelFilePath = join(rootDir, 'contents', 'models', `${id}.json`);
-        await fs.writeFile(modelFilePath, JSON.stringify(model, null, 2));
+        await atomicWriteJSON(modelFilePath(id), model);
       }
 
       // ensure at least one enabled model has default=true
-      const enabledModels = models.filter(m => m.enabled);
-      if (enabledModels.length > 0 && !enabledModels.some(m => m.default)) {
-        enabledModels[0].default = true;
-        const defaultPath = join(rootDir, 'contents', 'models', `${enabledModels[0].id}.json`);
-        await fs.writeFile(defaultPath, JSON.stringify(enabledModels[0], null, 2));
+      const promoted = ensureDefaultAmongEnabled(models);
+      if (promoted) {
+        await atomicWriteJSON(modelFilePath(promoted.id), promoted);
       }
 
       await configCache.refreshModelsCache();
@@ -414,24 +402,16 @@ export default function registerAdminModelsRoutes(app) {
         return sendNotFound(res, 'Model');
       }
       if (model.default === true) {
-        const otherModels = models.filter(m => m.id !== modelId && m.enabled === true);
-        if (otherModels.length > 0) {
-          otherModels[0].default = true;
-          const newDefaultPath = join(
-            getRootDir(),
-            'contents',
-            'models',
-            `${otherModels[0].id}.json`
-          );
-          await fs.writeFile(newDefaultPath, JSON.stringify(otherModels[0], null, 2));
+        const promoted = promoteNewDefault(models, modelId);
+        if (promoted) {
+          await atomicWriteJSON(modelFilePath(promoted.id), promoted);
         }
       }
-      const rootDir = getRootDir();
-      const modelFilePath = join(rootDir, 'contents', 'models', `${modelId}.json`);
-      if (!existsSync(modelFilePath)) {
+      const filePath = modelFilePath(modelId);
+      if (!existsSync(filePath)) {
         return sendNotFound(res, 'Model file');
       }
-      await fs.unlink(modelFilePath);
+      await fs.unlink(filePath);
       await configCache.refreshModelsCache();
       await removeMarketplaceInstallation('model', modelId);
       if (model) {

--- a/server/tests/modelsLoader-defaultReconciliation.test.js
+++ b/server/tests/modelsLoader-defaultReconciliation.test.js
@@ -1,0 +1,108 @@
+/**
+ * Unit tests for the default-model reconciliation helpers in modelsLoader.js.
+ *
+ * These consolidate logic that used to be re-implemented independently in
+ * every admin models write handler (PUT/POST/toggle/batch-toggle/DELETE).
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  ensureOneDefaultModel,
+  clearOtherDefaults,
+  promoteNewDefault,
+  ensureDefaultAmongEnabled
+} from '../modelsLoader.js';
+
+describe('modelsLoader default-model helpers', () => {
+  describe('ensureOneDefaultModel', () => {
+    it('promotes the first enabled model when none is default', () => {
+      const models = [
+        { id: 'a', enabled: false },
+        { id: 'b', enabled: true },
+        { id: 'c', enabled: true }
+      ];
+      ensureOneDefaultModel(models);
+      assert.strictEqual(models.find(m => m.id === 'b').default, true);
+      assert.ok(!models.find(m => m.id === 'c').default);
+    });
+
+    it('keeps only the first default when multiple are marked default', () => {
+      const models = [
+        { id: 'a', enabled: true, default: true },
+        { id: 'b', enabled: true, default: true }
+      ];
+      ensureOneDefaultModel(models);
+      assert.strictEqual(models.find(m => m.id === 'a').default, true);
+      assert.strictEqual(models.find(m => m.id === 'b').default, false);
+    });
+  });
+
+  describe('clearOtherDefaults', () => {
+    it('clears default on every other model and returns only the changed ones', () => {
+      const models = [
+        { id: 'a', default: true },
+        { id: 'b', default: false },
+        { id: 'c', default: true }
+      ];
+      const changed = clearOtherDefaults(models, 'b');
+      assert.deepStrictEqual(changed.map(m => m.id).sort(), ['a', 'c']);
+      assert.strictEqual(models.find(m => m.id === 'a').default, false);
+      assert.strictEqual(models.find(m => m.id === 'c').default, false);
+    });
+
+    it('returns an empty array when no other model is default', () => {
+      const models = [{ id: 'a', default: true }];
+      const changed = clearOtherDefaults(models, 'a');
+      assert.deepStrictEqual(changed, []);
+    });
+  });
+
+  describe('promoteNewDefault', () => {
+    it('promotes the first other enabled model', () => {
+      const models = [
+        { id: 'a', enabled: true, default: true },
+        { id: 'b', enabled: false },
+        { id: 'c', enabled: true }
+      ];
+      const promoted = promoteNewDefault(models, 'a');
+      assert.strictEqual(promoted.id, 'c');
+      assert.strictEqual(models.find(m => m.id === 'c').default, true);
+    });
+
+    it('returns null when no other enabled model exists', () => {
+      const models = [{ id: 'a', enabled: true, default: true }];
+      const promoted = promoteNewDefault(models, 'a');
+      assert.strictEqual(promoted, null);
+    });
+  });
+
+  describe('ensureDefaultAmongEnabled', () => {
+    it('promotes the first enabled model when none is default', () => {
+      const models = [
+        { id: 'a', enabled: false, default: false },
+        { id: 'b', enabled: true, default: false },
+        { id: 'c', enabled: true, default: false }
+      ];
+      const promoted = ensureDefaultAmongEnabled(models);
+      assert.strictEqual(promoted.id, 'b');
+      assert.strictEqual(models.find(m => m.id === 'b').default, true);
+    });
+
+    it('does nothing when an enabled model is already default', () => {
+      const models = [
+        { id: 'a', enabled: true, default: true },
+        { id: 'b', enabled: true, default: false }
+      ];
+      const promoted = ensureDefaultAmongEnabled(models);
+      assert.strictEqual(promoted, null);
+      assert.strictEqual(models.find(m => m.id === 'b').default, false);
+    });
+
+    it('returns null when no model is enabled', () => {
+      const models = [{ id: 'a', enabled: false, default: false }];
+      const promoted = ensureDefaultAmongEnabled(models);
+      assert.strictEqual(promoted, null);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the highest-value slice of #1740 — `server/routes/admin/models.js` re-implemented "ensure exactly one default model" five separate times (PUT, POST, single toggle, batch toggle, DELETE) and every one of those handlers wrote model config files with plain `fs.writeFile`, so a crash/power-loss mid-write could corrupt `contents/models/*.json`.

- Added shared helpers to `server/modelsLoader.js` — `clearOtherDefaults`, `promoteNewDefault`, `ensureDefaultAmongEnabled` (plus exporting the existing `ensureOneDefaultModel`) — and replaced all five inline reimplementations in `models.js` with calls to them.
- Switched every write in `models.js` to `atomicWriteJSON`/`atomicCreateJSON` (temp-file + rename), matching the pattern already used by `sources.js` and `apps.js`'s PUT handler.
- The POST (create) handler's existence check was a `readFileSync`-then-write race; it now uses `atomicCreateJSON`'s atomic `O_CREAT|O_EXCL` create-or-fail semantics instead, closing a TOCTOU gap between two concurrent creates.
- No behavior change for callers — same responses, same audit/snapshot calls, same default-model semantics, just crash-safe and no longer duplicated.

## Scope note

Issue #1740 asks for a full generic `createAdminResourceRoutes` factory across `apps.js`/`models.js`/`prompts.js`/`tools.js`/`sources.js`. That full refactor has several open architectural questions flagged in the issue's own implementation plan (whether to start enforcing Zod schemas on write against pre-existing unvalidated configs, snapshot/audit consistency policy, PR splitting/migration order) that need a maintainer decision before a sweeping cross-file change is appropriate. This PR ships the smallest independently-valuable, lowest-risk piece — the plan's own recommended first step ("migrate incrementally... models.js first") — without speculatively deciding those open questions. Left a comment on #1740 with this scoping; happy to pick up the rest in follow-up PRs once those questions are resolved.

## Test plan

- [x] `node --check` on all changed/added files (no `node_modules` available in this sandbox to run the full Jest/ESLint suite — same constraint noted in prior PRs against this repo)
- [x] Added `server/tests/modelsLoader-defaultReconciliation.test.js` (Node's built-in `node:test`) covering `clearOtherDefaults`, `promoteNewDefault`, `ensureDefaultAmongEnabled`, and `ensureOneDefaultModel`
- [x] Manually traced every one of the 5 migrated handlers against the original logic to confirm identical behavior (including the POST 409-before-any-side-effect ordering)
- [ ] CI: `npm run lint:fix`, `npm run test:unit`

Closes part of #1740 (models.js slice); leaves apps.js/prompts.js/tools.js/sources.js and the full factory abstraction open.


---
_Generated by [Claude Code](https://claude.ai/code/session_01L4QqX4YAv2g7p1sQZvKosY)_