### PR TITLE
fix(chat): attach app-as-tool variables to the message so they substitute

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,13 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## App-as-Tool Invocations Now Substitute Input Variables
+
+Apps that define input **Variables** and are enabled as an agent tool (App-as-tool) now correctly
+substitute `{{variable}}` placeholders in the system prompt when an agent calls them. Previously
+the variables an agent passed when calling the app were silently dropped, so the app answered
+using its raw, unfilled prompt template instead of the agent-supplied values.
+
+- Affects any app with `variables` defined that is exposed to agents via App-as-tool.
+- No configuration or admin action is required — existing apps pick up the fix automatically.

--- a/server/services/chat/ChatService.js
+++ b/server/services/chat/ChatService.js
@@ -71,17 +71,32 @@ class ChatService {
     });
 
     try {
+      // `prepareChatRequest`/`processMessageTemplates` read variables off the
+      // last user message (`lastUserMessage.variables`), not from a top-level
+      // request param — attach them here so app-as-tool invocations get the
+      // same `{{variable}}` substitution the chat UI relies on.
+      let effectiveMessages = messages;
+      if (variables && Object.keys(variables).length > 0) {
+        const idx = messages.map(m => m.role).lastIndexOf('user');
+        if (idx !== -1) {
+          effectiveMessages = [...messages];
+          effectiveMessages[idx] = {
+            ...effectiveMessages[idx],
+            variables: { ...effectiveMessages[idx].variables, ...variables }
+          };
+        }
+      }
+
       const prepResult = await this.prepareChatRequest({
         appId,
         modelId: modelOverride,
-        messages,
+        messages: effectiveMessages,
         language,
         // No streaming: pass `res` (the sink) and no `clientRes`.
         res: sink,
         clientRes: null,
         user,
-        chatId,
-        variables
+        chatId
       });
       if (!prepResult.success) {
         sink.stopListening();

--- a/server/tests/app-as-tool-variables.test.js
+++ b/server/tests/app-as-tool-variables.test.js
@@ -1,0 +1,97 @@
+/**
+ * Regression tests for #1725: variables passed to `ChatService.invokeAppInternal`
+ * (used by the App-as-tool gateway) were silently discarded because
+ * `prepareChatRequest`/`PromptService.processMessageTemplates` only read
+ * variables off `lastUserMessage.variables`, never from a top-level request
+ * param. Apps invoked as agent tools therefore left `{{variable}}`
+ * placeholders unsubstituted in their system prompt.
+ */
+
+import ChatService from '../services/chat/ChatService.js';
+
+function buildFakeRequestBuilder(capture) {
+  return {
+    prepareChatRequest: async params => {
+      capture.params = params;
+      return {
+        success: true,
+        data: {
+          model: { id: 'test-model', provider: 'openai' },
+          llmMessages: params.messages,
+          request: {},
+          tools: []
+        }
+      };
+    }
+  };
+}
+
+function fakeNonStreamingHandler() {
+  return {
+    executeNonStreamingResponse: async ({ res }) => {
+      res.json({ choices: [{ message: { content: 'ok' } }] });
+    }
+  };
+}
+
+describe('ChatService.invokeAppInternal variable passthrough (#1725)', () => {
+  test('attaches variables onto the last user message so PromptService substitution picks them up', async () => {
+    const capture = {};
+    const chatService = new ChatService({
+      requestBuilder: buildFakeRequestBuilder(capture),
+      nonStreamingHandler: fakeNonStreamingHandler()
+    });
+
+    const result = await chatService.invokeAppInternal({
+      appId: 'test-app',
+      user: { id: 'agent' },
+      messages: [{ role: 'user', content: 'translate this' }],
+      variables: { targetLanguage: 'French' },
+      runId: 'test-run'
+    });
+
+    expect(result.status).toBe('ok');
+    expect(capture.params).not.toBeNull();
+    const lastUserMessage = capture.params.messages.findLast(m => m.role === 'user');
+    expect(lastUserMessage.variables).toEqual({ targetLanguage: 'French' });
+    // Nothing downstream reads a top-level `variables` param — it must not be forwarded.
+    expect(capture.params.variables).toBeUndefined();
+  });
+
+  test('does not mutate the caller-provided message objects', async () => {
+    const capture = {};
+    const chatService = new ChatService({
+      requestBuilder: buildFakeRequestBuilder(capture),
+      nonStreamingHandler: fakeNonStreamingHandler()
+    });
+
+    const originalMessage = { role: 'user', content: 'translate this' };
+    await chatService.invokeAppInternal({
+      appId: 'test-app',
+      user: { id: 'agent' },
+      messages: [originalMessage],
+      variables: { targetLanguage: 'French' },
+      runId: 'test-run-mutate'
+    });
+
+    expect(originalMessage.variables).toBeUndefined();
+  });
+
+  test('is a no-op when no variables are provided', async () => {
+    const capture = {};
+    const chatService = new ChatService({
+      requestBuilder: buildFakeRequestBuilder(capture),
+      nonStreamingHandler: fakeNonStreamingHandler()
+    });
+
+    await chatService.invokeAppInternal({
+      appId: 'test-app',
+      user: { id: 'agent' },
+      messages: [{ role: 'user', content: 'hi' }],
+      runId: 'test-run-no-vars'
+    });
+
+    const lastUserMessage = capture.params.messages.findLast(m => m.role === 'user');
+    expect(lastUserMessage.variables).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1725 — App-as-tool invocations silently dropped `variables`.

- `appAsToolGateway.invokeAppTool` builds `variables` from the tool-call args and passes them to `ChatService.invokeAppInternal`, which forwarded them as a top-level `variables` param into `prepareChatRequest`.
- Neither `RequestBuilder.prepareChatRequest` nor `PromptService.processMessageTemplates` accept/read a top-level `variables` param — `processMessageTemplates` only picks up variables from `lastUserMessage.variables` (the same convention the normal chat UI already uses, see `AppChat.jsx`).
- As a result, apps with input `variables` invoked as agent tools (`app__<appId>`) got their system prompt with `{{variable}}` placeholders left unsubstituted.

## Fix

In `server/services/chat/ChatService.js`'s `invokeAppInternal`, attach the incoming `variables` onto (a clone of) the last user message before calling `prepareChatRequest`, matching how the chat UI already sends variables. Dropped the now-meaningless top-level `variables` param from the `prepareChatRequest` call since nothing downstream read it.

## Test plan

- [x] Added `server/tests/app-as-tool-variables.test.js`: asserts variables are attached to the last user message and forwarded correctly, the original message object passed by the caller is not mutated, and the no-variables case is a no-op.
- [x] `npx eslint server/services/chat/ChatService.js server/tests/app-as-tool-variables.test.js` — clean.
- [x] `npx prettier --check` on the same files — clean.
- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/app-as-tool-variables.test.js` — 3/3 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HAgRk18jfJcerCBH8WQgzo)_