### PR TITLE
Use atomic writes for admin tools create/update/toggle/script endpoints

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -461,6 +461,17 @@ field) and the multimodal audio-upload path (which sends audio to a chat LLM).
 **Before using:** add or enable a transcription model under **Admin → Models** (model type
 "Transcription"), set its realtime URL, then enable transcription on the desired app.
 
+## Admin Tools API Writes Are Now Crash-Safe
+
+The admin Tools API (create, update, toggle, and script-content edits) now writes tool files
+atomically instead of writing directly to the target file in place.
+
+- A crash or process kill mid-save can no longer leave a truncated or corrupted tool file on disk.
+- Creating two tools with the same new ID at the same time no longer lets both requests succeed;
+  the second now gets a clear "Tool with this ID already exists" error instead of silently
+  overwriting the first.
+- No configuration or admin action required.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/server/routes/admin/tools.js
+++ b/server/routes/admin/tools.js
@@ -8,6 +8,7 @@ import { loadAllTools } from '../../toolsLoader.js';
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import { validateIdForPath, resolveAndValidatePath } from '../../utils/pathSecurity.js';
+import { atomicWriteJSON, atomicCreateJSON, atomicWriteFile } from '../../utils/atomicWrite.js';
 import logger from '../../utils/logger.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
 import {
@@ -394,7 +395,7 @@ export default function registerAdminToolsRoutes(app) {
       if (!toolFilePath) {
         return sendBadRequest(res, 'Invalid tool path');
       }
-      await fs.writeFile(toolFilePath, JSON.stringify(updatedTool, null, 2));
+      await atomicWriteJSON(toolFilePath, updatedTool);
 
       // Refresh cache
       await configCache.refreshToolsCache();
@@ -512,7 +513,14 @@ export default function registerAdminToolsRoutes(app) {
       if (!newToolFilePath) {
         return sendBadRequest(res, 'Invalid tool path');
       }
-      await fs.writeFile(newToolFilePath, JSON.stringify(newTool, null, 2));
+      try {
+        await atomicCreateJSON(newToolFilePath, newTool);
+      } catch (err) {
+        if (err.code === 'EEXIST') {
+          return sendBadRequest(res, 'Tool with this ID already exists');
+        }
+        throw err;
+      }
 
       // Refresh cache
       await configCache.refreshToolsCache();
@@ -735,7 +743,7 @@ export default function registerAdminToolsRoutes(app) {
       if (!toolFilePath) {
         return sendBadRequest(res, 'Invalid tool path');
       }
-      await fs.writeFile(toolFilePath, JSON.stringify(tool, null, 2));
+      await atomicWriteJSON(toolFilePath, tool);
 
       // Refresh cache
       await configCache.refreshToolsCache();
@@ -942,7 +950,7 @@ export default function registerAdminToolsRoutes(app) {
       }
 
       // Write the new content
-      await fs.writeFile(scriptPath, content, 'utf-8');
+      await atomicWriteFile(scriptPath, content, 'utf-8');
 
       res.json({ message: 'Script updated successfully' });
     } catch (error) {

--- a/server/tests/admin-tools-atomic-write.test.js
+++ b/server/tests/admin-tools-atomic-write.test.js
@@ -108,11 +108,9 @@ describe('Admin tools atomic writes (#1719)', () => {
       'utf-8'
     );
 
-    const renameSpy = jest
-      .spyOn(fs.promises, 'rename')
-      .mockImplementationOnce(async () => {
-        throw new Error('Simulated write failure');
-      });
+    const renameSpy = jest.spyOn(fs.promises, 'rename').mockImplementationOnce(async () => {
+      throw new Error('Simulated write failure');
+    });
 
     const app = createTestApp();
     const response = await request(app)

--- a/server/tests/admin-tools-atomic-write.test.js
+++ b/server/tests/admin-tools-atomic-write.test.js
@@ -1,0 +1,155 @@
+/**
+ * Regression tests for #1719: tool create/update/toggle writes must be
+ * atomic (crash mid-write must not corrupt the existing file) and the
+ * create endpoint must not allow two concurrent requests for the same new
+ * tool ID to both succeed.
+ *
+ * Note: The repo's source is native ESM (uses `import.meta.url`), so this
+ * file uses `jest.unstable_mockModule` + dynamic imports rather than the
+ * CommonJS-only `jest.mock` API. Run with
+ * `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import fs, { promises as fsPromises } from 'fs';
+import os from 'os';
+import path from 'path';
+
+const mockAdminUser = {
+  id: 'admin-user',
+  username: 'admin',
+  groups: ['admin']
+};
+
+const mockGroups = {
+  admin: {
+    id: 'admin',
+    permissions: { adminAccess: true }
+  }
+};
+
+// Mutable holder so each test can point the mocked loader at a fresh temp
+// root / tool list without re-registering the mock factories.
+const state = { rootDir: null, tools: [] };
+
+jest.unstable_mockModule('../pathUtils.js', () => ({
+  getRootDir: () => state.rootDir
+}));
+
+jest.unstable_mockModule('../toolsLoader.js', () => ({
+  loadAllTools: async () => state.tools
+}));
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: {
+    refreshToolsCache: async () => {}
+  }
+}));
+
+jest.unstable_mockModule('../services/ChangeHistoryService.js', () => ({
+  saveSnapshot: async () => {}
+}));
+
+jest.unstable_mockModule('../utils/authorization.js', () => ({
+  loadGroupsConfiguration: () => ({ groups: mockGroups }),
+  enhanceUserWithPermissions: user => user,
+  isAnonymousAccessAllowed: () => false
+}));
+
+// Dynamic import after mocks are registered.
+const { default: registerAdminToolsRoutes } = await import('../routes/admin/tools.js');
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.user = mockAdminUser;
+    next();
+  });
+  registerAdminToolsRoutes(app);
+  return app;
+}
+
+describe('Admin tools atomic writes (#1719)', () => {
+  let tmpRoot;
+  let toolsDir;
+
+  beforeEach(async () => {
+    tmpRoot = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'ihub-tools-atomic-test-'));
+    toolsDir = path.join(tmpRoot, 'contents', 'tools');
+    await fsPromises.mkdir(toolsDir, { recursive: true });
+    await fsPromises.mkdir(path.join(tmpRoot, 'server', 'tools'), { recursive: true });
+
+    state.rootDir = tmpRoot;
+    state.tools = [
+      {
+        id: 'existingTool',
+        name: { en: 'Existing Tool' },
+        enabled: true
+      }
+    ];
+
+    await fsPromises.writeFile(
+      path.join(toolsDir, 'existingTool.json'),
+      JSON.stringify(state.tools[0], null, 2)
+    );
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    await fsPromises.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  test('a simulated rename failure during update leaves the original tool file untouched', async () => {
+    const originalContent = await fsPromises.readFile(
+      path.join(toolsDir, 'existingTool.json'),
+      'utf-8'
+    );
+
+    const renameSpy = jest
+      .spyOn(fs.promises, 'rename')
+      .mockImplementationOnce(async () => {
+        throw new Error('Simulated write failure');
+      });
+
+    const app = createTestApp();
+    const response = await request(app)
+      .put('/api/admin/tools/existingTool')
+      .send({ id: 'existingTool', name: { en: 'Existing Tool (updated)' }, enabled: false });
+
+    expect(response.status).toBe(500);
+    renameSpy.mockRestore();
+
+    const contentAfterFailure = await fsPromises.readFile(
+      path.join(toolsDir, 'existingTool.json'),
+      'utf-8'
+    );
+    expect(contentAfterFailure).toBe(originalContent);
+
+    // No leftover temp file from the aborted write.
+    const files = await fsPromises.readdir(toolsDir);
+    expect(files.filter(f => f.startsWith('.tmp_'))).toHaveLength(0);
+  });
+
+  test('two concurrent creates for the same new tool ID result in exactly one success', async () => {
+    const app = createTestApp();
+
+    const [first, second] = await Promise.all([
+      request(app)
+        .post('/api/admin/tools')
+        .send({ id: 'raceTool', name: { en: 'Race Tool A' } }),
+      request(app)
+        .post('/api/admin/tools')
+        .send({ id: 'raceTool', name: { en: 'Race Tool B' } })
+    ]);
+
+    const statuses = [first.status, second.status].sort();
+    expect(statuses).toEqual([201, 400]);
+
+    const written = await fsPromises.readFile(path.join(toolsDir, 'raceTool.json'), 'utf-8');
+    const parsed = JSON.parse(written);
+    expect(['Race Tool A', 'Race Tool B']).toContain(parsed.name.en);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1719.

The original report described a `GET /api/admin/tools` side effect that rewrote the whole shared `config/tools.json` file, plus all mutation handlers using non-atomic `fs.writeFile`. Since the report was filed, #1879 split tools into individual files under `contents/tools/<id>.json` and removed the shared `tools.json` entirely — so the GET side-effect write no longer exists (confirmed by re-reading the current code). What remained, and is fixed here, is that the per-tool write handlers still used plain `fs.writeFile`, which is not crash-safe, and the create handler had a check-then-act race.

- `PUT /api/admin/tools/:toolId` and `POST /api/admin/tools/:toolId/toggle` now use `atomicWriteJSON` (write to a temp file + rename), so a crash or kill mid-write can no longer truncate/corrupt a tool's JSON file.
- `POST /api/admin/tools` (create) now uses `atomicCreateJSON`, which opens with `O_CREAT|O_EXCL`. Two concurrent "create tool X" requests can no longer both succeed — the loser now gets a clean 400 "Tool with this ID already exists" instead of silently overwriting the first tool's file.
- `PUT /api/admin/tools/:toolId/script` (script content) now uses `atomicWriteFile`.

These helpers (`server/utils/atomicWrite.js`) already existed and are used elsewhere in the codebase (e.g. `server/routes/admin/agents.js`); this change brings `tools.js` in line with that pattern.

## Test plan

- [x] Added `server/tests/admin-tools-atomic-write.test.js`:
  - Simulates a `fs.rename` failure during a `PUT` update and asserts the original tool file is left untouched (no corruption, no leftover temp file).
  - Fires two concurrent `POST /api/admin/tools` requests for the same new tool ID and asserts exactly one succeeds (201) and the other is rejected (400).
- [x] Existing `server/tests/admin-tools-script-path.test.js` still passes unchanged.
- [x] `npm run lint:fix` — no issues in changed files.
- [x] Verified end-to-end against a locally running dev server (logged in as the default local admin): create → toggle → update → duplicate-create (400) → delete, all behave correctly and the on-disk JSON file reflects each change.
- [x] Full server test suite run; the two pre-existing failures (`group-handling.test.js`, `comprehensive-api-documentation.test.js`) are unrelated to this change (a `jest-mock` API mismatch and a live-API-key-only test respectively) and fail identically without this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q9Tv6dWHrW2uDiKq7KaTh4

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9Tv6dWHrW2uDiKq7KaTh4)_