### PR TITLE
fix: AdminAgentEditPage JSON mode swallows keystrokes on invalid intermediate JSON

### DIFF
--- a/client/src/features/admin/pages/AdminAgentEditPage.jsx
+++ b/client/src/features/admin/pages/AdminAgentEditPage.jsx
@@ -119,6 +119,8 @@ export default function AdminAgentEditPage() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState(null);
   const [mode, setMode] = useState('form');
+  const [jsonText, setJsonText] = useState(() => JSON.stringify(profile, null, 2));
+  const [jsonError, setJsonError] = useState(null);
 
   const { blocker, markSaved } = useUnsavedChanges(initialData, profile);
 
@@ -203,6 +205,14 @@ export default function AdminAgentEditPage() {
       serviceAccount: { ...prev.serviceAccount, ...partial }
     }));
   }
+  function toggleMode() {
+    if (mode === 'form') {
+      setJsonText(JSON.stringify(profile, null, 2));
+      setJsonError(null);
+    }
+    setMode(mode === 'form' ? 'json' : 'form');
+  }
+
   function handleCronSchedule(cron) {
     setProfile(prev => {
       const triggers = cron ? [{ type: 'schedule', config: { cron, timezone: 'UTC' } }] : [];
@@ -340,7 +350,7 @@ export default function AdminAgentEditPage() {
           </h1>
           <div className="flex gap-2">
             <button
-              onClick={() => setMode(mode === 'form' ? 'json' : 'form')}
+              onClick={toggleMode}
               className="px-3 py-2 text-sm border bg-white rounded hover:bg-gray-50"
             >
               {mode === 'form'
@@ -349,7 +359,7 @@ export default function AdminAgentEditPage() {
             </button>
             <button
               onClick={handleSave}
-              disabled={saving}
+              disabled={saving || (mode === 'json' && !!jsonError)}
               className="px-4 py-2 text-sm bg-indigo-600 text-white rounded disabled:opacity-50"
             >
               {saving ? t('common.saving', 'Saving…') : t('common.save', 'Save')}
@@ -370,17 +380,23 @@ export default function AdminAgentEditPage() {
         )}
 
         {mode === 'json' ? (
-          <textarea
-            className="w-full h-[600px] font-mono text-xs p-3 border rounded"
-            value={JSON.stringify(profile, null, 2)}
-            onChange={e => {
-              try {
-                setProfile(JSON.parse(e.target.value));
-              } catch {
-                // ignore parse errors while typing
-              }
-            }}
-          />
+          <div>
+            <textarea
+              className="w-full h-[600px] font-mono text-xs p-3 border rounded"
+              value={jsonText}
+              onChange={e => {
+                const text = e.target.value;
+                setJsonText(text);
+                try {
+                  setProfile(JSON.parse(text));
+                  setJsonError(null);
+                } catch (err) {
+                  setJsonError(err.message);
+                }
+              }}
+            />
+            {jsonError && <p className="mt-1 text-sm text-red-600">{jsonError}</p>}
+          </div>
         ) : (
           <div className="space-y-6">
             {/* Identity */}


### PR DESCRIPTION
## Summary
- Fixes #1714
- `AdminAgentEditPage`'s JSON mode textarea was controlled directly by `JSON.stringify(profile, null, 2)`, and `onChange` re-parsed on every keystroke via `setProfile(JSON.parse(...))`. Any keystroke that left the JSON momentarily invalid (adding a key, typing a quote, deleting a brace) threw inside the `try`, was silently swallowed, and the textarea snapped back to the last valid serialization — making JSON mode effectively unusable for structural edits.
- Introduced a local `jsonText` buffer decoupled from `profile`, which the textarea now reads/writes directly. `profile` is only updated on a successful `JSON.parse`; parse errors are captured in `jsonError` and surfaced under the textarea instead of being discarded.
- `jsonText` is re-synced from `profile` only when switching from form mode into JSON mode, so typing in JSON mode is never fought by external state changes.
- The Save button is now also disabled while the JSON buffer is invalid, preventing a save with dangling invalid JSON left in the textarea.

## Test plan
- [ ] `npm run dev`, open an existing agent profile in `/admin/agents`, switch to JSON mode, add a new key and delete/retype a closing brace mid-edit — verify cursor position and typed text are preserved and `profile` only updates once JSON is valid again.
- [ ] Verify parse errors appear under the textarea and Save is disabled while JSON is invalid.
- [ ] Verify switching back to form mode and re-entering JSON mode reflects the latest form edits.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01YQQFNBwVYTEdf5KbLBwH7j


---
_Generated by [Claude Code](https://claude.ai/code/session_01YQQFNBwVYTEdf5KbLBwH7j)_