### PR TITLE
fix(auth): re-derive manually-assigned groups per request instead of trusting the JWT

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,19 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Group Changes Now Take Effect Immediately, Not Just After the Token Expires
+
+Revoking or granting a user's group in **Admin → Users** could previously take up to 8 hours (or up
+to a year for a static API key) to take effect, because a signed-in user's groups were read straight
+from their existing session token instead of being re-checked against the current user record.
+Demoting an admin, for example, did not actually remove their admin access until they logged back in.
+
+- Local, OIDC, LDAP, Microsoft Teams, and NTLM sessions now re-derive the user's manually-assigned
+  groups from the current user record on every request, so a group change made in the admin UI
+  applies to that user's very next request — no logout/login or waiting for token expiry required.
+- Groups mapped from an external identity provider (OIDC/LDAP claims, "authenticated", provider
+  defaults) are unaffected by this change and continue to refresh on the user's next login, as
+  before.
+- No admin action is required — the fix takes effect automatically on upgrade. Tokens issued before
+  upgrading behave as before until they naturally expire.

--- a/server/middleware/jwtAuth.js
+++ b/server/middleware/jwtAuth.js
@@ -1,10 +1,36 @@
 import { loadOAuthClients, findClientById } from '../utils/oauthClientManager.js';
-import { loadUsers, isUserActive } from '../utils/userManager.js';
+import { loadUsers, isUserActive, mergeUserGroups } from '../utils/userManager.js';
 import { verifyJwt, decodeJwt } from '../utils/tokenService.js';
 import { recordAuthEvent } from '../telemetry/metrics.js';
+import { enhanceUserGroups } from '../utils/authorization.js';
 import configCache from '../configCache.js';
 import logger from '../utils/logger.js';
 import { getClearAuthCookieOptions } from '../utils/cookieSettings.js';
+
+/**
+ * Re-hydrate the manually-assigned (admin-editable) portion of a user's groups from the
+ * current users.json record, so that revoking/granting a group in the admin UI takes
+ * effect immediately instead of waiting for the token to expire.
+ *
+ * Externally-mapped/automatic groups (IdP group claims, provider defaults, "authenticated")
+ * are intentionally left as they were at token-mint time — those aren't admin-editable
+ * per-request and re-deriving them would require re-contacting the identity provider. Only
+ * the subset of `decoded.groups` that was captured in `decoded.internalGroups` at mint time
+ * (i.e. the manually-assigned groups) is swapped out for the user's current internalGroups.
+ *
+ * @param {Object} decoded - Decoded JWT payload
+ * @param {Object} [userRecord] - Current user record from users.json, if found
+ * @returns {string[]} Effective groups to use for this request
+ */
+function resolveEffectiveGroups(decoded, userRecord) {
+  const decodedGroups = Array.isArray(decoded.groups) ? decoded.groups : [];
+  const staleManualGroups = Array.isArray(decoded.internalGroups) ? decoded.internalGroups : [];
+  const currentManualGroups = Array.isArray(userRecord?.internalGroups)
+    ? userRecord.internalGroups
+    : [];
+  const baseGroups = decodedGroups.filter(group => !staleManualGroups.includes(group));
+  return mergeUserGroups(baseGroups, currentManualGroups);
+}
 
 /**
  * JWT authentication middleware
@@ -375,13 +401,24 @@ export default function jwtAuthMiddleware(req, res, next) {
             });
           }
 
-          // User exists and is active, create user object from token
+          // User exists and is active, create user object from token. Groups are
+          // re-derived fresh from userRecord on every request (rather than trusting
+          // decoded.groups) so that group/permission changes made via the admin UI take
+          // effect immediately instead of being frozen until the token expires — local
+          // users have no external/IdP-sourced groups, so this can safely be a full
+          // recompute mirroring the login flow in localAuth.js.
+          const localAuthConfigForGroups = platform.auth || {};
+          const freshGroups = enhanceUserGroups(
+            { id: userId, groups: userRecord.internalGroups || ['users'] },
+            localAuthConfigForGroups
+          ).groups;
+
           user = {
             id: userId,
             username: decoded.username || userId,
             name: decoded.name || decoded.username || userId,
             email: decoded.email || '',
-            groups: decoded.groups || [],
+            groups: freshGroups,
             authMode: 'local',
             timestamp: Date.now()
           };
@@ -440,13 +477,16 @@ export default function jwtAuthMiddleware(req, res, next) {
           });
         }
 
-        // User either doesn't exist (not yet persisted) or is active
+        // User either doesn't exist (not yet persisted) or is active. Re-hydrate the
+        // manually-assigned portion of groups from the current record so admin changes
+        // (e.g. revoking an internal group) take effect immediately (see
+        // resolveEffectiveGroups doc comment).
         user = {
           id: decoded.sub || decoded.username,
           username: decoded.username || decoded.preferred_username || decoded.sub,
           name: decoded.name || decoded.given_name || decoded.username,
           email: decoded.email || '',
-          groups: decoded.groups || [],
+          groups: resolveEffectiveGroups(decoded, userRecord),
           authMode: 'oidc',
           timestamp: Date.now()
         };
@@ -501,7 +541,7 @@ export default function jwtAuthMiddleware(req, res, next) {
           username: decoded.username || decoded.sub,
           name: decoded.name || decoded.displayName || decoded.username,
           email: decoded.email || decoded.mail || '',
-          groups: decoded.groups || [],
+          groups: resolveEffectiveGroups(decoded, userRecord),
           authMode: 'ldap',
           timestamp: Date.now()
         };
@@ -548,7 +588,7 @@ export default function jwtAuthMiddleware(req, res, next) {
           username: decoded.username || decoded.userPrincipalName,
           name: decoded.name || decoded.displayName || decoded.username,
           email: decoded.email || decoded.userPrincipalName,
-          groups: decoded.groups || [],
+          groups: resolveEffectiveGroups(decoded, userRecord),
           authMode: 'teams',
           timestamp: Date.now()
         };
@@ -597,7 +637,7 @@ export default function jwtAuthMiddleware(req, res, next) {
           username: decoded.username || decoded.id,
           name: decoded.name || decoded.username || decoded.id,
           email: decoded.email || '',
-          groups: decoded.groups || [],
+          groups: resolveEffectiveGroups(decoded, userRecord),
           authMode: 'ntlm',
           domain: decoded.domain,
           timestamp: Date.now()

--- a/server/tests/jwt-user-validation.test.js
+++ b/server/tests/jwt-user-validation.test.js
@@ -2,16 +2,20 @@
  * JWT User Validation Security Test Suite
  *
  * Tests to verify that JWT tokens are validated against the user database
- * to ensure disabled or deleted users cannot access the system with valid JWTs.
+ * to ensure disabled or deleted users cannot access the system with valid JWTs,
+ * and that group/permission changes made via the admin UI are not frozen in an
+ * already-issued token until it expires.
  */
 
+import { jest } from '@jest/globals';
 import request from 'supertest';
 import express from 'express';
 import jwt from 'jsonwebtoken';
-import { setupMiddleware } from '../middleware/setup.js';
-import registerAuthRoutes from '../routes/auth.js';
-import jwtAuthMiddleware from '../middleware/jwtAuth.js';
-import { authRequired } from '../middleware/authRequired.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Mock JWT secret
 const TEST_JWT_SECRET = 'test-jwt-secret-key-12345';
@@ -21,6 +25,12 @@ const mockPlatformConfig = {
   auth: {
     mode: 'local',
     jwtSecret: TEST_JWT_SECRET
+  },
+  // Tokens below are signed with jsonwebtoken's default (HS256) algorithm using a plain
+  // shared secret; without this, getJwtAlgorithm() defaults to RS256 and verifyJwt()
+  // rejects every token in this suite as a signature mismatch.
+  jwt: {
+    algorithm: 'HS256'
   },
   localAuth: {
     enabled: true,
@@ -57,6 +67,43 @@ const mockTestUsersConfig = {
       internalGroups: ['users'],
       createdAt: '2025-01-01T00:00:00.000Z',
       updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_demoted_local_test: {
+      id: 'user_demoted_local_test',
+      username: 'demotedlocaluser',
+      email: 'demotedlocal@example.com',
+      name: 'Demoted Local User',
+      active: true,
+      passwordHash: '$2b$12$testHash',
+      // Admin group has since been revoked in users.json, but a still-valid token
+      // minted while the user was an admin carries the old `groups` claim.
+      internalGroups: ['users'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_demoted_oidc_test: {
+      id: 'user_demoted_oidc_test',
+      username: 'demotedoidcuser',
+      email: 'demotedoidc@example.com',
+      name: 'Demoted OIDC User',
+      active: true,
+      authMethods: ['oidc'],
+      // 'admin' manual group has been revoked since the token was minted.
+      internalGroups: [],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
+    },
+    user_promoted_oidc_test: {
+      id: 'user_promoted_oidc_test',
+      username: 'promotedoidcuser',
+      email: 'promotedoidc@example.com',
+      name: 'Promoted OIDC User',
+      active: true,
+      authMethods: ['oidc'],
+      // 'manager' manual group has been granted since the token was minted.
+      internalGroups: ['manager'],
+      createdAt: '2025-01-01T00:00:00.000Z',
+      updatedAt: '2025-01-01T00:00:00.000Z'
     }
   },
   metadata: {
@@ -65,14 +112,16 @@ const mockTestUsersConfig = {
   }
 };
 
-// Mock configCache
-jest.mock('../configCache.js', () => ({
+// Mock configCache. Must use unstable_mockModule (not jest.mock) because this project's
+// Jest config runs source files as native ESM (transform: {}), where plain jest.mock calls
+// are not hoisted above the static imports that pull in the real module.
+jest.unstable_mockModule('../configCache.js', () => ({
   __esModule: true,
   default: {
     getPlatform: () => mockPlatformConfig,
     get: key => {
       if (key === 'config/users.json' || key === 'config/users-test.json') {
-        return mockTestUsersConfig;
+        return { data: mockTestUsersConfig };
       }
       return null;
     },
@@ -83,18 +132,81 @@ jest.mock('../configCache.js', () => ({
 }));
 
 // Mock config
-jest.mock('../config.js', () => ({
+jest.unstable_mockModule('../config.js', () => ({
   __esModule: true,
   default: {
     JWT_SECRET: TEST_JWT_SECRET,
-    PORT: 3000
+    PORT: 3000,
+    CONTENTS_DIR: 'contents'
   }
 }));
+
+const { setupMiddleware } = await import('../middleware/setup.js');
+const { default: registerAuthRoutes } = await import('../routes/auth.js');
+const { default: jwtAuthMiddleware } = await import('../middleware/jwtAuth.js');
+const { authRequired } = await import('../middleware/authRequired.js');
+
+// enhanceUserWithPermissions (invoked by setupMiddleware on every authenticated
+// request) calls loadGroupsConfiguration(), which reads contents/config/groups.json
+// directly from disk rather than through configCache. Ensure a minimal fixture exists
+// for the test process and tear it down afterwards. If the file already exists (full
+// dev environment), leave it alone. Mirrors the pattern in ntlmAuth-domain.test.js.
+const groupsConfigPath = path.join(__dirname, '../../contents/config/groups.json');
+let createdGroupsFixture = false;
+let createdContentsConfig = false;
+let createdContents = false;
 
 describe('JWT User Validation Security Tests', () => {
   let app;
 
   beforeAll(() => {
+    const contentsConfigDir = path.dirname(groupsConfigPath);
+    const contentsDir = path.dirname(contentsConfigDir);
+    if (!fs.existsSync(contentsDir)) {
+      fs.mkdirSync(contentsDir);
+      createdContents = true;
+    }
+    if (!fs.existsSync(contentsConfigDir)) {
+      fs.mkdirSync(contentsConfigDir);
+      createdContentsConfig = true;
+    }
+    if (!fs.existsSync(groupsConfigPath)) {
+      fs.writeFileSync(
+        groupsConfigPath,
+        JSON.stringify({
+          groups: {
+            anonymous: { id: 'anonymous', name: 'Anonymous', permissions: {} },
+            authenticated: {
+              id: 'authenticated',
+              name: 'Authenticated',
+              inherits: ['anonymous'],
+              permissions: {}
+            },
+            users: { id: 'users', name: 'Users', inherits: ['authenticated'], permissions: {} },
+            admin: {
+              id: 'admin',
+              name: 'Admin',
+              inherits: ['users'],
+              permissions: { adminAccess: true }
+            },
+            'oidc-default': {
+              id: 'oidc-default',
+              name: 'OIDC Default',
+              inherits: ['authenticated'],
+              permissions: {}
+            },
+            manager: {
+              id: 'manager',
+              name: 'Manager',
+              inherits: ['authenticated'],
+              permissions: {}
+            }
+          }
+        })
+      );
+      createdGroupsFixture = true;
+    }
+
     // Create test app
     app = express();
     app.set('platform', mockPlatformConfig);
@@ -114,10 +226,19 @@ describe('JWT User Validation Security Tests', () => {
         success: true,
         user: {
           id: req.user.id,
-          name: req.user.name
+          name: req.user.name,
+          groups: req.user.groups
         }
       });
     });
+  });
+
+  afterAll(() => {
+    if (createdGroupsFixture) fs.rmSync(groupsConfigPath, { force: true });
+    if (createdContentsConfig)
+      fs.rmSync(path.dirname(groupsConfigPath), { force: true, recursive: true });
+    if (createdContents)
+      fs.rmSync(path.dirname(path.dirname(groupsConfigPath)), { force: true, recursive: true });
   });
 
   describe('Active User JWT Validation', () => {
@@ -135,7 +256,8 @@ describe('JWT User Validation Security Tests', () => {
         TEST_JWT_SECRET,
         {
           expiresIn: '7d',
-          issuer: 'ihub-apps'
+          issuer: 'ihub-apps',
+          audience: 'ihub-apps'
         }
       );
 
@@ -164,7 +286,8 @@ describe('JWT User Validation Security Tests', () => {
         TEST_JWT_SECRET,
         {
           expiresIn: '7d',
-          issuer: 'ihub-apps'
+          issuer: 'ihub-apps',
+          audience: 'ihub-apps'
         }
       );
 
@@ -193,7 +316,8 @@ describe('JWT User Validation Security Tests', () => {
         TEST_JWT_SECRET,
         {
           expiresIn: '7d',
-          issuer: 'ihub-apps'
+          issuer: 'ihub-apps',
+          audience: 'ihub-apps'
         }
       );
 
@@ -226,7 +350,8 @@ describe('JWT User Validation Security Tests', () => {
         TEST_JWT_SECRET,
         {
           expiresIn: '7d',
-          issuer: 'ihub-apps'
+          issuer: 'ihub-apps',
+          audience: 'ihub-apps'
         }
       );
 
@@ -258,7 +383,8 @@ describe('JWT User Validation Security Tests', () => {
         TEST_JWT_SECRET,
         {
           expiresIn: '7d',
-          issuer: 'ihub-apps'
+          issuer: 'ihub-apps',
+          audience: 'ihub-apps'
         }
       );
 
@@ -269,6 +395,90 @@ describe('JWT User Validation Security Tests', () => {
       expect(response.status).toBe(403);
       expect(response.body.error).toBe('access_denied');
       expect(response.body.error_description).toBe('User account has been disabled');
+    });
+  });
+
+  describe('Group revocation is not frozen in the JWT', () => {
+    test('local: a still-valid token minted before a group demotion loses the revoked group immediately', async () => {
+      // Token was minted while the user was in the 'admin' group.
+      const token = jwt.sign(
+        {
+          sub: 'user_demoted_local_test',
+          username: 'demotedlocaluser',
+          name: 'Demoted Local User',
+          email: 'demotedlocal@example.com',
+          groups: ['users', 'admin', 'authenticated'],
+          authMode: 'local'
+        },
+        TEST_JWT_SECRET,
+        { expiresIn: '7d', issuer: 'ihub-apps', audience: 'ihub-apps' }
+      );
+
+      const response = await request(app)
+        .get('/api/test/protected')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      // users.json now only lists 'users' as an internal group for this user —
+      // groups must be re-derived from that, not trusted from the stale token.
+      expect(response.body.user.groups).toEqual(expect.arrayContaining(['users', 'authenticated']));
+      expect(response.body.user.groups).not.toContain('admin');
+    });
+
+    test('oidc: revoking a manually-assigned group takes effect before the token expires', async () => {
+      // Token minted while 'admin' was a manually-assigned internal group. The
+      // internalGroups claim records that snapshot so it can be diffed later.
+      const token = jwt.sign(
+        {
+          sub: 'user_demoted_oidc_test',
+          username: 'demotedoidcuser',
+          name: 'Demoted OIDC User',
+          email: 'demotedoidc@example.com',
+          groups: ['authenticated', 'oidc-default', 'admin'],
+          internalGroups: ['admin'],
+          authMode: 'oidc'
+        },
+        TEST_JWT_SECRET,
+        { expiresIn: '7d', issuer: 'ihub-apps', audience: 'ihub-apps' }
+      );
+
+      const response = await request(app)
+        .get('/api/test/protected')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      // 'admin' was removed from users.json since mint time, so it must be gone,
+      // while the externally-mapped groups from the token are left untouched.
+      expect(response.body.user.groups).toEqual(
+        expect.arrayContaining(['authenticated', 'oidc-default'])
+      );
+      expect(response.body.user.groups).not.toContain('admin');
+    });
+
+    test('oidc: granting a new manually-assigned group takes effect before the token expires', async () => {
+      // Token minted before the 'manager' internal group was granted.
+      const token = jwt.sign(
+        {
+          sub: 'user_promoted_oidc_test',
+          username: 'promotedoidcuser',
+          name: 'Promoted OIDC User',
+          email: 'promotedoidc@example.com',
+          groups: ['authenticated', 'oidc-default'],
+          internalGroups: [],
+          authMode: 'oidc'
+        },
+        TEST_JWT_SECRET,
+        { expiresIn: '7d', issuer: 'ihub-apps', audience: 'ihub-apps' }
+      );
+
+      const response = await request(app)
+        .get('/api/test/protected')
+        .set('Authorization', `Bearer ${token}`);
+
+      expect(response.status).toBe(200);
+      expect(response.body.user.groups).toEqual(
+        expect.arrayContaining(['authenticated', 'oidc-default', 'manager'])
+      );
     });
   });
 });

--- a/server/utils/tokenService.js
+++ b/server/utils/tokenService.js
@@ -114,6 +114,10 @@ export function generateJwt(user, options = {}) {
     name: user.name,
     email: user.email,
     groups: user.groups || [],
+    // Snapshot of the manually-assigned (admin-editable) groups at mint time. Used by
+    // jwtAuth to detect and revoke groups an admin has since removed from users.json,
+    // without needing to re-derive externally-mapped groups on every request.
+    internalGroups: user.internalGroups || [],
     provider: user.provider,
     authMode: options.authMode || user.authMethod,
     authProvider: options.authProvider || user.provider,

--- a/server/utils/userManager.js
+++ b/server/utils/userManager.js
@@ -491,6 +491,10 @@ export async function validateAndPersistExternalUser(externalUser, platformConfi
       ...externalUser,
       id: persistedUser.id,
       groups: mergedGroups,
+      // Snapshot of the manually-assigned groups at token-mint time, so jwtAuth can
+      // later diff against the current users.json record and revoke groups an admin
+      // has since removed, without needing to re-run the external IdP mapping.
+      internalGroups: manualInternalGroups,
       active: persistedUser.active,
       authMethods: persistedUser.authMethods || [authMethod],
       lastActiveDate: persistedUser.lastActiveDate,
@@ -547,6 +551,8 @@ export async function validateAndPersistExternalUser(externalUser, platformConfi
     ...externalUser,
     id: persistedUser.id,
     groups: combinedGroups,
+    // Snapshot of the manually-assigned groups at token-mint time (see comment above).
+    internalGroups: manualInternalGroups,
     active: true,
     authMethods: [authMethod],
     lastActiveDate: persistedUser.lastActiveDate,


### PR DESCRIPTION
## Summary

Fixes #1737.

`jwtAuth.js` built a request's `req.user.groups` straight from the signed JWT's `groups` claim for every persisted auth mode (local/OIDC/LDAP/Teams/NTLM). Since `isAdmin`/permissions are derived from `user.groups`, an admin revoking a user's group membership (e.g. removing `admin`) had no effect until that user's token expired — up to 8h for session cookies and up to 365 days for static API keys.

- **Local auth**: fully recomputes `groups` from the current `users.json` record (`userRecord.internalGroups`) plus `enhanceUserGroups` on every request, mirroring the login flow. Local users have no externally-sourced groups, so a full recompute is safe.
- **OIDC/LDAP/Teams/NTLM**: a new `internalGroups` JWT claim snapshots the manually-assigned (admin-editable) groups at mint time. On each request, `jwtAuth.js` diffs that snapshot against the user's *current* `internalGroups` and swaps out only that portion — externally-mapped/automatic groups (IdP claims, `authenticated`, provider defaults) are left untouched and continue to refresh on next login as before.
- `tokenService.generateJwt` now includes `internalGroups` in the payload; `userManager.validateAndPersistExternalUser` now attaches the manually-assigned groups snapshot to the user object it returns so it flows into the token.

## Changes

- `server/middleware/jwtAuth.js`: added `resolveEffectiveGroups()` helper; local branch recomputes fresh groups from `userRecord`; oidc/ldap/teams/ntlm branches use the new diff-based re-hydration.
- `server/utils/tokenService.js`: `generateJwt` includes an `internalGroups` claim.
- `server/utils/userManager.js`: `validateAndPersistExternalUser` attaches `internalGroups` to the returned user object (both existing-user and new-user paths).
- `server/tests/jwt-user-validation.test.js`: added regression tests for group revocation/grant across local and OIDC. Also fixed this suite's mocking, which was silently broken (missing `@jest/globals` import, `jest.mock` used instead of `jest.unstable_mockModule` under this project's native-ESM Jest config, and a missing token `audience` claim) — the whole file wasn't actually exercising any assertions before this change.
- `docs/releases/5.5.0/features.md`: changelog entry.

## Test plan

- [x] `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/jwt-user-validation.test.js` — all 8 tests pass (5 pre-existing + 3 new revocation/grant regression tests).
- [x] `npx eslint` / `npx prettier --check` on all changed files — clean (one pre-existing unrelated warning in `userManager.js`).
- [x] Confirmed `tests/group-handling.test.js` and `tests/userPasswordHashing.test.js` failures are pre-existing on `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014hfuHQKWBUs4dWAkgGYCuW


---
_Generated by [Claude Code](https://claude.ai/code/session_014hfuHQKWBUs4dWAkgGYCuW)_