### PR TITLE
fix(workflow): fail deadlocked runs instead of hanging in RUNNING forever

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,14 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Deadlocked Workflow Runs No Longer Get Stuck in "Running" Forever
+
+Agent workflow runs that hit a deadlock — a step waiting on another step that can never
+complete, typically caused by a misconfigured `dependsOn` in a custom workflow — now fail
+immediately with a clear error instead of silently freezing in "Running" status.
+
+- The run is marked Failed with a `WORKFLOW_DEADLOCK` error identifying the blocked step(s),
+  and the run list/status views update accordingly instead of showing an indefinitely spinning run.
+- No configuration or admin action required; this only affects runs that would previously have
+  hung forever.

--- a/server/services/workflow/WorkflowEngine.js
+++ b/server/services/workflow/WorkflowEngine.js
@@ -610,11 +610,35 @@ export class WorkflowEngine {
             // Workflow complete
             await this._completeWorkflow(executionId, state, customStatus);
           } else {
-            // Nodes are blocked (shouldn't happen in valid workflow)
-            logger.warn('Workflow has blocked nodes', {
+            // Nodes are blocked on unsatisfiable dependencies (deadlock)
+            logger.error('Workflow has blocked/deadlocked nodes', {
               component: 'WorkflowEngine',
               executionId,
               blockedNodes: state.currentNodes
+            });
+
+            await this.stateManager.update(executionId, {
+              status: WorkflowStatus.FAILED,
+              completedAt: new Date().toISOString()
+            });
+
+            await this.stateManager.addError(executionId, {
+              message: `Workflow deadlocked: node(s) ${state.currentNodes.join(', ')} have unsatisfiable dependencies`,
+              code: 'WORKFLOW_DEADLOCK'
+            });
+
+            // Persist failed state to disk
+            await this.stateManager.checkpoint(executionId, 'deadlock_failure');
+
+            const registry = getExecutionRegistry();
+            registry.updateStatus(executionId, WorkflowStatus.FAILED, { currentNode: null });
+
+            this._emitEvent('workflow.failed', {
+              executionId,
+              error: {
+                message: 'Workflow deadlocked — one or more nodes have unsatisfiable dependencies',
+                code: 'WORKFLOW_DEADLOCK'
+              }
             });
           }
           break;

--- a/server/tests/services/workflow/WorkflowEngine.deadlock.test.js
+++ b/server/tests/services/workflow/WorkflowEngine.deadlock.test.js
@@ -1,0 +1,75 @@
+/**
+ * WorkflowEngine._runExecutionLoop deadlock handling.
+ *
+ * When the scheduler returns zero executable nodes but the state still has
+ * non-empty currentNodes (a node blocked on an unsatisfiable dependency),
+ * the loop must fail the run instead of silently breaking and leaving the
+ * execution stuck in RUNNING forever.
+ */
+
+import { jest } from '@jest/globals';
+import { WorkflowEngine } from '../../../services/workflow/WorkflowEngine.js';
+import { WorkflowStatus } from '../../../services/workflow/StateManager.js';
+import { getExecutionRegistry } from '../../../services/workflow/ExecutionRegistry.js';
+import { actionTracker } from '../../../actionTracker.js';
+
+function createEngine(state) {
+  const stateManager = {
+    get: jest.fn().mockResolvedValue(state),
+    update: jest.fn().mockResolvedValue(undefined),
+    addError: jest.fn().mockResolvedValue(undefined),
+    checkpoint: jest.fn().mockResolvedValue(undefined)
+  };
+  const scheduler = {
+    getExecutableNodes: jest.fn().mockReturnValue([])
+  };
+  const engine = new WorkflowEngine({ stateManager, scheduler });
+  return { engine, stateManager, scheduler };
+}
+
+describe('WorkflowEngine deadlock handling', () => {
+  test('fails the run when nodes are blocked on unsatisfiable dependencies', async () => {
+    const executionId = 'exec-deadlock-1';
+    const state = {
+      status: WorkflowStatus.RUNNING,
+      currentNodes: ['nodeA'],
+      completedNodes: [],
+      data: {}
+    };
+    const { engine, stateManager } = createEngine(state);
+
+    const registryUpdateSpy = jest.spyOn(getExecutionRegistry(), 'updateStatus');
+    const emitSpy = jest.spyOn(actionTracker, 'emit');
+
+    const workflow = { nodes: [] };
+    const controller = new AbortController();
+
+    await engine._runExecutionLoop(workflow, executionId, {}, controller.signal);
+
+    expect(stateManager.update).toHaveBeenCalledWith(
+      executionId,
+      expect.objectContaining({ status: WorkflowStatus.FAILED })
+    );
+    expect(stateManager.addError).toHaveBeenCalledWith(
+      executionId,
+      expect.objectContaining({ code: 'WORKFLOW_DEADLOCK' })
+    );
+    expect(stateManager.checkpoint).toHaveBeenCalledWith(executionId, 'deadlock_failure');
+    expect(registryUpdateSpy).toHaveBeenCalledWith(
+      executionId,
+      WorkflowStatus.FAILED,
+      expect.objectContaining({ currentNode: null })
+    );
+    expect(emitSpy).toHaveBeenCalledWith(
+      'fire-sse',
+      expect.objectContaining({
+        event: 'workflow.failed',
+        executionId,
+        error: expect.objectContaining({ code: 'WORKFLOW_DEADLOCK' })
+      })
+    );
+
+    registryUpdateSpy.mockRestore();
+    emitSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1711.

`WorkflowEngine._runExecutionLoop` breaks out of its loop when the scheduler reports zero executable nodes. Previously, if `state.currentNodes` was still non-empty at that point (a node blocked on an unsatisfiable dependency — i.e. a deadlock), the engine only logged a warning and silently exited the loop: no terminal status was set, no error was recorded, the `ExecutionRegistry` was never updated, and no `workflow.failed` event was emitted. The run stayed in `RUNNING` forever with no way for clients or operators to notice.

- The blocked-node branch now mirrors the existing timeout (`MAX_EXECUTION_TIME_EXCEEDED`) and max-iterations (`MAX_ITERATIONS_EXCEEDED`) failure paths: it marks the execution `FAILED`, records a `WORKFLOW_DEADLOCK` error naming the blocked node(s), checkpoints the state, updates the `ExecutionRegistry`, and emits `workflow.failed`.
- Added a regression test (`server/tests/services/workflow/WorkflowEngine.deadlock.test.js`) that stubs the scheduler/state manager to reproduce the blocked-node scenario and asserts all of the above side effects occur.
- Added a changelog entry under `docs/releases/5.5.0/features.md` per the repo's changelog convention.

## Test plan

- [x] `npm test -- tests/services/workflow/WorkflowEngine.deadlock.test.js tests/services/workflow/WorkflowEngine.executeWithTimeout.test.js` — both suites pass
- [x] `npx eslint server/services/workflow/WorkflowEngine.js server/tests/services/workflow/WorkflowEngine.deadlock.test.js` — clean
- [x] `npx prettier --check` on changed files — clean
- [ ] Manual verification against a live deadlocked workflow run (not exercised in this session; covered by the new unit test instead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fgGZbaKto39XVuE4X2Y54

---
_Generated by [Claude Code](https://claude.ai/code/session_014fgGZbaKto39XVuE4X2Y54)_