### PR TITLE
Fix Express route shadowing in admin prompts/sources routes

### DIFF
--- a/server/routes/admin/prompts.js
+++ b/server/routes/admin/prompts.js
@@ -324,6 +324,115 @@ export default function registerAdminPromptsRoutes(app) {
 
   /**
    * @swagger
+   * /api/admin/prompts/app-generator:
+   *   get:
+   *     summary: Get the app generator prompt template for a specific language
+   *     description: |
+   *       Retrieves the app generator prompt template localized for the specified language.
+   *       This special endpoint provides access to the app generation prompt used by the
+   *       iHub Apps platform to create new application configurations.
+   *
+   *       **Admin Access Required**: This endpoint requires administrator authentication.
+   *
+   *       **Language Fallback**: If the requested language is not available, falls back to the default platform language.
+   *
+   *       **Special Purpose**: This endpoint is specifically designed for the app generator functionality
+   *       and returns the prompt text rather than the full configuration object.
+   *     tags:
+   *       - Admin - Prompts
+   *     security:
+   *       - bearerAuth: []
+   *       - sessionAuth: []
+   *     parameters:
+   *       - in: query
+   *         name: lang
+   *         required: false
+   *         description: Language code for localization (defaults to platform default language)
+   *         schema:
+   *           type: string
+   *         example: "en"
+   *     responses:
+   *       200:
+   *         description: App generator prompt successfully retrieved
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/AppGeneratorPrompt'
+   *             example:
+   *               id: "app-generator"
+   *               prompt: "You are an expert in the iHub Apps platform. Your job is to help users create complete and valid JSON configurations..."
+   *               language: "en"
+   *       401:
+   *         description: Authentication required
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/AdminError'
+   *             example:
+   *               error: "Admin authentication required"
+   *       403:
+   *         description: Forbidden - insufficient admin privileges
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/AdminError'
+   *             example:
+   *               error: "Admin access required"
+   *       404:
+   *         description: App-generator prompt not found
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/AdminError'
+   *             example:
+   *               error: "App-generator prompt not found"
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/AdminError'
+   *             examples:
+   *               configError:
+   *                 summary: Configuration load error
+   *                 value:
+   *                   error: "Failed to load prompts configuration"
+   *               internalError:
+   *                 summary: General internal error
+   *                 value:
+   *                   error: "Internal server error"
+   */
+  app.get(
+    buildServerPath('/api/admin/prompts/app-generator'),
+    contentAdminAuth,
+    async (req, res) => {
+      try {
+        const platformConfig = configCache.getPlatform();
+        const defaultLanguage = platformConfig?.defaultLanguage || 'en';
+        const { lang = defaultLanguage } = req.query;
+        const { data: prompts } = configCache.getPrompts(true);
+        if (!prompts) {
+          return sendFailedOperationError(
+            res,
+            'load prompts configuration',
+            new Error('prompts is null')
+          );
+        }
+        const appGeneratorPrompt = prompts.find(p => p.id === 'app-generator');
+        if (!appGeneratorPrompt) {
+          return sendNotFound(res, 'App-generator prompt');
+        }
+        const promptText =
+          appGeneratorPrompt.prompt[lang] || appGeneratorPrompt.prompt[defaultLanguage];
+        res.json({ id: appGeneratorPrompt.id, prompt: promptText, language: lang });
+      } catch (error) {
+        return sendInternalError(res, error, 'fetch app-generator prompt');
+      }
+    }
+  );
+
+  /**
+   * @swagger
    * /api/admin/prompts/{promptId}:
    *   get:
    *     summary: Get a specific prompt template by ID
@@ -1274,113 +1383,4 @@ export default function registerAdminPromptsRoutes(app) {
       sendErrorResponse(res, 500, errorMessage, { details: error.message });
     }
   });
-
-  /**
-   * @swagger
-   * /api/admin/prompts/app-generator:
-   *   get:
-   *     summary: Get the app generator prompt template for a specific language
-   *     description: |
-   *       Retrieves the app generator prompt template localized for the specified language.
-   *       This special endpoint provides access to the app generation prompt used by the
-   *       iHub Apps platform to create new application configurations.
-   *
-   *       **Admin Access Required**: This endpoint requires administrator authentication.
-   *
-   *       **Language Fallback**: If the requested language is not available, falls back to the default platform language.
-   *
-   *       **Special Purpose**: This endpoint is specifically designed for the app generator functionality
-   *       and returns the prompt text rather than the full configuration object.
-   *     tags:
-   *       - Admin - Prompts
-   *     security:
-   *       - bearerAuth: []
-   *       - sessionAuth: []
-   *     parameters:
-   *       - in: query
-   *         name: lang
-   *         required: false
-   *         description: Language code for localization (defaults to platform default language)
-   *         schema:
-   *           type: string
-   *         example: "en"
-   *     responses:
-   *       200:
-   *         description: App generator prompt successfully retrieved
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/AppGeneratorPrompt'
-   *             example:
-   *               id: "app-generator"
-   *               prompt: "You are an expert in the iHub Apps platform. Your job is to help users create complete and valid JSON configurations..."
-   *               language: "en"
-   *       401:
-   *         description: Authentication required
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/AdminError'
-   *             example:
-   *               error: "Admin authentication required"
-   *       403:
-   *         description: Forbidden - insufficient admin privileges
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/AdminError'
-   *             example:
-   *               error: "Admin access required"
-   *       404:
-   *         description: App-generator prompt not found
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/AdminError'
-   *             example:
-   *               error: "App-generator prompt not found"
-   *       500:
-   *         description: Internal server error
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/AdminError'
-   *             examples:
-   *               configError:
-   *                 summary: Configuration load error
-   *                 value:
-   *                   error: "Failed to load prompts configuration"
-   *               internalError:
-   *                 summary: General internal error
-   *                 value:
-   *                   error: "Internal server error"
-   */
-  app.get(
-    buildServerPath('/api/admin/prompts/app-generator'),
-    contentAdminAuth,
-    async (req, res) => {
-      try {
-        const platformConfig = configCache.getPlatform();
-        const defaultLanguage = platformConfig?.defaultLanguage || 'en';
-        const { lang = defaultLanguage } = req.query;
-        const { data: prompts } = configCache.getPrompts(true);
-        if (!prompts) {
-          return sendFailedOperationError(
-            res,
-            'load prompts configuration',
-            new Error('prompts is null')
-          );
-        }
-        const appGeneratorPrompt = prompts.find(p => p.id === 'app-generator');
-        if (!appGeneratorPrompt) {
-          return sendNotFound(res, 'App-generator prompt');
-        }
-        const promptText =
-          appGeneratorPrompt.prompt[lang] || appGeneratorPrompt.prompt[defaultLanguage];
-        res.json({ id: appGeneratorPrompt.id, prompt: promptText, language: lang });
-      } catch (error) {
-        return sendInternalError(res, error, 'fetch app-generator prompt');
-      }
-    }
-  );
 }

--- a/server/routes/admin/sources.js
+++ b/server/routes/admin/sources.js
@@ -499,6 +499,133 @@ export default function registerAdminSourcesRoutes(app) {
 
   /**
    * @swagger
+   * /api/admin/sources/_stats:
+   *   get:
+   *     summary: Get sources statistics
+   *     description: Retrieve statistical information about all sources (admin access required)
+   *     tags: [Admin - Sources]
+   *     security:
+   *       - bearerAuth: []
+   *       - sessionAuth: []
+   *     responses:
+   *       200:
+   *         description: Sources statistics retrieved successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/SourceStats'
+   *       401:
+   *         description: Unauthorized - Invalid or missing authentication
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - Insufficient admin permissions
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+  app.get(
+    buildServerPath('/api/admin/sources/_stats'),
+    requireFeature('sources'),
+    contentAdminAuth,
+    async (req, res) => {
+      try {
+        const { data: sources } = configCache.getSources(true);
+
+        const stats = {
+          total: sources.length,
+          enabled: sources.filter(s => s.enabled !== false).length,
+          disabled: sources.filter(s => s.enabled === false).length,
+          byType: {
+            filesystem: sources.filter(s => s.type === 'filesystem').length,
+            url: sources.filter(s => s.type === 'url').length,
+            ifinder: sources.filter(s => s.type === 'ifinder').length
+          },
+          byExposeAs: {
+            prompt: sources.filter(s => s.exposeAs === 'prompt').length,
+            tool: sources.filter(s => s.exposeAs === 'tool').length
+          }
+        };
+
+        res.json(stats);
+      } catch (error) {
+        sendFailedOperationError(res, 'fetch source statistics', error);
+      }
+    }
+  );
+
+  /**
+   * @swagger
+   * /api/admin/sources/_types:
+   *   get:
+   *     summary: Get available source types
+   *     description: Retrieve all available source types with their configurations (admin access required)
+   *     tags: [Admin - Sources]
+   *     security:
+   *       - bearerAuth: []
+   *       - sessionAuth: []
+   *     responses:
+   *       200:
+   *         description: Source types retrieved successfully
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: array
+   *               items:
+   *                 $ref: '#/components/schemas/SourceType'
+   *       401:
+   *         description: Unauthorized - Invalid or missing authentication
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       403:
+   *         description: Forbidden - Insufficient admin permissions
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   *       500:
+   *         description: Internal server error
+   *         content:
+   *           application/json:
+   *             schema:
+   *               $ref: '#/components/schemas/ErrorResponse'
+   */
+  app.get(
+    buildServerPath('/api/admin/sources/_types'),
+    requireFeature('sources'),
+    contentAdminAuth,
+    async (req, res) => {
+      try {
+        const manager = getSourceManager();
+        const handlerTypes = manager.getHandlerTypes();
+
+        const types = handlerTypes.map(type => ({
+          id: type,
+          name: type.charAt(0).toUpperCase() + type.slice(1),
+          description: getTypeDescription(type),
+          defaultConfig: getDefaultSourceConfig(type)
+        }));
+
+        res.json(types);
+      } catch (error) {
+        sendFailedOperationError(res, 'fetch source types', error);
+      }
+    }
+  );
+
+  /**
+   * @swagger
    * /api/admin/sources/{id}:
    *   get:
    *     summary: Get specific source
@@ -1360,133 +1487,6 @@ export default function registerAdminSourcesRoutes(app) {
         res.json({ message: `${updatedCount} sources ${enabled ? 'enabled' : 'disabled'}` });
       } catch (error) {
         sendFailedOperationError(res, 'toggle sources', error);
-      }
-    }
-  );
-
-  /**
-   * @swagger
-   * /api/admin/sources/_stats:
-   *   get:
-   *     summary: Get sources statistics
-   *     description: Retrieve statistical information about all sources (admin access required)
-   *     tags: [Admin - Sources]
-   *     security:
-   *       - bearerAuth: []
-   *       - sessionAuth: []
-   *     responses:
-   *       200:
-   *         description: Sources statistics retrieved successfully
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/SourceStats'
-   *       401:
-   *         description: Unauthorized - Invalid or missing authentication
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/ErrorResponse'
-   *       403:
-   *         description: Forbidden - Insufficient admin permissions
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/ErrorResponse'
-   *       500:
-   *         description: Internal server error
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/ErrorResponse'
-   */
-  app.get(
-    buildServerPath('/api/admin/sources/_stats'),
-    requireFeature('sources'),
-    contentAdminAuth,
-    async (req, res) => {
-      try {
-        const { data: sources } = configCache.getSources(true);
-
-        const stats = {
-          total: sources.length,
-          enabled: sources.filter(s => s.enabled !== false).length,
-          disabled: sources.filter(s => s.enabled === false).length,
-          byType: {
-            filesystem: sources.filter(s => s.type === 'filesystem').length,
-            url: sources.filter(s => s.type === 'url').length,
-            ifinder: sources.filter(s => s.type === 'ifinder').length
-          },
-          byExposeAs: {
-            prompt: sources.filter(s => s.exposeAs === 'prompt').length,
-            tool: sources.filter(s => s.exposeAs === 'tool').length
-          }
-        };
-
-        res.json(stats);
-      } catch (error) {
-        sendFailedOperationError(res, 'fetch source statistics', error);
-      }
-    }
-  );
-
-  /**
-   * @swagger
-   * /api/admin/sources/_types:
-   *   get:
-   *     summary: Get available source types
-   *     description: Retrieve all available source types with their configurations (admin access required)
-   *     tags: [Admin - Sources]
-   *     security:
-   *       - bearerAuth: []
-   *       - sessionAuth: []
-   *     responses:
-   *       200:
-   *         description: Source types retrieved successfully
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: array
-   *               items:
-   *                 $ref: '#/components/schemas/SourceType'
-   *       401:
-   *         description: Unauthorized - Invalid or missing authentication
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/ErrorResponse'
-   *       403:
-   *         description: Forbidden - Insufficient admin permissions
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/ErrorResponse'
-   *       500:
-   *         description: Internal server error
-   *         content:
-   *           application/json:
-   *             schema:
-   *               $ref: '#/components/schemas/ErrorResponse'
-   */
-  app.get(
-    buildServerPath('/api/admin/sources/_types'),
-    requireFeature('sources'),
-    contentAdminAuth,
-    async (req, res) => {
-      try {
-        const manager = getSourceManager();
-        const handlerTypes = manager.getHandlerTypes();
-
-        const types = handlerTypes.map(type => ({
-          id: type,
-          name: type.charAt(0).toUpperCase() + type.slice(1),
-          description: getTypeDescription(type),
-          defaultConfig: getDefaultSourceConfig(type)
-        }));
-
-        res.json(types);
-      } catch (error) {
-        sendFailedOperationError(res, 'fetch source types', error);
       }
     }
   );


### PR DESCRIPTION
## Summary

- `GET /api/admin/prompts/app-generator` was registered **after** `GET /api/admin/prompts/:promptId`, so Express always matched the parameterized route first and returned the raw localized `prompt` object instead of the resolved string — the App Creation Wizard's "generate app from description" step sent this broken object as the LLM system prompt.
- `GET /api/admin/sources/_stats` and `GET /api/admin/sources/_types` were similarly shadowed by `GET /api/admin/sources/:id`, making both endpoints unreachable.
- Fixed by moving each literal route registration above its parameterized sibling, matching the existing correct pattern already used in `apps.js` (`/templates` registered before `/:appId`). No handler logic was changed — this is a pure reordering.

## Test plan

- [x] `node --check` on both modified files
- [x] `npx eslint` on both modified files — no new warnings/errors introduced
- [x] Booted the dev server locally, logged in as the default local admin, and confirmed via curl:
  - `GET /api/admin/prompts/app-generator` now returns `{ id, prompt: "<string>", language }` instead of the raw localized map
  - `GET /api/admin/sources/_stats` now returns the statistics object
  - `GET /api/admin/sources/_types` now returns the source type list
  - Existing parameterized routes still work correctly for real ids: `GET /api/admin/prompts/summarize` and `GET /api/admin/sources/faq` both return the expected records, and `GET /api/admin/prompts/<nonexistent>` still 404s

Closes #1709

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QnQZzRmAX4vu4qdVgkHqTd)_