### PR TITLE
fix: keep configCache auto-refresh alive across unchanged/error cycles

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,18 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Configuration Hot-Reload No Longer Silently Stops
+
+Automatic reloading of Apps, Models, Prompts, Workflows, Agents, Tools, Groups, Platform, and
+Credentials configuration could permanently stop after the first refresh cycle that found no
+change, requiring a server restart to pick up any later edit. Separately, `platform.json`'s
+`${VAR}`-style placeholders (e.g. `deployment.environment`) made its change-detection compare
+mismatched data on every cycle, so it reloaded needlessly on every tick instead.
+
+- The periodic refresh timer for each configuration file now always re-arms, whether or not that
+  cycle found a change, so edits made after a quiet period are picked up on the next tick as
+  documented.
+- Change detection now compares the same (environment-resolved) representation on both sides, so
+  configs containing `${VAR}` placeholders no longer produce false "changed" reloads.
+- No admin action is required — the fix takes effect automatically on upgrade.

--- a/server/configCache.js
+++ b/server/configCache.js
@@ -571,6 +571,25 @@ class ConfigCache {
   }
 
   /**
+   * Resolve env-var placeholders + IHUB_* overrides for a config key and
+   * compute the resulting ETag. Shared by setCacheEntry (to cache the
+   * resolved data) and refreshCacheEntry (to compare a freshly-loaded value
+   * against the previously cached ETag). Both sides must go through this
+   * same resolution step — comparing a raw, unresolved reload against an
+   * ETag computed from resolved data made the "unchanged" check never match
+   * for any config containing `${VAR}` placeholders (e.g. platform.json,
+   * or model configs with `${OPENAI_API_KEY}`-style entries).
+   */
+  resolveForCache(key, data) {
+    const resolvedData = resolveEnvVarsInObject(data, {
+      skipPaths: ENV_VAR_SKIP_PATHS_BY_KEY[key]
+    });
+    applyIhubEnvOverrides(key, resolvedData);
+    const etag = this.generateETag(resolvedData);
+    return { resolvedData, etag };
+  }
+
+  /**
    * Set a cache entry with automatic refresh timer
    */
   setCacheEntry(key, data) {
@@ -579,17 +598,7 @@ class ConfigCache {
       clearTimeout(this.refreshTimers.get(key));
     }
 
-    // Resolve environment variables in the data, opting specific fields out
-    // when they contain user-data templates instead of env var references.
-    const resolvedData = resolveEnvVarsInObject(data, {
-      skipPaths: ENV_VAR_SKIP_PATHS_BY_KEY[key]
-    });
-
-    // Apply IHUB_* environment variable overrides
-    applyIhubEnvOverrides(key, resolvedData);
-
-    // Generate ETag for the data
-    const etag = this.generateETag(resolvedData);
+    const { resolvedData, etag } = this.resolveForCache(key, data);
 
     // Set cache entry
     this.cache.set(key, {
@@ -616,7 +625,7 @@ class ConfigCache {
       // Special handling for apps.json - load from both sources
       if (key === 'config/apps.json') {
         const apps = await loadAllApps(true, false);
-        const newEtag = this.generateETag(apps);
+        const { etag: newEtag } = this.resolveForCache(key, apps);
         const existing = this.cache.get(key);
         if (!existing || existing.etag !== newEtag) {
           this.setCacheEntry(key, apps);
@@ -632,7 +641,7 @@ class ConfigCache {
       // Special handling for models.json - load from both sources
       if (key === 'config/models.json') {
         const models = await loadAllModels(true, false);
-        const newEtag = this.generateETag(models);
+        const { etag: newEtag } = this.resolveForCache(key, models);
         const existing = this.cache.get(key);
         if (!existing || existing.etag !== newEtag) {
           this.setCacheEntry(key, models);
@@ -648,7 +657,7 @@ class ConfigCache {
       // Special handling for prompts.json - load from both sources
       if (key === 'config/prompts.json') {
         const prompts = await loadAllPrompts(true, false);
-        const newEtag = this.generateETag(prompts);
+        const { etag: newEtag } = this.resolveForCache(key, prompts);
         const existing = this.cache.get(key);
         if (!existing || existing.etag !== newEtag) {
           this.setCacheEntry(key, prompts);
@@ -664,7 +673,7 @@ class ConfigCache {
       // Special handling for workflows.json - load from both sources
       if (key === 'config/workflows.json') {
         const workflows = await loadAllWorkflows(true, false);
-        const newEtag = this.generateETag(workflows);
+        const { etag: newEtag } = this.resolveForCache(key, workflows);
         const existing = this.cache.get(key);
         if (!existing || existing.etag !== newEtag) {
           this.setCacheEntry(key, workflows);
@@ -681,7 +690,7 @@ class ConfigCache {
       if (key === 'config/agents.json') {
         try {
           const profiles = await loadAllAgentProfiles(true, false);
-          const newEtag = this.generateETag(profiles);
+          const { etag: newEtag } = this.resolveForCache(key, profiles);
           const existing = this.cache.get(key);
           if (!existing || existing.etag !== newEtag) {
             this.setCacheEntry(key, profiles);
@@ -704,7 +713,7 @@ class ConfigCache {
       if (key === 'config/tools.json') {
         const allTools = await loadAllTools(true, false);
         const expanded = expandToolFunctions(allTools);
-        const newEtag = this.generateETag(expanded);
+        const { etag: newEtag } = this.resolveForCache(key, expanded);
         const existing = this.cache.get(key);
         if (!existing || existing.etag !== newEtag) {
           this.setCacheEntry(key, expanded);
@@ -722,7 +731,7 @@ class ConfigCache {
         const groupsConfig = await loadJson(key, { useCache: false });
         if (groupsConfig !== null) {
           const resolvedConfig = resolveGroupInheritance(groupsConfig);
-          const newEtag = this.generateETag(resolvedConfig);
+          const { etag: newEtag } = this.resolveForCache(key, resolvedConfig);
           const existing = this.cache.get(key);
           if (!existing || existing.etag !== newEtag) {
             this.setCacheEntry(key, resolvedConfig);
@@ -740,7 +749,7 @@ class ConfigCache {
       if (key === 'config/platform.json') {
         const platformData = await loadJson(key, { useCache: false });
         if (platformData !== null) {
-          const newEtag = this.generateETag(platformData);
+          const { etag: newEtag } = this.resolveForCache(key, platformData);
           const existing = this.cache.get(key);
           if (!existing || existing.etag !== newEtag) {
             this.setCacheEntry(key, platformData);
@@ -754,7 +763,7 @@ class ConfigCache {
         const credentialsData = await loadJson(key, { useCache: false });
         const resolved = credentialsData !== null ? credentialsData : { credentials: {} };
         decryptCredentials(resolved);
-        const newEtag = this.generateETag(resolved);
+        const { etag: newEtag } = this.resolveForCache(key, resolved);
         const existing = this.cache.get(key);
         if (!existing || existing.etag !== newEtag) {
           this.setCacheEntry(key, resolved);
@@ -788,6 +797,24 @@ class ConfigCache {
       });
       // Keep the old data in cache on refresh failure
     } finally {
+      // Always re-arm the refresh timer, whether this cycle found changes,
+      // found no changes, or failed to reload. setCacheEntry() only re-arms
+      // when it is actually called, and several branches above skip it when
+      // the ETag comparison says "unchanged" — without this, a single quiet
+      // cycle (or transient read error) permanently stops future refreshes
+      // for this key (see #1707). Re-arming here is a harmless reset even
+      // when setCacheEntry already scheduled a timer moments earlier in the
+      // same tick.
+      if (this.refreshTimers.has(key)) {
+        clearTimeout(this.refreshTimers.get(key));
+      }
+      this.refreshTimers.set(
+        key,
+        setTimeout(() => {
+          this.refreshCacheEntry(key);
+        }, this.cacheTTL)
+      );
+
       // Telemetry: emit reload counter + duration. Lazy-imported because
       // configCache.js is itself imported very early in the boot sequence.
       try {
@@ -1504,7 +1531,7 @@ class ConfigCache {
       const skills = [...discoveredSkills.values()];
 
       // Only update cache and log if content has changed (same pattern as other caches)
-      const newEtag = this.generateETag(skills);
+      const { etag: newEtag } = this.resolveForCache('skills', skills);
       const existing = this.cache.get('skills');
       if (!existing || existing.etag !== newEtag) {
         this.setCacheEntry('skills', skills);

--- a/server/tests/configCache-refresh.test.js
+++ b/server/tests/configCache-refresh.test.js
@@ -1,0 +1,101 @@
+// Plain-node test (node server/tests/configCache-refresh.test.js).
+//
+// Regression test for #1707: configCache's per-key refresh timer only got
+// re-armed inside setCacheEntry(), which several refreshCacheEntry() branches
+// skip when the freshly-loaded data's ETag matches the cached one — so after
+// one "unchanged" cycle, that config key never refreshed again. The ETag
+// comparison itself was also broken: it hashed the raw, unresolved reload
+// against an ETag computed from resolved (env-var-substituted) data, so any
+// config with a `${VAR}`-style placeholder (platform.json ships with
+// `deployment.environment: "${NODE_ENV:-production}"`) never matched and
+// reloaded on every single tick instead.
+import { performInitialSetup } from '../utils/setupUtils.js';
+import configCache from '../configCache.js';
+
+let failures = 0;
+function check(label, cond, detail) {
+  if (!cond) failures++;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && detail) console.log('   ' + detail);
+}
+
+async function run() {
+  // Populate contents/ from server/defaults so apps.json / platform.json etc.
+  // are available to load, same as a fresh dev checkout.
+  await performInitialSetup();
+  configCache.clear();
+
+  // --- Root cause 1: timer must re-arm even when a refresh finds no change ---
+  const appsKey = 'config/apps.json';
+  await configCache.refreshCacheEntry(appsKey);
+  const firstTimer = configCache.refreshTimers.get(appsKey);
+  const firstEtag = configCache.cache.get(appsKey)?.etag;
+  check('apps cached after first refresh', !!firstEtag);
+  check('timer armed after first refresh', !!firstTimer);
+
+  await configCache.refreshCacheEntry(appsKey);
+  const secondTimer = configCache.refreshTimers.get(appsKey);
+  const secondEtag = configCache.cache.get(appsKey)?.etag;
+
+  check(
+    'apps etag unchanged across two refreshes with no underlying edits',
+    secondEtag === firstEtag,
+    `first=${firstEtag} second=${secondEtag}`
+  );
+  check(
+    'refresh timer is re-armed even when the reload is a no-op',
+    !!secondTimer && secondTimer !== firstTimer
+  );
+
+  // --- Root cause 2: ETag comparison must use the same (resolved) representation ---
+  const platformKey = 'config/platform.json';
+  await configCache.refreshCacheEntry(platformKey);
+  const platformFirstEtag = configCache.cache.get(platformKey)?.etag;
+  check('platform config cached with a templated field', !!platformFirstEtag);
+
+  await configCache.refreshCacheEntry(platformKey);
+  const platformSecondEtag = configCache.cache.get(platformKey)?.etag;
+  check(
+    'platform.json etag is stable despite ${VAR} placeholders (raw vs. resolved no longer mismatch)',
+    platformSecondEtag === platformFirstEtag,
+    `first=${platformFirstEtag} second=${platformSecondEtag}`
+  );
+
+  // --- resolveForCache helper: comparison etag matches what setCacheEntry stores ---
+  const sampleKey = 'config/models.json';
+  const sample = [{ id: 'test-model', apiKey: '${SOME_TEST_ENV_VAR}' }];
+  process.env.SOME_TEST_ENV_VAR = 'resolved-value';
+  try {
+    configCache.setCacheEntry(sampleKey, sample);
+    const stored = configCache.cache.get(sampleKey);
+    const { etag: recomputed } = configCache.resolveForCache(sampleKey, sample);
+    check(
+      'resolveForCache reproduces the etag setCacheEntry stored for the same raw input',
+      recomputed === stored.etag
+    );
+    check(
+      'setCacheEntry actually resolved the ${VAR} placeholder',
+      stored.data[0].apiKey === 'resolved-value',
+      JSON.stringify(stored.data)
+    );
+  } finally {
+    delete process.env.SOME_TEST_ENV_VAR;
+  }
+
+  // Sanity check that clear() tears everything down cleanly.
+  configCache.clear();
+  check('clear() removes all refresh timers', configCache.refreshTimers.size === 0);
+  check('clear() empties the cache', configCache.cache.size === 0);
+
+  if (failures > 0) {
+    console.error(`\n${failures} check(s) failed`);
+    process.exitCode = 1;
+  } else {
+    console.log('\nAll configCache refresh checks passed');
+  }
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

Fixes #1707 — `configCache`'s auto-refresh could permanently and silently stop for a given config key.

Two root causes, both in `server/configCache.js`:

1. **Timer only re-armed on the "changed" path.** The refresh timer for a key is scheduled inside `setCacheEntry()`, but nine special-case branches in `refreshCacheEntry()` (apps, models, prompts, workflows, agents, tools, groups, platform, credentials) only call `setCacheEntry()` when a freshly-loaded ETag differs from the cached one. When a cycle finds no change — or the reload throws — `setCacheEntry()` is skipped, so the timer is never re-armed and that key stops refreshing forever. Editing `contents/apps/*.json` (or any other affected config) after the first quiet cycle was never picked up, contradicting the documented "reloaded automatically" behavior.
2. **ETag comparison used mismatched representations.** The "changed?" check hashed the raw, unresolved reload against an ETag computed from *resolved* (env-var-substituted) data. Any config containing a `${VAR}`-style placeholder — `platform.json` ships with `deployment.environment: "${NODE_ENV:-production}"`, and model configs commonly have `${OPENAI_API_KEY}`-style entries — could never match, so it looked "changed" and reloaded needlessly on every tick instead of ever settling into the "unchanged" (timer-skipping) branch.

## Changes

- Added `resolveForCache(key, data)`, a small helper that performs the env-var resolution + IHUB override step once and returns `{ resolvedData, etag }`. `setCacheEntry()` and every refresh branch's "did this change?" comparison now go through the same helper, so both sides of every ETag comparison use the same representation.
- `refreshCacheEntry()` now always re-arms the per-key refresh timer in a `finally` block, regardless of whether the cycle found a change, found nothing new, or failed to reload.
- Applied the same fix to the skills-from-filesystem loader (`_loadSkillsFromFilesystem`), which had the identical pattern.

## Test plan

- Added `server/tests/configCache-refresh.test.js` (plain-node test, run via `node server/tests/configCache-refresh.test.js`), which:
  - Confirms the refresh timer is a *new* timer object after two consecutive refreshes of `config/apps.json` with unchanged data (previously: the timer was never re-armed on this path).
  - Confirms `config/platform.json`'s ETag stays stable across two refreshes despite its `${NODE_ENV:-production}` placeholder (previously: raw vs. resolved ETags never matched).
  - Confirms `resolveForCache()` reproduces the same ETag `setCacheEntry()` stores, and that placeholders are actually resolved.
- Verified the test fails against the pre-fix code (reverted the diff locally) and passes with the fix applied.
- `npx eslint` / `npx prettier --check` clean on all changed files.
- Smoke-tested `node server/server.js` — boots cleanly with no new errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013zws4bZu8Yeio6QmY7xfus

---
_Generated by [Claude Code](https://claude.ai/code/session_013zws4bZu8Yeio6QmY7xfus)_