### PR TITLE
fix: bound ToolExecutor.clarificationCounts instead of leaking forever

### DIFF
--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -25,6 +25,14 @@ import {
  */
 const MAX_CLARIFICATIONS = MAX_CLARIFICATIONS_PER_CONVERSATION;
 
+/**
+ * Cap on tracked chatIds in clarificationCounts. ToolExecutor is a process-wide
+ * singleton with no "conversation ended" signal to clear entries on, so the Map
+ * is bounded (insertion-ordered, evict-oldest) instead — mirrors searchCache.js.
+ * @constant {number}
+ */
+const MAX_CHAT_ENTRIES = 5000;
+
 class ToolExecutor {
   constructor() {
     this.errorHandler = new ErrorHandler();
@@ -58,17 +66,15 @@ class ToolExecutor {
   incrementClarificationCount(chatId) {
     const current = this.getClarificationCount(chatId);
     const newCount = current + 1;
+    if (
+      !this.clarificationCounts.has(chatId) &&
+      this.clarificationCounts.size >= MAX_CHAT_ENTRIES
+    ) {
+      const oldest = this.clarificationCounts.keys().next().value;
+      if (oldest !== undefined) this.clarificationCounts.delete(oldest);
+    }
     this.clarificationCounts.set(chatId, newCount);
     return newCount;
-  }
-
-  /**
-   * Reset the clarification count for a conversation
-   * Called when a conversation ends or is explicitly reset
-   * @param {string} chatId - The conversation/chat ID
-   */
-  resetClarificationCount(chatId) {
-    this.clarificationCounts.delete(chatId);
   }
 
   /**

--- a/server/tests/toolExecutor-clarification-count-cap.test.js
+++ b/server/tests/toolExecutor-clarification-count-cap.test.js
@@ -1,0 +1,70 @@
+/**
+ * Regression test for #1727: ToolExecutor is a process-wide singleton and its
+ * clarificationCounts Map (chatId -> count) had no eviction, so it grew
+ * unbounded for the life of the process. This mirrors searchCache.js's
+ * bounded, insertion-ordered, evict-oldest pattern instead.
+ *
+ * Note: The repo's source is native ESM (uses `import.meta.url`), so this file
+ * uses `jest.unstable_mockModule` + dynamic imports rather than the
+ * CommonJS-only `jest.mock` API. Run with `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+
+jest.unstable_mockModule('../adapters/index.js', () => ({
+  createCompletionRequest: async () => ({
+    url: 'https://example.invalid/chat/completions',
+    method: 'POST',
+    headers: {},
+    body: {}
+  }),
+  getAdapter: () => {
+    throw new Error('getAdapter should not be called in this test');
+  }
+}));
+
+jest.unstable_mockModule('../requestThrottler.js', () => ({
+  throttledFetch: async () => {
+    throw new Error('should not be called in this test');
+  }
+}));
+
+jest.unstable_mockModule('../usageTracker.js', () => ({
+  estimateTokens: () => 0,
+  recordChatRequest: async () => {},
+  recordChatResponse: async () => {}
+}));
+
+const { default: ToolExecutor } = await import('../services/chat/ToolExecutor.js');
+
+const MAX_CHAT_ENTRIES = 5000;
+
+describe('ToolExecutor clarificationCounts cap (#1727)', () => {
+  test('evicts the oldest chatId once the cap is exceeded instead of growing unbounded', () => {
+    const toolExecutor = new ToolExecutor();
+
+    for (let i = 0; i < MAX_CHAT_ENTRIES; i++) {
+      toolExecutor.incrementClarificationCount(`chat-${i}`);
+    }
+    expect(toolExecutor.clarificationCounts.size).toBe(MAX_CHAT_ENTRIES);
+    expect(toolExecutor.getClarificationCount('chat-0')).toBe(1);
+
+    toolExecutor.incrementClarificationCount('chat-overflow');
+
+    expect(toolExecutor.clarificationCounts.size).toBe(MAX_CHAT_ENTRIES);
+    expect(toolExecutor.getClarificationCount('chat-0')).toBe(0);
+    expect(toolExecutor.getClarificationCount('chat-overflow')).toBe(1);
+  });
+
+  test('re-incrementing an existing chatId does not evict and keeps counting', () => {
+    const toolExecutor = new ToolExecutor();
+
+    toolExecutor.incrementClarificationCount('chat-a');
+    toolExecutor.incrementClarificationCount('chat-b');
+    toolExecutor.incrementClarificationCount('chat-a');
+
+    expect(toolExecutor.getClarificationCount('chat-a')).toBe(2);
+    expect(toolExecutor.getClarificationCount('chat-b')).toBe(1);
+    expect(toolExecutor.clarificationCounts.size).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1727 (the remaining, scoped-down half — see the issue's implementation-plan comment for the status update on the other half, which was already fixed by #1876).

- `ToolExecutor` is a process-wide singleton, and `resetClarificationCount` had zero callers anywhere in the repo, so `clarificationCounts` (chatId → count) grew unbounded for the life of the server process — one entry per chatId that ever asked a clarifying question.
- There's no safe "conversation ended forever" signal to hook a reset into: the existing `resetKnowledgeSources` calls fire mid-conversation, specifically at clarification pauses (`ToolExecutor.js:1241`, `1613`) — piggybacking a reset there would incorrectly reset the per-conversation clarification rate limit (`MAX_CLARIFICATIONS_PER_CONVERSATION`), letting a user bypass it by triggering a clarification.
- Instead, bound the Map with an insertion-ordered evict-oldest policy (cap `MAX_CHAT_ENTRIES = 5000`), mirroring the existing bounded-Map pattern already used in `server/services/searchCache.js`.
- Removed the now-fully-dead `resetClarificationCount` method rather than leaving unreachable code around.

## Test plan

- [x] Added `server/tests/toolExecutor-clarification-count-cap.test.js` covering: eviction of the oldest chatId once the cap is exceeded, and that re-incrementing an existing chatId doesn't trigger eviction.
- [x] `NODE_OPTIONS=--experimental-vm-modules npx jest tests/toolExecutor-clarification-count-cap.test.js tests/toolExecutor-error-done-events.test.js tests/toolExecutor-usage-telemetry.test.js` — all pass.
- [x] `npx eslint` / `npx prettier --check` on changed files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RMq2hHMFxmTV5XD31rkPg9


---
_Generated by [Claude Code](https://claude.ai/code/session_01RMq2hHMFxmTV5XD31rkPg9)_