### PR TITLE
fix: delegate ToolExecutor stream parsing to provider adapters

### DIFF
--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -1,11 +1,10 @@
-import { createCompletionRequest } from '../../adapters/index.js';
-import { convertResponseToGeneric, clearStreamingState } from '../../adapters/toolCalling/index.js';
+import { createCompletionRequest, getAdapter } from '../../adapters/index.js';
+import { clearStreamingState } from '../../adapters/toolCalling/index.js';
 import { logInteraction, getErrorDetails } from '../../utils.js';
 import { runTool } from '../../toolLoader.js';
 import { normalizeToolName } from '../../adapters/toolCalling/index.js';
 import { activeRequests } from '../../sse.js';
 import { actionTracker } from '../../actionTracker.js';
-import { createParser } from 'eventsource-parser';
 import { throttledFetch } from '../../requestThrottler.js';
 import ErrorHandler from '../../utils/ErrorHandler.js';
 import StreamingHandler from './StreamingHandler.js';
@@ -940,129 +939,117 @@ class ToolExecutor {
           });
         }
 
-        // Use getReadableStream to handle both native fetch (Web Streams) and node-fetch (Node.js streams)
-        const readableStream = this.streamingHandler.getReadableStream(llmResponse);
-        const reader = readableStream.getReader();
-        const decoder = new TextDecoder();
-        const events = [];
-        const parser = createParser({ onEvent: e => events.push(e) });
+        // Adapters expose parseResponseStream(response, ctx) which yields normalized
+        // result chunks. The default in BaseAdapter handles SSE; iAssistant uses the
+        // line-delimited SSE variant; Bedrock parses binary EventStream frames.
+        const adapter = getAdapter(model.provider);
+        const stream = adapter.parseResponseStream(llmResponse, { model, chatId, request });
 
-        while (!done) {
-          const { value, done: readerDone } = await reader.read();
-          if (readerDone || !activeRequests.has(chatId)) {
-            if (!activeRequests.has(chatId)) reader.cancel();
-            break;
+        for await (const result of stream) {
+          if (!activeRequests.has(chatId)) break;
+          if (!result) continue;
+
+          if (result.error) {
+            throw Object.assign(new Error(result.errorMessage || 'Error processing response'), {
+              code: 'PROCESSING_ERROR'
+            });
           }
 
-          const chunk = decoder.decode(value, { stream: true });
-          parser.feed(chunk);
+          // Usage may arrive either at the top level or under metadata.usage
+          // depending on which converter emitted it.
+          if (result.usage) {
+            accumulatedUsage = mergeUsage(accumulatedUsage, result.usage);
+          }
+          if (result.metadata?.usage) {
+            accumulatedUsage = mergeUsage(accumulatedUsage, result.metadata.usage);
+          }
 
-          while (events.length > 0) {
-            const evt = events.shift();
-            const result = await convertResponseToGeneric(evt.data, model.provider, chatId);
-
-            if (result.error) {
-              throw Object.assign(new Error(result.errorMessage || 'Error processing response'), {
-                code: 'PROCESSING_ERROR'
-              });
+          // logger.info(`Result for chat ID ${chatId}:`, result);
+          if (result.content?.length > 0) {
+            for (const text of result.content) {
+              assistantContent += text;
+              actionTracker.trackChunk(chatId, { content: text });
             }
+          }
 
-            // Usage may arrive either at the top level or under metadata.usage
-            // depending on which converter emitted it.
-            if (result.usage) {
-              accumulatedUsage = mergeUsage(accumulatedUsage, result.usage);
-            }
-            if (result.metadata?.usage) {
-              accumulatedUsage = mergeUsage(accumulatedUsage, result.metadata.usage);
-            }
+          // Process images (important for image generation with tools like google_search)
+          this.streamingHandler.processImages(result, chatId);
 
-            // logger.info(`Result for chat ID ${chatId}:`, result);
-            if (result.content?.length > 0) {
-              for (const text of result.content) {
-                assistantContent += text;
-                actionTracker.trackChunk(chatId, { content: text });
-              }
-            }
+          // Process thinking content
+          this.streamingHandler.processThinking(result, chatId);
 
-            // Process images (important for image generation with tools like google_search)
-            this.streamingHandler.processImages(result, chatId);
+          // Process grounding metadata (for Google Search grounding)
+          this.streamingHandler.processGroundingMetadata(result, chatId);
 
-            // Process thinking content
-            this.streamingHandler.processThinking(result, chatId);
+          // logger.info(`Tool calls for chat ID ${chatId}:`, result.tool_calls);
+          if (result.tool_calls?.length > 0) {
+            result.tool_calls.forEach(call => {
+              let existingCall = collectedToolCalls.find(c => c.index === call.index);
 
-            // Process grounding metadata (for Google Search grounding)
-            this.streamingHandler.processGroundingMetadata(result, chatId);
+              if (existingCall) {
+                // Merge properties into the existing tool call
+                if (call.id) existingCall.id = call.id;
+                if (call.type) existingCall.type = call.type;
+                // Preserve metadata (critical for thoughtSignature in Gemini 3)
+                if (call.metadata) existingCall.metadata = call.metadata;
+                if (call.function) {
+                  if (call.function.name) existingCall.function.name = call.function.name;
 
-            // logger.info(`Tool calls for chat ID ${chatId}:`, result.tool_calls);
-            if (result.tool_calls?.length > 0) {
-              result.tool_calls.forEach(call => {
-                let existingCall = collectedToolCalls.find(c => c.index === call.index);
-
-                if (existingCall) {
-                  // Merge properties into the existing tool call
-                  if (call.id) existingCall.id = call.id;
-                  if (call.type) existingCall.type = call.type;
-                  // Preserve metadata (critical for thoughtSignature in Gemini 3)
-                  if (call.metadata) existingCall.metadata = call.metadata;
-                  if (call.function) {
-                    if (call.function.name) existingCall.function.name = call.function.name;
-
-                    // Handle arguments accumulation for streaming
-                    let callArgs = call.function.arguments;
-                    if (call.arguments && call.arguments.__raw_arguments) {
-                      callArgs = call.arguments.__raw_arguments;
-                    }
-                    if (callArgs) {
-                      // Smart concatenation: avoid empty {} + real args pattern
-                      const existing = existingCall.function.arguments;
-                      if (!existing || existing === '{}' || existing.trim() === '') {
-                        // If existing is empty or just {}, replace it entirely
-                        existingCall.function.arguments = callArgs;
-                      } else if (callArgs !== '{}' && callArgs.trim() !== '') {
-                        // Only concatenate if new args aren't empty
-                        existingCall.function.arguments += callArgs;
-                      }
-                    }
-                  }
-                } else if (call.index !== undefined) {
-                  // Create a new tool call if it doesn't exist
-                  let initialArgs = call.function?.arguments || '';
+                  // Handle arguments accumulation for streaming
+                  let callArgs = call.function.arguments;
                   if (call.arguments && call.arguments.__raw_arguments) {
-                    initialArgs = call.arguments.__raw_arguments;
+                    callArgs = call.arguments.__raw_arguments;
                   }
-
-                  // Clean up initial args - avoid starting with empty {}
-                  if (initialArgs === '{}' || initialArgs.trim() === '') {
-                    initialArgs = '';
-                  }
-
-                  collectedToolCalls.push({
-                    index: call.index,
-                    id: call.id || null,
-                    type: call.type || 'function',
-                    metadata: call.metadata || {}, // Preserve metadata (critical for thoughtSignature)
-                    function: {
-                      name: call.function?.name || '',
-                      arguments: initialArgs
+                  if (callArgs) {
+                    // Smart concatenation: avoid empty {} + real args pattern
+                    const existing = existingCall.function.arguments;
+                    if (!existing || existing === '{}' || existing.trim() === '') {
+                      // If existing is empty or just {}, replace it entirely
+                      existingCall.function.arguments = callArgs;
+                    } else if (callArgs !== '{}' && callArgs.trim() !== '') {
+                      // Only concatenate if new args aren't empty
+                      existingCall.function.arguments += callArgs;
                     }
-                  });
+                  }
                 }
-              });
-            }
+              } else if (call.index !== undefined) {
+                // Create a new tool call if it doesn't exist
+                let initialArgs = call.function?.arguments || '';
+                if (call.arguments && call.arguments.__raw_arguments) {
+                  initialArgs = call.arguments.__raw_arguments;
+                }
 
-            // logger.info(`Finish Reason for chat ID ${chatId}:`, finishReason);
-            if (result.finishReason) {
-              finishReason = result.finishReason;
-            }
+                // Clean up initial args - avoid starting with empty {}
+                if (initialArgs === '{}' || initialArgs.trim() === '') {
+                  initialArgs = '';
+                }
 
-            // logger.info(
-            //   `Completed processing for chat ID ${chatId} - done? ${done}:`,
-            //   JSON.stringify({ finishReason, collectedToolCalls }, null, 2)
-            // );
-            if (result.complete) {
-              done = true;
-              break;
-            }
+                collectedToolCalls.push({
+                  index: call.index,
+                  id: call.id || null,
+                  type: call.type || 'function',
+                  metadata: call.metadata || {}, // Preserve metadata (critical for thoughtSignature)
+                  function: {
+                    name: call.function?.name || '',
+                    arguments: initialArgs
+                  }
+                });
+              }
+            });
+          }
+
+          // logger.info(`Finish Reason for chat ID ${chatId}:`, finishReason);
+          if (result.finishReason) {
+            finishReason = result.finishReason;
+          }
+
+          // logger.info(
+          //   `Completed processing for chat ID ${chatId} - done? ${done}:`,
+          //   JSON.stringify({ finishReason, collectedToolCalls }, null, 2)
+          // );
+          if (result.complete) {
+            done = true;
+            break;
           }
         }
 
@@ -1425,99 +1412,91 @@ class ToolExecutor {
             });
           }
 
-          // Use getReadableStream to handle both native fetch (Web Streams) and node-fetch (Node.js streams)
-          const readableStream = this.streamingHandler.getReadableStream(llmResponse);
-          const reader = readableStream.getReader();
-          const decoder = new TextDecoder();
-          const events = [];
-          const parser = createParser({ onEvent: e => events.push(e) });
+          // Adapters expose parseResponseStream(response, ctx) which yields normalized
+          // result chunks. The default in BaseAdapter handles SSE; iAssistant uses the
+          // line-delimited SSE variant; Bedrock parses binary EventStream frames.
+          const adapter = getAdapter(model.provider);
+          const stream = adapter.parseResponseStream(llmResponse, {
+            model,
+            chatId,
+            request: followRequest
+          });
 
-          while (!done) {
-            const { value, done: readerDone } = await reader.read();
-            if (readerDone || !activeRequests.has(chatId)) {
-              if (!activeRequests.has(chatId)) reader.cancel();
-              break;
+          for await (const result of stream) {
+            if (!activeRequests.has(chatId)) break;
+            if (!result) continue;
+
+            if (result.error) {
+              throw Object.assign(new Error(result.errorMessage || 'Error processing response'), {
+                code: 'PROCESSING_ERROR'
+              });
             }
 
-            const chunk = decoder.decode(value, { stream: true });
-            parser.feed(chunk);
+            // Usage may arrive either at the top level or under metadata.usage
+            // depending on which converter emitted it.
+            if (result.usage) {
+              accumulatedUsage = mergeUsage(accumulatedUsage, result.usage);
+            }
+            if (result.metadata?.usage) {
+              accumulatedUsage = mergeUsage(accumulatedUsage, result.metadata.usage);
+            }
 
-            while (events.length > 0) {
-              const evt = events.shift();
-              const result = await convertResponseToGeneric(evt.data, model.provider, chatId);
-
-              if (result.error) {
-                throw Object.assign(new Error(result.errorMessage || 'Error processing response'), {
-                  code: 'PROCESSING_ERROR'
-                });
+            if (result.content?.length > 0) {
+              for (const text of result.content) {
+                assistantContent += text;
+                actionTracker.trackChunk(chatId, { content: text });
               }
+            }
 
-              // Usage may arrive either at the top level or under metadata.usage
-              // depending on which converter emitted it.
-              if (result.usage) {
-                accumulatedUsage = mergeUsage(accumulatedUsage, result.usage);
-              }
-              if (result.metadata?.usage) {
-                accumulatedUsage = mergeUsage(accumulatedUsage, result.metadata.usage);
-              }
+            if (result.tool_calls?.length > 0) {
+              result.tool_calls.forEach(call => {
+                let existingCall = collectedToolCalls.find(c => c.index === call.index);
 
-              if (result.content?.length > 0) {
-                for (const text of result.content) {
-                  assistantContent += text;
-                  actionTracker.trackChunk(chatId, { content: text });
-                }
-              }
-
-              if (result.tool_calls?.length > 0) {
-                result.tool_calls.forEach(call => {
-                  let existingCall = collectedToolCalls.find(c => c.index === call.index);
-
-                  if (existingCall) {
-                    if (call.id) existingCall.id = call.id;
-                    if (call.type) existingCall.type = call.type;
-                    if (call.function) {
-                      if (call.function.name) existingCall.function.name = call.function.name;
-                      if (call.function.arguments)
-                        existingCall.function.arguments += call.function.arguments;
-                    }
-                    // Merge metadata (important for Gemini thoughtSignatures)
-                    if (call.metadata) {
-                      existingCall.metadata = { ...existingCall.metadata, ...call.metadata };
-                    }
-                  } else if (call.index !== undefined) {
-                    const toolCall = {
-                      index: call.index,
-                      id: call.id || null,
-                      type: call.type || 'function',
-                      function: {
-                        name: call.function?.name || '',
-                        arguments: call.function?.arguments || ''
-                      },
-                      // Preserve metadata for provider-specific requirements (e.g., Gemini thoughtSignatures)
-                      metadata: call.metadata || {}
-                    };
-                    collectedToolCalls.push(toolCall);
+                if (existingCall) {
+                  if (call.id) existingCall.id = call.id;
+                  if (call.type) existingCall.type = call.type;
+                  if (call.function) {
+                    if (call.function.name) existingCall.function.name = call.function.name;
+                    if (call.function.arguments)
+                      existingCall.function.arguments += call.function.arguments;
                   }
-                });
-              }
+                  // Merge metadata (important for Gemini thoughtSignatures)
+                  if (call.metadata) {
+                    existingCall.metadata = { ...existingCall.metadata, ...call.metadata };
+                  }
+                } else if (call.index !== undefined) {
+                  const toolCall = {
+                    index: call.index,
+                    id: call.id || null,
+                    type: call.type || 'function',
+                    function: {
+                      name: call.function?.name || '',
+                      arguments: call.function?.arguments || ''
+                    },
+                    // Preserve metadata for provider-specific requirements (e.g., Gemini thoughtSignatures)
+                    metadata: call.metadata || {}
+                  };
+                  collectedToolCalls.push(toolCall);
+                }
+              });
+            }
 
-              // Collect thoughtSignatures for Google Gemini thinking models
-              if (result.thoughtSignatures && result.thoughtSignatures.length > 0) {
-                collectedThoughtSignatures.push(...result.thoughtSignatures);
-                logger.info('Collected thoughtSignatures from response', {
-                  component: 'ToolExecutor',
-                  count: result.thoughtSignatures.length
-                });
-              }
+            // Collect thoughtSignatures for Google Gemini thinking models
+            if (result.thoughtSignatures && result.thoughtSignatures.length > 0) {
+              collectedThoughtSignatures.push(...result.thoughtSignatures);
+              logger.info('Collected thoughtSignatures from response', {
+                component: 'ToolExecutor',
+                count: result.thoughtSignatures.length
+              });
+            }
 
-              if (result.finishReason) {
-                finishReason = result.finishReason;
-              }
+            if (result.finishReason) {
+              finishReason = result.finishReason;
+            }
 
-              if (result.complete) {
-                done = true;
-                break;
-              }
+            if (result.complete) {
+              done = true;
+              break;
             }
           }
 

--- a/server/tests/toolExecutor-usage-telemetry.test.js
+++ b/server/tests/toolExecutor-usage-telemetry.test.js
@@ -22,20 +22,27 @@ jest.unstable_mockModule('../adapters/index.js', () => ({
     headers: {},
     body: { model: model.modelId, temperature: opts.temperature }
   }),
-  // StreamingHandler (imported transitively by ToolExecutor) needs this export
-  // to exist even though these tests never reach it.
-  getAdapter: () => {
-    throw new Error('getAdapter should not be called in this test');
-  }
+  // ToolExecutor now delegates stream parsing to the provider adapter (like
+  // StreamingHandler already did) instead of hand-rolling SSE parsing, so the
+  // fake adapter just replays the pre-built generic result chunks directly —
+  // bypassing real provider-specific wire-format parsing, which isn't what's
+  // under test here.
+  getAdapter: () => ({
+    parseResponseStream: async function* (response) {
+      for (const chunk of response.chunks) {
+        yield chunk;
+      }
+    }
+  })
 }));
 
 jest.unstable_mockModule('../adapters/toolCalling/index.js', () => ({
   normalizeToolName: id => id,
   isFailureFinishReason: () => false,
   clearStreamingState: () => {},
-  // Each mocked SSE event's `data` is a JSON-encoded generic result chunk —
-  // bypass real provider-specific parsing since that's not what's under test.
-  convertResponseToGeneric: async data => JSON.parse(data)
+  // Unused by ToolExecutor directly, but utils.js (a transitive dependency)
+  // statically imports it, so the mock module must still provide it.
+  convertResponseToGeneric: async () => ({})
 }));
 
 // usageTracker.js also schedules an un-refed, module-scope setInterval (its
@@ -70,21 +77,11 @@ jest.unstable_mockModule('../requestThrottler.js', () => ({
 const { default: ToolExecutor } = await import('../services/chat/ToolExecutor.js');
 
 /**
- * Build a fetch-like Response whose body streams the given generic result
- * chunks as SSE `data:` events (matching what convertResponseToGeneric, mocked
- * above, expects to receive as its raw `data` argument).
+ * Build a fetch-like Response carrying the pre-built generic result chunks
+ * that the fake adapter (mocked above) replays as-is via parseResponseStream.
  */
 function sseResponse(chunks) {
-  const encoder = new TextEncoder();
-  const body = new ReadableStream({
-    start(controller) {
-      for (const chunk of chunks) {
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`));
-      }
-      controller.close();
-    }
-  });
-  return { ok: true, body };
+  return { ok: true, chunks };
 }
 
 function buildLogData() {

--- a/tests/unit/server/tool-executor-answer-source-detection.test.js
+++ b/tests/unit/server/tool-executor-answer-source-detection.test.js
@@ -46,22 +46,29 @@ jest.mock('../../../server/requestThrottler.js', () => ({
   }))
 }));
 
-// convertResponseToGeneric turns each SSE data frame into a normalized result.
-// Return a final answer with no tool calls so the loop terminates immediately.
 jest.mock('../../../server/adapters/toolCalling/index.js', () => ({
-  convertResponseToGeneric: jest.fn(async () => ({
-    content: ['Here is your answer.'],
-    finishReason: 'stop',
-    complete: true,
-    tool_calls: []
-  })),
   clearStreamingState: jest.fn(),
-  normalizeToolName: x => x
+  normalizeToolName: x => x,
+  // Unused by ToolExecutor directly, but utils.js (a transitive dependency)
+  // statically imports it, so the mock module must still provide it.
+  convertResponseToGeneric: jest.fn(async () => ({}))
 }));
 
+// ToolExecutor delegates stream parsing to the provider adapter's
+// parseResponseStream(); yield a final answer with no tool calls so the loop
+// terminates immediately.
 jest.mock('../../../server/adapters/index.js', () => ({
   createCompletionRequest: jest.fn(),
-  getAdapter: () => ({})
+  getAdapter: () => ({
+    parseResponseStream: async function* () {
+      yield {
+        content: ['Here is your answer.'],
+        finishReason: 'stop',
+        complete: true,
+        tool_calls: []
+      };
+    }
+  })
 }));
 
 jest.mock('../../../server/toolLoader.js', () => ({


### PR DESCRIPTION
## Summary

Fixes #1704.

`ToolExecutor` hand-rolled SSE parsing (`eventsource-parser` + `convertResponseToGeneric`) in both of its streaming loops instead of delegating to the provider adapter's `parseResponseStream()`, the way `StreamingHandler` already does. For providers whose streams aren't `text/event-stream` (Bedrock's binary EventStream framing, iAssistant's line-delimited variant), the hand-rolled SSE parser silently produced no events — any app with `tools` enabled on those providers returned an empty response with no error.

- Both loops in `server/services/chat/ToolExecutor.js` now do `const adapter = getAdapter(model.provider); for await (const result of adapter.parseResponseStream(llmResponse, { model, chatId, request })) { ... }`, matching `StreamingHandler.js`'s existing pattern. Stream-format knowledge now lives only in the adapters (`BaseAdapter.parseSseStream`, `bedrock.js`, `iassistant-conversation.js`).
- Removed the now-unused `createParser` (`eventsource-parser`) and `convertResponseToGeneric` imports from `ToolExecutor.js`.
- `result.error` still throws the same `PROCESSING_ERROR` so the existing outer catch/error handling in `ToolExecutor` is unaffected; breaking out of the `for await` loop still runs each adapter generator's `finally` cleanup (reader release, `clearStreamingState`), so the explicit reader-cancel-on-disconnect branch is no longer needed.
- Updated two tests (`server/tests/toolExecutor-usage-telemetry.test.js`, `tests/unit/server/tool-executor-answer-source-detection.test.js`) that previously mocked `convertResponseToGeneric` directly to instead mock `getAdapter()` to return a fake adapter with `parseResponseStream`, matching the new call path (mirroring the pattern already used in `tests/unit/server/streaming-answer-source-detection.test.js`).

## Test plan

- [x] `npm run lint:fix` / `prettier --check` on changed files — clean
- [x] `NODE_OPTIONS=--experimental-vm-modules npx jest tests/toolExecutor-usage-telemetry.test.js tests/toolExecutor-error-done-events.test.js` (server/tests) — pass
- [x] `NODE_OPTIONS=--experimental-vm-modules npx jest --config tests/config/jest.config.js tests/unit/server/tool-executor-answer-source-detection.test.js` — pre-existing ESM/`require` infra failure in this suite reproduces identically on unmodified `main` (unrelated to this change, tracked separately by #1705/#1706)
- [x] Full `server/tests` jest run — same 3 suites fail before and after this change (`gemini-thought-signature`, `group-handling`, `comprehensive-api-documentation`), confirming no new regressions
- [x] `node server/server.js` boots cleanly after the change
- [ ] Manual end-to-end test against a real Bedrock model with tools enabled (no Bedrock credentials available in this environment — recommend verifying in a follow-up or staging environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ar9r8FKM3pZeHWd3EDP6xS

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar9r8FKM3pZeHWd3EDP6xS)_