### PR TITLE
refactor: extract shared LLM retry/backoff helper; remove dead ChatService field

### DIFF
--- a/server/services/llm/retryWithBackoff.js
+++ b/server/services/llm/retryWithBackoff.js
@@ -1,0 +1,139 @@
+/**
+ * Shared transient-error retry/backoff helper for LLM HTTP calls.
+ *
+ * Extracted from WorkflowLLMHelper (the only LLM invocation path that had any
+ * retry logic) so other paths (simpleCompletion, etc.) can reuse the same
+ * transient-error classification and backoff computation instead of having
+ * none at all. WorkflowLLMHelper re-exports these for backward compatibility
+ * with existing importers.
+ *
+ * @module services/llm/retryWithBackoff
+ */
+
+const NETWORK_ERROR_CODES =
+  /ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EPIPE|ECONNABORTED/i;
+const NETWORK_ERROR_MESSAGES = /fetch failed|network|socket hang up|timeout|terminated|aborted/i;
+
+/**
+ * Whether an HTTP status from a provider is a TRANSIENT failure worth retrying.
+ * 429 (rate limit — honor Retry-After) and any 5xx (server-side / overload).
+ * 4xx other than 429 are caller errors (bad request, auth, context window) and
+ * must NOT be retried — retrying can't fix them and just wastes the budget.
+ *
+ * @param {number} status - HTTP status code
+ * @returns {boolean}
+ */
+export function isTransientHttpStatus(status) {
+  if (typeof status !== 'number') return false;
+  if (status === 429) return true;
+  return status >= 500 && status < 600;
+}
+
+/**
+ * Whether a thrown error should be retried. Two transient classes:
+ *   1. A classified HTTP error (has `.status`) whose status is transient.
+ *   2. A transport/network fault thrown BEFORE any response (no `.status`),
+ *      recognized by its node error code or message. We deliberately do NOT
+ *      treat an arbitrary status-less error (e.g. a logic bug) as transient,
+ *      so we don't silently retry real defects.
+ *
+ * @param {Error & { status?: number, code?: string }} err
+ * @returns {boolean}
+ */
+export function isTransientLlmError(err) {
+  if (!err) return false;
+  if (err.status != null) return isTransientHttpStatus(err.status);
+  const code = typeof err.code === 'string' ? err.code : '';
+  const msg = typeof err.message === 'string' ? err.message : '';
+  return NETWORK_ERROR_CODES.test(code) || NETWORK_ERROR_MESSAGES.test(msg);
+}
+
+/**
+ * Parse a `Retry-After` header into milliseconds. Supports the integer-seconds
+ * form (what Google sends) and an HTTP-date; returns null when absent or
+ * unparseable so the caller falls back to exponential backoff.
+ *
+ * @param {string|number|null|undefined} retryAfter - raw header value
+ * @returns {number|null} delay in ms, or null
+ */
+export function parseRetryAfterMs(retryAfter) {
+  if (retryAfter == null) return null;
+  const s = String(retryAfter).trim();
+  if (s === '') return null;
+  if (/^\d+$/.test(s)) return Number(s) * 1000;
+  const dateMs = Date.parse(s);
+  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
+  return null;
+}
+
+/**
+ * Compute the delay before the next retry. Honors a server-instructed
+ * `Retry-After` (bounded only by `retryAfterCapMs`); otherwise exponential
+ * backoff (base · 2^attempt) plus up to `baseMs` of jitter, capped at `capMs`.
+ *
+ * A server-instructed delay is NOT clamped to the small backoff `capMs`:
+ * retrying before the server's stated window has elapsed just re-trips the
+ * rate limit and burns the whole retry budget. It is bounded by a separate,
+ * larger `retryAfterCapMs` only to guard against an absurd header value.
+ *
+ * @param {number} attempt - zero-based attempt index that just failed
+ * @param {Object} [opts]
+ * @param {number|null} [opts.retryAfterMs] - server-instructed delay, if any
+ * @param {number} [opts.baseMs=1000]
+ * @param {number} [opts.capMs=15000] - cap for computed exponential backoff
+ * @param {number} [opts.retryAfterCapMs=60000] - upper bound for an explicit Retry-After
+ * @param {() => number} [opts.jitter=Math.random]
+ * @returns {number} delay in ms
+ */
+export function computeRetryDelayMs(
+  attempt,
+  {
+    retryAfterMs = null,
+    baseMs = 1000,
+    capMs = 15000,
+    retryAfterCapMs = 60000,
+    jitter = Math.random
+  } = {}
+) {
+  if (typeof retryAfterMs === 'number' && retryAfterMs >= 0) {
+    return Math.min(retryAfterMs, retryAfterCapMs);
+  }
+  const exp = baseMs * Math.pow(2, attempt);
+  const jitterMs = Math.floor(jitter() * baseMs);
+  return Math.min(exp + jitterMs, capMs);
+}
+
+function defaultSleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Run `fn` and retry it on transient errors with exponential backoff.
+ *
+ * `fn(attempt)` is invoked once per attempt and must either return a value
+ * (success) or throw. A thrown error is retried only when
+ * `isTransientLlmError` says so and the retry budget remains; otherwise it
+ * propagates unchanged. A `.retryAfterMs` on the error (parsed from a
+ * provider Retry-After header) overrides the computed backoff.
+ *
+ * @param {(attempt: number) => Promise<any>} fn
+ * @param {Object} [opts]
+ * @param {number} [opts.maxRetries=3]
+ * @param {(info: {attempt:number, err:Error, delayMs:number}) => void} [opts.onRetry]
+ * @param {(ms: number) => Promise<void>} [opts.sleep] - overridable for tests
+ * @returns {Promise<any>} fn's successful return value
+ */
+export async function runWithRetries(fn, { maxRetries = 3, onRetry, sleep = defaultSleep } = {}) {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await fn(attempt);
+    } catch (err) {
+      if (attempt >= maxRetries || !isTransientLlmError(err)) throw err;
+      const delayMs = computeRetryDelayMs(attempt, {
+        retryAfterMs: typeof err?.retryAfterMs === 'number' ? err.retryAfterMs : null
+      });
+      if (onRetry) onRetry({ attempt, err, delayMs });
+      await sleep(delayMs);
+    }
+  }
+}

--- a/server/services/workflow/WorkflowLLMHelper.js
+++ b/server/services/workflow/WorkflowLLMHelper.js
@@ -22,6 +22,18 @@ import ErrorHandler from '../../utils/ErrorHandler.js';
 import logger from '../../utils/logger.js';
 import { createParser } from 'eventsource-parser';
 import { filterAdapterOptions as filterAdapterOptionsPure } from './adapterOptions.js';
+import {
+  isTransientHttpStatus,
+  isTransientLlmError,
+  parseRetryAfterMs,
+  computeRetryDelayMs,
+  runWithRetries
+} from '../llm/retryWithBackoff.js';
+
+// Re-exported for backward compatibility — these used to be defined here;
+// the implementation now lives in services/llm/retryWithBackoff.js so other
+// LLM invocation paths (e.g. simpleCompletion) can share it too.
+export { isTransientHttpStatus, isTransientLlmError, parseRetryAfterMs, computeRetryDelayMs };
 
 /**
  * Default number of retries for transient LLM errors. A brief Google 503
@@ -34,99 +46,6 @@ const DEFAULT_TRANSIENT_RETRIES = (() => {
   const fromEnv = Number(process.env.WORKFLOW_LLM_TRANSIENT_RETRIES);
   return Number.isFinite(fromEnv) && fromEnv >= 0 ? fromEnv : 3;
 })();
-
-const NETWORK_ERROR_CODES =
-  /ECONNRESET|ETIMEDOUT|ENOTFOUND|EAI_AGAIN|ECONNREFUSED|EPIPE|ECONNABORTED/i;
-const NETWORK_ERROR_MESSAGES = /fetch failed|network|socket hang up|timeout|terminated|aborted/i;
-
-/**
- * Whether an HTTP status from a provider is a TRANSIENT failure worth retrying.
- * 429 (rate limit — honor Retry-After) and any 5xx (server-side / overload).
- * 4xx other than 429 are caller errors (bad request, auth, context window) and
- * must NOT be retried — retrying can't fix them and just wastes the budget.
- *
- * @param {number} status - HTTP status code
- * @returns {boolean}
- */
-export function isTransientHttpStatus(status) {
-  if (typeof status !== 'number') return false;
-  if (status === 429) return true;
-  return status >= 500 && status < 600;
-}
-
-/**
- * Whether a thrown error should be retried. Two transient classes:
- *   1. A classified HTTP error (has `.status`) whose status is transient.
- *   2. A transport/network fault thrown BEFORE any response (no `.status`),
- *      recognized by its node error code or message. We deliberately do NOT
- *      treat an arbitrary status-less error (e.g. a logic bug) as transient,
- *      so we don't silently retry real defects.
- *
- * @param {Error & { status?: number, code?: string }} err
- * @returns {boolean}
- */
-export function isTransientLlmError(err) {
-  if (!err) return false;
-  if (err.status != null) return isTransientHttpStatus(err.status);
-  const code = typeof err.code === 'string' ? err.code : '';
-  const msg = typeof err.message === 'string' ? err.message : '';
-  return NETWORK_ERROR_CODES.test(code) || NETWORK_ERROR_MESSAGES.test(msg);
-}
-
-/**
- * Parse a `Retry-After` header into milliseconds. Supports the integer-seconds
- * form (what Google sends) and an HTTP-date; returns null when absent or
- * unparseable so the caller falls back to exponential backoff.
- *
- * @param {string|number|null|undefined} retryAfter - raw header value
- * @returns {number|null} delay in ms, or null
- */
-export function parseRetryAfterMs(retryAfter) {
-  if (retryAfter == null) return null;
-  const s = String(retryAfter).trim();
-  if (s === '') return null;
-  if (/^\d+$/.test(s)) return Number(s) * 1000;
-  const dateMs = Date.parse(s);
-  if (!Number.isNaN(dateMs)) return Math.max(0, dateMs - Date.now());
-  return null;
-}
-
-/**
- * Compute the delay before the next retry. Honors a server-instructed
- * `Retry-After` (bounded only by `retryAfterCapMs`); otherwise exponential
- * backoff (base · 2^attempt) plus up to `baseMs` of jitter, capped at `capMs`.
- *
- * A server-instructed delay is NOT clamped to the small backoff `capMs`:
- * retrying before the server's stated window has elapsed just re-trips the
- * rate limit and burns the whole retry budget. It is bounded by a separate,
- * larger `retryAfterCapMs` only to guard against an absurd header value.
- *
- * @param {number} attempt - zero-based attempt index that just failed
- * @param {Object} [opts]
- * @param {number|null} [opts.retryAfterMs] - server-instructed delay, if any
- * @param {number} [opts.baseMs=1000]
- * @param {number} [opts.capMs=15000] - cap for computed exponential backoff
- * @param {number} [opts.retryAfterCapMs=60000] - upper bound for an explicit Retry-After
- * @param {() => number} [opts.jitter=Math.random]
- * @returns {number} delay in ms
- */
-export function computeRetryDelayMs(
-  attempt,
-  {
-    retryAfterMs = null,
-    baseMs = 1000,
-    capMs = 15000,
-    retryAfterCapMs = 60000,
-    jitter = Math.random
-  } = {}
-) {
-  if (typeof retryAfterMs === 'number' && retryAfterMs >= 0) {
-    return Math.min(retryAfterMs, retryAfterCapMs);
-  }
-  const exp = baseMs * Math.pow(2, attempt);
-  const jitterMs = Math.floor(jitter() * baseMs);
-  return Math.min(exp + jitterMs, capMs);
-}
 
 /**
  * Helper class for workflow LLM operations.
@@ -179,18 +98,7 @@ export class WorkflowLLMHelper {
    */
   async _runWithRetries(fn, { maxRetries, onRetry } = {}) {
     const budget = Number.isFinite(maxRetries) ? maxRetries : this.maxRetries;
-    for (let attempt = 0; ; attempt++) {
-      try {
-        return await fn(attempt);
-      } catch (err) {
-        if (attempt >= budget || !isTransientLlmError(err)) throw err;
-        const delayMs = computeRetryDelayMs(attempt, {
-          retryAfterMs: typeof err?.retryAfterMs === 'number' ? err.retryAfterMs : null
-        });
-        if (onRetry) onRetry({ attempt, err, delayMs });
-        await this._sleep(delayMs);
-      }
-    }
+    return runWithRetries(fn, { maxRetries: budget, onRetry, sleep: ms => this._sleep(ms) });
   }
 
   /**

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -8,15 +8,14 @@
  * - Parse structured output according to a schema
  * - Maintain conversation context within the workflow
  *
- * This executor integrates with the existing ChatService and ToolExecutor
- * to provide full LLM capabilities within a workflow context.
+ * This executor invokes the LLM directly via WorkflowLLMHelper and runs its
+ * own tool-calling loop (see executeLLMWithTools/executeToolCall below).
  *
  * @module services/workflow/executors/PromptNodeExecutor
  */
 
 import { BaseNodeExecutor } from './BaseNodeExecutor.js';
 import { thinkingConfigToOptions } from '../thinkingOptions.js';
-import ChatService from '../../chat/ChatService.js';
 import { normalizeToolName } from '../../../adapters/toolCalling/index.js';
 import { actionTracker } from '../../../actionTracker.js';
 import { getToolsForApp, runTool, resolveNativeWebSearchProvider } from '../../../toolLoader.js';
@@ -96,7 +95,6 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
    */
   constructor(options = {}) {
     super(options);
-    this.chatService = options.chatService || new ChatService();
     this.llmHelper = options.llmHelper || new WorkflowLLMHelper();
     this.maxIterations = options.maxIterations || 10;
     this.contextSummarizer = new ContextSummarizer();

--- a/server/utils.js
+++ b/server/utils.js
@@ -8,6 +8,7 @@ import { throttledFetch } from './requestThrottler.js';
 import configCache from './configCache.js';
 import tokenStorageService from './services/TokenStorageService.js';
 import logger from './utils/logger.js';
+import { runWithRetries, parseRetryAfterMs } from './services/llm/retryWithBackoff.js';
 
 /**
  * Sanitize user-provided input for logging to prevent log injection
@@ -548,16 +549,27 @@ export async function simpleCompletion(
     responseSchema
   });
 
-  const response = await throttledFetch(modelConfig.id, request.url, {
-    method: 'POST',
-    headers: request.headers,
-    body: JSON.stringify(request.body)
-  });
+  // Retry transient provider failures (429 / 5xx / network blips) with
+  // exponential backoff — this path previously had zero retry, unlike the
+  // workflow LLM path, so a single transient 503 failed the whole call.
+  const response = await runWithRetries(async () => {
+    const res = await throttledFetch(modelConfig.id, request.url, {
+      method: 'POST',
+      headers: request.headers,
+      body: JSON.stringify(request.body)
+    });
 
-  if (!response.ok) {
-    const errorBody = await response.text();
-    throw new Error(`LLM API request failed with status ${response.status}: ${errorBody}`);
-  }
+    if (!res.ok) {
+      const errorBody = await res.text();
+      const error = new Error(`LLM API request failed with status ${res.status}: ${errorBody}`);
+      error.status = res.status;
+      error.retryAfterMs = parseRetryAfterMs(
+        typeof res.headers?.get === 'function' ? res.headers.get('retry-after') : null
+      );
+      throw error;
+    }
+    return res;
+  });
 
   const responseData = await response.json();
 


### PR DESCRIPTION
## Summary

Closes part of #1702 ("Consolidate five parallel LLM invocation paths"). That issue's own implementation plan recommends a staged rollout (dead-code removal → SSE parser → retry wrapper → usage normalization → tool-loop merge, in order of risk). This PR lands the two lowest-risk, purely additive stages; the rest is left as follow-up work, as the plan itself suggests.

- **Extract a shared retry/backoff helper.** `WorkflowLLMHelper` was the only one of the five LLM invocation paths (chat pipeline, workflow tool loop, `WorkflowLLMHelper`, `simpleCompletion`, `openaiProxy`) with any transient-error retry logic. Moved `isTransientHttpStatus`, `isTransientLlmError`, `parseRetryAfterMs`, `computeRetryDelayMs`, and the retry loop itself into a new standalone module, `server/services/llm/retryWithBackoff.js`, so other paths can reuse it. `WorkflowLLMHelper` now delegates to it and re-exports the same names for backward compatibility (verified via the existing `server/tests/workflow-llm-retry.test.js`, unchanged and passing).
- **Apply retry to `simpleCompletion`** (`server/utils.js`), used by magic-prompt, translate, admin model-test, and agent tools. It previously had zero retry, so a single transient 503/429 failed the call outright. It now retries with the same backoff policy as the workflow path.
- **Delete confirmed dead code**: `PromptNodeExecutor`'s `this.chatService = options.chatService || new ChatService()` field had zero reads anywhere in the file (verified by grep) and its class docstring's claim of integrating with `ChatService` was stale. Removed the field, its import, and corrected the docstring.

## Why

Per #1702: bugs and improvements to retry/error-handling/usage-accounting currently have to be fixed in up to four places, and are verifiably *not* consistently — e.g. only the workflow path had retry at all. Consolidating the retry logic first is the highest-value, lowest-risk step per the issue's own analysis, since it's purely additive (nothing to regress, only new resilience). The `ChatService` field was pure waste: every `PromptNodeExecutor` construction instantiated a full `ChatService` (which itself constructs `RequestBuilder`/`NonStreamingHandler`/`StreamingHandler`/`ToolExecutor`) that was never used.

## Out of scope (tracked in #1702 for follow-up)

- Canonicalizing the three divergent SSE-parsing implementations (`BaseAdapter.parseSseStream`, `ToolExecutor`'s inline parser, `WorkflowLLMHelper`'s inline parser) plus `openaiProxy`'s hand-rolled buffer splitter.
- Merging `ToolExecutor.continueWithToolExecution` and `PromptNodeExecutor.executeLLMWithTools`'s two independent tool-calling loops.
- Normalizing usage/token accounting to one shape across all five paths (including fixing `openaiProxy`'s hardcoded `{0,0,0}` non-streaming usage).
- Wiring retry into `StreamingHandler`/`ToolExecutor`/`NonStreamingHandler`/`openaiProxy` — these paths don't currently throw a classifiable error on a non-OK response (they track/return instead), so wiring retry in cleanly needs its own scoped change rather than a purely additive one.

## Test plan

- [x] `node server/tests/workflow-llm-retry.test.js` — all existing retry-logic assertions pass unchanged (confirms the extraction didn't change behavior).
- [x] `node server/tests/completion-request-await.test.js` — covers `createCompletionRequest`'s await contract used by `simpleCompletion`; passes.
- [x] Ran the `PromptNodeExecutor`-related test files (`agent-temporal-context`, `agent-audit-trail`, `agent-artifact-versioning`, `agent-citation-contract`, `agent-task-context-bound`, plus three others) — all pass or fail identically to `main` (three pre-existing failures unrelated to this change, a `ReferenceError: nativeWebSearch is not defined` reproduced on unmodified `main` too — tracked separately, not touched by this PR).
- [x] Manual smoke test of the new `runWithRetries` helper: confirmed it retries transient (503) errors to success and propagates non-transient (400) errors immediately without retrying.
- [x] `npx eslint` on all changed/new files — no new errors (pre-existing unrelated warnings only).


---
_Generated by [Claude Code](https://claude.ai/code/session_01LNKTErpLbzZMYjw4i1aTg6)_