### PR TITLE
fix(security): disable demo accounts and rotate admin password by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -552,7 +552,10 @@ A fresh `contents/` (auto-populated by `performInitialSetup`) ships with a built
 local admin login:
 
 - **Username:** `admin`
-- **Password:** `password123`
+- **Password:** `password123` — **only when `NODE_ENV=development`** (e.g. `npm run dev`).
+  Everywhere else (production builds, Docker images, `npm run start:prod`), `performInitialSetup`
+  rotates this to a randomly generated password on first boot and logs it once — check the
+  server logs for `"Generated a new local admin password"` to find it.
 - **Endpoint:** `POST /api/auth/local/login` → returns a `Set-Cookie: authToken=…` JWT
 - **Groups:** `admins`, `authenticated` (full admin access)
 

--- a/docker-compose.quickstart.yml
+++ b/docker-compose.quickstart.yml
@@ -7,6 +7,10 @@
 #   docker compose -f docker-compose.quickstart.yml up
 #
 # Then open http://localhost:3000 and go to Admin → Configuration to add your API keys.
+#
+# First boot generates a random admin password and prints it once — run
+# `docker compose -f docker-compose.quickstart.yml logs | grep "admin password"`
+# to find it, then log in at /login as "admin".
 
 services:
   ihub-apps:

--- a/docs/authentication-architecture.md
+++ b/docs/authentication-architecture.md
@@ -248,7 +248,7 @@ For groups to be retrieved:
   "localAuth": {
     "enabled": true,
     "usersFile": "contents/config/users.json",
-    "showDemoAccounts": true,
+    "showDemoAccounts": false,
     "sessionTimeoutMinutes": 480
   }
 }

--- a/docs/external-authentication.md
+++ b/docs/external-authentication.md
@@ -453,6 +453,12 @@ The system uses an enhanced bcryptjs hashing method that incorporates the user I
 - Username: `admin`, Password: `password123` (admin group)
 - Username: `user`, Password: `password123` (user group)
 
+These shipped `password123` hashes only remain active when the server runs with
+`NODE_ENV=development` (e.g. `npm run dev`). In production and Docker deployments, the
+admin password is rotated to a randomly generated value on first boot and logged once —
+check the server logs for `"Generated a new local admin password"`. `showDemoAccounts` also
+defaults to `false` and is never shown on the login page outside development.
+
 ### 3. OIDC Mode
 
 OpenID Connect authentication with external providers like Google, Microsoft, Auth0, and others.

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -505,14 +505,14 @@ Built-in username/password authentication.
   "localAuth": {
     "enabled": true,
     "usersFile": "contents/config/users.json",
-    "showDemoAccounts": true
+    "showDemoAccounts": false
   }
 }
 ```
 
 - **enabled** (boolean) – Enable local authentication. Default: `false`
 - **usersFile** (string) – Path to users configuration file. Default: `"contents/config/users.json"`
-- **showDemoAccounts** (boolean) – Show demo accounts on login page. Default: `true`
+- **showDemoAccounts** (boolean) – Show demo accounts (admin/user) on the login page. Keep disabled in production — the shipped demo password hashes are public. Default: `false`
 
 ### **proxyAuth**
 Header-based authentication for reverse proxy setups.

--- a/docs/releases/5.5.0/breaking-changes.md
+++ b/docs/releases/5.5.0/breaking-changes.md
@@ -18,6 +18,26 @@ now lives in its own file under `contents/tools/`, and there is no fallback to t
 have external tooling that reads or writes `contents/config/tools.json` directly, update it to
 manage individual files under `contents/tools/` instead.
 
+## Demo Accounts No Longer Shown or Usable by Default
+
+`localAuth.showDemoAccounts` now defaults to `false`, and the login page hides the demo-account
+hint outside development regardless of what the config says. If you rely on the demo `admin` /
+`user` accounts in a non-development deployment (e.g. an internal test instance), you'll need to
+log in with the credentials directly — the hint text will no longer be shown.
+
+- A migration flips `showDemoAccounts` to `false` on upgrade for any install that never explicitly
+  changed it from the old default.
+- On a fresh install started outside development, the shipped admin account's password is also
+  rotated to a randomly generated value on first boot (see the Features entry for this release) —
+  the old `admin` / `password123` login will not work on such installs. Check the server logs for
+  the generated password, or reset it via the users file / admin UI.
+
+**Before upgrading:** No action needed for normal use. If you depend on the static
+`admin` / `password123` login outside local development, set `localAuth.showDemoAccounts: true`
+explicitly in `contents/config/platform.json` before upgrading — note this only restores the login
+page hint in development; the account password itself is unaffected on installs that already exist
+(only fresh installs get a rotated password).
+
 ## Electron Desktop App Target Removed
 
 The `npm run electron:dev` and `npm run electron:build` scripts, the `electron/` source directory,

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -31,6 +31,22 @@ existing native-search behavior already available for Gemini and GPT models.
   now resolved directly from the app/workflow configuration and passed straight to the model
   provider.
 
+## Demo Accounts Are Now Hidden and the Admin Password Is Rotated by Default
+
+Fresh installs no longer expose the well-known `admin` / `password123` login by default outside
+local development, closing off a trivial takeover path on internet-reachable deployments.
+
+- `localAuth.showDemoAccounts` now defaults to `false`. Existing installs that never explicitly
+  changed this setting are switched to `false` automatically on upgrade.
+- The login page's demo-account hint is now only ever shown when the server is running in
+  development — even if `showDemoAccounts` is explicitly set to `true` in your config, it stays
+  hidden in production.
+- On a genuinely fresh install running outside development (a new Docker deployment, for example),
+  the shipped admin account's password is rotated to a randomly generated value on first boot and
+  printed once to the server logs — look for `"Generated a new local admin password"`.
+- Local development (`npm run dev`) is unaffected: the documented `admin` / `password123` login
+  still works so existing test workflows keep working.
+
 ## iHub Support Bot Can Now Answer Questions About the Platform
 
 The bundled **iHub Support Bot** app now references the built-in iHub Documentation source, so it

--- a/server/defaults/config/platform.json
+++ b/server/defaults/config/platform.json
@@ -127,7 +127,7 @@
   "localAuth": {
     "enabled": true,
     "usersFile": "contents/config/users.json",
-    "showDemoAccounts": true
+    "showDemoAccounts": false
   },
   "swagger": {
     "enabled": true,

--- a/server/migrations/V075__disable_demo_accounts_by_default.js
+++ b/server/migrations/V075__disable_demo_accounts_by_default.js
@@ -1,0 +1,27 @@
+export const version = '075';
+export const description = 'disable_demo_accounts_by_default';
+
+// The shipped default for localAuth.showDemoAccounts changed from true to
+// false (issue #1699) — the demo admin/user password hashes are public in
+// the OSS repo, so displaying them on the login page is a takeover risk on
+// any deployment that never touched this setting. Existing installs whose
+// config still has the untouched old default are flipped to the safe value;
+// admins who explicitly re-enabled it after installing keep their choice,
+// since we can't distinguish that case from an untouched default.
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  if (platform.localAuth?.showDemoAccounts === true) {
+    platform.localAuth.showDemoAccounts = false;
+    await ctx.writeJson('config/platform.json', platform);
+    ctx.warn(
+      'Disabled localAuth.showDemoAccounts (was true). The shipped demo account password hashes are public — re-enable explicitly in Admin > Authentication only for non-production use.'
+    );
+  } else {
+    ctx.log('localAuth.showDemoAccounts already customized or absent, leaving unchanged');
+  }
+}

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -15,6 +15,7 @@ import { sendBadRequest, sendAuthRequired, sendErrorResponse } from '../utils/re
 import { recordAuthEvent } from '../telemetry/metrics.js';
 import { logAudit } from '../services/AuditLogService.js';
 import { getAuthCookieOptions, getClearAuthCookieOptions } from '../utils/cookieSettings.js';
+import config from '../config.js';
 
 /**
  * Sanitize and validate authentication input
@@ -692,7 +693,11 @@ export default function registerAuthRoutes(app) {
         },
         local: {
           enabled: localAuthConfig.enabled ?? false,
-          showDemoAccounts: localAuthConfig.showDemoAccounts ?? true
+          // Demo account hints are only ever shown in development, regardless
+          // of the stored config value, since the shipped demo password
+          // hashes are public (issue #1699).
+          showDemoAccounts:
+            config.NODE_ENV === 'development' && (localAuthConfig.showDemoAccounts ?? false)
         },
         oidc: {
           enabled: oidcAuthConfig.enabled ?? false,

--- a/server/utils/setupUtils.js
+++ b/server/utils/setupUtils.js
@@ -1,8 +1,11 @@
 import fs from 'fs/promises';
 import path from 'path';
+import crypto from 'crypto';
+import bcrypt from 'bcryptjs';
 import { getRootDir } from '../pathUtils.js';
 import config from '../config.js';
 import logger from './logger.js';
+import { atomicWriteJSON } from './atomicWrite.js';
 
 /**
  * Recursively copies files and directories from source to destination,
@@ -191,6 +194,42 @@ export async function syncManagedDefaultFiles() {
 }
 
 /**
+ * Rotates the shipped demo admin account's password on a fresh install.
+ * The default admin/password123 bcrypt hash is committed to the public repo,
+ * so leaving it in place makes any freshly deployed instance trivially
+ * takeover-able. The generated password is logged once — it is not
+ * recoverable afterwards, only resettable via the users.json file or the
+ * admin UI.
+ * @param {string} usersFilePath - Absolute path to the freshly copied users.json
+ * @returns {Promise<void>}
+ */
+async function rotateDefaultAdminPassword(usersFilePath) {
+  try {
+    const raw = await fs.readFile(usersFilePath, 'utf8');
+    const usersConfig = JSON.parse(raw);
+    const adminEntry = Object.values(usersConfig.users || {}).find(u => u.username === 'admin');
+
+    if (!adminEntry) {
+      return;
+    }
+
+    const generatedPassword = crypto.randomBytes(18).toString('base64url');
+    const salt = await bcrypt.genSalt(12);
+    adminEntry.passwordHash = await bcrypt.hash(`${adminEntry.id}:${generatedPassword}`, salt);
+    adminEntry.updatedAt = new Date().toISOString();
+
+    await atomicWriteJSON(usersFilePath, usersConfig);
+
+    logger.warn(
+      `Generated a new local admin password for this fresh install. Username: "${adminEntry.username}", password: "${generatedPassword}". This is shown only once — store it now; it cannot be recovered later, only reset.`,
+      { component: 'Setup' }
+    );
+  } catch (error) {
+    logger.error('Failed to rotate default admin password', { component: 'Setup', error });
+  }
+}
+
+/**
  * Performs initial setup by copying any missing default configuration files
  * This function should be called during server startup
  * @returns {Promise<boolean>} True if any files were copied
@@ -199,12 +238,28 @@ export async function performInitialSetup() {
   try {
     logger.info('Checking for missing default configuration files', { component: 'Setup' });
 
+    const usersFilePath = path.join(getRootDir(), config.CONTENTS_DIR, 'config', 'users.json');
+    let usersFileExistedBefore = true;
+    try {
+      await fs.stat(usersFilePath);
+    } catch (error) {
+      if (error.code !== 'ENOENT') throw error;
+      usersFileExistedBefore = false;
+    }
+
     const filesCopied = await copyDefaultConfiguration();
 
     if (filesCopied) {
       logger.info('Initial setup completed - missing default files have been copied', {
         component: 'Setup'
       });
+
+      // Keep the well-known admin/password123 login in development so the
+      // documented local dev/testing flow (CLAUDE.md) keeps working; rotate
+      // it everywhere else, since the shipped hash is public in the repo.
+      if (!usersFileExistedBefore && config.NODE_ENV !== 'development') {
+        await rotateDefaultAdminPassword(usersFilePath);
+      }
     } else {
       logger.info('All default configuration files already exist, no setup needed', {
         component: 'Setup'

--- a/server/validators/platformConfigSchema.js
+++ b/server/validators/platformConfigSchema.js
@@ -141,7 +141,7 @@ export const platformConfigSchema = z
         enabled: z.boolean().default(false),
         usersFile: z.string().default('contents/config/users.json'),
         sessionTimeoutMinutes: z.number().min(1).default(480),
-        showDemoAccounts: z.boolean().default(true)
+        showDemoAccounts: z.boolean().default(false)
       })
       .default({}),
     oidcAuth: z


### PR DESCRIPTION
## Summary

Fixes #1699. Every fresh install shipped a well-known `admin` / `password123` account, enabled and shown on the login page by default — a trivial takeover path on any internet-reachable deployment (including the zero-config `docker-compose.quickstart.yml` pulling `ghcr.io/intrafind/ihub-apps:latest`).

- `localAuth.showDemoAccounts` now defaults to `false` in both the Zod schema (`server/validators/platformConfigSchema.js`) and the shipped default (`server/defaults/config/platform.json`), matching what `docs/security.md` already recommended.
- New migration `server/migrations/V075__disable_demo_accounts_by_default.js` flips existing installs whose config still has the untouched old `true` default to `false`, with a warning log. Installs that explicitly re-set the value are left alone (can't be distinguished from an untouched default, so we treat "still true" as untouched).
- The login page's demo-account hint is now also gated **server-side**, in `server/routes/auth.js`: `showDemoAccounts` only ever resolves `true` when `NODE_ENV === 'development'`, regardless of the stored config value. This closes the gap where an admin could re-enable the setting in production and still leak the hint (and, before this change, the hardcoded fallback `?? true`).
- On a **genuinely fresh install** (i.e. `contents/config/users.json` did not exist before `performInitialSetup` ran) started **outside development**, the shipped admin account's password is rotated to a randomly generated value and logged once (`server/utils/setupUtils.js`). Local dev (`npm run dev`, which sets `NODE_ENV=development`) keeps the documented `admin` / `password123` login so existing manual test workflows and `CLAUDE.md`'s guidance keep working.
- Updated `CLAUDE.md`, `docs/platform.md`, `docs/authentication-architecture.md`, `docs/external-authentication.md`, and `docker-compose.quickstart.yml` to describe the new behavior.
- Added a changelog entry to `docs/releases/5.5.0/features.md` and a note in `docs/releases/5.5.0/breaking-changes.md`.

### Why generate a password instead of forcing a change on first login?

The issue's own posted implementation plan flagged two viable approaches (generate-on-boot vs. force-change-on-login) and recommended the smaller one (generate-on-boot) given the issue's `Effort: small` tag; a proper forced-password-change UX would touch `LoginForm.jsx` and the `auth.js` login contract and is a larger follow-up if wanted.

### Why gate password rotation behind `NODE_ENV`, not just "fresh install"?

Unconditionally randomizing the password on every fresh install would break the documented `npm run dev` local/testing flow in `CLAUDE.md` (and a couple of manual test scripts) that assume a known `admin` / `password123` login. The Docker image already sets `NODE_ENV=production` (`docker/Dockerfile:77`), so the vulnerable "zero-config quickstart" path is unaffected by this carve-out and still gets a rotated password.

## Test plan

- [x] `npm run lint:fix` / `npm run format:fix` — no errors, no diffs beyond intended changes
- [x] Booted the server (`node server/server.js`) against the existing `contents/` — migration `V075` ran and flipped `showDemoAccounts` from `true` to `false`; server started and `/api/health` responded
- [x] Logged in via `POST /api/auth/local/login` with `admin` / `password123` in dev mode — still works (existing `contents/`, `NODE_ENV` defaults to development)
- [x] Verified `/api/auth/status`'s `showDemoAccounts` resolves `false` in `NODE_ENV=production` even with config explicitly `true`, and `true` in `NODE_ENV=development` with config `true`
- [x] Simulated a fresh install (`performInitialSetup` against an empty `contents/`) outside development — confirmed the admin password hash was rotated, a plaintext password was logged once, and the new password validates correctly against the existing `hashPasswordWithUserId`-style verification scheme (`${userId}:${password}` + bcrypt)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_012fFpT1bWWy1iAjM15oBhMY)_