### PR TITLE
fix(security): register base-path rewrite before auth chain and rate limiters

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,18 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Subpath Deployments No Longer Bypass Authentication or Rate Limits
+
+Closed a security gap where requests carrying an `X-Forwarded-Prefix` header (used for reverse
+proxy subpath deployments, e.g. `/ihub/`) could, in some configurations, reach protected API
+endpoints without going through authentication or rate limiting.
+
+- The base-path rewrite now runs before authentication and rate limiting instead of after, so every
+  downstream check consistently sees the final, rewritten request path.
+- The `X-Forwarded-Prefix` header is now only honored when the request arrives through a hop that
+  the server's `trust proxy` setting actually trusts, instead of being accepted unconditionally from
+  any direct client.
+- No admin action is required — the fix takes effect automatically on upgrade. Deployments that
+  rely on a specific reverse proxy for subpath routing should confirm their `trust proxy`
+  configuration reflects their actual proxy topology.

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1023,3 +1023,18 @@ how many entries are behind it.
   `?resource=app` keep working.
 - Audit log queries now scan each daily file once instead of loading the whole date range into
   memory and sorting it, so a wide range costs materially less.
+
+## Subpath Deployments No Longer Bypass Authentication or Rate Limits
+
+Closed a security gap where requests carrying an `X-Forwarded-Prefix` header (used for reverse
+proxy subpath deployments, e.g. `/ihub/`) could, in some configurations, reach protected API
+endpoints without going through authentication or rate limiting.
+
+- The base-path rewrite now runs before authentication and rate limiting instead of after, so every
+  downstream check consistently sees the final, rewritten request path.
+- The `X-Forwarded-Prefix` header is now only honored when the request arrives through a hop that
+  the server's `trust proxy` setting actually trusts, instead of being accepted unconditionally from
+  any direct client.
+- No admin action is required — the fix takes effect automatically on upgrade. Deployments that
+  rely on a specific reverse proxy for subpath routing should confirm their `trust proxy`
+  configuration reflects their actual proxy topology.

--- a/server/server.js
+++ b/server/server.js
@@ -426,20 +426,25 @@ if (cluster.isPrimary && workerCount > 1) {
    */
   // Error localization and API key validation implemented in serverHelpers.js
 
-  // Middleware
-  // Use the resolved platform config from configCache (which applies IHUB_PLATFORM__*
-  // env overrides and decrypts secrets) so boot-time middleware (body-size limit,
-  // rate limiters, sessions, auth chain) picks up all overrides.  Fall back to
-  // the raw JSON value only if configCache failed to initialize.
-  setupMiddleware(app, configCache.getPlatform() || platformConfig);
-
-  // Add base path middleware chain:
+  // Add base path middleware chain BEFORE any other middleware (body parser,
+  // rate limiters, auth chain). This must run first so that every downstream
+  // check sees the rewritten req.url — otherwise a non-stripping reverse proxy
+  // (or a spoofed X-Forwarded-Prefix header) makes the auth-skip heuristic and
+  // path-mounted rate limiters see an un-rewritten path, letting requests slip
+  // through unauthenticated / unlimited.
   // 1. Rewrite: strips X-Forwarded-Prefix from req.url (handles non-stripping proxies)
   // 2. Detection: stores current request for runtime base path resolution
   // 3. Validation: warns on invalid X-Forwarded-Prefix values
   app.use(basePathRewriteMiddleware);
   app.use(basePathDetectionMiddleware);
   app.use(basePathValidationMiddleware);
+
+  // Middleware
+  // Use the resolved platform config from configCache (which applies IHUB_PLATFORM__*
+  // env overrides and decrypts secrets) so boot-time middleware (body-size limit,
+  // rate limiters, sessions, auth chain) picks up all overrides.  Fall back to
+  // the raw JSON value only if configCache failed to initialize.
+  setupMiddleware(app, configCache.getPlatform() || platformConfig);
 
   // Helper to verify API key exists for a model and provide a meaningful error
   // Implemented in serverHelpers.js

--- a/server/server.js
+++ b/server/server.js
@@ -472,20 +472,25 @@ if (cluster.isPrimary && workerCount > 1) {
    */
   // Error localization and API key validation implemented in serverHelpers.js
 
-  // Middleware
-  // Use the resolved platform config from configCache (which applies IHUB_PLATFORM__*
-  // env overrides and decrypts secrets) so boot-time middleware (body-size limit,
-  // rate limiters, sessions, auth chain) picks up all overrides.  Fall back to
-  // the raw JSON value only if configCache failed to initialize.
-  setupMiddleware(app, configCache.getPlatform() || platformConfig);
-
-  // Add base path middleware chain:
+  // Add base path middleware chain BEFORE any other middleware (body parser,
+  // rate limiters, auth chain). This must run first so that every downstream
+  // check sees the rewritten req.url — otherwise a non-stripping reverse proxy
+  // (or a spoofed X-Forwarded-Prefix header) makes the auth-skip heuristic and
+  // path-mounted rate limiters see an un-rewritten path, letting requests slip
+  // through unauthenticated / unlimited.
   // 1. Rewrite: strips X-Forwarded-Prefix from req.url (handles non-stripping proxies)
   // 2. Detection: stores current request for runtime base path resolution
   // 3. Validation: warns on invalid X-Forwarded-Prefix values
   app.use(basePathRewriteMiddleware);
   app.use(basePathDetectionMiddleware);
   app.use(basePathValidationMiddleware);
+
+  // Middleware
+  // Use the resolved platform config from configCache (which applies IHUB_PLATFORM__*
+  // env overrides and decrypts secrets) so boot-time middleware (body-size limit,
+  // rate limiters, sessions, auth chain) picks up all overrides.  Fall back to
+  // the raw JSON value only if configCache failed to initialize.
+  setupMiddleware(app, configCache.getPlatform() || platformConfig);
 
   // Helper to verify API key exists for a model and provide a meaningful error
   // Implemented in serverHelpers.js

--- a/server/server.js
+++ b/server/server.js
@@ -472,18 +472,17 @@ if (cluster.isPrimary && workerCount > 1) {
    */
   // Error localization and API key validation implemented in serverHelpers.js
 
-  // Add base path middleware chain BEFORE any other middleware (body parser,
-  // rate limiters, auth chain). This must run first so that every downstream
-  // check sees the rewritten req.url — otherwise a non-stripping reverse proxy
-  // (or a spoofed X-Forwarded-Prefix header) makes the auth-skip heuristic and
-  // path-mounted rate limiters see an un-rewritten path, letting requests slip
-  // through unauthenticated / unlimited.
-  // 1. Rewrite: strips X-Forwarded-Prefix from req.url (handles non-stripping proxies)
-  // 2. Detection: stores current request for runtime base path resolution
-  // 3. Validation: warns on invalid X-Forwarded-Prefix values
+  // Rewrite the base path BEFORE any other middleware (body parser, rate
+  // limiters, auth chain). Rate limiters and the auth-skip heuristic are
+  // mounted/evaluated against a fixed, root-relative path (getBasePath()
+  // returns '' at startup, before any request exists) — they only match a
+  // subpath-deployed request correctly if req.url has already had its
+  // X-Forwarded-Prefix stripped by the time they run. Registering the
+  // rewrite any later — as it was before this fix — let a non-stripping
+  // reverse proxy (or a spoofed X-Forwarded-Prefix header) make the
+  // auth-skip heuristic and path-mounted rate limiters see an un-rewritten
+  // path, letting requests slip through unauthenticated / unlimited.
   app.use(basePathRewriteMiddleware);
-  app.use(basePathDetectionMiddleware);
-  app.use(basePathValidationMiddleware);
 
   // Middleware
   // Use the resolved platform config from configCache (which applies IHUB_PLATFORM__*
@@ -491,6 +490,16 @@ if (cluster.isPrimary && workerCount > 1) {
   // rate limiters, sessions, auth chain) picks up all overrides.  Fall back to
   // the raw JSON value only if configCache failed to initialize.
   setupMiddleware(app, configCache.getPlatform() || platformConfig);
+
+  // Detection/validation run after setupMiddleware because basePathDetectionMiddleware
+  // writes into the per-request AsyncLocalStorage context that setupMiddleware opens
+  // (the very first app.use() inside it) — setContext() silently no-ops before that
+  // context exists. Unlike the rewrite above, nothing here needs to run before the
+  // auth chain or rate limiters: they only depend on req.url (already rewritten),
+  // not on getBasePath(), which is consumed later by route handlers (e.g. building
+  // OIDC redirect / manifest URLs).
+  app.use(basePathDetectionMiddleware);
+  app.use(basePathValidationMiddleware);
 
   // Helper to verify API key exists for a model and provide a meaningful error
   // Implemented in serverHelpers.js

--- a/server/utils/basePath.js
+++ b/server/utils/basePath.js
@@ -199,9 +199,37 @@ export const toAbsolutePath = relativePath => {
 };
 
 /**
+ * Determine whether the given request arrived through a hop that Express's
+ * own `trust proxy` setting considers trusted. Reuses the app's compiled
+ * trust function so X-Forwarded-Prefix trust stays aligned with whatever
+ * `trust proxy` value (hop count, IP, subnet, etc.) the deployment has
+ * configured for X-Forwarded-For/req.ip — instead of trusting the header
+ * unconditionally from any direct client.
+ *
+ * @param {Object} req - Express request
+ * @returns {boolean} True if the immediate connecting peer is a trusted proxy
+ */
+const isFromTrustedProxy = req => {
+  try {
+    const trustFn = req.app?.get?.('trust proxy fn');
+    if (typeof trustFn === 'function') {
+      return trustFn(req.socket?.remoteAddress, 0);
+    }
+  } catch {
+    // Fall through to untrusted below
+  }
+  return false;
+};
+
+/**
  * Middleware to rewrite request URL by stripping the X-Forwarded-Prefix.
  * This allows non-stripping reverse proxies to work with root-registered routes.
  * Safe no-op when the proxy already strips the prefix or when no header is present.
+ *
+ * Only honors the header when the request comes from a trusted proxy hop
+ * (per Express's `trust proxy` setting) — otherwise a direct client could
+ * forge the header to make downstream auth/rate-limiter path checks see a
+ * different path than the one actually routed.
  *
  * Must be registered BEFORE all other middleware and routes.
  *
@@ -213,7 +241,7 @@ export const basePathRewriteMiddleware = (req, res, next) => {
   const headerName = process.env.BASE_PATH_HEADER || 'x-forwarded-prefix';
   let prefix = req.headers[headerName.toLowerCase()];
 
-  if (prefix) {
+  if (prefix && isFromTrustedProxy(req)) {
     // Normalize: remove trailing slashes
     while (prefix.endsWith('/')) prefix = prefix.slice(0, -1);
 

--- a/server/utils/basePath.js
+++ b/server/utils/basePath.js
@@ -188,9 +188,37 @@ export const toAbsolutePath = relativePath => {
 };
 
 /**
+ * Determine whether the given request arrived through a hop that Express's
+ * own `trust proxy` setting considers trusted. Reuses the app's compiled
+ * trust function so X-Forwarded-Prefix trust stays aligned with whatever
+ * `trust proxy` value (hop count, IP, subnet, etc.) the deployment has
+ * configured for X-Forwarded-For/req.ip — instead of trusting the header
+ * unconditionally from any direct client.
+ *
+ * @param {Object} req - Express request
+ * @returns {boolean} True if the immediate connecting peer is a trusted proxy
+ */
+const isFromTrustedProxy = req => {
+  try {
+    const trustFn = req.app?.get?.('trust proxy fn');
+    if (typeof trustFn === 'function') {
+      return trustFn(req.socket?.remoteAddress, 0);
+    }
+  } catch {
+    // Fall through to untrusted below
+  }
+  return false;
+};
+
+/**
  * Middleware to rewrite request URL by stripping the X-Forwarded-Prefix.
  * This allows non-stripping reverse proxies to work with root-registered routes.
  * Safe no-op when the proxy already strips the prefix or when no header is present.
+ *
+ * Only honors the header when the request comes from a trusted proxy hop
+ * (per Express's `trust proxy` setting) — otherwise a direct client could
+ * forge the header to make downstream auth/rate-limiter path checks see a
+ * different path than the one actually routed.
  *
  * Must be registered BEFORE all other middleware and routes.
  *
@@ -202,7 +230,7 @@ export const basePathRewriteMiddleware = (req, res, next) => {
   const headerName = process.env.BASE_PATH_HEADER || 'x-forwarded-prefix';
   let prefix = req.headers[headerName.toLowerCase()];
 
-  if (prefix) {
+  if (prefix && isFromTrustedProxy(req)) {
     // Normalize: remove trailing slashes
     while (prefix.endsWith('/')) prefix = prefix.slice(0, -1);
 

--- a/server/utils/basePath.js
+++ b/server/utils/basePath.js
@@ -249,6 +249,11 @@ export const basePathRewriteMiddleware = (req, res, next) => {
  * process-wide global, which would be subject to cross-request races under
  * concurrent traffic.
  *
+ * Applies the same trusted-proxy gate as basePathRewriteMiddleware: an
+ * untrusted direct client's header must not be able to influence generated
+ * response URLs (manifest, OIDC redirect construction, etc.) any more than
+ * it can influence routing.
+ *
  * Must run after the request context is opened (see setup.js) so
  * setContext() has a store to write into.
  *
@@ -259,7 +264,7 @@ export const basePathRewriteMiddleware = (req, res, next) => {
 export const basePathDetectionMiddleware = (req, res, next) => {
   const headerName = process.env.BASE_PATH_HEADER || 'x-forwarded-prefix';
   const detectedPath = req.headers[headerName.toLowerCase()];
-  if (detectedPath) {
+  if (detectedPath && isFromTrustedProxy(req)) {
     const normalized =
       detectedPath.endsWith('/') && detectedPath !== '/' ? detectedPath.slice(0, -1) : detectedPath;
     if (isValidBasePath(normalized)) {


### PR DESCRIPTION
## Summary

Fixes #1686.

`basePathRewriteMiddleware` (which strips a reverse proxy's `X-Forwarded-Prefix` from `req.url`) was registered **after** `setupMiddleware()` (rate limiters, auth chain) in `server/server.js`, even though its own doc comment requires it to run first. Under a non-stripping reverse proxy — or an attacker who simply sends `X-Forwarded-Prefix` on a direct request — downstream checks like the auth-skip heuristic (`isStaticAssetRequest`) and path-mounted rate limiters saw the *un-rewritten* URL, so e.g. `/x/api/auth/local/login` was misclassified as an SPA route and let through with **no authentication and no rate limiting**.

- Moved `basePathRewriteMiddleware` registration to run before `setupMiddleware(app, ...)` in `server/server.js`, so the auth chain and rate limiters (which are mounted/evaluated against fixed, root-relative paths computed once at startup) always see the final, rewritten `req.url`.
- `basePathRewriteMiddleware` and `basePathDetectionMiddleware` in `server/utils/basePath.js` now only honor `X-Forwarded-Prefix` when the request arrives through a hop trusted by Express's own `trust proxy` setting (via the app's compiled `trust proxy fn`), instead of trusting the header unconditionally from any direct client.
- `basePathDetectionMiddleware`/`basePathValidationMiddleware` stay registered *after* `setupMiddleware()` (unlike the rewrite) because they write into the per-request AsyncLocalStorage context that `setupMiddleware()` opens — this is a separate, already-landed mechanism (#1708) for `getBasePath()`'s response-URL generation, unrelated to the auth-bypass fix.
- Added a changelog entry to `docs/releases/5.5.0/features.md`.

**Known limitation (see review discussion below):** with the deployment's current `trust proxy: 1` (hop-count, not address-based), the trust gate doesn't reject a direct attacker — only an admin-configured address/CIDR-based `trust proxy` value would. The auth/rate-limit bypass this issue tracks is fixed regardless (verified below), independent of that gate's strength; tightening `trust proxy` itself is a deployment-topology decision left for a possible follow-up rather than bundled into this fix.

## Test plan

- [x] `npm run lint:fix` / prettier check on changed files — clean
- [x] Booted the server and confirmed it starts cleanly (single process and clustered)
- [x] `curl /api/health` (no header) → `200 OK`, root deployment (`basePath: ""`)
- [x] `curl -H "X-Forwarded-Prefix: /ihub" /ihub/api/health` → `200 OK`, `basePathConfig.basePath: "/ihub"` (confirms the already-landed AsyncLocalStorage-based detection still works after reordering)
- [x] `GET /x/api/admin/apps` with `X-Forwarded-Prefix: /x` → `401 Authentication required` (previously would have been treated as an SPA route and passed through unauthenticated)
- [x] Standalone script exercising `basePathRewriteMiddleware` directly: with `trust proxy: false`, a spoofed `X-Forwarded-Prefix` header is ignored (404 instead of being stripped); with `trust proxy: 1` (the deployment's current setting), the header is still honored for legitimate subpath deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RZucq8dmVvLSRKw3jCaHa8
