### PR TITLE
Close CodeNode VM sandbox escape; validate marketplace workflow/app/model installs

### DIFF
--- a/server/services/marketplace/ContentInstaller.js
+++ b/server/services/marketplace/ContentInstaller.js
@@ -52,12 +52,8 @@ const CONTENT_CONFIG = {
     ext: '.json',
     cacheRefresh: 'refreshAppsCache',
     validate: async data => {
-      try {
-        const { validateAppConfig } = await import('../../validators/appConfigSchema.js');
-        return validateAppConfig ? validateAppConfig(data) : { success: true };
-      } catch {
-        return { success: true };
-      }
+      const { appConfigSchema } = await import('../../validators/appConfigSchema.js');
+      return validateWithZodSchema(appConfigSchema, data);
     }
   },
   model: {
@@ -65,12 +61,8 @@ const CONTENT_CONFIG = {
     ext: '.json',
     cacheRefresh: 'refreshModelsCache',
     validate: async data => {
-      try {
-        const { validateModelConfig } = await import('../../validators/modelConfigSchema.js');
-        return validateModelConfig ? validateModelConfig(data) : { success: true };
-      } catch {
-        return { success: true };
-      }
+      const { modelConfigSchema } = await import('../../validators/modelConfigSchema.js');
+      return validateWithZodSchema(modelConfigSchema, data);
     }
   },
   prompt: {
@@ -89,9 +81,31 @@ const CONTENT_CONFIG = {
     dir: 'workflows',
     ext: '.json',
     cacheRefresh: 'refreshWorkflowsCache',
-    validate: async () => ({ success: true })
+    validate: async data => {
+      const { workflowConfigSchema } = await import('../../validators/workflowConfigSchema.js');
+      return validateWithZodSchema(workflowConfigSchema, data);
+    }
   }
 };
+
+/**
+ * Run a Zod schema's safeParse and adapt the result to the { success, errors }
+ * shape ContentInstaller callers expect.
+ *
+ * @param {import('zod').ZodSchema} schema
+ * @param {*} data
+ * @returns {{ success: boolean, errors?: string[] }}
+ */
+function validateWithZodSchema(schema, data) {
+  const result = schema.safeParse(data);
+  if (result.success) {
+    return { success: true };
+  }
+  return {
+    success: false,
+    errors: result.error.errors.map(e => `${e.path.join('.')}: ${e.message}`)
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Installations manifest helpers

--- a/server/services/workflow/executors/CodeNodeExecutor.js
+++ b/server/services/workflow/executors/CodeNodeExecutor.js
@@ -1,15 +1,25 @@
 /**
  * Executor for workflow code nodes.
  *
- * Code nodes run user-provided JavaScript in a secure VM sandbox.
- * They are useful for data transformation, validation, and computation
- * that is too complex for transform nodes but does not need LLM reasoning.
+ * Code nodes run user-provided JavaScript in a node:vm sandbox. This is
+ * best-effort isolation, NOT a hard security boundary — node:vm shares the
+ * host's heap, event loop, and process, and Node's own docs warn it must
+ * not be relied on to run genuinely untrusted code safely. It blocks the
+ * obvious footguns (prototype pollution, direct access to process/require/
+ * Function) but a sufficiently determined script could still exhaust CPU
+ * within the timeout window or find other V8-level escapes. Treat code
+ * nodes as trusted-author-only, the same way you would treat any other
+ * server-side script.
  *
- * Security measures:
+ * Isolation measures:
  * - Null-prototype sandbox context prevents __proto__ traversal
  * - JSON round-trip on input data breaks prototype chain references
  * - 'use strict' mode prevents `this` escape to global scope
  * - Dangerous globals (Function, setTimeout, process, require) are blocked
+ * - Host-realm built-ins (Array, String, Date, etc.) are never injected into
+ *   the sandbox — the vm context's own realm already provides them, and
+ *   injecting the host's versions would leak the host's Function via
+ *   `.constructor`, enabling `Array.constructor('return process')()`-style escapes
  * - Configurable timeout prevents infinite loops
  *
  * @module services/workflow/executors/CodeNodeExecutor
@@ -92,12 +102,15 @@ export class CodeNodeExecutor extends BaseNodeExecutor {
   }
 
   /**
-   * Execute the code node in a secure VM sandbox.
+   * Execute the code node in a node:vm sandbox (best-effort isolation, not a
+   * hard security boundary — see the module docstring above).
    *
    * The code runs in a strict-mode VM context with:
    * - `data` and `input`: Deep-cloned workflow state data (read-only semantics)
    * - `console.log/warn/error`: Captured to logs array
-   * - Standard JS built-ins: JSON, Math, Date, Array, String, Number, RegExp, etc.
+   * - Standard JS built-ins (JSON, Math, Date, Array, String, Number, RegExp,
+   *   etc.) available via the vm context's own realm — never injected from
+   *   the host, to avoid leaking the host's Function constructor
    * - `Object` with safe methods only (keys, values, entries, assign, freeze, etc.)
    * - No access to: Function, setTimeout, process, require, globalThis
    *
@@ -142,31 +155,23 @@ export class CodeNodeExecutor extends BaseNodeExecutor {
       // 4. Block dangerous globals that could escape the sandbox
       sandbox.Function = undefined;
 
-      // 5. Expose safe globals for user code
+      // 5. Expose only workflow data and a restricted Object; JSON, Math, Date,
+      // Array, String, Number, RegExp, Boolean, Map, Set, Promise, parseInt,
+      // parseFloat, isNaN, isFinite etc. are NOT injected here because doing so
+      // would hand the sandbox the *host realm's* intrinsics — whose `.constructor`
+      // is the host's Function, letting code escape via
+      // `Array.constructor('return process')()`. The fresh vm context already
+      // has its own copies of every standard built-in, scoped to this sandbox
+      // realm, so user code can still use them safely without host access.
       Object.assign(sandbox, {
         data: safeData,
         input: safeData,
-        JSON,
-        Math,
-        Date,
-        Array,
-        String,
-        Number,
-        RegExp,
-        Boolean,
-        parseInt,
-        parseFloat,
-        isNaN,
-        isFinite,
         Object: safeObject,
         console: {
           log: (...args) => logs.push(args.map(String).join(' ')),
           warn: (...args) => logs.push(args.map(String).join(' ')),
           error: (...args) => logs.push(args.map(String).join(' '))
         },
-        Map,
-        Set,
-        Promise,
         // Explicitly block async/timer/system APIs
         setTimeout: undefined,
         setInterval: undefined,

--- a/server/tests/codeNodeExecutor.sandboxEscape.test.js
+++ b/server/tests/codeNodeExecutor.sandboxEscape.test.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+/**
+ * Regression tests for CodeNodeExecutor's VM sandbox.
+ *
+ * CodeNodeExecutor used to inject host-realm built-ins (Array, String, Date,
+ * etc.) directly into the vm sandbox. Because those are the *host's*
+ * intrinsics, `Array.constructor` was the host's Function, letting user code
+ * escape the sandbox via `Array.constructor('return process')()` and get
+ * arbitrary code execution in the server process. The fix stops injecting
+ * host built-ins — the vm context's own realm already provides safe copies.
+ *
+ * Verifies:
+ *   - Common escape patterns (Array/String/Object/Function-constructor
+ *     chains) never yield the real `process`/`require`/`global`.
+ *   - Legitimate code using Array, Math, Date, JSON, RegExp, etc. still works.
+ *
+ * Run directly: `node server/tests/codeNodeExecutor.sandboxEscape.test.js`.
+ */
+
+import { CodeNodeExecutor } from '../services/workflow/executors/CodeNodeExecutor.js';
+
+let failures = 0;
+function check(label, cond, details) {
+  if (!cond) failures += 1;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && details !== undefined) console.log(`   ${JSON.stringify(details)}`);
+}
+
+function makeExecutor() {
+  return new CodeNodeExecutor();
+}
+
+async function runCode(code, data = {}) {
+  const executor = makeExecutor();
+  return executor.execute({ id: 'code-under-test', type: 'code', config: { code } }, { data }, {});
+}
+
+async function run() {
+  const escapeAttempts = [
+    "Array.constructor('return process')()",
+    "[].constructor.constructor('return process')()",
+    "({}).constructor.constructor('return process')()",
+    "String.constructor('return require')()",
+    "Object.getPrototypeOf([]).constructor.constructor('return globalThis')()"
+  ];
+
+  for (const attempt of escapeAttempts) {
+    const result = await runCode(attempt);
+    const leaked =
+      result.status === 'completed' &&
+      result.output?.result &&
+      typeof result.output.result === 'object' &&
+      (result.output.result.pid !== undefined ||
+        typeof result.output.result.require === 'function');
+    check(`escape blocked: ${attempt}`, !leaked, result.output);
+  }
+
+  // Legitimate use of standard built-ins must still work without host injection.
+  {
+    const result = await runCode(
+      `
+        const items = data.searchResults || [];
+        items.map(item => ({ title: item.name.toUpperCase(), score: Math.round(item.relevance * 100) }));
+      `,
+      { searchResults: [{ name: 'foo', relevance: 0.5 }] }
+    );
+    check('legit Array/Math usage → completed', result.status === 'completed', result);
+    check(
+      'legit Array/Math usage → correct output',
+      JSON.stringify(result.output?.result) === JSON.stringify([{ title: 'FOO', score: 50 }]),
+      result.output
+    );
+  }
+
+  {
+    const result = await runCode(
+      `({ now: Date.now() > 0, parsed: JSON.parse('{"a":1}').a, re: /^a+$/.test('aaa') });`
+    );
+    check('legit Date/JSON/RegExp usage → completed', result.status === 'completed', result);
+    check(
+      'legit Date/JSON/RegExp usage → correct output',
+      result.output?.result?.now === true &&
+        result.output?.result?.parsed === 1 &&
+        result.output?.result?.re === true,
+      result.output
+    );
+  }
+
+  console.log(`\n${failures === 0 ? '🎉 All tests passed.' : `❌ ${failures} failure(s).`}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+run().catch(err => {
+  console.error('Test harness error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Fixes #1695 — the workflow CodeNode sandbox was escapable to full RCE.

- **`CodeNodeExecutor.js`**: stopped injecting host-realm built-ins (`Array`, `String`, `Number`, `RegExp`, `Boolean`, `Map`, `Set`, `Promise`, `Date`, `JSON`, `parseInt`/`parseFloat`/`isNaN`/`isFinite`) into the `vm` sandbox. Because those were the *host's* intrinsics, `Array.constructor` was the host's `Function`, so any code node could run `Array.constructor('return process')()` and get arbitrary code execution in the server process — including from unvalidated marketplace-installed workflows. The `vm.createContext()` realm already provides its own safe copies of every standard built-in, so nothing needs to be injected for normal usage (`Array`, `Math`, `Date`, `JSON`, `RegExp`, etc. all still work inside code nodes). Corrected the module's "secure sandbox" comments to accurately describe `node:vm` as best-effort isolation, not a hard security boundary, per Node's own docs.
- **`ContentInstaller.js`**: the `app`, `model`, and `workflow` marketplace-install validators destructured `validateAppConfig`/`validateModelConfig` helper functions that don't actually exist in `appConfigSchema.js`/`modelConfigSchema.js` (only the raw Zod schemas are exported), and `workflow` had no validation wired up at all — so all three silently always returned `{ success: true }` regardless of content. They now call `schema.safeParse()` directly, so marketplace-installed apps, models, and workflows are actually schema-validated before being written to disk.
- Added a regression test (`server/tests/codeNodeExecutor.sandboxEscape.test.js`) asserting several sandbox-escape patterns (`Array.constructor(...)`, `[].constructor.constructor(...)`, etc.) never leak `process`/`require`/`globalThis`, and that legitimate code using standard built-ins still works correctly.

Deeper process/memory isolation (e.g. `isolated-vm` or a worker-thread sandbox) was intentionally scoped out — this PR closes the concrete RCE with no new dependencies. Verified against the pre-fix code that the new test does catch the escape (it returned the full host `process` object, including `pid`).

## Test plan

- [x] New regression test passes against the fix and fails (leaks `process`) against the pre-fix code
- [x] Existing `server/tests/ContentInstaller.skill-path-traversal.test.js` still passes
- [x] Confirmed `appConfigSchema`/`modelConfigSchema`/`workflowConfigSchema.safeParse()` correctly reject invalid minimal configs
- [x] `npm run lint:fix` / `prettier --check` clean on changed files
- [x] Server boots successfully with the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RzTgJGNe8vTziogiP4QL3j)_