### PR TITLE
Per-app copy response format configuration

### DIFF
--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -164,6 +164,38 @@ function AppFormEditor({
     onChange(updatedApp);
   };
 
+  // Per-app copy button configuration (which formats are offered, and the one-click default)
+  const copySettings = app.settings?.copy || {};
+  const copyFormats =
+    copySettings.formats && copySettings.formats.length > 0
+      ? copySettings.formats
+      : ['text', 'markdown', 'html'];
+  const copyDefaultFormat = copyFormats.includes(copySettings.defaultFormat)
+    ? copySettings.defaultFormat
+    : copyFormats[0];
+  const copyFormatOptions = [
+    { value: 'text', label: t('canvas.export.copyText', 'as Text') },
+    { value: 'markdown', label: t('canvas.export.copyMarkdown', 'as Markdown') },
+    { value: 'html', label: t('canvas.export.copyHTML', 'as HTML') }
+  ];
+
+  const updateCopySettings = updates =>
+    handleInputChange('settings', {
+      ...app.settings,
+      copy: { ...copySettings, formats: copyFormats, ...updates }
+    });
+
+  const toggleCopyFormat = format => {
+    const nextFormats = copyFormats.includes(format)
+      ? copyFormats.filter(f => f !== format)
+      : [...copyFormats, format];
+    if (nextFormats.length === 0) return; // keep at least one format enabled
+    const nextDefault = nextFormats.includes(copyDefaultFormat)
+      ? copyDefaultFormat
+      : nextFormats[0];
+    updateCopySettings({ formats: nextFormats, defaultFormat: nextDefault });
+  };
+
   const handleLocalizedChange = (field, value) => {
     const updatedApp = {
       ...app,
@@ -2888,6 +2920,65 @@ function AppFormEditor({
                         {t('admin.apps.edit.enableStyleControl', 'Enable Style Control')}
                       </label>
                     </div>
+
+                    <div className="flex items-center">
+                      <input
+                        type="checkbox"
+                        checked={copySettings.enabled !== false}
+                        onChange={e => updateCopySettings({ enabled: e.target.checked })}
+                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+                      />
+                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                        {t('admin.apps.edit.enableCopyControl', 'Enable Copy Response Button')}
+                      </label>
+                    </div>
+
+                    {copySettings.enabled !== false && (
+                      <div className="ml-6 space-y-3">
+                        <div>
+                          <p className="text-sm text-gray-700 dark:text-gray-300 mb-1">
+                            {t('admin.apps.edit.copyFormatsLabel', 'Available copy formats')}
+                          </p>
+                          <div className="flex flex-wrap gap-4">
+                            {copyFormatOptions.map(option => (
+                              <div key={option.value} className="flex items-center">
+                                <input
+                                  type="checkbox"
+                                  checked={copyFormats.includes(option.value)}
+                                  onChange={() => toggleCopyFormat(option.value)}
+                                  className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+                                />
+                                <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                                  {option.label}
+                                </label>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+
+                        <div>
+                          <label className="block text-sm text-gray-700 dark:text-gray-300 mb-1">
+                            {t(
+                              'admin.apps.edit.copyDefaultFormatLabel',
+                              'Default one-click copy format'
+                            )}
+                          </label>
+                          <select
+                            value={copyDefaultFormat}
+                            onChange={e => updateCopySettings({ defaultFormat: e.target.value })}
+                            className="block w-full max-w-xs rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                          >
+                            {copyFormatOptions
+                              .filter(option => copyFormats.includes(option.value))
+                              .map(option => (
+                                <option key={option.value} value={option.value}>
+                                  {option.label}
+                                </option>
+                              ))}
+                          </select>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </div>
               </div>

--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -120,6 +120,15 @@ function ChatMessage({
   const customRendererFromMessage = message.customResponseRenderer;
   const outputFormatFromMessage = message.outputFormat;
 
+  // Per-app copy configuration (which formats to expose, and which one the one-click button uses)
+  const copySettings = app?.settings?.copy;
+  const copyEnabled = copySettings?.enabled !== false;
+  const copyFormats =
+    copySettings?.formats?.length > 0 ? copySettings.formats : ['text', 'markdown', 'html'];
+  const copyDefaultFormat = copyFormats.includes(copySettings?.defaultFormat)
+    ? copySettings.defaultFormat
+    : copyFormats[0];
+
   // Close copy menu on outside click
   useEffect(() => {
     const handleClick = e => {
@@ -1036,44 +1045,54 @@ function ChatMessage({
           } ${isUser ? 'text-gray-500' : 'text-gray-500'}`}
         >
           {/* Standard actions first */}
-          <div className="relative inline-flex items-center" ref={copyMenuRef}>
-            <button
-              onClick={() => handleCopy('text')}
-              className="flex items-center gap-1 hover:text-gray-700 transition-colors duration-150"
-              title={t('pages.appChat.copyToClipboard')}
-            >
-              {copied ? <Icon name="check" size="sm" /> : <Icon name="copy" size="sm" />}
-            </button>
-            <button
-              onClick={() => setShowCopyMenu(!showCopyMenu)}
-              className="ml-1 hover:text-gray-700"
-              title={t('canvas.export.copyOptions', 'Copy Options')}
-            >
-              <Icon name="chevron-down" size="sm" />
-            </button>
-            {showCopyMenu && (
-              <div className="absolute right-0 mt-1 bg-white border border-gray-200 rounded shadow z-10 text-gray-700">
+          {copyEnabled && (
+            <div className="relative inline-flex items-center" ref={copyMenuRef}>
+              <button
+                onClick={() => handleCopy(copyDefaultFormat)}
+                className="flex items-center gap-1 hover:text-gray-700 transition-colors duration-150"
+                title={t('pages.appChat.copyToClipboard')}
+              >
+                {copied ? <Icon name="check" size="sm" /> : <Icon name="copy" size="sm" />}
+              </button>
+              {copyFormats.length > 1 && (
                 <button
-                  onClick={() => handleCopy('text')}
-                  className="block px-3 py-1 text-sm hover:bg-gray-100 w-full text-left whitespace-nowrap"
+                  onClick={() => setShowCopyMenu(!showCopyMenu)}
+                  className="ml-1 hover:text-gray-700"
+                  title={t('canvas.export.copyOptions', 'Copy Options')}
                 >
-                  {t('canvas.export.copyText', 'as Text')}
+                  <Icon name="chevron-down" size="sm" />
                 </button>
-                <button
-                  onClick={() => handleCopy('markdown')}
-                  className="block px-3 py-1 text-sm hover:bg-gray-100 w-full text-left whitespace-nowrap"
-                >
-                  {t('canvas.export.copyMarkdown', 'as Markdown')}
-                </button>
-                <button
-                  onClick={() => handleCopy('html')}
-                  className="block px-3 py-1 text-sm hover:bg-gray-100 w-full text-left whitespace-nowrap"
-                >
-                  {t('canvas.export.copyHTML', 'as HTML')}
-                </button>
-              </div>
-            )}
-          </div>
+              )}
+              {showCopyMenu && copyFormats.length > 1 && (
+                <div className="absolute right-0 mt-1 bg-white border border-gray-200 rounded shadow z-10 text-gray-700">
+                  {copyFormats.includes('text') && (
+                    <button
+                      onClick={() => handleCopy('text')}
+                      className="block px-3 py-1 text-sm hover:bg-gray-100 w-full text-left whitespace-nowrap"
+                    >
+                      {t('canvas.export.copyText', 'as Text')}
+                    </button>
+                  )}
+                  {copyFormats.includes('markdown') && (
+                    <button
+                      onClick={() => handleCopy('markdown')}
+                      className="block px-3 py-1 text-sm hover:bg-gray-100 w-full text-left whitespace-nowrap"
+                    >
+                      {t('canvas.export.copyMarkdown', 'as Markdown')}
+                    </button>
+                  )}
+                  {copyFormats.includes('html') && (
+                    <button
+                      onClick={() => handleCopy('html')}
+                      className="block px-3 py-1 text-sm hover:bg-gray-100 w-full text-left whitespace-nowrap"
+                    >
+                      {t('canvas.export.copyHTML', 'as HTML')}
+                    </button>
+                  )}
+                </div>
+              )}
+            </div>
+          )}
 
           {/* Download button - opens export dialog */}
           <button

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -644,6 +644,11 @@ The `settings` property controls which configuration options users can adjust fo
   "outputFormat": { "enabled": true },
   "chatHistory": { "enabled": true },
   "imageGeneration": { "enabled": true },
+  "copy": {
+    "enabled": true,
+    "formats": ["text", "markdown", "html"],
+    "defaultFormat": "text"
+  },
   "speechRecognition": {
     "service": "default",
     "host": "https://speech.example.com"
@@ -669,6 +674,9 @@ The `settings` property controls which configuration options users can adjust fo
 | `settings.outputFormat.enabled`       | Enable/disable output format selection                                   |
 | `settings.chatHistory.enabled`        | Enable/disable chat history toggle                                       |
 | `settings.imageGeneration.enabled`    | Show/hide the image generation settings panel                            |
+| `settings.copy.enabled`               | Show/hide the "copy response" button below chat messages. Default: `true` |
+| `settings.copy.formats`               | Which copy formats are offered: any of `"text"`, `"markdown"`, `"html"`. Default: all three |
+| `settings.copy.defaultFormat`         | Format used by the one-click copy button (must be included in `formats`). Default: `"text"` |
 | `settings.speechRecognition.service`  | Speech recognition backend: `"default"` (browser Web Speech API) or `"azure"` |
 | `settings.speechRecognition.host`     | Host URL for the speech recognition service (required when `service` is `"azure"`) |
 | `inputMode.microphone.mode`           | Mode for recording (`manual` or `automatic`)                             |

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,17 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Per-App Copy Response Options
+
+Admins can now control which "copy response" formats are offered below each chat message, and
+which one the one-click copy button uses, on a per-app basis — instead of every app always showing
+Text/Markdown/HTML with plain text as the one-click default.
+
+- New **Copy Response Button** controls in **Admin → Apps → [app] → Settings Configuration**:
+  enable/disable the copy control entirely, choose which formats to expose (Text, Markdown, HTML),
+  and pick which one runs on a single click.
+- For example, an app that only needs to paste into Word or Outlook can expose HTML only and make
+  it the one-click default; an app that only needs plain text can hide Markdown/HTML entirely.
+- Existing apps are unaffected — with no `copy` setting configured, behavior is unchanged (all
+  three formats shown, plain text as the one-click default).

--- a/server/tests/appConfigSchema-copySettings.test.js
+++ b/server/tests/appConfigSchema-copySettings.test.js
@@ -1,0 +1,66 @@
+/**
+ * Tests for the settings.copy field of appConfigSchema (issue #1642:
+ * per-app configuration of which "copy response" formats are offered
+ * and which one is used by the one-click copy button).
+ */
+import { appConfigSchema } from '../validators/appConfigSchema.js';
+
+function baseApp(overrides = {}) {
+  return {
+    id: 'test-app',
+    name: { en: 'Test App' },
+    description: { en: 'A test app' },
+    color: '#4F46E5',
+    icon: 'chat-bubble',
+    system: { en: 'You are a helpful assistant.' },
+    ...overrides
+  };
+}
+
+describe('appConfigSchema settings.copy', () => {
+  test('is optional and absent by default', () => {
+    const result = appConfigSchema.safeParse(baseApp());
+    expect(result.success).toBe(true);
+    expect(result.data.settings).toBeUndefined();
+  });
+
+  test('applies schema defaults when only partially specified', () => {
+    const result = appConfigSchema.safeParse(baseApp({ settings: { copy: {} } }));
+    expect(result.success).toBe(true);
+    expect(result.data.settings.copy).toEqual({
+      enabled: true,
+      formats: ['text', 'markdown', 'html'],
+      defaultFormat: 'text'
+    });
+  });
+
+  test('accepts a restricted format list with a matching default', () => {
+    const result = appConfigSchema.safeParse(
+      baseApp({ settings: { copy: { formats: ['html'], defaultFormat: 'html' } } })
+    );
+    expect(result.success).toBe(true);
+    expect(result.data.settings.copy).toEqual({
+      enabled: true,
+      formats: ['html'],
+      defaultFormat: 'html'
+    });
+  });
+
+  test('rejects a defaultFormat not present in formats', () => {
+    const result = appConfigSchema.safeParse(
+      baseApp({ settings: { copy: { formats: ['text', 'markdown'], defaultFormat: 'html' } } })
+    );
+    expect(result.success).toBe(false);
+  });
+
+  test('rejects an unknown format value', () => {
+    const result = appConfigSchema.safeParse(baseApp({ settings: { copy: { formats: ['pdf'] } } }));
+    expect(result.success).toBe(false);
+  });
+
+  test('allows disabling the copy control entirely', () => {
+    const result = appConfigSchema.safeParse(baseApp({ settings: { copy: { enabled: false } } }));
+    expect(result.success).toBe(true);
+    expect(result.data.settings.copy.enabled).toBe(false);
+  });
+});

--- a/server/validators/appConfigSchema.js
+++ b/server/validators/appConfigSchema.js
@@ -98,6 +98,19 @@ const settingsSchema = z
         enabled: z.boolean().optional().default(true)
       })
       .optional(),
+    copy: z
+      .object({
+        enabled: z.boolean().optional().default(true),
+        formats: z
+          .array(z.enum(['text', 'markdown', 'html']))
+          .optional()
+          .default(['text', 'markdown', 'html']),
+        defaultFormat: z.enum(['text', 'markdown', 'html']).optional().default('text')
+      })
+      .refine(data => !data.formats?.length || data.formats.includes(data.defaultFormat), {
+        message: 'defaultFormat must be included in formats'
+      })
+      .optional(),
     imageGeneration: z
       .object({
         enabled: z.boolean().optional().default(true)


### PR DESCRIPTION
## Summary

Closes #1642.

BMAS requested the ability to configure the "copy response" control below each chat message on a per-app basis: which formats (text/markdown/HTML) are offered, and which one the one-click copy button uses by default. Previously this was hardcoded for every app — all three formats always shown, plain text always the one-click default.

- New `settings.copy` schema field in `server/validators/appConfigSchema.js`: `enabled` (default `true`), `formats` (subset of `text`/`markdown`/`html`, default all three), `defaultFormat` (must be one of `formats`, default `text`).
- New **Copy Response Button** controls in the admin app editor (`AppFormEditor.jsx`, Settings Configuration section): enable/disable the control, choose which formats to expose, and pick the one-click default from the selected formats.
- `ChatMessage.jsx` now reads `app?.settings?.copy` to decide which formats to render in the copy dropdown and which format the one-click button copies, hiding the chevron/dropdown entirely when only one format remains. Apps without `settings.copy` configured keep the current behavior (all three formats, text default) for backward compatibility.
- Documented the new field in `docs/apps.md` and added a changelog entry under `docs/releases/5.5.0/features.md`.

Per the implementation plan discussed on the issue, this ships per-app configuration only (no new platform-level default) and keeps `text` as the schema default to preserve existing behavior for every app that doesn't opt in.

## Test plan

- [x] Added `server/tests/appConfigSchema-copySettings.test.js` covering: default-absent, default-filled, restricted format list, `defaultFormat` not in `formats` (rejected), unknown format value (rejected), and `enabled: false`.
- [x] `node server/tests/appConfigSchema-copySettings.test.js` via Jest — all 6 pass.
- [x] `npm run lint:fix` / `npx prettier --check` clean on all changed files (no new warnings/errors).
- [x] `node server/server.js` boots successfully with the schema change.
- [x] `npx vite build` succeeds with the `ChatMessage.jsx` / `AppFormEditor.jsx` changes.
- [ ] Manual browser verification of the admin UI controls and the chat copy dropdown was not performed in this sandboxed session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dt1UvFnmdk6zqvF8B8ZbLN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dt1UvFnmdk6zqvF8B8ZbLN)_