### PR TITLE
Add SSRF guard to screenshot tools

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -461,6 +461,18 @@ field) and the multimodal audio-upload path (which sends audio to a chat LLM).
 **Before using:** add or enable a transcription model under **Admin → Models** (model type
 "Transcription"), set its realtime URL, then enable transcription on the desired app.
 
+## Screenshot Tools No Longer Navigate to Internal/Private URLs (SSRF Guard)
+
+The **Website Screenshot** tools (Playwright and Selenium) now validate a target URL before
+launching a browser, matching the protection already in place for the web content extractor tool.
+Previously either tool would navigate to any caller-supplied URL with no checks, letting a crafted
+tool call point the server's browser at internal-only hosts or cloud metadata endpoints
+(e.g. `169.254.169.254`) and return the result as a screenshot or extracted PDF text.
+
+- Both tools now reject missing or malformed URLs, non-`http(s)` schemes (e.g. `file:`), and
+  hostnames that resolve to a private, loopback, or link-local IP address.
+- No configuration or admin action is required — the fix takes effect automatically on upgrade.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -51,6 +51,7 @@
         "passport": "^0.7.0",
         "passport-oauth2": "^1.8.0",
         "pdf-lib": "^1.17.1",
+        "pdf-parse": "^1.1.1",
         "pdfjs-dist": "^5.3.31",
         "playwright": "^1.55.1",
         "pngjs": "^7.0.0",
@@ -9476,6 +9477,12 @@
         "node": ">=10.5.0"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
@@ -9965,6 +9972,22 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.4.tgz",
+      "integrity": "sha512-XRIRcLgk6ZnUbsHsYXExMw+krrPE81hJ6FQPLdBNhhBefqIQKXu/WeTgNBGSwPrfU0v+UCEwn7AoAUOsVKHFvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/mehmet-kozan"
+      }
     },
     "node_modules/pdfjs-dist": {
       "version": "5.4.530",

--- a/server/package.json
+++ b/server/package.json
@@ -57,6 +57,7 @@
     "passport": "^0.7.0",
     "passport-oauth2": "^1.8.0",
     "pdf-lib": "^1.17.1",
+    "pdf-parse": "^1.1.1",
     "pdfjs-dist": "^5.3.31",
     "playwright": "^1.55.1",
     "pngjs": "^7.0.0",

--- a/server/tests/screenshotTools-ssrf.test.js
+++ b/server/tests/screenshotTools-ssrf.test.js
@@ -1,0 +1,113 @@
+/**
+ * Regression tests for #1691: playwrightScreenshot and seleniumScreenshot must
+ * validate the caller-supplied URL (protocol + SSRF guard) before ever
+ * launching a browser, matching the guard webContentExtractor already has.
+ *
+ * The repo's source is native ESM (uses `import.meta.url`), so this file uses
+ * `jest.unstable_mockModule` + dynamic imports rather than the CommonJS-only
+ * `jest.mock` API. Run with `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+import os from 'os';
+
+const page = {
+  goto: jest.fn(async () => {}),
+  pdf: jest.fn(async () => {}),
+  screenshot: jest.fn(async () => {})
+};
+const browser = {
+  newPage: jest.fn(async () => page),
+  close: jest.fn(async () => {})
+};
+const chromiumLaunch = jest.fn(async () => browser);
+
+jest.unstable_mockModule('playwright', () => ({
+  chromium: { launch: chromiumLaunch }
+}));
+
+jest.unstable_mockModule('pdfjs-dist/legacy/build/pdf.mjs', () => ({
+  getDocument: () => ({ promise: Promise.resolve({ numPages: 0 }) })
+}));
+
+const driver = {
+  get: jest.fn(async () => {}),
+  executeScript: jest.fn(async () => 0),
+  manage: jest.fn(() => ({ window: () => ({ setRect: jest.fn(async () => {}) }) })),
+  takeScreenshot: jest.fn(async () => Buffer.from('').toString('base64')),
+  getDevToolsSession: jest.fn(async () => ({ send: jest.fn(async () => ({ data: '' })) })),
+  quit: jest.fn(async () => {})
+};
+const seleniumBuild = jest.fn(async () => driver);
+const chromeOptions = { addArguments: jest.fn() };
+
+jest.unstable_mockModule('selenium-webdriver', () => ({
+  Builder: jest.fn(() => ({
+    forBrowser: jest.fn(() => ({
+      setChromeOptions: jest.fn(() => ({ build: seleniumBuild }))
+    }))
+  }))
+}));
+
+jest.unstable_mockModule('selenium-webdriver/chrome.js', () => ({
+  default: { Options: jest.fn(() => chromeOptions) }
+}));
+
+jest.unstable_mockModule('pdf-parse', () => ({
+  default: jest.fn(async () => ({ text: '' }))
+}));
+
+jest.unstable_mockModule('../pathUtils.js', () => ({
+  getRootDir: () => os.tmpdir()
+}));
+
+const { default: playwrightScreenshot } = await import('../tools/playwrightScreenshot.js');
+const { default: seleniumScreenshot } = await import('../tools/seleniumScreenshot.js');
+
+describe.each([
+  ['playwrightScreenshot', playwrightScreenshot, chromiumLaunch],
+  ['seleniumScreenshot', seleniumScreenshot, seleniumBuild]
+])('%s SSRF guard', (_name, tool, launchSpy) => {
+  it('rejects a missing url', async () => {
+    await expect(tool({})).rejects.toMatchObject({ code: 'MISSING_URL' });
+    expect(launchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a malformed url', async () => {
+    await expect(tool({ url: 'not a url' })).rejects.toMatchObject({ code: 'INVALID_URL' });
+    expect(launchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a non-http(s) protocol', async () => {
+    await expect(tool({ url: 'file:///etc/passwd' })).rejects.toMatchObject({
+      code: 'UNSUPPORTED_PROTOCOL'
+    });
+    expect(launchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a private IP literal (SSRF)', async () => {
+    await expect(tool({ url: 'http://127.0.0.1/secret' })).rejects.toMatchObject({
+      code: 'SSRF_BLOCKED'
+    });
+    expect(launchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects the cloud metadata link-local address', async () => {
+    await expect(tool({ url: 'http://169.254.169.254/latest/meta-data' })).rejects.toMatchObject({
+      code: 'SSRF_BLOCKED'
+    });
+    expect(launchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects localhost by hostname', async () => {
+    await expect(tool({ url: 'http://localhost:8080/' })).rejects.toMatchObject({
+      code: 'SSRF_BLOCKED'
+    });
+    expect(launchSpy).not.toHaveBeenCalled();
+  });
+
+  it('allows a public IP literal through to the browser launch', async () => {
+    await expect(tool({ url: 'http://8.8.8.8/page' })).resolves.toBeDefined();
+    expect(launchSpy).toHaveBeenCalled();
+  });
+});

--- a/server/tools/playwrightScreenshot.js
+++ b/server/tools/playwrightScreenshot.js
@@ -5,6 +5,13 @@ import { chromium } from 'playwright';
 import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.mjs';
 import { getRootDir } from '../pathUtils.js';
 import config from '../config.js';
+import { assertSafeHost } from '../services/mcp/safeFetch.js';
+
+function createError(message, code) {
+  const err = new Error(message);
+  err.code = code;
+  return err;
+}
 
 /**
  * Take a screenshot or generate a PDF of a web page using Playwright
@@ -23,8 +30,20 @@ export default async function playwrightScreenshot({
   chatId = 'default'
 }) {
   if (!url) {
-    throw new Error('url parameter is required');
+    throw createError('url parameter is required', 'MISSING_URL');
   }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (error) {
+    throw createError(`Invalid URL: ${error.message}`, 'INVALID_URL');
+  }
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw createError('Only HTTP and HTTPS URLs are supported', 'UNSUPPORTED_PROTOCOL');
+  }
+  await assertSafeHost(parsedUrl.hostname);
+
   const dataDir = config.DATA_DIR;
   const toolId = 'playwrightScreenshot';
   const ext = format === 'pdf' ? 'pdf' : 'png';

--- a/server/tools/seleniumScreenshot.js
+++ b/server/tools/seleniumScreenshot.js
@@ -6,6 +6,13 @@ import chrome from 'selenium-webdriver/chrome.js';
 import { getRootDir } from '../pathUtils.js';
 import config from '../config.js';
 import pdfParse from 'pdf-parse';
+import { assertSafeHost } from '../services/mcp/safeFetch.js';
+
+function createError(message, code) {
+  const err = new Error(message);
+  err.code = code;
+  return err;
+}
 
 /**
  * Take a screenshot or generate a PDF of a web page using Selenium WebDriver
@@ -24,8 +31,20 @@ export default async function seleniumScreenshot({
   chatId = 'default'
 }) {
   if (!url) {
-    throw new Error('url parameter is required');
+    throw createError('url parameter is required', 'MISSING_URL');
   }
+
+  let parsedUrl;
+  try {
+    parsedUrl = new URL(url);
+  } catch (error) {
+    throw createError(`Invalid URL: ${error.message}`, 'INVALID_URL');
+  }
+  if (!['http:', 'https:'].includes(parsedUrl.protocol)) {
+    throw createError('Only HTTP and HTTPS URLs are supported', 'UNSUPPORTED_PROTOCOL');
+  }
+  await assertSafeHost(parsedUrl.hostname);
+
   const dataDir = config.DATA_DIR;
   const toolId = 'seleniumScreenshot';
   const ext = format === 'pdf' ? 'pdf' : 'png';


### PR DESCRIPTION
## Summary

Fixes #1691.

`playwrightScreenshot` and `seleniumScreenshot` launched a real headless browser and navigated to a caller-supplied URL (`page.goto(url)` / `driver.get(url)`) with zero validation — no protocol check, no private/internal IP block. The sibling `webContentExtractor` tool already blocks loopback/private/link-local ranges; these two tools didn't, so a browser could be pointed at `169.254.169.254` (cloud metadata) or internal-only hosts and return the result as a screenshot or extracted PDF text.

- Both tools now validate the URL *before* launching a browser:
  - Missing URL → `MISSING_URL`
  - Malformed URL → `INVALID_URL`
  - Non-`http`/`https` protocol (e.g. `file:`) → `UNSUPPORTED_PROTOCOL`
  - Hostname resolving to a private/loopback/link-local IP → `SSRF_BLOCKED` (via `assertSafeHost` from `server/services/mcp/safeFetch.js`, which also respects the admin-configurable `platform.ssrf.allowedHosts` allowlist)
- Added `server/tests/screenshotTools-ssrf.test.js` covering both tools: missing/invalid URL, unsupported protocol, private IP literal, cloud metadata IP, `localhost`, and a public-IP happy path that reaches the (mocked) browser launch.
- Added a changelog entry under `docs/releases/5.5.0/features.md`.

### Adjacent fix

While writing tests I found `seleniumScreenshot.js` imports `pdf-parse` for PDF text extraction, but that package was never declared in `server/package.json` — so the tool has always crashed with a module-not-found error on any invocation (png or pdf). Added `pdf-parse@^1.1.1` as a dependency to fix this pre-existing, unrelated bug (it was blocking me from even importing/testing the module).

### Known residual gap (not addressed here, per the issue's own scoping note)

`assertSafeHost` does a single DNS resolution before navigation, but the browser does its own DNS resolution and follows redirects independently, so a public hostname that redirects or DNS-rebinds to a private IP after the initial check could still land the browser on an internal host. This is the same class of gap tracked separately for `webContentExtractor` in #1693, and closing it for the browser tools would need a network-level control (CDP request interception) — left as a follow-up rather than folding into this fix.

## Test plan

- [x] `npm run lint:fix` / `npx eslint` on changed files — clean
- [x] `npx prettier --check` on changed files — clean
- [x] New unit tests pass: `server/tests/screenshotTools-ssrf.test.js` (14/14)
- [x] Existing `server/tests/mcp/safeFetch.test.js` still passes (22/22)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nj1PwAZLh2Jf34rc8bnk3V)_