### PR TITLE
Refactor: move provider-specific tool-schema sanitization into each adapter

### DIFF
--- a/server/adapters/toolCalling/AnthropicConverter.js
+++ b/server/adapters/toolCalling/AnthropicConverter.js
@@ -10,11 +10,24 @@ import {
   createGenericToolCall,
   createGenericStreamingResponse,
   normalizeFinishReason,
-  sanitizeSchemaForProvider
+  cloneAndWalkSchema
 } from './GenericToolCalling.js';
 import { validateProviderToolName } from './toolNameValidator.js';
 import logger from '../../utils/logger.js';
 import { parseJsonAsync } from '../../utils/asyncJson.js';
+
+/**
+ * Sanitize a JSON Schema for Anthropic's tool `input_schema`. Anthropic's
+ * schema support is generally more flexible than other providers, so this
+ * currently only deep-clones the schema — kept as an explicit hook other
+ * converters (e.g. Bedrock, which reuses this) can call, and where future
+ * Anthropic-specific restrictions can be added without touching shared code.
+ * @param {Object} schema - JSON Schema
+ * @returns {Object} Sanitized schema
+ */
+export function sanitizeSchema(schema) {
+  return cloneAndWalkSchema(schema, () => {});
+}
 
 /**
  * Convert generic tools to Anthropic format
@@ -55,7 +68,7 @@ export function convertGenericToolsToAnthropic(genericTools = []) {
   return filteredTools.map(tool => ({
     name: tool.id || tool.name,
     description: tool.description,
-    input_schema: sanitizeSchemaForProvider(tool.parameters, 'anthropic')
+    input_schema: sanitizeSchema(tool.parameters)
   }));
 }
 

--- a/server/adapters/toolCalling/BedrockConverter.js
+++ b/server/adapters/toolCalling/BedrockConverter.js
@@ -9,9 +9,9 @@
 import {
   createGenericTool,
   createGenericToolCall,
-  createGenericStreamingResponse,
-  sanitizeSchemaForProvider
+  createGenericStreamingResponse
 } from './GenericToolCalling.js';
+import { sanitizeSchema as sanitizeAnthropicSchema } from './AnthropicConverter.js';
 import { validateProviderToolName } from './toolNameValidator.js';
 import { parseJsonAsync } from '../../utils/asyncJson.js';
 import logger from '../../utils/logger.js';
@@ -48,10 +48,10 @@ export function convertGenericToolsToBedrock(genericTools = []) {
       name: tool.id || tool.name,
       description: tool.description || '',
       inputSchema: {
-        json: sanitizeSchemaForProvider(
-          tool.parameters || { type: 'object', properties: {} },
-          'anthropic'
-        )
+        // Bedrock's Converse API tool schema shape matches Anthropic's, so
+        // intentionally reuse Anthropic's schema sanitization rather than
+        // duplicating it.
+        json: sanitizeAnthropicSchema(tool.parameters || { type: 'object', properties: {} })
       }
     }
   }));

--- a/server/adapters/toolCalling/GenericToolCalling.js
+++ b/server/adapters/toolCalling/GenericToolCalling.js
@@ -258,31 +258,37 @@ export function normalizeFinishReason(providerFinishReason, provider) {
 }
 
 /**
- * Sanitize JSON Schema for provider compatibility
+ * Deep-clone a JSON Schema and recursively visit every schema node, letting
+ * `visitSchemaNode` mutate it in place. This is the provider-agnostic part of
+ * schema sanitization; provider-specific field deletions/normalizations live
+ * in each converter's own `sanitizeSchema()` (see AnthropicConverter.js,
+ * GoogleConverter.js, etc.) and are passed in as `visitSchemaNode`.
+ *
+ * A node is a "schema" (where keywords like `title`/`format`/`minLength`
+ * are JSON Schema annotations a provider might want to strip) only if it
+ * declares a `type`. A `properties` container — whose keys ARE property
+ * names — has no `type` of its own, so it is never passed to
+ * `visitSchemaNode`. Otherwise a property literally named
+ * `title`/`format`/`minLength` would get deleted from its parent's
+ * `properties`, and any `required: ['title']` pointing at it would then fail
+ * the provider's strict schema check.
+ *
  * @param {Object} schema - JSON Schema
- * @param {string} provider - Target provider
+ * @param {(node: Object) => void} visitSchemaNode - mutates a schema node in place
  * @returns {Object} Sanitized schema
  */
-//FIXME: This function is used to normalize finish reasons from different providers. the specific handling should be done in the provider-specific adapters.
-export function sanitizeSchemaForProvider(schema, provider) {
+export function cloneAndWalkSchema(schema, visitSchemaNode) {
   if (!schema || typeof schema !== 'object') {
     return { type: 'object', properties: {} };
   }
 
   const sanitized = JSON.parse(JSON.stringify(schema)); // Deep clone
 
-  // A node is a "schema" (where keywords like `title`/`format`/`minLength`
-  // are JSON Schema annotations we want to strip) only if it declares a
-  // `type`. A `properties` container — whose keys ARE property names — has
-  // no `type` of its own, so we must NOT apply the keyword strip there.
-  // Otherwise a property literally named `title`/`format`/`minLength` gets
-  // deleted from its parent's `properties`, then any `required: ['title']`
-  // pointing at it fails the provider's strict schema check.
   function isSchemaNode(obj) {
     return obj && typeof obj === 'object' && typeof obj.type === 'string';
   }
 
-  function cleanObject(obj, parentKey) {
+  function walk(obj, parentKey) {
     if (!obj || typeof obj !== 'object') return obj;
 
     // Inside a `properties` container, each key is a user-defined property
@@ -291,47 +297,16 @@ export function sanitizeSchemaForProvider(schema, provider) {
     const isPropertiesContainer = parentKey === 'properties' && !isSchemaNode(obj);
 
     if (!isPropertiesContainer) {
-      // Remove provider-specific incompatible fields
-      if (provider === 'google') {
-        // Normalize non-standard type values to valid JSON Schema types
-        if (
-          obj.type &&
-          !['string', 'number', 'integer', 'boolean', 'array', 'object'].includes(obj.type)
-        ) {
-          obj.type = 'string';
-        }
-        // Ensure description is a plain string (not a multilingual object)
-        if (obj.description && typeof obj.description === 'object') {
-          obj.description = obj.description.en || Object.values(obj.description)[0] || '';
-        }
-        delete obj.exclusiveMaximum;
-        delete obj.exclusiveMinimum;
-        delete obj.title;
-        delete obj.format; // Google has limited format support
-        delete obj.minLength; // Use 'minimum' instead for strings
-        delete obj.maxLength; // Use 'maximum' instead for strings
-        // JSON Schema meta keywords that Google's restricted OpenAPI subset
-        // rejects with HTTP 400 ("Unknown name ..."). MCP tools routinely emit
-        // these ($schema + additionalProperties: false from their JSON Schema
-        // draft), so strip them or every MCP tool call to Gemini fails.
-        delete obj.$schema;
-        delete obj.$id;
-        delete obj.additionalProperties;
-        delete obj.patternProperties;
-      }
-
-      if (provider === 'anthropic') {
-        // Anthropic is generally more flexible, but we might need to add restrictions here
-      }
+      visitSchemaNode(obj);
     }
 
-    // Recursively clean nested objects
+    // Recursively walk nested objects
     for (const key in obj) {
       if (obj[key] && typeof obj[key] === 'object') {
         if (Array.isArray(obj[key])) {
-          obj[key] = obj[key].map(item => cleanObject(item, key));
+          obj[key] = obj[key].map(item => walk(item, key));
         } else {
-          obj[key] = cleanObject(obj[key], key);
+          obj[key] = walk(obj[key], key);
         }
       }
     }
@@ -339,5 +314,5 @@ export function sanitizeSchemaForProvider(schema, provider) {
     return obj;
   }
 
-  return cleanObject(sanitized);
+  return walk(sanitized);
 }

--- a/server/adapters/toolCalling/GoogleConverter.js
+++ b/server/adapters/toolCalling/GoogleConverter.js
@@ -10,7 +10,7 @@ import {
   createGenericToolCall,
   createGenericStreamingResponse,
   normalizeFinishReason,
-  sanitizeSchemaForProvider,
+  cloneAndWalkSchema,
   normalizeToolName
 } from './GenericToolCalling.js';
 import { isPlausibleToolName, describeInvalidToolName } from './toolNameValidator.js';
@@ -22,6 +22,44 @@ const HALLUCINATION_NOTICE_PREFIX = '[provider:google dropped malformed function
 function truncateForLog(value, max = 200) {
   if (typeof value !== 'string') return value;
   return value.length > max ? `${value.slice(0, max)}…(${value.length})` : value;
+}
+
+/**
+ * Sanitize a JSON Schema for Google's restricted OpenAPI-subset tool schema
+ * support: normalize non-standard `type` values, flatten multilingual
+ * `description` objects to a plain string, and strip keywords Gemini's API
+ * rejects with HTTP 400 ("Unknown name ...").
+ * @param {Object} schema - JSON Schema
+ * @returns {Object} Sanitized schema
+ */
+export function sanitizeSchema(schema) {
+  return cloneAndWalkSchema(schema, obj => {
+    // Normalize non-standard type values to valid JSON Schema types
+    if (
+      obj.type &&
+      !['string', 'number', 'integer', 'boolean', 'array', 'object'].includes(obj.type)
+    ) {
+      obj.type = 'string';
+    }
+    // Ensure description is a plain string (not a multilingual object)
+    if (obj.description && typeof obj.description === 'object') {
+      obj.description = obj.description.en || Object.values(obj.description)[0] || '';
+    }
+    delete obj.exclusiveMaximum;
+    delete obj.exclusiveMinimum;
+    delete obj.title;
+    delete obj.format; // Google has limited format support
+    delete obj.minLength; // Use 'minimum' instead for strings
+    delete obj.maxLength; // Use 'maximum' instead for strings
+    // JSON Schema meta keywords that Google's restricted OpenAPI subset
+    // rejects with HTTP 400 ("Unknown name ..."). MCP tools routinely emit
+    // these ($schema + additionalProperties: false from their JSON Schema
+    // draft), so strip them or every MCP tool call to Gemini fails.
+    delete obj.$schema;
+    delete obj.$id;
+    delete obj.additionalProperties;
+    delete obj.patternProperties;
+  });
 }
 
 /**
@@ -66,7 +104,7 @@ export function convertGenericToolsToGoogle(genericTools = []) {
       functionDeclarations: functionTools.map(tool => ({
         name: normalizeToolName(tool.id),
         description: tool.description,
-        parameters: sanitizeSchemaForProvider(tool.parameters, 'google')
+        parameters: sanitizeSchema(tool.parameters)
       }))
     }
   ];

--- a/server/adapters/toolCalling/MistralConverter.js
+++ b/server/adapters/toolCalling/MistralConverter.js
@@ -17,10 +17,21 @@ import {
 import {
   createGenericStreamingResponse,
   normalizeFinishReason,
-  sanitizeSchemaForProvider
+  cloneAndWalkSchema
 } from './GenericToolCalling.js';
 import logger from '../../utils/logger.js';
 import { parseJsonAsync } from '../../utils/asyncJson.js';
+
+/**
+ * Sanitize a JSON Schema for Mistral's tool `parameters`. Mistral has no
+ * known schema restrictions today, so this currently only deep-clones the
+ * schema — kept as an explicit hook for future Mistral-specific rules.
+ * @param {Object} schema - JSON Schema
+ * @returns {Object} Sanitized schema
+ */
+export function sanitizeSchema(schema) {
+  return cloneAndWalkSchema(schema, () => {});
+}
 
 /**
  * Convert generic tools to Mistral format
@@ -61,7 +72,7 @@ export function convertGenericToolsToMistral(genericTools = []) {
     function: {
       name: tool.id || tool.name,
       description: tool.description,
-      parameters: sanitizeSchemaForProvider(tool.parameters, 'mistral')
+      parameters: sanitizeSchema(tool.parameters)
     }
   }));
 }

--- a/server/adapters/toolCalling/OpenAIConverter.js
+++ b/server/adapters/toolCalling/OpenAIConverter.js
@@ -10,11 +10,22 @@ import {
   createGenericToolCall,
   createGenericStreamingResponse,
   normalizeFinishReason,
-  sanitizeSchemaForProvider
+  cloneAndWalkSchema
 } from './GenericToolCalling.js';
 import { isPlausibleToolName, validateProviderToolName } from './toolNameValidator.js';
 import logger from '../../utils/logger.js';
 import { parseJsonAsync } from '../../utils/asyncJson.js';
+
+/**
+ * Sanitize a JSON Schema for OpenAI's tool `parameters`. OpenAI has no known
+ * schema restrictions today, so this currently only deep-clones the schema —
+ * kept as an explicit hook for future OpenAI-specific rules.
+ * @param {Object} schema - JSON Schema
+ * @returns {Object} Sanitized schema
+ */
+export function sanitizeSchema(schema) {
+  return cloneAndWalkSchema(schema, () => {});
+}
 
 /**
  * Convert generic tools to OpenAI format
@@ -56,7 +67,7 @@ export function convertGenericToolsToOpenAI(genericTools = []) {
     function: {
       name: tool.id || tool.name,
       description: tool.description,
-      parameters: sanitizeSchemaForProvider(tool.parameters, 'openai')
+      parameters: sanitizeSchema(tool.parameters)
     }
   }));
 }

--- a/server/adapters/toolCalling/OpenAIResponsesConverter.js
+++ b/server/adapters/toolCalling/OpenAIResponsesConverter.js
@@ -11,10 +11,22 @@ import {
   createGenericToolCall,
   createGenericStreamingResponse,
   normalizeFinishReason,
-  sanitizeSchemaForProvider
+  cloneAndWalkSchema
 } from './GenericToolCalling.js';
 import logger from '../../utils/logger.js';
 import { parseJsonAsync } from '../../utils/asyncJson.js';
+
+/**
+ * Sanitize a JSON Schema for the OpenAI Responses API's tool `parameters`.
+ * The Responses API has no known schema restrictions beyond strict mode
+ * (handled separately by `addStrictModeToSchema`), so this currently only
+ * deep-clones the schema — kept as an explicit hook for future rules.
+ * @param {Object} schema - JSON Schema
+ * @returns {Object} Sanitized schema
+ */
+export function sanitizeSchema(schema) {
+  return cloneAndWalkSchema(schema, () => {});
+}
 
 /**
  * Add strict mode requirements to a schema for OpenAI Responses API
@@ -117,7 +129,7 @@ export function convertGenericToolsToOpenaiResponses(genericTools = []) {
   });
 
   return functionTools.map(tool => {
-    const sanitizedParams = sanitizeSchemaForProvider(tool.parameters, 'openai-responses');
+    const sanitizedParams = sanitizeSchema(tool.parameters);
     const strictParams = addStrictModeToSchema(sanitizedParams);
 
     return {

--- a/server/adapters/toolCalling/README.md
+++ b/server/adapters/toolCalling/README.md
@@ -171,9 +171,9 @@ Normalize tool names to be compatible with all providers.
 
 Normalize finish reasons across providers (`"stop"`, `"length"`, `"tool_calls"`, `"content_filter"`).
 
-#### `sanitizeSchemaForProvider(schema, provider)`
+#### `cloneAndWalkSchema(schema, visitSchemaNode)`
 
-Clean JSON Schema for provider-specific compatibility.
+Deep-clone a JSON Schema and recursively visit each schema node, skipping `properties` containers. Provider-specific field deletions/normalizations live in each converter's own `sanitizeSchema(schema)` (e.g. `GoogleConverter.sanitizeSchema`, `AnthropicConverter.sanitizeSchema`), which pass their cleanup logic in as `visitSchemaNode`.
 
 ### Error Handling
 

--- a/server/adapters/toolCalling/index.js
+++ b/server/adapters/toolCalling/index.js
@@ -49,7 +49,7 @@ export {
   normalizeFinishReason,
   isFailureFinishReason,
   FAILURE_FINISH_REASONS,
-  sanitizeSchemaForProvider
+  cloneAndWalkSchema
 } from './GenericToolCalling.js';
 
 // Export individual provider converters for advanced use cases


### PR DESCRIPTION
## Summary

Closes #1567.

`sanitizeSchemaForProvider(schema, provider)` in `server/adapters/toolCalling/GenericToolCalling.js` held a growing pile of `if (provider === '...')` branches inside a function named *generic*, and all six tool-calling converters delegated to it. This made it impossible to tell what actually happens to a tool schema for a given provider without jumping into shared code, and it had already let Google's schema-cleaning drift out of sync between the tool-parameters path and `google.js`'s `response_schema` path (fixed narrowly in #1566).

- Extracted the provider-agnostic part (deep clone + recursive walk + the `properties`-container guard that prevents deleting a property literally named `title`/`additionalProperties`/etc.) into a new shared `cloneAndWalkSchema(schema, visitSchemaNode)` in `GenericToolCalling.js`.
- Each converter now owns an exported `sanitizeSchema(schema)` built on that helper:
  - `GoogleConverter.sanitizeSchema` — carries forward the full Google-only cleanup (type normalization, multilingual description flattening, and stripping `title`/`format`/`minLength`/`maxLength`/`$schema`/`$id`/`additionalProperties`/`patternProperties`/`exclusiveMaximum`/`exclusiveMinimum`).
  - `AnthropicConverter.sanitizeSchema`, `MistralConverter.sanitizeSchema`, `OpenAIConverter.sanitizeSchema`, `OpenAIResponsesConverter.sanitizeSchema` — currently no-op clones (matching today's behavior, since the old shared function had no branch for these providers), now with an obvious place to add provider-specific rules later.
  - `BedrockConverter` imports and calls `AnthropicConverter.sanitizeSchema` directly rather than duplicating it, since Bedrock's Converse API tool schema shape matches Anthropic's (this is what the old code did by passing `'anthropic'` as the provider string).
- Removed `sanitizeSchemaForProvider` and its `//FIXME` from `GenericToolCalling.js`, and updated `toolCalling/index.js`'s exports and the module README accordingly.

**Out of scope (intentionally):** `google.js`'s separate `removeAdditionalProperties` closure for the `response_schema` (structured-output) path is left untouched. Consolidating it with `GoogleConverter.sanitizeSchema` would strip additional keywords (`title`/`format`/`$schema`/etc.) from structured-output requests that aren't stripped today — a real behavior change, not just a structural refactor. The issue's own implementation-plan comment flagged this explicitly as a separate follow-up rather than something to fold in silently.

## Why

No behavior change for any of the six converters' tool-parameter sanitization — same wire payload sent to every provider for existing tools. This is purely a structural move so each adapter is self-contained and the next provider-specific quirk gets added to that provider's converter instead of a shared "generic" file.

## Test plan

- [x] `npm run test:adapters` (openai, mistral, anthropic, google, bedrock, vllm-images) — all pass
- [x] `npm run test:tool-calling` — passes (pre-existing, unrelated SSE-prefix parse errors logged by that suite are present on `main` too and don't affect its exit code)
- [x] `node server/tests/openaiResponsesToolCalling.test.js` — passes
- [x] `node server/tests/google-tool-schema-validation.test.js` — passes, including the regression test covering a property literally named `additionalProperties`
- [x] `npx eslint` / `npx prettier --check` on all changed files — clean
- [x] Verified server boots correctly with the change (`node server/server.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LrXDUdNKesYeZxmj9UMMkL)_