### PR TITLE
fix: catch blocks logging the wrong variable crash the error handler itself

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -461,6 +461,22 @@ field) and the multimodal audio-upload path (which sends audio to a chat LLM).
 **Before using:** add or enable a transcription model under **Admin → Models** (model type
 "Transcription"), set its realtime URL, then enable transcription on the desired app.
 
+## More Resilient Error Handling Across Auth, Chat, and Background Jobs
+
+A recurring copy-paste bug in ~17 error-logging call sites meant that failures in proxy-auth JWT
+verification, chat prompt building, short links, admin config saves, Office 365 drive listing, and
+marketplace installs could crash the error handler itself instead of failing gracefully and logging
+a useful message.
+
+- Affected failure paths now log correctly and degrade gracefully (e.g. skip a style/skill, fall
+  back to a default) instead of raising an unrelated internal error.
+- Proxy authentication's JWKS key cache (for JWT-based providers) now refreshes every 10 hours
+  instead of caching signing keys forever, so a rotated identity-provider signing key is picked up
+  without a server restart.
+- The server now logs and, for unrecoverable errors, restarts the affected worker instead of
+  silently hanging or dying with no diagnostic trail.
+- No configuration or admin action required.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -106,6 +106,20 @@ export default [
         ...globals.node,
         ...globals.es2024
       }
+    },
+    rules: {
+      // Catches copy-pasted catch blocks that log a variable name other than
+      // the bound catch parameter (e.g. `catch (error) { ...error: err }`),
+      // which throws a ReferenceError inside the error handler itself.
+      'no-undef': 'error'
+    }
+  },
+  {
+    files: ['server/tests/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.jest
+      }
     }
   }
 ];

--- a/server/adapters/toolCalling/OpenAIConverter.js
+++ b/server/adapters/toolCalling/OpenAIConverter.js
@@ -382,7 +382,7 @@ export async function convertOpenAIResponseToGeneric(data, streamId = 'default')
             } catch (error) {
               logger.warn('Failed to parse accumulated OpenAI tool arguments', {
                 component: 'OpenAIConverter',
-                error: e
+                error
               });
               parsedArgs = { __raw_arguments: pending.arguments };
             }

--- a/server/adapters/toolCalling/index.js
+++ b/server/adapters/toolCalling/index.js
@@ -20,6 +20,9 @@
  * // Now you have a uniform response format regardless of provider
  */
 
+import { createUnifiedInterface } from './ToolCallingConverter.js';
+import { normalizeToolName } from './GenericToolCalling.js';
+
 // Export main converter interface
 export {
   convertToolsToGeneric,

--- a/server/middleware/proxyAuth.js
+++ b/server/middleware/proxyAuth.js
@@ -1,47 +1,50 @@
 import jwt from 'jsonwebtoken';
-import { httpFetch } from '../utils/httpConfig.js';
-import * as jose from 'jose';
+import jwksRsa from 'jwks-rsa';
+import { promisify } from 'util';
 import config from '../config.js';
 import configCache from '../configCache.js';
 import { enhanceUserGroups } from '../utils/authorization.js';
 import { validateAndPersistExternalUser } from '../utils/userManager.js';
 import logger from '../utils/logger.js';
 
-const jwksCache = new Map();
+// JWKS clients per provider jwkUrl, each with its own TTL'd key cache so
+// rotated IdP signing keys are picked up instead of being cached forever.
+const jwksClients = new Map();
 
-async function getJwks(jwkUrl) {
-  if (jwksCache.has(jwkUrl)) return jwksCache.get(jwkUrl);
-  try {
-    const res = await httpFetch(jwkUrl);
-    if (!res.ok) throw new Error(`Failed to load JWKs: ${res.status}`);
-    const jwks = await res.json();
-    jwksCache.set(jwkUrl, jwks);
-    return jwks;
-  } catch (error) {
-    logger.error('Error fetching JWKs', { component: 'ProxyAuth', error: err });
-    return null;
+function getJwksClient(jwkUrl) {
+  if (!jwksClients.has(jwkUrl)) {
+    jwksClients.set(
+      jwkUrl,
+      jwksRsa({
+        jwksUri: jwkUrl,
+        cache: true,
+        cacheMaxEntries: 5,
+        cacheMaxAge: 10 * 60 * 60 * 1000 // 10 hours
+      })
+    );
   }
+  return jwksClients.get(jwkUrl);
 }
 
 async function verifyJwt(token, provider) {
   try {
-    const jwks = await getJwks(provider.jwkUrl);
-    if (!jwks || !jwks.keys?.length) throw new Error('No keys');
     const decoded = jwt.decode(token, { complete: true });
     const kid = decoded?.header?.kid;
-    const jwk = kid ? jwks.keys.find(k => k.kid === kid) : jwks.keys[0];
-    if (!jwk) throw new Error('Key not found');
 
-    // Use jose to import the JWK and verify the JWT
-    const publicKey = await jose.importJWK(jwk, 'RS256');
-    const { payload } = await jose.jwtVerify(token, publicKey, {
+    const client = getJwksClient(provider.jwkUrl);
+    const getSigningKey = promisify(client.getSigningKey);
+    const key = await getSigningKey(kid);
+    const signingKey = key.publicKey || key.rsaPublicKey;
+
+    const payload = jwt.verify(token, signingKey, {
+      algorithms: ['RS256'],
       issuer: provider.issuer,
       audience: provider.audience
     });
 
     return payload;
   } catch (error) {
-    logger.error('JWT verification failed', { component: 'ProxyAuth', error: err });
+    logger.error('JWT verification failed', { component: 'ProxyAuth', error });
     return null;
   }
 }

--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -408,7 +408,7 @@ export default function registerAdminConfigRoutes(app) {
             component: 'AdminConfigs'
           });
         } catch (error) {
-          logger.warn('Could not reset iFinder caches', { component: 'AdminConfigs', error: err });
+          logger.warn('Could not reset iFinder caches', { component: 'AdminConfigs', error });
         }
       }
 

--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -344,8 +344,8 @@ export default function registerSessionRoutes(
     chatAuthRequired,
     validate(chatConnectSchema),
     async (req, res) => {
+      const { appId, chatId } = req.params;
       try {
-        const { appId, chatId } = req.params;
         const channel = createSseChannel({
           req,
           res,

--- a/server/routes/shortLinkRoutes.js
+++ b/server/routes/shortLinkRoutes.js
@@ -118,7 +118,7 @@ export default function registerShortLinkRoutes(app) {
       }
       res.redirect(link.url);
     } catch (error) {
-      logger.error('Error redirecting short link', { component: 'ShortLinkRoutes', error: e });
+      logger.error('Error redirecting short link', { component: 'ShortLinkRoutes', error });
       res.status(500).send('Error');
     }
   });

--- a/server/server.js
+++ b/server/server.js
@@ -77,6 +77,29 @@ dotenv.config();
 
 import config from './config.js';
 
+// Process-level safety net: a rejected promise with no local .catch (or an
+// exception missed by Express's synchronous error handling) would otherwise
+// crash the process silently (or hang the request) with no diagnostic trail.
+process.on('unhandledRejection', reason => {
+  logger.error('Unhandled promise rejection', {
+    component: 'Server',
+    error: reason instanceof Error ? reason.message : reason,
+    stack: reason instanceof Error ? reason.stack : undefined
+  });
+});
+
+process.on('uncaughtException', error => {
+  logger.error('Uncaught exception, exiting', {
+    component: 'Server',
+    error: error.message,
+    stack: error.stack
+  });
+  // The process is now in an undefined state; exit rather than keep serving
+  // requests on a possibly-corrupted worker. Under clustering (WORKERS > 1)
+  // the primary's `exit` handler respawns the worker automatically.
+  process.exit(1);
+});
+
 // ----- Cluster setup -----
 const workerCount = config.WORKERS;
 

--- a/server/services/PromptService.js
+++ b/server/services/PromptService.js
@@ -375,7 +375,7 @@ class PromptService {
         } catch (error) {
           logger.error('Error loading skills for system prompt', {
             component: 'PromptService',
-            error: err
+            error
           });
         }
       }
@@ -403,7 +403,7 @@ class PromptService {
           logger.error('Error pre-activating skill', {
             component: 'PromptService',
             requestedSkill,
-            error: err
+            error
           });
         }
       }
@@ -422,7 +422,7 @@ class PromptService {
             });
           }
         } catch (error) {
-          logger.error('Error loading styles', { component: 'PromptService', error: err });
+          logger.error('Error loading styles', { component: 'PromptService', error });
         }
       }
 

--- a/server/services/UsageAggregator.js
+++ b/server/services/UsageAggregator.js
@@ -171,7 +171,7 @@ export async function generateDailyRollups() {
     logger.info('Generated daily rollups', { component: 'UsageAggregator', daysGenerated });
     return { eventsProcessed: events.length, daysGenerated };
   } catch (error) {
-    logger.error('Failed to generate daily rollups', { component: 'UsageAggregator', error: e });
+    logger.error('Failed to generate daily rollups', { component: 'UsageAggregator', error });
     return { eventsProcessed: 0, daysGenerated: 0 };
   }
 }
@@ -212,7 +212,7 @@ export async function generateMonthlyRollups() {
     logger.info('Generated monthly rollups', { component: 'UsageAggregator', monthsGenerated });
     return { monthsGenerated };
   } catch (error) {
-    logger.error('Failed to generate monthly rollups', { component: 'UsageAggregator', error: e });
+    logger.error('Failed to generate monthly rollups', { component: 'UsageAggregator', error });
     return { monthsGenerated: 0 };
   }
 }

--- a/server/services/integrations/Office365Service.js
+++ b/server/services/integrations/Office365Service.js
@@ -963,7 +963,7 @@ class Office365Service {
           logger.warn('Could not load drives for site', {
             component: 'Office365Service',
             siteName: site.displayName,
-            error: e
+            error
           });
         }
       }

--- a/server/services/marketplace/ContentInstaller.js
+++ b/server/services/marketplace/ContentInstaller.js
@@ -242,7 +242,7 @@ async function buildSkillContent(item, skillMd, authHeaders) {
     try {
       companions = await registryService.discoverCompanions(item.source.url, authHeaders);
     } catch (error) {
-      logger.warn('Companion discovery fallback failed', { component: COMPONENT, error: err });
+      logger.warn('Companion discovery fallback failed', { component: COMPONENT, error });
     }
   }
 
@@ -278,7 +278,7 @@ async function buildSkillContent(item, skillMd, authHeaders) {
         logger.warn('Failed to fetch companion file', {
           component: COMPONENT,
           relativePath,
-          error: err
+          error
         });
       }
     })

--- a/server/services/workflow/ExecutionRegistry.js
+++ b/server/services/workflow/ExecutionRegistry.js
@@ -435,7 +435,7 @@ export class ExecutionRegistry {
         if (error.code !== 'ENOENT') {
           logger.warn('Error loading registry file, will rebuild from checkpoints', {
             component: 'ExecutionRegistry',
-            error: err
+            error
           });
         }
       }
@@ -515,7 +515,7 @@ export class ExecutionRegistry {
           logger.debug('Skipping directory without valid checkpoint', {
             component: 'ExecutionRegistry',
             executionId,
-            error: err
+            error
           });
         }
       }
@@ -524,7 +524,7 @@ export class ExecutionRegistry {
         // State directory doesn't exist yet, that's fine
         logger.debug('State directory does not exist yet', { component: 'ExecutionRegistry' });
       } else {
-        throw err;
+        throw error;
       }
     }
   }

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -534,7 +534,8 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
         tools,
         config,
         context: contextForLLM,
-        nodeId: node.id
+        nodeId: node.id,
+        nativeWebSearch
       });
 
       // Finalise the step transcript with timing + outcome.
@@ -1392,7 +1393,7 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
    * @returns {Promise<Object>} Final response with content
    * @private
    */
-  async executeLLMWithTools({ model, messages, tools, config, context, nodeId }) {
+  async executeLLMWithTools({ model, messages, tools, config, context, nodeId, nativeWebSearch }) {
     // Budget-driven continuation (Claude Code TOKEN_BUDGET analog). The agent
     // runs as long as the task and budget require, rather than a fixed count.
     // `maxToolRoundsPerNode` is a safety backstop above the token budget; the

--- a/server/shortLinkManager.js
+++ b/server/shortLinkManager.js
@@ -51,7 +51,7 @@ function scheduleSave() {
     try {
       await saveLinks();
     } catch (error) {
-      logger.error('Failed to save short link data', { component: 'ShortLinkManager', error: e });
+      logger.error('Failed to save short link data', { component: 'ShortLinkManager', error });
     }
   }, SAVE_INTERVAL_MS);
 }

--- a/server/utils/installationCleanup.js
+++ b/server/utils/installationCleanup.js
@@ -34,7 +34,7 @@ export async function removeMarketplaceInstallation(type, itemId) {
       component: 'InstallationCleanup',
       type,
       itemId,
-      error: err
+      error
     });
   }
 }


### PR DESCRIPTION
## Summary

Fixes #1681.

A recurring copy-paste bug: `catch (error) { ... error: err }` / `error: e` — the logged identifier doesn't match the bound catch parameter, so the error handler itself throws a `ReferenceError` on any failure. What should be a graceful log-and-continue instead crashes the handler (unhandled rejection with no process-level handler in the normal `server.js` path, or a swallowed/duplicated error depending on the call site).

Fixed all ~14 sites called out in the issue, plus 3 more of the exact same bug class that turned up while verifying the fix and enabling `no-undef`:

- `server/middleware/proxyAuth.js` (JWKS fetch + JWT verification)
- `server/services/PromptService.js` (skills / requested-skill / styles loading, 3 sites)
- `server/adapters/toolCalling/OpenAIConverter.js` (tool-argument parse recovery)
- `server/services/UsageAggregator.js` (daily/monthly rollups, 2 sites)
- `server/shortLinkManager.js`, `server/routes/shortLinkRoutes.js`
- `server/routes/admin/configs.js` (iFinder cache reset)
- `server/services/integrations/Office365Service.js` (drive listing)
- `server/services/marketplace/ContentInstaller.js` (companion discovery, 2 sites)
- `server/utils/installationCleanup.js` *(new — same bug class)*
- `server/services/workflow/ExecutionRegistry.js` *(new — 2 sites, one of which was `throw err` re-raising an undefined variable)*
- `server/routes/chat/sessionRoutes.js` *(new — a related scope bug: `chatId` was destructured inside the `try` block, so it was unreachable in the `catch`)*
- `server/services/workflow/executors/PromptNodeExecutor.js` *(new — `nativeWebSearch` referenced in `executeLLMWithTools` without ever being passed in, throwing on every tool-enabled call; same root cause as #1683/#2033 but flagged independently here by the new lint rule)*

Also, per the issue's recommended fix:

- **JWKS TTL**: `proxyAuth.js`'s hand-rolled JWKS cache never expired, so a rotated OIDC/proxy-auth signing key was never picked up. Replaced it with a `jwks-rsa` client (10h TTL), mirroring the existing pattern in `teamsAuth.js`.
- **Process-level safety net**: added `unhandledRejection` (log) and `uncaughtException` (log + `process.exit(1)`, so a clustered worker gets auto-respawned) handlers in `server.js`, matching the pattern already used in `sea-server.cjs` for the standalone binary.
- **Prevent recurrence**: enabled `no-undef` for `server/**/*.js` (with jest globals added for `server/tests/**`) so this class of bug is caught at lint time. Verified `npm run lint` is clean (0 errors) after the change.

## Test plan

- [x] `npm run lint` — 0 errors (was previously not possible to detect this bug class at all)
- [x] `npx prettier --check` on all touched files
- [x] Wrote a standalone smoke script exercising the new `jwks-rsa`-based JWT verification (JWKS fetch by `kid`, issuer/audience validation, rejects wrong issuer) — confirms parity with the previous `jose`-based implementation
- [x] Ran the full `server` Jest suite before and after the change — identical pass/fail set (45 failing tests, all pre-existing/unrelated to this change; no new failures)
- [x] Added a changelog entry under `docs/releases/5.5.0/features.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01X826FuvTYGgBoNS4iEmbmP)_