### PR TITLE
fix: resolve duplicate migration version numbers V018, V043, V073

### DIFF
--- a/server/migrations/V075__add_setup_configured_flag.js
+++ b/server/migrations/V075__add_setup_configured_flag.js
@@ -1,4 +1,4 @@
-export const version = '018';
+export const version = '075';
 export const description = 'add_setup_configured_flag';
 
 export async function precondition(ctx) {

--- a/server/migrations/V076__fix_ifinder_jwt_subject_template.js
+++ b/server/migrations/V076__fix_ifinder_jwt_subject_template.js
@@ -1,5 +1,5 @@
 /**
- * Migration V043 — Fix iFinder.jwtSubjectField template syntax
+ * Migration V076 — Fix iFinder.jwtSubjectField template syntax
  *
  * Background: the JWT subject template in `iFinder.jwtSubjectField` used the
  * `${field}` placeholder syntax (e.g. `"BMG\\${username}"`). configCache's
@@ -21,7 +21,7 @@
  * they are looked up by `iFinderJwt.resolveJwtSubject`, not template-replaced.
  */
 
-export const version = '043';
+export const version = '076';
 export const description = 'fix_ifinder_jwt_subject_template';
 
 const STANDARD_VALUES = new Set(['email', 'username', 'domain\\username']);

--- a/server/migrations/V077__seed_voxtral_transcription_model.js
+++ b/server/migrations/V077__seed_voxtral_transcription_model.js
@@ -1,4 +1,4 @@
-export const version = '073';
+export const version = '077';
 export const description = 'seed_voxtral_transcription_model';
 
 const MODEL_PATH = 'models/voxtral-mini-realtime.json';

--- a/server/migrations/runner.js
+++ b/server/migrations/runner.js
@@ -68,7 +68,73 @@ export async function scanMigrationFiles(migrationsDir) {
   }
 
   migrations.sort((a, b) => a.version.localeCompare(b.version));
+
+  const fileByVersion = new Map();
+  for (const migration of migrations) {
+    const existing = fileByVersion.get(migration.version);
+    if (existing) {
+      throw new Error(
+        `Duplicate migration version V${migration.version}: ${existing} and ${migration.file} both declare the same version. Each migration must have a unique version number.`
+      );
+    }
+    fileByVersion.set(migration.version, migration.file);
+  }
+
   return migrations;
+}
+
+/**
+ * Historical migration renumberings, keyed by the version/filename a file
+ * used to ship under before it was renumbered to resolve a version collision.
+ * Existing installs may have a history entry recorded under the old
+ * version/file; reconcile it to the new version so it isn't re-applied and
+ * doesn't trigger a spurious checksum mismatch against the file that kept
+ * the original number.
+ */
+const RENAMED_MIGRATIONS = [
+  {
+    oldVersion: '018',
+    oldFile: 'V018__add_setup_configured_flag.js',
+    newVersion: '075',
+    newFile: 'V075__add_setup_configured_flag.js'
+  },
+  {
+    oldVersion: '043',
+    oldFile: 'V043__fix_ifinder_jwt_subject_template.js',
+    newVersion: '076',
+    newFile: 'V076__fix_ifinder_jwt_subject_template.js'
+  },
+  {
+    oldVersion: '073',
+    oldFile: 'V073__seed_voxtral_transcription_model.js',
+    newVersion: '077',
+    newFile: 'V077__seed_voxtral_transcription_model.js'
+  }
+];
+
+/**
+ * Rewrite history entries for migrations that were renumbered to resolve a
+ * duplicate-version collision. Matches on the recorded `file` name (not just
+ * version) so it only touches the entry that actually corresponds to the
+ * renamed file, leaving the sibling that kept its original number untouched.
+ * @param {object} history
+ * @returns {boolean} whether any entry was changed
+ */
+export function reconcileRenamedMigrations(history) {
+  let changed = false;
+  for (const { oldVersion, oldFile, newVersion, newFile } of RENAMED_MIGRATIONS) {
+    const entry = history.migrations.find(m => m.version === oldVersion && m.file === oldFile);
+    if (entry) {
+      entry.version = newVersion;
+      entry.file = newFile;
+      changed = true;
+      logger.info(
+        `Reconciled migration history entry: ${oldFile} (V${oldVersion}) -> ${newFile} (V${newVersion})`,
+        { component: 'Migration' }
+      );
+    }
+  }
+  return changed;
 }
 
 /**
@@ -340,6 +406,14 @@ export async function runConfigMigrations() {
           component: 'Migration'
         });
       }
+    }
+
+    // Reconcile history entries for migrations renumbered to resolve a
+    // duplicate-version collision (see RENAMED_MIGRATIONS), before validating
+    // checksums so a renamed file's old history entry doesn't show up as
+    // "removed from disk" or collide with its sibling's checksum.
+    if (reconcileRenamedMigrations(history)) {
+      await saveHistory(contentsDir, history);
     }
 
     // Validate previously applied migrations

--- a/server/tests/iFinderJwtSubject-securityBug.test.js
+++ b/server/tests/iFinderJwtSubject-securityBug.test.js
@@ -1,7 +1,7 @@
 /**
  * Regression tests for the iFinder JWT subject env-var leak.
  *
- * Bug (pre-V043 / pre-skip-list): configCache's `resolveEnvVars` matched
+ * Bug (pre-V076 / pre-skip-list): configCache's `resolveEnvVars` matched
  * `${field}` placeholders in `iFinder.jwtSubjectField` against process.env.
  * On Windows `process.env.username` is set to the OS user running the
  * server, so a template like `BMG\${username}` was rewritten to
@@ -15,13 +15,13 @@
  *   2. iFinderJwt's template regex matches both `${field}` (legacy) and
  *      `${user.field}` (preferred) syntaxes, and the legacy detector
  *      flags only the unprefixed form.
- *   3. The V043 migration converts `${field}` to `${user.field}` in
+ *   3. The V076 migration converts `${field}` to `${user.field}` in
  *      existing platform.json files.
  */
 import { describe, it, before, after } from 'node:test';
 import assert from 'node:assert/strict';
 import { resolveEnvVarsInObject } from '../configCache.js';
-import { up as migrationUp } from '../migrations/V043__fix_ifinder_jwt_subject_template.js';
+import { up as migrationUp } from '../migrations/V076__fix_ifinder_jwt_subject_template.js';
 
 describe('iFinder JWT subject — env var resolution skip', () => {
   // configCache passes this skipPaths list when caching the platform config.
@@ -108,7 +108,7 @@ describe('iFinder JWT subject — template regex pin', () => {
   // These regexes are intentionally duplicated from `resolveJwtSubject` in
   // iFinderJwt.js. They are the part of the contract that callers (admins
   // writing templates) depend on — if you change the regex, update both
-  // sites AND bump V043 (or add a new migration) to convert existing configs.
+  // sites AND bump V076 (or add a new migration) to convert existing configs.
 
   const TEMPLATE_RE = /\$\{(?:user\.)?(\w+)\}/g;
   const LEGACY_DETECT_RE = /\$\{(?!user\.)\w+\}/;
@@ -139,7 +139,7 @@ describe('iFinder JWT subject — template regex pin', () => {
   });
 });
 
-describe('V043 migration', () => {
+describe('V076 migration', () => {
   function makeCtx(initialPlatform) {
     let platform = JSON.parse(JSON.stringify(initialPlatform));
     const logs = [];

--- a/server/tests/migrations-runner.test.js
+++ b/server/tests/migrations-runner.test.js
@@ -14,7 +14,12 @@ import {
   removeById,
   transformWhere
 } from '../migrations/utils.js';
-import { scanMigrationFiles, loadHistory, computeChecksum } from '../migrations/runner.js';
+import {
+  scanMigrationFiles,
+  loadHistory,
+  computeChecksum,
+  reconcileRenamedMigrations
+} from '../migrations/runner.js';
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
@@ -295,6 +300,77 @@ describe('Migration Runner', () => {
       const files = await scanMigrationFiles(tmpDir);
       expect(files).toHaveLength(1);
       expect(files[0].version).toBe('001');
+    });
+
+    it('should throw when two files declare the same version', async () => {
+      await fs.writeFile(
+        path.join(tmpDir, 'V018__add_cookie_settings.js'),
+        'export const version = "018";'
+      );
+      await fs.writeFile(
+        path.join(tmpDir, 'V018__add_setup_configured_flag.js'),
+        'export const version = "018";'
+      );
+
+      await expect(scanMigrationFiles(tmpDir)).rejects.toThrow(/Duplicate migration version V018/);
+    });
+
+    it('should not throw when all versions are unique', async () => {
+      await fs.writeFile(path.join(tmpDir, 'V001__first.js'), 'export const version = "001";');
+      await fs.writeFile(path.join(tmpDir, 'V002__second.js'), 'export const version = "002";');
+
+      await expect(scanMigrationFiles(tmpDir)).resolves.toHaveLength(2);
+    });
+  });
+
+  describe('reconcileRenamedMigrations', () => {
+    it('rewrites a history entry recorded under a renamed migration file', () => {
+      const history = {
+        schemaVersion: '1.0',
+        migrations: [
+          {
+            version: '018',
+            description: 'add_setup_configured_flag',
+            file: 'V018__add_setup_configured_flag.js',
+            checksum: 'abc123',
+            status: 'success'
+          }
+        ]
+      };
+
+      const changed = reconcileRenamedMigrations(history);
+
+      expect(changed).toBe(true);
+      expect(history.migrations[0].version).toBe('075');
+      expect(history.migrations[0].file).toBe('V075__add_setup_configured_flag.js');
+    });
+
+    it('leaves the sibling that kept its original version number untouched', () => {
+      const history = {
+        schemaVersion: '1.0',
+        migrations: [
+          {
+            version: '018',
+            description: 'add_cookie_settings',
+            file: 'V018__add_cookie_settings.js',
+            checksum: 'abc123',
+            status: 'success'
+          }
+        ]
+      };
+
+      const changed = reconcileRenamedMigrations(history);
+
+      expect(changed).toBe(false);
+      expect(history.migrations[0].version).toBe('018');
+      expect(history.migrations[0].file).toBe('V018__add_cookie_settings.js');
+    });
+
+    it('is a no-op on a fresh install with no matching history entries', () => {
+      const history = { schemaVersion: '1.0', migrations: [] };
+
+      expect(reconcileRenamedMigrations(history)).toBe(false);
+      expect(history.migrations).toEqual([]);
     });
   });
 


### PR DESCRIPTION
## Summary

Three pairs of migration files shared the same version number: `V018` (`add_cookie_settings` / `add_setup_configured_flag`), `V043` (`add_content_admin_group` / `fix_ifinder_jwt_subject_template` — the iFinder JWT subject leak security fix), and an undocumented third pair, `V073` (`retire_native_search_tool_files` / `seed_voxtral_transcription_model`).

The migration runner keys everything by version number alone:
- `filesByVersion = new Map(migrationFiles.map(f => [f.version, f]))` collapses duplicates, causing a spurious "checksum mismatch" warning (or hard startup failure under `checksumValidation: 'strict'`) on every startup.
- `appliedVersions.has(f.version)` pending-detection means an install that already recorded one file of a pair will **silently never apply the sibling** — including the `V043` iFinder JWT security fix.

- Renumbered the later file in each pair to a fresh, unique version:
  - `V018__add_setup_configured_flag.js` → `V075__add_setup_configured_flag.js`
  - `V043__fix_ifinder_jwt_subject_template.js` → `V076__fix_ifinder_jwt_subject_template.js`
  - `V073__seed_voxtral_transcription_model.js` → `V077__seed_voxtral_transcription_model.js`
- `scanMigrationFiles` now throws immediately if two files declare the same version, so this bug class can't ship again.
- Added `reconcileRenamedMigrations()`, run once before checksum validation on every startup: for an existing install whose `.migration-history.json` has an entry matching a renamed file's *old* version **and** filename, it rewrites that entry to the new version/filename in place. This prevents the renamed migration from re-running and avoids a checksum mismatch against the sibling that kept its original number. Entries that don't match (fresh installs, or the sibling that kept its number) are left untouched.
- Fixed `iFinderJwtSubject-securityBug.test.js`, which imported the `V043` migration module directly by its old filename.

## Test plan

- [x] `server/tests/migrations-runner.test.js` — added tests for the duplicate-version guard (`scanMigrationFiles` throws) and `reconcileRenamedMigrations` (rewrites the renamed entry, leaves the sibling untouched, no-op on fresh install). All 46 tests pass.
- [x] `server/tests/iFinderJwtSubject-securityBug.test.js` — updated import path; all 16 tests pass via `node --test`.
- [x] Verified `scanMigrationFiles` against the real `server/migrations/` directory: 72 files, no duplicate versions.
- [x] `npx eslint` clean on all changed files.

Closes #1685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PjRcJ2QJnrFKHsCf49cuRW

---
_Generated by [Claude Code](https://claude.ai/code/session_01PjRcJ2QJnrFKHsCf49cuRW)_