### PR TITLE
feat(chat): follow-up suggestion chips after assistant responses

### DIFF
--- a/client/src/api/endpoints/apps.js
+++ b/client/src/api/endpoints/apps.js
@@ -125,6 +125,27 @@ export const checkAppChatStatus = async (appId, chatId) => {
   );
 };
 
+/**
+ * Generate follow-up question suggestions for the most recent exchange.
+ * @param {string} appId - App ID
+ * @param {string} chatId - Chat session ID
+ * @param {Array<{role: string, content: string}>} messages - Recent conversation turns
+ * @param {Object} [options]
+ * @param {string} [options.language] - BCP 47 language code for the suggestions
+ */
+export const fetchFollowUpSuggestions = async (appId, chatId, messages, options = {}) => {
+  return handleApiResponse(
+    () =>
+      apiClient.post(`/apps/${appId}/chat/${chatId}/followup-suggestions`, {
+        messages,
+        ...options
+      }),
+    null, // No caching
+    null,
+    false // Don't deduplicate
+  );
+};
+
 // Print an HTML document via a hidden, same-origin iframe.
 //
 // We deliberately avoid `window.open()` here: inside sandboxed/embedded hosts

--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -2507,6 +2507,55 @@ function AppFormEditor({
               </div>
             </div>
 
+            {/* Follow-Up Suggestions Configuration */}
+            <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+              <div className="md:grid md:grid-cols-3 md:gap-6">
+                <div className="md:col-span-1">
+                  <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+                    {t('admin.apps.edit.followUpSuggestions', 'Follow-Up Suggestions')}
+                  </h3>
+                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                    {t(
+                      'admin.apps.edit.followUpSuggestionsDesc',
+                      'Suggest contextual follow-up questions as clickable chips after assistant responses'
+                    )}
+                  </p>
+                </div>
+                <div className="mt-5 md:col-span-2 md:mt-0">
+                  <div className="space-y-4">
+                    <div className="flex items-center">
+                      <input
+                        type="checkbox"
+                        checked={app.features?.followUpSuggestions?.enabled !== false}
+                        onChange={e =>
+                          handleInputChange('features', {
+                            ...app.features,
+                            followUpSuggestions: {
+                              ...app.features?.followUpSuggestions,
+                              enabled: e.target.checked
+                            }
+                          })
+                        }
+                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+                      />
+                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                        {t(
+                          'admin.apps.edit.enableFollowUpSuggestions',
+                          'Enable Follow-Up Suggestions'
+                        )}
+                      </label>
+                    </div>
+                    <p className="text-xs text-gray-500 dark:text-gray-400">
+                      {t(
+                        'admin.apps.edit.followUpSuggestionsNote',
+                        'When enabled, 2-3 contextual follow-up questions are suggested as clickable chips below each completed assistant response. The platform-level feature must also be enabled for this to work.'
+                      )}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
             {/* Input Mode & Microphone Configuration */}
             <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
               <div className="md:grid md:grid-cols-3 md:gap-6">

--- a/client/src/features/apps/pages/AppChat.jsx
+++ b/client/src/features/apps/pages/AppChat.jsx
@@ -7,7 +7,7 @@ import {
 } from '../../../utils/chatId';
 import { getConversationMessages } from '../../../api/endpoints/apps';
 import { useParams, useNavigate, useSearchParams } from 'react-router-dom';
-import { fetchAppDetails } from '../../../api';
+import { fetchAppDetails, fetchFollowUpSuggestions } from '../../../api';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import { useTranslation } from 'react-i18next';
 import { getLocalizedContent } from '../../../utils/localizeContent';
@@ -507,6 +507,108 @@ function AppChat({ preloadedApp = null }) {
     // the chat settings. When on, nothing is persisted to browser storage.
     ephemeral
   });
+
+  // Follow-up suggestion chips: once the latest assistant message finishes
+  // streaming, fetch 2-3 contextual follow-up questions and attach them to
+  // that message. Fire-and-forget — a failure just means no chips render.
+  // Not supported in compare mode (multiple panels, no single "last message").
+  const followUpRequestedRef = useRef(new Set());
+  useEffect(() => {
+    if (compareModeActive) return;
+    if (!app || !featureFlags.isBothEnabled(app, 'followUpSuggestions', true)) return;
+
+    const lastMessage = messages[messages.length - 1];
+    if (
+      !lastMessage ||
+      lastMessage.role !== 'assistant' ||
+      lastMessage.loading ||
+      lastMessage.awaitingInput ||
+      lastMessage.error
+    ) {
+      return;
+    }
+    if (followUpRequestedRef.current.has(lastMessage.id)) return;
+    followUpRequestedRef.current.add(lastMessage.id);
+
+    const lastMessageIndex = messages.length - 1;
+    const prevUserMessage = [...messages.slice(0, lastMessageIndex)]
+      .reverse()
+      .find(m => m.role === 'user');
+
+    const contextMessages = [
+      ...(prevUserMessage
+        ? [{ role: 'user', content: prevUserMessage.rawContent || prevUserMessage.content }]
+        : []),
+      { role: 'assistant', content: lastMessage.content }
+    ].filter(m => typeof m.content === 'string' && m.content.trim().length > 0);
+
+    if (contextMessages.length === 0) return;
+
+    fetchFollowUpSuggestions(appId, chatId.current, contextMessages, {
+      language: currentLanguage
+    })
+      .then(response => {
+        if (Array.isArray(response?.suggestions) && response.suggestions.length > 0) {
+          updateAssistantMessage(lastMessage.id, lastMessage.content, false, {
+            followUpSuggestions: response.suggestions
+          });
+        }
+      })
+      .catch(err => console.warn('Failed to fetch follow-up suggestions:', err));
+  }, [
+    messages,
+    compareModeActive,
+    app,
+    featureFlags,
+    appId,
+    currentLanguage,
+    updateAssistantMessage
+  ]);
+
+  const handleFollowUpSelect = useCallback(
+    suggestion => {
+      if (!suggestion || processing) return;
+      sendChatMessage({
+        displayMessage: { content: suggestion },
+        apiMessage: { content: suggestion, promptTemplate: app?.prompt || null, variables: {} },
+        params: {
+          modelId: selectedModel,
+          style: selectedStyle,
+          temperature,
+          outputFormat: selectedOutputFormat,
+          language: currentLanguage,
+          ...(thinkingEnabled !== null ? { thinkingEnabled } : {}),
+          ...(thinkingBudget !== null ? { thinkingBudget } : {}),
+          ...(thinkingThoughts !== null ? { thinkingThoughts } : {}),
+          ...(effectiveEnabledTools !== null && effectiveEnabledTools !== undefined
+            ? { enabledTools: effectiveEnabledTools }
+            : {}),
+          ...(app?.websearch?.enabled ? { websearchEnabled } : {})
+        },
+        sendChatHistory,
+        messageMetadata: {
+          customResponseRenderer: app?.customResponseRenderer,
+          outputFormat: selectedOutputFormat
+        }
+      });
+    },
+    [
+      processing,
+      sendChatMessage,
+      app,
+      selectedModel,
+      selectedStyle,
+      temperature,
+      selectedOutputFormat,
+      currentLanguage,
+      thinkingEnabled,
+      thinkingBudget,
+      thinkingThoughts,
+      effectiveEnabledTools,
+      websearchEnabled,
+      sendChatHistory
+    ]
+  );
 
   // Resume conversation from conversation API on mount (iAssistant Conversation)
   const conversationResumed = useRef(false);
@@ -2178,6 +2280,7 @@ function AppChat({ preloadedApp = null }) {
                         onClarificationSubmit={handleClarificationSubmit}
                         onClarificationSkip={handleClarificationSkip}
                         onDocumentAction={handleDocumentAction}
+                        onFollowUpSelect={handleFollowUpSelect}
                       />
                     </div>
                   ) : (
@@ -2219,6 +2322,7 @@ function AppChat({ preloadedApp = null }) {
                         onClarificationSubmit={handleClarificationSubmit}
                         onClarificationSkip={handleClarificationSkip}
                         onDocumentAction={handleDocumentAction}
+                        onFollowUpSelect={handleFollowUpSelect}
                       />
                     </div>
                   ) : (
@@ -2259,6 +2363,7 @@ function AppChat({ preloadedApp = null }) {
                     onClarificationSubmit={handleClarificationSubmit}
                     onClarificationSkip={handleClarificationSkip}
                     onDocumentAction={handleDocumentAction}
+                    onFollowUpSelect={handleFollowUpSelect}
                   />
                 </div>
                 <div className="flex-shrink-0 px-4 pt-2">{renderChatInput()}</div>
@@ -2289,6 +2394,7 @@ function AppChat({ preloadedApp = null }) {
                   onClarificationSubmit={handleClarificationSubmit}
                   onClarificationSkip={handleClarificationSkip}
                   onDocumentAction={handleDocumentAction}
+                  onFollowUpSelect={handleFollowUpSelect}
                 />
 
                 {renderChatInput()}

--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -50,6 +50,7 @@ function ChatCheckpoint({ executionId, checkpoint }) {
   );
 }
 import AnswerSourceBadge from './AnswerSourceBadge';
+import FollowUpChips from './FollowUpChips';
 import ExportDialog from './ExportDialog';
 import './ChatMessage.css';
 
@@ -74,7 +75,8 @@ function ChatMessage({
   models = [], // Available models for determining if model param should be included in link
   onClarificationSubmit = null, // Callback when a clarification response is submitted
   onClarificationSkip = null, // Callback when a clarification is skipped
-  onDocumentAction = null // Callback for citation document actions (preview, download, openInApp)
+  onDocumentAction = null, // Callback for citation document actions (preview, download, openInApp)
+  onFollowUpSelect = null // Callback when a follow-up suggestion chip is clicked
 }) {
   const { t } = useTranslation();
 
@@ -920,6 +922,16 @@ function ChatMessage({
           </div>
         )}
       </div>
+
+      {/* Follow-up suggestion chips - only on the latest completed assistant message */}
+      {!isUser &&
+        !isError &&
+        !message.loading &&
+        isLatestAssistantMessage &&
+        onFollowUpSelect &&
+        message.followUpSuggestions?.length > 0 && (
+          <FollowUpChips suggestions={message.followUpSuggestions} onSelect={onFollowUpSelect} />
+        )}
 
       {/*
         Primary insert action (Office taskpane). Renders as a labelled brand-coloured

--- a/client/src/features/chat/components/ChatMessageList.jsx
+++ b/client/src/features/chat/components/ChatMessageList.jsx
@@ -36,7 +36,9 @@ function ChatMessageList({
   onClarificationSkip = null, // Callback when a clarification is skipped
   // Citation document action handlers
   onDocumentAction = null,
-  showAvatars = true
+  showAvatars = true,
+  // Called with suggestion text when a follow-up suggestion chip is clicked
+  onFollowUpSelect = null
 }) {
   const { t } = useTranslation();
   const chatContainerRef = useRef(null);
@@ -183,6 +185,7 @@ function ChatMessageList({
                 onClarificationSubmit={onClarificationSubmit}
                 onClarificationSkip={onClarificationSkip}
                 onDocumentAction={onDocumentAction}
+                onFollowUpSelect={onFollowUpSelect}
               />
             </div>
           </div>

--- a/client/src/features/chat/components/FollowUpChips.jsx
+++ b/client/src/features/chat/components/FollowUpChips.jsx
@@ -1,0 +1,41 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * Clickable follow-up question chips shown below a completed assistant
+ * response. Clicking a chip sends its text as the next user message.
+ *
+ * @param {Object} props
+ * @param {string[]} props.suggestions - Follow-up question strings (max 3 expected)
+ * @param {Function} props.onSelect - Called with the suggestion text when a chip is clicked
+ */
+function FollowUpChips({ suggestions, onSelect }) {
+  const { t } = useTranslation();
+
+  if (!suggestions || suggestions.length === 0) return null;
+
+  return (
+    <div
+      role="listbox"
+      aria-label={t('followup.suggestions', 'Follow-up suggestions')}
+      className="flex flex-wrap gap-2 mt-2"
+    >
+      {suggestions.map((suggestion, index) => (
+        <button
+          key={`${index}-${suggestion}`}
+          type="button"
+          role="option"
+          aria-selected="false"
+          onClick={() => onSelect(suggestion)}
+          className="inline-flex items-center px-3.5 py-2 rounded-full text-sm font-medium
+            min-h-[36px] transition-colors duration-150 ease-in-out
+            bg-gray-100 text-gray-700 hover:bg-gray-200 dark:bg-gray-700 dark:text-gray-300 dark:hover:bg-gray-600
+            focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+        >
+          {suggestion}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export default FollowUpChips;

--- a/client/src/features/chat/hooks/useAppChat.js
+++ b/client/src/features/chat/hooks/useAppChat.js
@@ -323,7 +323,7 @@ function useAppChat({
 
             updateAssistantMessage(lastMessageIdRef.current, fullContent, false, metadata);
             if (onMessageComplete) {
-              onMessageComplete(fullContent, lastUserMessageRef.current);
+              onMessageComplete(fullContent, lastUserMessageRef.current, lastMessageIdRef.current);
             }
           }
           setProcessing(false);

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -71,6 +71,7 @@
     - [Realtime Voice & Transcription](voice-transcription.md)
     - [Web Tools](web-tools.md)
     - [Magic Prompt](magic-prompt-feature.md)
+    - [Follow-Up Suggestions](follow-up-suggestions-feature.md)
     - [Image Upload Feature](image-upload-feature.md)
     - [OCR Feature](ocr-feature.md)
     - [React Component Feature](react-component-feature.md)

--- a/docs/follow-up-suggestions-feature.md
+++ b/docs/follow-up-suggestions-feature.md
@@ -1,0 +1,80 @@
+# Follow-Up Suggestions Feature Documentation
+
+## Overview
+
+The follow-up suggestions feature reduces the "blank box" problem after an assistant
+response by proposing 2-3 short, contextual follow-up questions the user might ask
+next. Suggestions render as clickable chips below the completed assistant message;
+clicking one sends its text as the next user message.
+
+## Platform Configuration
+
+The feature is registered in the feature registry as `followUpSuggestions` (category
+`ai`, enabled by default). Toggle it platform-wide from Admin → Platform → Features.
+
+## App Configuration
+
+Override the feature per app by adding a `followUpSuggestions` object under the
+`features` section:
+
+```json
+"features": {
+  "followUpSuggestions": {
+    "enabled": true,
+    "model": "gpt-4o-mini"
+  }
+}
+```
+
+`followUpSuggestions` is opt-out at the app level, like `compareMode`: if the object
+is present but `enabled` is omitted, the feature is treated as enabled. Both the
+platform-level and app-level flags must be enabled for chips to appear. If `model`
+is omitted, the platform's default model is used.
+
+## API Endpoint
+
+**POST /api/apps/{appId}/chat/{chatId}/followup-suggestions**
+
+Request body:
+
+| Field      | Type   | Required | Description                                                          |
+| ---------- | ------ | -------- | ---------------------------------------------------------------------- |
+| `messages` | array  | Yes      | Recent conversation turns (`{ role: 'user' \| 'assistant', content }`) |
+| `language` | string | No       | BCP 47 language code for the generated suggestions                     |
+
+Response body:
+
+```json
+{
+  "suggestions": ["Can you give an example?", "What are the tradeoffs?"]
+}
+```
+
+The endpoint never returns an error status for generation failures — it responds with
+`{ "suggestions": [] }` instead, since this is a non-critical UX enhancement that
+should never surface as a visible chat error. It returns `404` only when the app
+itself does not exist.
+
+## Client Flow
+
+1. When the latest assistant message finishes streaming (and isn't an error or an
+   in-progress clarification), the client fires a single request to the
+   `followup-suggestions` endpoint with the last user/assistant exchange as context.
+2. On a non-empty response, the suggestions are attached to that message and rendered
+   as chips (`FollowUpChips`) below it.
+3. Chips are only shown on the most recent assistant message and disappear once the
+   user sends the next message (a new "latest assistant message" takes over).
+4. Clicking a chip sends its text through the normal chat pipeline, using the
+   currently selected model/style/temperature and other active chat parameters.
+
+Not currently supported in Compare Mode (multiple response panels have no single
+"latest message" to attach chips to).
+
+## Suggestion Generation
+
+The server prompts the configured model to return a bare JSON array of 2-3 short
+follow-up questions (each under 60 characters), using only the last exchange as
+context. Since not every model/provider reliably honors structured-output
+instructions, the response is parsed defensively: a JSON array is extracted from the
+completion if present, falling back to a line-by-line split (stripping bullets and
+numbering) if the model didn't return valid JSON. At most 3 suggestions are returned.

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,16 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Follow-Up Suggestion Chips After Assistant Responses
+
+Chat apps can now suggest 2-3 short follow-up questions as clickable chips below a completed
+assistant response, so users aren't left staring at a blank input box after an answer.
+
+- Clicking a chip sends its text as the next message, using the same model/style/settings as the
+  ongoing conversation.
+- New platform feature flag **Follow-Up Suggestions** (Admin → Platform → Features), enabled by
+  default, with a per-app override under an app's **Follow-Up Suggestions** settings section.
+- Suggestions are generated from the last exchange only and never block or fail the chat — if
+  generation fails or the feature is disabled, no chips are shown.
+- Not yet available in Compare Mode.

--- a/server/featureRegistry.js
+++ b/server/featureRegistry.js
@@ -155,6 +155,16 @@ export const featureRegistry = [
     category: 'preview',
     default: false,
     preview: true
+  },
+  {
+    id: 'followUpSuggestions',
+    name: { en: 'Follow-Up Suggestions', de: 'Anschlussvorschläge' },
+    description: {
+      en: 'Suggest contextual follow-up questions as clickable chips after assistant responses',
+      de: 'Kontextbezogene Anschlussfragen als klickbare Chips nach Assistenten-Antworten vorschlagen'
+    },
+    category: 'ai',
+    default: true
   }
 ];
 

--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -1,6 +1,6 @@
 import configCache from '../../configCache.js';
 import { createCompletionRequest } from '../../adapters/index.js';
-import { getErrorDetails, logInteraction, trackSession } from '../../utils.js';
+import { getErrorDetails, logInteraction, trackSession, simpleCompletion } from '../../utils.js';
 import { clients, activeRequests } from '../../sse.js';
 import { actionTracker } from '../../actionTracker.js';
 import { createSseChannel } from '../../utils/sseChannel.js';
@@ -10,10 +10,16 @@ import {
   chatAuthRequired,
   modelAccessRequired
 } from '../../middleware/authRequired.js';
+import { isFeatureEnabled } from '../../featureRegistry.js';
 
 import ChatService from '../../services/chat/ChatService.js';
 import validate from '../../validators/validate.js';
-import { chatTestSchema, chatPostSchema, chatConnectSchema } from '../../validators/index.js';
+import {
+  chatTestSchema,
+  chatPostSchema,
+  chatConnectSchema,
+  followUpSuggestionsSchema
+} from '../../validators/index.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import logger from '../../utils/logger.js';
 import {
@@ -1090,4 +1096,175 @@ export default function registerSessionRoutes(
     }
     return res.status(200).json({ active: false });
   });
+
+  /**
+   * @swagger
+   * /apps/{appId}/chat/{chatId}/followup-suggestions:
+   *   post:
+   *     summary: Generate follow-up question suggestions
+   *     description: |
+   *       Generates 2-3 short contextual follow-up questions based on the most recent
+   *       exchange, for display as clickable chips below a completed assistant response.
+   *       Returns an empty list (rather than an error) when the feature is disabled or
+   *       generation fails, since this is a non-critical UX enhancement.
+   *     tags:
+   *       - Chat
+   *     security:
+   *       - bearerAuth: []
+   *       - sessionAuth: []
+   *     parameters:
+   *       - in: path
+   *         name: appId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The app ID
+   *       - in: path
+   *         name: chatId
+   *         required: true
+   *         schema:
+   *           type: string
+   *         description: The chat session ID
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - messages
+   *             properties:
+   *               messages:
+   *                 type: array
+   *                 description: Recent conversation turns (user/assistant), most relevant last
+   *                 items:
+   *                   type: object
+   *                   properties:
+   *                     role:
+   *                       type: string
+   *                       enum: [user, assistant]
+   *                     content:
+   *                       type: string
+   *               language:
+   *                 type: string
+   *                 description: BCP 47 language code for the generated suggestions
+   *     responses:
+   *       200:
+   *         description: Generated suggestions (possibly empty)
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 suggestions:
+   *                   type: array
+   *                   items:
+   *                     type: string
+   *       401:
+   *         description: Authentication required
+   *       404:
+   *         description: App not found
+   */
+  app.post(
+    buildServerPath('/api/apps/:appId/chat/:chatId/followup-suggestions'),
+    chatAuthRequired,
+    validate(followUpSuggestionsSchema),
+    async (req, res) => {
+      try {
+        const { appId } = req.params;
+        const { messages, language } = req.body;
+
+        const { data: apps = [] } = configCache.getApps();
+        const app = apps.find(a => a.id === appId);
+        if (!app) {
+          return sendNotFound(res, 'App');
+        }
+
+        const platformEnabled = isFeatureEnabled('followUpSuggestions', configCache.getFeatures());
+        const appFeatureConfig = app.features?.followUpSuggestions;
+        const appEnabled = appFeatureConfig?.enabled !== false;
+        if (!platformEnabled || !appEnabled) {
+          return res.json({ suggestions: [] });
+        }
+
+        const { data: models = [] } = configCache.getModels();
+        if (!models || models.length === 0) {
+          return res.json({ suggestions: [] });
+        }
+        const defaultModelId = models.find(m => m.default)?.id;
+        const configuredModelId = appFeatureConfig?.model;
+        const modelId =
+          (configuredModelId && models.some(m => m.id === configuredModelId)
+            ? configuredModelId
+            : null) ||
+          defaultModelId ||
+          models[0].id;
+
+        const clientLanguage =
+          language ||
+          req.headers['accept-language']?.split(',')[0] ||
+          configCache.getPlatform()?.defaultLanguage ||
+          'en';
+
+        const systemPrompt =
+          `Based on the end of this conversation, suggest 2-3 short follow-up questions the ` +
+          `user might naturally ask next. Reply in language "${clientLanguage}". ` +
+          `Respond with ONLY a JSON array of strings, no other text, no markdown, no numbering. ` +
+          `Each string must be a complete question under 60 characters. Example: ` +
+          `["Can you give an example?", "What are the tradeoffs?"]`;
+
+        const result = await simpleCompletion(
+          [{ role: 'system', content: systemPrompt }, ...messages.slice(-4)],
+          { modelId, temperature: 0.7, maxTokens: 300 }
+        );
+
+        return res.json({ suggestions: parseFollowUpSuggestions(result.content) });
+      } catch (error) {
+        // Non-critical UX enhancement — never fail the chat over this.
+        logger.warn('Error generating follow-up suggestions', {
+          component: 'sessionRoutes',
+          error: error.message
+        });
+        return res.json({ suggestions: [] });
+      }
+    }
+  );
+}
+
+/**
+ * Parse follow-up suggestions out of an LLM completion that was asked to return
+ * a bare JSON array of strings. Tolerates code fences, leading/trailing prose,
+ * and models that ignore the "no numbering" instruction, since not every
+ * provider/model combination honors free-text formatting requests reliably.
+ * @param {string} content - Raw completion text
+ * @returns {string[]} Up to 3 non-empty suggestion strings
+ */
+function parseFollowUpSuggestions(content) {
+  if (!content || typeof content !== 'string') return [];
+
+  const arrayMatch = content.match(/\[[\s\S]*\]/);
+  if (arrayMatch) {
+    try {
+      const parsed = JSON.parse(arrayMatch[0]);
+      if (Array.isArray(parsed)) {
+        return parsed
+          .filter(s => typeof s === 'string' && s.trim().length > 0)
+          .map(s => s.trim())
+          .slice(0, 3);
+      }
+    } catch {
+      // Fall through to line-based parsing below
+    }
+  }
+
+  return content
+    .split('\n')
+    .map(line =>
+      line
+        .replace(/^[\s"'\-*\d.)]+/, '')
+        .replace(/["',]+$/, '')
+        .trim()
+    )
+    .filter(line => line.length > 0)
+    .slice(0, 3);
 }

--- a/server/validators/appConfigSchema.js
+++ b/server/validators/appConfigSchema.js
@@ -267,6 +267,13 @@ const featuresSchema = z
         // unset, treat it as enabled. The client uses `enabled !== false` for the same reason.
         enabled: z.boolean().optional().default(true)
       })
+      .optional(),
+    followUpSuggestions: z
+      .object({
+        // Opt-out at the app level, same convention as compareMode above.
+        enabled: z.boolean().optional().default(true),
+        model: z.string().optional()
+      })
       .optional()
   })
   .passthrough(); // Allow additional feature flags

--- a/server/validators/index.js
+++ b/server/validators/index.js
@@ -61,6 +61,25 @@ export const chatConnectSchema = {
   })
 };
 
+export const followUpSuggestionsSchema = {
+  params: z.object({
+    appId: z.string().min(1),
+    chatId: z.string().min(1)
+  }),
+  body: z.object({
+    messages: z
+      .array(
+        z.object({
+          role: z.enum(['user', 'assistant']),
+          content: z.string()
+        })
+      )
+      .min(1)
+      .max(10),
+    language: z.string().optional()
+  })
+};
+
 export const chatPostSchema = {
   params: z.object({
     appId: z.string().min(1),

--- a/tests/unit/client/use-app-chat-event-handlers.test.jsx
+++ b/tests/unit/client/use-app-chat-event-handlers.test.jsx
@@ -131,7 +131,9 @@ test("'done' completes the message (no setSearchStatus ReferenceError)", async (
   expect(done.content).toBe('final answer');
   expect(done.loading).toBe(false);
   expect(result.current.processing).toBe(false);
-  expect(onMessageComplete).toHaveBeenCalledWith('final answer', 'hello');
+  // Third arg is the completed message's id, so callers (e.g. follow-up
+  // suggestion generation) can attach results to the right message.
+  expect(onMessageComplete).toHaveBeenCalledWith('final answer', 'hello', assistant.id);
 });
 
 test("a 'response.message.id' then 'done' sequence keeps both effects", async () => {


### PR DESCRIPTION
## Summary

Closes #1504.

After an assistant response finishes streaming, the chat now suggests 2-3 contextual follow-up questions as clickable chips below the message. Clicking a chip sends its text as the next user message.

- New `POST /api/apps/:appId/chat/:chatId/followup-suggestions` endpoint. Generates suggestions from the last exchange via a lightweight, non-streaming LLM call (`simpleCompletion`), and defensively parses the response (JSON array, or falls back to line-based parsing) since not every provider reliably honors structured-output instructions.
- New `followUpSuggestions` platform feature flag (default **on**), with a per-app opt-out + model override under `app.features.followUpSuggestions`, following the existing `compareMode` convention. Admin UI toggle added to the app editor alongside Compare Mode.
- The endpoint never turns a generation failure (missing API key, malformed model output, disabled feature) into a chat-visible error — it always returns `{ suggestions: [] }`, and the client just shows no chips.
- New `FollowUpChips` component, wired through `ChatMessageList` → `ChatMessage` using the existing `isLatestAssistantMessage` prop so chips only ever show on the most recent completed assistant message, and disappear once the user sends the next message.
- Docs (`docs/follow-up-suggestions-feature.md`) and a changelog entry (`docs/releases/5.5.0/features.md`) added.

### A deliberate deviation from the literal spec in the issue

The issue suggested delivering suggestions as a new SSE event fired after `done`. I found that's not actually deliverable: the client (`useEventSource.js`) aborts the SSE fetch connection synchronously the moment it receives the `done` event, to release the browser's HTTP/1.1 connection slot. Any event emitted after `done` — which an LLM round-trip always is — would race that teardown and be lost. Instead, the client fires a plain REST call to the new endpoint after the message completes, and attaches the result to that message once it resolves.

### Known limitation

Not yet wired up for Compare Mode (multiple response panels, no single "latest message" to attach chips to).

## Test plan

- [x] `npm run lint:fix` / `npm run format:fix` — clean, no new warnings introduced (diffed against `git stash` baseline)
- [x] `npm run build` (client) — builds successfully
- [x] Booted the server against a fresh `contents/` and exercised the new endpoint live as the default local admin:
  - Valid app/chat + messages → `200 { "suggestions": [] }` (no LLM API keys configured in this sandbox, confirms graceful degradation instead of a 500)
  - Server logs confirm the model call was attempted and the caught error was logged as a warning, not surfaced as a request failure
  - Nonexistent app → `404`
  - Empty `messages` array → `400` (schema validation)
- [x] Verified `isFeatureEnabled('followUpSuggestions', ...)` platform gating and the zod `featuresSchema` parse a sample app config with `features.followUpSuggestions` directly
- [ ] Manual click-through of the chip → send-message flow in a browser with a real model configured (not possible in this sandbox — no LLM API keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kh5yo6xpjGcU7S5M5LjhC9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kh5yo6xpjGcU7S5M5LjhC9)_