### PR TITLE
feat(outlook): auto-insert assistant reply into the email (#1447)

### DIFF
--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -21,6 +21,7 @@ import {
   displayReplyFormWithAssistantResponse,
   displayNewEmailFormWithAssistantResponse
 } from '../utilities/replyForm';
+import { isAutoInsertEnabled } from '../utilities/autoInsertSetting';
 import {
   buildPromptTemplate,
   combineUserTextWithEmailContext,
@@ -65,10 +66,21 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   // Chat ID: use a stable ref, reset on item change or new chat
   const chatIdRef = useRef(`office-${uuidv4()}`);
   const selectedStarterPromptRef = useRef(null);
+  // Gates the read-mode auto-insert branch (which opens a fresh reply window
+  // per call) to once per conversation; reset alongside chatIdRef wherever a
+  // new conversation begins. See displayReplyFormWithAssistantResponse.
+  const hasAutoInsertedRef = useRef(false);
 
   const adapter = useOfficeChatAdapter({
     appId: selectedApp?.id,
-    chatId: chatIdRef.current
+    chatId: chatIdRef.current,
+    onMessageComplete: fullContent => {
+      if (!isAutoInsertEnabled()) return;
+      displayReplyFormWithAssistantResponse(fullContent, {
+        silent: true,
+        autoInsertOnceRef: hasAutoInsertedRef
+      });
+    }
   });
 
   const {
@@ -221,6 +233,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
       if (pinnedEmailsRef.current.length === 0) {
         chatIdRef.current = `office-${uuidv4()}`;
         selectedStarterPromptRef.current = null;
+        hasAutoInsertedRef.current = false;
         adapterRef.current.clearMessages();
         setInputValue('');
       }
@@ -484,6 +497,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
     newApp => {
       chatIdRef.current = `office-${uuidv4()}`;
       selectedStarterPromptRef.current = null;
+      hasAutoInsertedRef.current = false;
       adapter.clearMessages();
       setInputValue('');
       setPinnedEmails([]);
@@ -496,6 +510,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   const handleNewChat = useCallback(() => {
     chatIdRef.current = `office-${uuidv4()}`;
     selectedStarterPromptRef.current = null;
+    hasAutoInsertedRef.current = false;
     adapter.clearMessages();
     setInputValue('');
     setPinnedEmails([]);

--- a/client/src/features/office/components/settings-dialog/index.jsx
+++ b/client/src/features/office/components/settings-dialog/index.jsx
@@ -2,12 +2,15 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { officeLocale, SUPPORTED_LANGUAGES, setOfficeLocale } from '../../utilities/officeLocale';
+import { isAutoInsertEnabled, setAutoInsertEnabled } from '../../utilities/autoInsertSetting';
 
 export default function SettingsDialog({ user, isOpen, onClose }) {
   const { t } = useTranslation();
   const [selectedLanguage, setSelectedLanguage] = useState(officeLocale);
+  const [autoInsert, setAutoInsert] = useState(() => isAutoInsertEnabled());
 
   const handleSave = () => {
+    setAutoInsertEnabled(autoInsert);
     if (selectedLanguage !== officeLocale) {
       setOfficeLocale(selectedLanguage);
     } else {
@@ -79,6 +82,23 @@ export default function SettingsDialog({ user, isOpen, onClose }) {
                 </option>
               ))}
             </select>
+          </div>
+
+          <div>
+            <p className="text-xs font-semibold text-slate-500 uppercase tracking-wide mb-2">
+              {t('office.settingsDialog.replies', 'Replies')}
+            </p>
+            <label className="flex items-start gap-2 px-2 py-2 sm:px-3 sm:py-2.5 bg-slate-50 rounded-lg border border-slate-200 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={autoInsert}
+                onChange={e => setAutoInsert(e.target.checked)}
+                className="mt-0.5 h-4 w-4 rounded border-slate-300 text-slate-900 focus:ring-slate-400"
+              />
+              <span className="text-sm text-slate-900">
+                {t('office.settingsDialog.autoInsert', 'Insert replies into email automatically')}
+              </span>
+            </label>
           </div>
         </div>
 

--- a/client/src/features/office/utilities/autoInsertSetting.js
+++ b/client/src/features/office/utilities/autoInsertSetting.js
@@ -1,0 +1,18 @@
+const AUTO_INSERT_STORAGE_KEY = 'office_ihub_auto_insert';
+
+export function isAutoInsertEnabled() {
+  try {
+    const stored = localStorage.getItem(AUTO_INSERT_STORAGE_KEY);
+    return stored === null ? true : stored === 'true';
+  } catch {
+    return true;
+  }
+}
+
+export function setAutoInsertEnabled(enabled) {
+  try {
+    localStorage.setItem(AUTO_INSERT_STORAGE_KEY, enabled ? 'true' : 'false');
+  } catch {
+    // localStorage unavailable
+  }
+}

--- a/client/src/features/office/utilities/replyForm.js
+++ b/client/src/features/office/utilities/replyForm.js
@@ -4,15 +4,32 @@ import { isOutlookMailItemAvailable } from './outlookMailContext';
 import { isMailboxAvailable } from './officeCapabilities';
 import { marked } from 'marked';
 
-export function displayReplyFormWithAssistantResponse(assistantMarkdownText) {
+/**
+ * @param {string} assistantMarkdownText
+ * @param {Object} [options]
+ * @param {boolean} [options.silent] - Suppress user-facing alerts on failure (still logs to
+ *   console). Used by auto-insert so a background attempt never interrupts the chat with a
+ *   popup; the explicit manual "Insert" button keeps alerts.
+ * @param {Object} [options.autoInsertOnceRef] - A ref gating the read-mode branch, which opens a
+ *   brand-new reply window on every call. When set and `.current` is already `true`, the read-mode
+ *   branch no-ops instead of spawning another window; it's flipped to `true` the first time that
+ *   branch actually fires. Not consulted in compose mode, where repeated prepends are safe.
+ */
+export function displayReplyFormWithAssistantResponse(assistantMarkdownText, options = {}) {
+  const { silent = false, autoInsertOnceRef } = options;
+
   if (!isOutlookMailItemAvailable()) {
-    window.alert('Insert is only available when you open this add-in from an email in Outlook.');
+    console.error('[iHub] Insert requested with no Outlook mail item available.');
+    if (!silent) {
+      window.alert('Insert is only available when you open this add-in from an email in Outlook.');
+    }
     return;
   }
 
   const item = Office.context.mailbox.item;
   if (!item) {
-    window.alert('No mail item available.');
+    console.error('[iHub] Insert requested with no mail item available.');
+    if (!silent) window.alert('No mail item available.');
     return;
   }
 
@@ -26,7 +43,9 @@ export function displayReplyFormWithAssistantResponse(assistantMarkdownText) {
     item.body.prependAsync(html, { coercionType: Office.CoercionType.Html }, result => {
       if (result.status === Office.AsyncResultStatus.Failed) {
         console.error('[iHub] body.prependAsync failed:', result.error);
-        window.alert('Could not insert content into the draft. ' + (result.error?.message || ''));
+        if (!silent) {
+          window.alert('Could not insert content into the draft. ' + (result.error?.message || ''));
+        }
       }
     });
     return;
@@ -34,12 +53,16 @@ export function displayReplyFormWithAssistantResponse(assistantMarkdownText) {
 
   // Read mode: open a reply form pre-filled with the response
   if (typeof item.displayReplyFormAsync === 'function') {
+    if (autoInsertOnceRef?.current) return;
     item.displayReplyFormAsync({ htmlBody: html }, result => {
       if (result.status === Office.AsyncResultStatus.Failed) {
         console.error('[iHub] displayReplyFormAsync failed:', result.error);
-        window.alert('Could not open reply form. ' + (result.error?.message || ''));
+        if (!silent) {
+          window.alert('Could not open reply form. ' + (result.error?.message || ''));
+        }
       }
     });
+    if (autoInsertOnceRef) autoInsertOnceRef.current = true;
     return;
   }
 
@@ -49,7 +72,8 @@ export function displayReplyFormWithAssistantResponse(assistantMarkdownText) {
     return;
   }
 
-  window.alert('Insert is not supported for this item type.');
+  console.error('[iHub] Insert is not supported for this item type.');
+  if (!silent) window.alert('Insert is not supported for this item type.');
 }
 
 export function displayNewEmailFormWithAssistantResponse(assistantMarkdownText) {

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -461,6 +461,22 @@ field) and the multimodal audio-upload path (which sends audio to a chat LLM).
 **Before using:** add or enable a transcription model under **Admin → Models** (model type
 "Transcription"), set its realtime URL, then enable transcription on the desired app.
 
+## Outlook Add-in: Assistant Replies Insert into the Email Automatically
+
+The Outlook task pane no longer requires an extra click to get the assistant's answer into the
+email — completed replies are inserted automatically, since "put the answer into the email" is the
+whole point of the add-in.
+
+- In compose mode, every completed reply is prepended into the draft body automatically.
+- In read mode, the reply-form window opens automatically for the first completed reply in a
+  conversation; later replies in the same conversation fall back to the manual button so the pane
+  doesn't spawn a new window per turn.
+- A new **"Insert replies into email automatically"** toggle in the add-in's Settings dialog lets
+  users turn this off; it's on by default and persists across sessions. With it off, behavior is
+  unchanged from before.
+- The manual **Insert** button remains available in both modes as a fallback or to re-insert a
+  reply.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -168,6 +168,8 @@
       "title": "Einstellungen",
       "account": "Konto",
       "language": "Sprache",
+      "replies": "Antworten",
+      "autoInsert": "Antworten automatisch in die E-Mail einfügen",
       "cancel": "Abbrechen",
       "save": "Speichern"
     }

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -147,6 +147,8 @@
       "title": "Settings",
       "account": "Account",
       "language": "Language",
+      "replies": "Replies",
+      "autoInsert": "Insert replies into email automatically",
       "cancel": "Cancel",
       "save": "Save"
     }

--- a/tests/unit/client/office-reply-form-auto-insert.test.jsx
+++ b/tests/unit/client/office-reply-form-auto-insert.test.jsx
@@ -1,0 +1,150 @@
+/**
+ * Unit tests for client/src/features/office/utilities/replyForm.js
+ *
+ * Regression coverage for issue #1447 ("[Outlook] Auto-insert assistant reply
+ * into the email"):
+ *   - `silent: true` must suppress every user-facing `window.alert` (auto-insert
+ *     runs after every completed reply and must never interrupt the chat with a
+ *     popup), while still logging failures to the console.
+ *   - Without `silent`, the manual "Insert" button keeps its existing alerts.
+ *   - `autoInsertOnceRef` gates the read-mode branch (which opens a brand-new
+ *     reply window on every call) to fire only once; compose mode has no such
+ *     gate since repeated prepends are safe.
+ */
+
+import '@testing-library/jest-dom';
+
+const {
+  displayReplyFormWithAssistantResponse
+} = require('../../../client/src/features/office/utilities/replyForm');
+
+const SUCCEEDED = 'succeeded';
+const FAILED = 'failed';
+
+function installOfficeMock() {
+  global.Office = {
+    AsyncResultStatus: { Succeeded: SUCCEEDED, Failed: FAILED },
+    CoercionType: { Html: 'html' },
+    context: { mailbox: { item: null } }
+  };
+  return global.Office;
+}
+
+function makeComposeItem() {
+  const calls = [];
+  return {
+    calls,
+    item: {
+      body: {
+        prependAsync: (html, opts, cb) => {
+          calls.push({ html, opts });
+          cb({ status: SUCCEEDED });
+        }
+      }
+    }
+  };
+}
+
+function makeReadItem() {
+  const calls = [];
+  return {
+    calls,
+    item: {
+      displayReplyFormAsync: (opts, cb) => {
+        calls.push(opts);
+        cb({ status: SUCCEEDED });
+      }
+    }
+  };
+}
+
+describe('displayReplyFormWithAssistantResponse — auto-insert (issue #1447)', () => {
+  let alertSpy;
+  let errorSpy;
+
+  beforeEach(() => {
+    installOfficeMock();
+    alertSpy = jest.spyOn(window, 'alert').mockImplementation(() => {});
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    alertSpy.mockRestore();
+    errorSpy.mockRestore();
+    delete global.Office;
+  });
+
+  test('silent suppresses window.alert when no Outlook item is available, but still logs', () => {
+    global.Office = undefined;
+
+    displayReplyFormWithAssistantResponse('hello', { silent: true });
+
+    expect(alertSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  test('without silent, missing Outlook item still alerts (manual Insert unchanged)', () => {
+    global.Office = undefined;
+
+    displayReplyFormWithAssistantResponse('hello');
+
+    expect(alertSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('compose mode inserts on every call regardless of silent — no gating', () => {
+    const { item, calls } = makeComposeItem();
+    global.Office.context.mailbox.item = item;
+
+    displayReplyFormWithAssistantResponse('first reply', { silent: true });
+    displayReplyFormWithAssistantResponse('second reply', { silent: true });
+
+    expect(calls).toHaveLength(2);
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
+  test('read mode: autoInsertOnceRef fires displayReplyFormAsync only once per conversation', () => {
+    const { item, calls } = makeReadItem();
+    global.Office.context.mailbox.item = item;
+    const onceRef = { current: false };
+
+    displayReplyFormWithAssistantResponse('first reply', {
+      silent: true,
+      autoInsertOnceRef: onceRef
+    });
+    displayReplyFormWithAssistantResponse('second reply', {
+      silent: true,
+      autoInsertOnceRef: onceRef
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(onceRef.current).toBe(true);
+  });
+
+  test('read mode: manual insert (no autoInsertOnceRef) fires every time', () => {
+    const { item, calls } = makeReadItem();
+    global.Office.context.mailbox.item = item;
+
+    displayReplyFormWithAssistantResponse('first reply');
+    displayReplyFormWithAssistantResponse('second reply');
+
+    expect(calls).toHaveLength(2);
+  });
+
+  test('a fresh autoInsertOnceRef (new conversation) fires again after reset', () => {
+    const { item, calls } = makeReadItem();
+    global.Office.context.mailbox.item = item;
+    const firstConversationRef = { current: false };
+    const secondConversationRef = { current: false };
+
+    displayReplyFormWithAssistantResponse('first reply', {
+      silent: true,
+      autoInsertOnceRef: firstConversationRef
+    });
+    displayReplyFormWithAssistantResponse('reply in new conversation', {
+      silent: true,
+      autoInsertOnceRef: secondConversationRef
+    });
+
+    expect(calls).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1447. Removes the extra "Insert" click users had to make on every assistant reply in the Outlook add-in — the reply now lands in the compose/reply window automatically, with an opt-out.

## What changed

- **`client/src/features/office/utilities/replyForm.js`** — `displayReplyFormWithAssistantResponse` now accepts `{ silent, autoInsertOnceRef }`:
  - `silent: true` suppresses every user-facing `window.alert` on failure (still logs via `console.error`), so a background auto-insert attempt never pops a dialog. The manual "Insert" button keeps its existing alerts.
  - `autoInsertOnceRef` gates the **read-mode** branch (`displayReplyFormAsync`, which opens a brand-new reply window on every call) to fire only once per conversation. Compose mode (`body.prependAsync`) has no such gate — repeated prepends into the same draft are safe and expected.
- **`client/src/features/office/utilities/autoInsertSetting.js`** (new) — `isAutoInsertEnabled()` / `setAutoInsertEnabled()`, localStorage-backed (`office_ihub_auto_insert`), default **on**.
- **`client/src/features/office/components/OfficeChatPanel.jsx`** — wires `onMessageComplete` into `useOfficeChatAdapter` to call `displayReplyFormWithAssistantResponse(fullContent, { silent: true, autoInsertOnceRef })` whenever auto-insert is enabled (already skipped for the clarification-question path, since `useAppChat` doesn't fire `onMessageComplete` there). The gating ref is reset alongside `chatIdRef` at every "new conversation" boundary (`ihub:itemchanged` with no pinned emails, new chat, app switch).
- **`client/src/features/office/components/settings-dialog/index.jsx`** — new "Insert replies into email automatically" checkbox under a "Replies" section, saved alongside the existing language setting on Save.
- **`shared/i18n/en.json` / `de.json`** — new `office.settingsDialog.replies` / `autoInsert` keys.
- **`docs/releases/5.5.0/features.md`** — changelog entry.

The existing manual "Insert" button (`handleInsert` in `OfficeChatPanel.jsx`) is unchanged and remains available as a fallback / re-insert action in both modes, per the issue's acceptance criteria.

## Testing

- New `tests/unit/client/office-reply-form-auto-insert.test.jsx` (jest + jsdom, mocked `Office` global) — covers silent vs. non-silent alerting, compose-mode firing on every call, and read-mode's once-per-conversation gating. 6/6 pass.
- `npx jest --config tests/config/jest.config.js tests/unit/client/` — all 146 tests pass.
- `npx eslint` on the changed files — no new errors (pre-existing warnings unrelated to this change untouched).
- `npx prettier --write` on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfBdMiSCjvHS3oq2SGXx4W


---
_Generated by [Claude Code](https://claude.ai/code/session_01RfBdMiSCjvHS3oq2SGXx4W)_