### PR TITLE
Remove dead LoginForm fallback in LoginPage (#1758)

### DIFF
--- a/client/src/pages/LoginPage.jsx
+++ b/client/src/pages/LoginPage.jsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../shared/contexts/AuthContext.jsx';
-import LoginForm from '../features/auth/components/LoginForm.jsx';
 
 export default function LoginPage() {
   const [searchParams] = useSearchParams();
@@ -58,19 +57,12 @@ export default function LoginPage() {
   }
 
   // The auth gate (full-page overlay) renders the login UI on top of this page.
-  // Show a spinner underneath while it loads. Fall back to the in-page form only
-  // if the gate is somehow unavailable (it is inlined on every index.html entry).
-  if (window.__authGate) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
-      </div>
-    );
-  }
-
+  // It is inlined into every index.html entry that renders this route (see
+  // vite-plugin-auth-gate.js), so window.__authGate is always defined here —
+  // just show a spinner underneath while it loads.
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <LoginForm />
+      <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Partial fix for #1758 ("Remove one of the two complete login UI implementations").

- Removes the `window.__authGate ? <spinner> : <LoginForm />` fallback branch in `client/src/pages/LoginPage.jsx`. That branch was already suspected dead by an existing code comment ("it is inlined on every index.html entry"); I verified this by tracing `client/vite-plugins/vite-plugin-auth-gate.js` (inlines the gate into every `*/index.html` build target) against `client/vite.config.js`'s `rollupOptions.input` — the only entry that renders `LoginPage`/`App.jsx` at all is `main: index.html`, and that entry always gets the gate injected in both dev and production builds. The Office/browser-extension/Nextcloud-embed entries use separate root elements and entry scripts and never mount `LoginPage`.
- Removed the now-unused `LoginForm` import from `LoginPage.jsx`.

## Why only a partial fix

The issue asks to keep exactly one login UI implementation. `LoginForm.jsx` is still legitimately used by `SetupWizard.jsx` (embedded as an in-wizard step, not a full-page/overlay). Retiring it there would require the singleton `auth-gate.js` (which always renders into the hardcoded `#auth-gate-root` element via `document.getElementById`) to support rendering into an arbitrary caller-supplied container inside the React tree — a real, non-trivial change to security-sensitive authentication code (handles credentials, OIDC/NTLM redirects, tokens), not a mechanical dedup.

I've left a comment on #1758 with the investigation findings and a recommendation for that follow-up, so it can get an explicit go/no-go before someone takes it on.

This PR ships the safe, verified, zero-behavior-change part now: deleting code that was already confirmed unreachable.

## Test plan

- [x] `npx eslint client/src/pages/LoginPage.jsx` — clean
- [x] `npx prettier --check client/src/pages/LoginPage.jsx` — clean
- [x] `npx vite build --mode production` in `client/` — succeeds; verified `dist/index.html` still has the auth-gate inlined (`auth-gate-root`/`auth-gate-script`/`auth-gate-styles`)
- [x] Confirmed `LoginForm` is no longer imported/used anywhere except `SetupWizard.jsx`
- [ ] Manual smoke test of `/login` in a running dev server (not done in this sandbox — no test coverage exists for this component today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kb92cEZsd9REpBvzg1wPEx

---
_Generated by [Claude Code](https://claude.ai/code/session_01Kb92cEZsd9REpBvzg1wPEx)_