### PR TITLE
fix(admin): use atomic writes for apps/prompts create/update/toggle

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,5 +1,16 @@
 # Features — 5.5.0
 
+## Apps and Prompts Are Saved More Safely
+
+Admin saves for **Apps** and **Prompts** (create, update, enable/disable, and batch enable/disable)
+now write to disk atomically instead of overwriting the file in place.
+
+- A server crash or restart in the middle of a save can no longer leave a truncated or corrupted
+  `contents/apps/*.json` or `contents/prompts/*.json` file.
+- Creating a new app or prompt whose ID is claimed by a concurrent request is now reliably rejected
+  with "already exists" instead of one request silently overwriting the other.
+- No admin action is required — the fix takes effect automatically on upgrade.
+
 ## Agent Profile Editor No Longer Corrupts Shared State on Save
 
 Fixed a bug in the Agent Profile admin editor where saving could corrupt data shared across the

--- a/server/routes/admin/apps.js
+++ b/server/routes/admin/apps.js
@@ -2,7 +2,7 @@ import { readFileSync } from 'fs';
 import { promises as fs } from 'fs';
 import { join } from 'path';
 import { getRootDir } from '../../pathUtils.js';
-import { atomicWriteJSON } from '../../utils/atomicWrite.js';
+import { atomicWriteJSON, atomicCreateJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { contentAdminAuth } from '../../middleware/contentAdminAuth.js';
 import {
@@ -748,7 +748,15 @@ export default function registerAdminAppsRoutes(app) {
       }
       // Ensure directory exists before writing
       await fs.mkdir(appsDir, { recursive: true });
-      await fs.writeFile(appFilePath, JSON.stringify(newApp, null, 2));
+      try {
+        // lgtm[js/path-injection] -- newApp.id validated via validateIdForPath above.
+        await atomicCreateJSON(appFilePath, newApp);
+      } catch (err) {
+        if (err.code === 'EEXIST') {
+          return sendErrorResponse(res, 409, 'App with this ID already exists');
+        }
+        throw err;
+      }
       await configCache.refreshAppsCache();
       await logAudit({
         req,
@@ -840,7 +848,7 @@ export default function registerAdminAppsRoutes(app) {
         return sendNotFound(res, 'App file');
       }
       const appFilePath = join(appsDir, filename);
-      await fs.writeFile(appFilePath, JSON.stringify(app, null, 2));
+      await atomicWriteJSON(appFilePath, app);
       await configCache.refreshAppsCache();
       await logAudit({
         req,
@@ -963,7 +971,7 @@ export default function registerAdminAppsRoutes(app) {
               continue;
             }
             const appFilePath = join(appsDir, filename);
-            await fs.writeFile(appFilePath, JSON.stringify(app, null, 2));
+            await atomicWriteJSON(appFilePath, app);
           }
         }
 

--- a/server/routes/admin/prompts.js
+++ b/server/routes/admin/prompts.js
@@ -3,6 +3,7 @@ import { promises as fs } from 'fs';
 import { join, resolve } from 'path';
 import path from 'path';
 import { getRootDir } from '../../pathUtils.js';
+import { atomicWriteJSON, atomicCreateJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { contentAdminAuth } from '../../middleware/contentAdminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
@@ -543,7 +544,7 @@ export default function registerAdminPromptsRoutes(app) {
       const oldPrompt = currentPrompts.find(p => p.id === promptId);
       const rootDir = getRootDir();
       const promptFilePath = join(rootDir, 'contents', 'prompts', `${promptId}.json`);
-      await fs.writeFile(promptFilePath, JSON.stringify(updatedPrompt, null, 2));
+      await atomicWriteJSON(promptFilePath, updatedPrompt);
       await configCache.refreshPromptsCache();
       if (oldPrompt) {
         await saveSnapshot({
@@ -684,7 +685,15 @@ export default function registerAdminPromptsRoutes(app) {
       } catch {
         // file not found
       }
-      await fs.writeFile(promptFilePath, JSON.stringify(newPrompt, null, 2));
+      try {
+        // lgtm[js/path-injection] -- newPrompt.id validated via validateIdForPath above.
+        await atomicCreateJSON(promptFilePath, newPrompt);
+      } catch (err) {
+        if (err.code === 'EEXIST') {
+          return sendErrorResponse(res, 409, 'Prompt with this ID already exists');
+        }
+        throw err;
+      }
       await configCache.refreshPromptsCache();
       await logAudit({
         req,
@@ -796,7 +805,7 @@ export default function registerAdminPromptsRoutes(app) {
         prompt.enabled = newEnabledState;
         const rootDir = getRootDir();
         const promptFilePath = join(rootDir, 'contents', 'prompts', `${promptId}.json`);
-        await fs.writeFile(promptFilePath, JSON.stringify(prompt, null, 2));
+        await atomicWriteJSON(promptFilePath, prompt);
         await configCache.refreshPromptsCache();
         await logAudit({
           req,
@@ -948,7 +957,7 @@ export default function registerAdminPromptsRoutes(app) {
           if (prompt.enabled !== enabled) {
             prompt.enabled = enabled;
             const promptFilePath = join(rootDir, 'contents', 'prompts', `${id}.json`);
-            await fs.writeFile(promptFilePath, JSON.stringify(prompt, null, 2));
+            await atomicWriteJSON(promptFilePath, prompt);
           }
         }
 


### PR DESCRIPTION
## Summary

- `server/routes/admin/apps.js` and `server/routes/admin/prompts.js` wrote most of their admin CRUD mutations (create, toggle, batch-toggle) via plain `fs.writeFile(path, JSON.stringify(...))`. A crash or restart mid-write could leave a truncated/corrupted `contents/apps/*.json` or `contents/prompts/*.json` file. Only the `PUT` (update) handler in `apps.js` was already using `atomicWriteJSON`.
- Switched every remaining write in both files to go through `server/utils/atomicWrite.js`:
  - Create handlers now use `atomicCreateJSON` (`fs.writeFile` with the `wx` flag), which fails with `EEXIST` if a concurrent request already created the same ID — mapped to the same `409 "... already exists"` response the existing pre-check already returns, so there's no change to the API contract, just a closed race window.
  - Update / toggle / batch-toggle now use `atomicWriteJSON` (write-to-temp + rename), matching the pattern already used by `apps.js`'s `PUT` handler and `server/routes/admin/agents.js`'s create handler.
- Added a changelog entry under `docs/releases/5.5.0/features.md`.

This is a narrowly-scoped slice of the crash-safety issue called out in #1703 and its duplicate #1740 ("Factor the copy-pasted admin CRUD handlers into a resource-route factory"). Those issues' own implementation plans flagged the bigger factory/schema-enforcement-on-write refactor as needing explicit maintainer sign-off (PR splitting, retroactive Zod validation of existing configs, response-shape changes) — this PR deliberately does **not** attempt that. It only fixes the concrete, already-evidenced bug (non-atomic writes can corrupt config) for the two resources (`apps`, `prompts`) that didn't yet have a targeted fix, using the exact same safe pattern already applied to `models.js` (#1740) and `tools.js` (#1719) in separate PRs.

Closes the `apps.js`/`prompts.js` portion of the "non-atomic write" evidence in #1703 / #1740 (the full factory consolidation remains open, pending the architectural decisions already flagged in those issues' comments).

## Test plan

- [x] `npx eslint server/routes/admin/apps.js server/routes/admin/prompts.js` — 0 errors (2 pre-existing, unrelated unused-import warnings in `prompts.js`, confirmed present before this change too)
- [x] `npx prettier --check` on all changed files — clean
- [x] Both route modules import cleanly under Node ESM (`import()` smoke test) after the changes
- [x] Standalone script exercising `atomicCreateJSON`/`atomicWriteJSON` against a temp dir: confirms first create succeeds, a second create on the same path throws `EEXIST`, and a subsequent `atomicWriteJSON` overwrite succeeds
- [ ] Full `server/tests/admin-endpoints-security.test.js` Jest run — attempted locally but the sandboxed environment made the full suite too slow/uncertain to complete in this session; recommend CI run this on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AygTHp9AfVLyCwnTGwHi7h


---
_Generated by [Claude Code](https://claude.ai/code/session_01AygTHp9AfVLyCwnTGwHi7h)_