### PR TITLE
Citation badges: hover/focus preview + a11y (#1466)

### DIFF
--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -560,7 +560,12 @@ function ChatMessage({
             : contentToRender;
         return (
           <div className="flex flex-col">
-            <StreamingMarkdown content={mdContent} hasCitations={!!message.citations} streaming />
+            <StreamingMarkdown
+              content={mdContent}
+              hasCitations={!!message.citations}
+              citations={message.citations}
+              streaming
+            />
             {message.searchStatus && message.loading && (
               <SearchStatusIndicator status={message.searchStatus} />
             )}
@@ -668,7 +673,13 @@ function ChatMessage({
         }
         mdContent = `\u0060\u0060\u0060json\n${jsonString}\n\u0060\u0060\u0060`;
       }
-      return <StreamingMarkdown content={mdContent} hasCitations={!!message.citations} />;
+      return (
+        <StreamingMarkdown
+          content={mdContent}
+          hasCitations={!!message.citations}
+          citations={message.citations}
+        />
+      );
     }
 
     return (

--- a/client/src/features/chat/components/StreamingMarkdown.css
+++ b/client/src/features/chat/components/StreamingMarkdown.css
@@ -149,6 +149,11 @@
     transform: scale(1.1);
   }
 
+  & .citation-badge:focus-visible {
+    outline: 2px solid rgb(99, 102, 241);
+    outline-offset: 1px;
+  }
+
   & .citation-source {
     background-color: rgb(224, 231, 255);
     color: rgb(67, 56, 202);
@@ -170,6 +175,28 @@
 .streaming-markdown.is-streaming {
   will-change: transform;
   transform: translateZ(0);
+}
+
+/*
+ * Citation hover/focus preview tooltip. Appended once to document.body (not
+ * scoped under .streaming-markdown) since it must render above the message
+ * bubble and any scroll containers, and is positioned in JS via getBoundingClientRect.
+ */
+.citation-tooltip {
+  display: none;
+  position: absolute;
+  z-index: 50;
+  max-width: 20rem;
+  padding: 0.375rem 0.625rem;
+  font-size: 0.75rem;
+  line-height: 1.25;
+  color: rgb(255, 255, 255);
+  background-color: rgb(31, 41, 55);
+  border-radius: 0.375rem;
+  box-shadow:
+    0 4px 6px -1px rgb(0 0 0 / 0.1),
+    0 2px 4px -2px rgb(0 0 0 / 0.1);
+  pointer-events: none;
 }
 
 /* Hide interactive UI elements when printing */

--- a/client/src/features/chat/components/StreamingMarkdown.jsx
+++ b/client/src/features/chat/components/StreamingMarkdown.jsx
@@ -15,12 +15,14 @@ import './StreamingMarkdown.css';
  * @param {Object} props
  * @param {string} props.content - Markdown content to render
  * @param {boolean} [props.hasCitations] - Whether content may contain cite tags
+ * @param {Object} [props.citations] - Message citations ({ references: [], resultItems: [] }),
+ *   used to give each citation badge a short excerpt for its hover/focus preview.
  * @param {boolean} [props.streaming] - Whether the message is actively streaming.
  *   While true the container is GPU-promoted (will-change/translateZ) for smooth
  *   incremental updates; once streaming ends the promotion is dropped so finished
  *   messages don't each hold a permanent compositor layer.
  */
-function StreamingMarkdown({ content, hasCitations, streaming = false }) {
+function StreamingMarkdown({ content, hasCitations, citations, streaming = false }) {
   const containerRef = useRef(null);
   const [htmlContent, setHtmlContent] = useState('');
   const [renderKey, setRenderKey] = useState(0);
@@ -46,7 +48,9 @@ function StreamingMarkdown({ content, hasCitations, streaming = false }) {
 
     if (contentChanged || needsCitationTransform) {
       try {
-        const transformHtml = hasCitations ? transformCitations : undefined;
+        const transformHtml = hasCitations
+          ? html => transformCitations(html, citations)
+          : undefined;
         const parsedContent = renderMarkdown(content, {
           transformHtml
         });
@@ -62,7 +66,7 @@ function StreamingMarkdown({ content, hasCitations, streaming = false }) {
         console.error('Error parsing markdown:', error);
       }
     }
-  }, [content, hasCitations]);
+  }, [content, hasCitations, citations]);
 
   // Attach citation click handlers after DOM update
   useEffect(() => {

--- a/client/src/utils/citationTransformer.js
+++ b/client/src/utils/citationTransformer.js
@@ -7,33 +7,140 @@
  * - type="r" -> result item/document citation (scrolls to document tile in CitationPanel)
  */
 
+const PREVIEW_MAX_LENGTH = 160;
+
+function escapeHtmlAttribute(str) {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+function truncatePreview(text) {
+  if (!text || typeof text !== 'string') return '';
+  const clean = text.replace(/\s+/g, ' ').trim();
+  return clean.length > PREVIEW_MAX_LENGTH ? `${clean.slice(0, PREVIEW_MAX_LENGTH)}…` : clean;
+}
+
+/**
+ * Build lookup maps from a message's citations object so badges can carry a
+ * short excerpt for the hover/focus preview.
+ * @param {Object} [citations] - { references: [], resultItems: [] }
+ */
+function buildCitationPreviewMaps(citations) {
+  const sourceMap = new Map();
+  const resultMap = new Map();
+
+  const references = citations?.references || [];
+  for (const ref of references) {
+    if (ref?.index != null && ref.content) {
+      sourceMap.set(Number(ref.index), ref.content);
+    }
+  }
+
+  const resultItems = citations?.resultItems || [];
+  resultItems.forEach((item, i) => {
+    const title = item?.title || item?.additional_document_metadata?.title;
+    const text = Array.isArray(title) ? title[0] : title;
+    if (text) resultMap.set(i + 1, text);
+  });
+
+  return { sourceMap, resultMap };
+}
+
+function renderCitationBadge(type, num, rawPreview) {
+  const label = type === 's' ? 'Source' : 'Document';
+  const preview = truncatePreview(rawPreview);
+  const ariaLabel = preview ? `${label} ${num}: ${preview}` : `${label} ${num}`;
+  const cssClass = type === 's' ? 'citation-source' : 'citation-result';
+  const previewAttr = preview ? ` data-citation-preview="${escapeHtmlAttribute(preview)}"` : '';
+
+  return (
+    `<span class="citation-badge ${cssClass}" data-citation-type="${type}" data-citation-num="${num}" ` +
+    `role="button" tabindex="0" aria-label="${escapeHtmlAttribute(ariaLabel)}"${previewAttr}>${num}</span>`
+  );
+}
+
 /**
  * Transform cite tags in HTML string into interactive citation badges.
  * @param {string} html - Rendered HTML string
+ * @param {Object} [citations] - Message citations ({ references: [], resultItems: [] })
+ *   used to embed a short excerpt on each badge for the hover/focus preview.
  * @returns {string} Transformed HTML with interactive citation badges
  */
-export function transformCitations(html) {
+export function transformCitations(html, citations) {
   if (!html || typeof html !== 'string') return html;
 
+  const { sourceMap, resultMap } = buildCitationPreviewMaps(citations);
+
   // Replace <cite type="s">N</cite> with source citation badges
-  let result = html.replace(
-    /<cite\s+type="s"\s*>(\d+)<\/cite>/gi,
-    (_, num) =>
-      `<span class="citation-badge citation-source" data-citation-type="s" data-citation-num="${num}" role="button" tabindex="0" title="Source ${num}">${num}</span>`
+  let result = html.replace(/<cite\s+type="s"\s*>(\d+)<\/cite>/gi, (_, num) =>
+    renderCitationBadge('s', num, sourceMap.get(Number(num)))
   );
 
   // Replace <cite type="r">N</cite> with result item citation badges
-  result = result.replace(
-    /<cite\s+type="r"\s*>(\d+)<\/cite>/gi,
-    (_, num) =>
-      `<span class="citation-badge citation-result" data-citation-type="r" data-citation-num="${num}" role="button" tabindex="0" title="Document ${num}">${num}</span>`
+  result = result.replace(/<cite\s+type="r"\s*>(\d+)<\/cite>/gi, (_, num) =>
+    renderCitationBadge('r', num, resultMap.get(Number(num)))
   );
 
   return result;
 }
 
+let citationTooltipEl = null;
+
+function getCitationTooltipElement() {
+  if (citationTooltipEl && document.body.contains(citationTooltipEl)) return citationTooltipEl;
+  citationTooltipEl = document.createElement('div');
+  citationTooltipEl.className = 'citation-tooltip';
+  citationTooltipEl.setAttribute('role', 'tooltip');
+  document.body.appendChild(citationTooltipEl);
+  return citationTooltipEl;
+}
+
+function showCitationTooltip(badge, text) {
+  if (!text) return;
+  const tooltip = getCitationTooltipElement();
+  tooltip.textContent = text;
+  tooltip.style.visibility = 'hidden';
+  tooltip.style.display = 'block';
+
+  const badgeRect = badge.getBoundingClientRect();
+  const tooltipRect = tooltip.getBoundingClientRect();
+
+  let top = badgeRect.top - tooltipRect.height - 8;
+  if (top < 8) top = badgeRect.bottom + 8;
+
+  let left = badgeRect.left + badgeRect.width / 2 - tooltipRect.width / 2;
+  left = Math.max(8, Math.min(left, window.innerWidth - tooltipRect.width - 8));
+
+  tooltip.style.top = `${top + window.scrollY}px`;
+  tooltip.style.left = `${left + window.scrollX}px`;
+  tooltip.style.visibility = 'visible';
+}
+
+function hideCitationTooltip() {
+  if (citationTooltipEl) {
+    citationTooltipEl.style.display = 'none';
+  }
+}
+
 /**
- * Attach click handlers to citation badges within a container element.
+ * Briefly highlight a citation's target in the CitationPanel without scrolling
+ * to it — used for hover/focus preview so it doesn't yank the viewport around.
+ * A no-op when the target isn't currently rendered (e.g. a passage whose
+ * parent document is collapsed).
+ */
+function setCitationPeek(type, num, active) {
+  const el = document.getElementById(`citation-${type}-${num}`);
+  if (!el) return;
+  el.classList.toggle('ring-2', active);
+  el.classList.toggle('ring-indigo-400', active);
+}
+
+/**
+ * Attach click and hover/focus preview handlers to citation badges within a
+ * container element.
  * @param {HTMLElement} container - The DOM element containing citation badges
  * @param {Function} onCitationClick - Callback: (type, num) => void
  */
@@ -43,9 +150,10 @@ export function attachCitationHandlers(container, onCitationClick) {
   const badges = container.querySelectorAll('.citation-badge');
   badges.forEach(badge => {
     const type = badge.dataset.citationType;
-    const num = badge.dataset.citationNum;
+    const num = parseInt(badge.dataset.citationNum, 10);
+    const preview = badge.dataset.citationPreview;
 
-    const handler = () => onCitationClick(type, parseInt(num, 10));
+    const handler = () => onCitationClick(type, num);
     badge.addEventListener('click', handler);
     badge.addEventListener('keydown', e => {
       if (e.key === 'Enter' || e.key === ' ') {
@@ -53,6 +161,20 @@ export function attachCitationHandlers(container, onCitationClick) {
         handler();
       }
     });
+
+    const showPeek = () => {
+      showCitationTooltip(badge, preview);
+      setCitationPeek(type, num, true);
+    };
+    const hidePeek = () => {
+      hideCitationTooltip();
+      setCitationPeek(type, num, false);
+    };
+
+    badge.addEventListener('mouseenter', showPeek);
+    badge.addEventListener('mouseleave', hidePeek);
+    badge.addEventListener('focus', showPeek);
+    badge.addEventListener('blur', hidePeek);
   });
 }
 

--- a/client/src/utils/citationTransformer.test.js
+++ b/client/src/utils/citationTransformer.test.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+
+/**
+ * Tests for transformCitations()'s hover-preview/a11y attributes.
+ *
+ * Assistant messages contain <cite type="s">N</cite> / <cite type="r">N</cite>
+ * tags emitted by the LLM. transformCitations() turns those into interactive
+ * badges; this covers the excerpt lookup (from citations.references /
+ * citations.resultItems), truncation, HTML-attribute escaping, and the
+ * no-citations-data fallback.
+ *
+ * Run directly: `node client/src/utils/citationTransformer.test.js`.
+ */
+
+import { transformCitations } from './citationTransformer.js';
+
+let failures = 0;
+function check(label, cond, details) {
+  if (!cond) failures += 1;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && details) console.log(`   ${details}`);
+}
+
+console.log('🧪 transformCitations\n');
+
+// --- Source passage citations (type="s") ---
+
+const withSourcePreview = transformCitations('<p>Answer <cite type="s">1</cite>.</p>', {
+  references: [{ index: 1, content: 'The sky is blue because of Rayleigh scattering.' }]
+});
+
+check(
+  'source badge embeds a data-citation-preview excerpt',
+  withSourcePreview.includes(
+    'data-citation-preview="The sky is blue because of Rayleigh scattering."'
+  ),
+  withSourcePreview
+);
+
+check(
+  'source badge aria-label includes the excerpt',
+  withSourcePreview.includes(
+    'aria-label="Source 1: The sky is blue because of Rayleigh scattering."'
+  ),
+  withSourcePreview
+);
+
+check(
+  'source badge keeps type/num data attributes and a11y role/tabindex',
+  withSourcePreview.includes('data-citation-type="s"') &&
+    withSourcePreview.includes('data-citation-num="1"') &&
+    withSourcePreview.includes('role="button"') &&
+    withSourcePreview.includes('tabindex="0"'),
+  withSourcePreview
+);
+
+// --- Result/document citations (type="r"), 1-based position in resultItems ---
+
+const withResultPreview = transformCitations('<p>See <cite type="r">2</cite>.</p>', {
+  resultItems: [{ title: 'First Doc' }, { title: 'Annual Report 2025' }]
+});
+
+check(
+  "result badge (2nd resultItem) uses that item's title as the excerpt",
+  withResultPreview.includes('data-citation-preview="Annual Report 2025"') &&
+    withResultPreview.includes('aria-label="Document 2: Annual Report 2025"'),
+  withResultPreview
+);
+
+// --- No citations data supplied: falls back to a plain numbered label ---
+
+const withoutCitations = transformCitations('<cite type="s">3</cite>');
+check(
+  'falls back to "Source N" aria-label with no data-citation-preview when citations are absent',
+  withoutCitations.includes('aria-label="Source 3"') &&
+    !withoutCitations.includes('data-citation-preview'),
+  withoutCitations
+);
+
+// --- Long excerpts are truncated ---
+
+const longContent = 'x'.repeat(300);
+const withLongPreview = transformCitations('<cite type="s">1</cite>', {
+  references: [{ index: 1, content: longContent }]
+});
+check(
+  'excerpts longer than 160 chars are truncated with an ellipsis',
+  withLongPreview.includes(`${'x'.repeat(160)}…`) && !withLongPreview.includes('x'.repeat(161)),
+  withLongPreview
+);
+
+// --- Excerpt text is escaped for safe attribute embedding ---
+
+const withUnsafeContent = transformCitations('<cite type="s">1</cite>', {
+  references: [{ index: 1, content: 'Says "hello" <b>&amp;</b> goodbye' }]
+});
+check(
+  'excerpt text is HTML-attribute-escaped',
+  withUnsafeContent.includes(
+    'data-citation-preview="Says &quot;hello&quot; &lt;b&gt;&amp;amp;&lt;/b&gt; goodbye"'
+  ),
+  withUnsafeContent
+);
+
+// --- Non-string / empty input passes through untouched ---
+
+check('null input passes through unchanged', transformCitations(null) === null);
+check('empty string passes through unchanged', transformCitations('') === '');
+
+console.log(`\n${failures === 0 ? '✅ All tests passed' : `❌ ${failures} test(s) failed`}`);
+process.exit(failures === 0 ? 0 : 1);

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -475,3 +475,18 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Citation Badges Now Show a Preview and Are Screen-Reader Friendly
+
+Inline citation badges (the small numbered pills that link an answer back to a source passage or
+document) now give a preview of what they point to, instead of only a plain "Source N" tooltip.
+
+- Hovering or keyboard-focusing a citation badge shows a short excerpt of the cited passage (or the
+  document's title for whole-document citations) in a small popup.
+- The same excerpt is exposed as the badge's accessible name, so screen reader users hear what a
+  citation refers to instead of just its number.
+- The corresponding entry in the source panel below the answer is briefly highlighted while hovering
+  or focusing a badge, without jumping the scroll position — clicking a badge still scrolls to it as
+  before.
+- Citation badges now show a visible focus ring when navigated to with the keyboard.
+- No admin action is required.


### PR DESCRIPTION
## Summary

Part of #1466. Extends the existing citation UI (`<cite type="s|r">N</cite>` pills rendered by
`client/src/utils/citationTransformer.js`) with a real hover/focus preview and better accessibility,
matching two of the issue's acceptance criteria:

- **Hover preview**: badges now carry a short excerpt of the passage they cite (from
  `citations.references[].content`) or the document's title (from `citations.resultItems[].title`
  for whole-document citations), shown in a small custom tooltip on mouse hover *and* keyboard
  focus (native `title` tooltips don't fire on focus, so this is also an a11y improvement, not
  just cosmetic).
- **Accessible name**: each badge's `aria-label` now includes that excerpt (e.g. `"Source 1: The
  sky is blue because of..."`) instead of a bare `"Source 1"`, so screen reader users hear what a
  citation actually refers to.
- **Source panel highlight on hover**: hovering/focusing a badge briefly highlights the
  corresponding entry in `CitationPanel.jsx` (same ring style already used for click-to-scroll) —
  but without auto-scrolling or auto-expanding a collapsed passage, so it can't yank the viewport
  around. Clicking a badge keeps its existing scroll-and-expand behavior unchanged.
- **Keyboard focus ring**: `.citation-badge:focus-visible` now has a visible outline (previously
  only present in an unused, never-imported CSS string export — the real, wired-up
  `StreamingMarkdown.css` had no focus-visible affordance at all).

Excerpt text is HTML-attribute-escaped and truncated to 160 characters before being embedded.

## Scope note

This issue also proposes an opt-in **answer-verification pass** (a second LLM call flagging
claims not supported by the cited sources) and a citation-format change. Per the implementation
plan already posted on the issue, that half has several open, genuinely blocking design questions
(model selection/cost accounting, persistence across reloads, whether it should also cover
web-search-derived claims) that need a product decision before implementation. This PR intentionally
covers only the citation-UI polish, which needed no such decision — the verification pass is left
as a follow-up.

## Test plan

- [x] New `client/src/utils/citationTransformer.test.js` (plain-node test, matches this repo's
      existing client-side test convention) covering: excerpt lookup for both citation types,
      truncation at 160 chars, HTML-attribute escaping, and the no-citations-data fallback. All 9
      assertions pass (`node client/src/utils/citationTransformer.test.js`).
- [x] `npx eslint` on all changed files — 0 errors (pre-existing warnings only, unrelated to this
      change).
- [x] `npx prettier --write` on all changed files.
- [x] `npx vite build` succeeds.
- [ ] Manual browser verification of the hover/focus tooltip and panel highlight was not performed
      in this sandboxed session.

Changelog entry added under `docs/releases/5.5.0/features.md` per this repo's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RD2jqx3Z5Zoarw3UjsktAP)_