### PR TITLE
refactor(admin): extract Tools/MCP/Workflows/Skills sections from AppFormEditor

### DIFF
--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -1,10 +1,10 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import DynamicLanguageEditor from '../../../shared/components/DynamicLanguageEditor';
-import ToolsSelector from '../../../shared/components/ToolsSelector';
-import McpToolsSelector from './McpToolsSelector';
-import SkillsSelector from '../../../shared/components/SkillsSelector';
-import WorkflowsSelector from '../../../shared/components/WorkflowsSelector';
+import ToolsConfigSection from './app-form/ToolsConfigSection';
+import McpToolsConfigSection from './app-form/McpToolsConfigSection';
+import SkillsConfigSection from './app-form/SkillsConfigSection';
+import WorkflowsConfigSection from './app-form/WorkflowsConfigSection';
 import SourcePicker from './SourcePicker';
 import ResourceSelector from './ResourceSelector';
 import Icon from '../../../shared/components/Icon';
@@ -1294,106 +1294,33 @@ function AppFormEditor({
             </div>
 
             {/* Tools Configuration */}
-            <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-              <div className="md:grid md:grid-cols-3 md:gap-6">
-                <div className="md:col-span-1">
-                  <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                    {t('admin.apps.edit.tools', 'Tools')}
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    {t(
-                      'admin.apps.edit.toolsDesc',
-                      'Configure which tools are available for this app'
-                    )}
-                  </p>
-                </div>
-                <div className="mt-5 md:mt-0 md:col-span-2">
-                  <ToolsSelector
-                    selectedTools={app.tools || []}
-                    onToolsChange={tools => handleInputChange('tools', tools)}
-                    excludeToolIds={[
-                      'braveSearch',
-                      'enhancedWebSearch',
-                      'webContentExtractor',
-                      ...mcpToolIds
-                    ]}
-                  />
-                </div>
-              </div>
-            </div>
+            <ToolsConfigSection
+              selectedTools={app.tools || []}
+              onToolsChange={tools => handleInputChange('tools', tools)}
+              mcpToolIds={mcpToolIds}
+            />
 
             {/* MCP Server Tools */}
-            <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-              <div className="md:grid md:grid-cols-3 md:gap-6">
-                <div className="md:col-span-1">
-                  <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                    {t('admin.apps.edit.mcpTools.title', 'MCP server tools')}
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    {t(
-                      'admin.apps.edit.mcpTools.desc',
-                      'Enable tools provided by connected MCP servers for this app.'
-                    )}
-                  </p>
-                </div>
-                <div className="mt-5 md:mt-0 md:col-span-2">
-                  <McpToolsSelector
-                    selectedTools={app.tools || []}
-                    onToolsChange={tools => handleInputChange('tools', tools)}
-                    onMcpToolIdsChange={setMcpToolIds}
-                  />
-                </div>
-              </div>
-            </div>
+            <McpToolsConfigSection
+              selectedTools={app.tools || []}
+              onToolsChange={tools => handleInputChange('tools', tools)}
+              onMcpToolIdsChange={setMcpToolIds}
+            />
 
             {/* Workflows Configuration */}
             {featureFlags.isEnabled('workflows', true) && (
-              <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-                <div className="md:grid md:grid-cols-3 md:gap-6">
-                  <div className="md:col-span-1">
-                    <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                      {t('admin.apps.edit.workflows', 'Workflows')}
-                    </h3>
-                    <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                      {t(
-                        'admin.apps.edit.workflowsDesc',
-                        'Attach workflows to this app. Users can trigger them in chat with @workflow-id.'
-                      )}
-                    </p>
-                  </div>
-                  <div className="mt-5 md:mt-0 md:col-span-2">
-                    <WorkflowsSelector
-                      selectedWorkflows={app.workflows || []}
-                      onWorkflowsChange={workflows => handleInputChange('workflows', workflows)}
-                    />
-                  </div>
-                </div>
-              </div>
+              <WorkflowsConfigSection
+                selectedWorkflows={app.workflows || []}
+                onWorkflowsChange={workflows => handleInputChange('workflows', workflows)}
+              />
             )}
 
             {/* Skills Configuration */}
             {featureFlags.isEnabled('skills', false) && (
-              <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-                <div className="md:grid md:grid-cols-3 md:gap-6">
-                  <div className="md:col-span-1">
-                    <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                      {t('admin.apps.edit.skills', 'Skills')}
-                    </h3>
-                    <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                      {t(
-                        'admin.apps.edit.skillsDesc',
-                        'Configure which agent skills are available for this app'
-                      )}
-                    </p>
-                  </div>
-                  <div className="mt-5 md:mt-0 md:col-span-2">
-                    <SkillsSelector
-                      selectedSkills={app.skills || []}
-                      onSkillsChange={skills => handleInputChange('skills', skills)}
-                    />
-                  </div>
-                </div>
-              </div>
+              <SkillsConfigSection
+                selectedSkills={app.skills || []}
+                onSkillsChange={skills => handleInputChange('skills', skills)}
+              />
             )}
 
             {/* Variables Configuration */}

--- a/client/src/features/admin/components/app-form/McpToolsConfigSection.jsx
+++ b/client/src/features/admin/components/app-form/McpToolsConfigSection.jsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next';
+import McpToolsSelector from '../McpToolsSelector';
+
+function McpToolsConfigSection({ selectedTools, onToolsChange, onMcpToolIdsChange }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.mcpTools.title', 'MCP server tools')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.apps.edit.mcpTools.desc',
+              'Enable tools provided by connected MCP servers for this app.'
+            )}
+          </p>
+        </div>
+        <div className="mt-5 md:mt-0 md:col-span-2">
+          <McpToolsSelector
+            selectedTools={selectedTools}
+            onToolsChange={onToolsChange}
+            onMcpToolIdsChange={onMcpToolIdsChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default McpToolsConfigSection;

--- a/client/src/features/admin/components/app-form/SkillsConfigSection.jsx
+++ b/client/src/features/admin/components/app-form/SkillsConfigSection.jsx
@@ -1,0 +1,29 @@
+import { useTranslation } from 'react-i18next';
+import SkillsSelector from '../../../../shared/components/SkillsSelector';
+
+function SkillsConfigSection({ selectedSkills, onSkillsChange }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.skills', 'Skills')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.apps.edit.skillsDesc',
+              'Configure which agent skills are available for this app'
+            )}
+          </p>
+        </div>
+        <div className="mt-5 md:mt-0 md:col-span-2">
+          <SkillsSelector selectedSkills={selectedSkills} onSkillsChange={onSkillsChange} />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SkillsConfigSection;

--- a/client/src/features/admin/components/app-form/ToolsConfigSection.jsx
+++ b/client/src/features/admin/components/app-form/ToolsConfigSection.jsx
@@ -1,0 +1,35 @@
+import { useTranslation } from 'react-i18next';
+import ToolsSelector from '../../../../shared/components/ToolsSelector';
+
+function ToolsConfigSection({ selectedTools, onToolsChange, mcpToolIds }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.tools', 'Tools')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t('admin.apps.edit.toolsDesc', 'Configure which tools are available for this app')}
+          </p>
+        </div>
+        <div className="mt-5 md:mt-0 md:col-span-2">
+          <ToolsSelector
+            selectedTools={selectedTools}
+            onToolsChange={onToolsChange}
+            excludeToolIds={[
+              'braveSearch',
+              'enhancedWebSearch',
+              'webContentExtractor',
+              ...mcpToolIds
+            ]}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ToolsConfigSection;

--- a/client/src/features/admin/components/app-form/WorkflowsConfigSection.jsx
+++ b/client/src/features/admin/components/app-form/WorkflowsConfigSection.jsx
@@ -1,0 +1,32 @@
+import { useTranslation } from 'react-i18next';
+import WorkflowsSelector from '../../../../shared/components/WorkflowsSelector';
+
+function WorkflowsConfigSection({ selectedWorkflows, onWorkflowsChange }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.workflows', 'Workflows')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.apps.edit.workflowsDesc',
+              'Attach workflows to this app. Users can trigger them in chat with @workflow-id.'
+            )}
+          </p>
+        </div>
+        <div className="mt-5 md:mt-0 md:col-span-2">
+          <WorkflowsSelector
+            selectedWorkflows={selectedWorkflows}
+            onWorkflowsChange={onWorkflowsChange}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default WorkflowsConfigSection;


### PR DESCRIPTION
## Summary

Continues the `AppFormEditor.jsx` decomposition tracked in #1781 (currently a 2,900-line single component). This PR extracts four of the remaining inline config sections into standalone components:

- `client/src/features/admin/components/app-form/ToolsConfigSection.jsx`
- `client/src/features/admin/components/app-form/McpToolsConfigSection.jsx`
- `client/src/features/admin/components/app-form/WorkflowsConfigSection.jsx`
- `client/src/features/admin/components/app-form/SkillsConfigSection.jsx`

Each new component takes simple field-level props (`selectedTools`/`onToolsChange`, etc.) mirroring the underlying selector components (`ToolsSelector`, `McpToolsSelector`, `WorkflowsSelector`, `SkillsSelector`) they wrap — no whole-app object is threaded through, since these sections only ever set a single flat array field via `AppFormEditor`'s existing `handleInputChange`.

`AppFormEditor.jsx` shrinks from 2,902 to 2,829 lines. No behavior change — this is a pure structural refactor; the rendered markup, translation keys, and feature-flag gating (`workflows`/`skills`) are unchanged.

Scoped to avoid collision with other open decomposition PRs against #1781 (#1942 Upload, #2044 Variables, #2046 Starter Prompts) — this PR only touches the Tools/MCP/Workflows/Skills block (previously lines ~1296-1398), which none of those PRs modify.

## Test plan

- [x] `npx eslint` on changed/new files — 0 errors (pre-existing unrelated warnings only)
- [x] `npx prettier --write` applied to changed/new files
- [x] `npx vite build` succeeds with no errors
- [ ] Manual smoke test in Admin > Apps > Edit: Tools, MCP Tools, Workflows, and Skills sections still render and toggle correctly (not run in this environment — no live server)

Refs #1781


---
_Generated by [Claude Code](https://claude.ai/code/session_01FztgrBBXcPEzG7i81D4Yv6)_