### PR TITLE
refactor(admin): extract Transcription section from AppFormEditor

### DIFF
--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -10,6 +10,7 @@ import ResourceSelector from './ResourceSelector';
 import Icon from '../../../shared/components/Icon';
 import IconPicker from '../../../shared/components/IconPicker';
 import MimeTypeSelector from './MimeTypeSelector';
+import TranscriptionSection from './app-form/TranscriptionSection';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import {
   validateWithSchema,
@@ -2149,178 +2150,14 @@ function AppFormEditor({
             </div>
 
             {/* Transcription Configuration */}
-            <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-              <div className="md:grid md:grid-cols-3 md:gap-6">
-                <div className="md:col-span-1">
-                  <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                    {t('admin.apps.edit.transcription', 'Transcription')}
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    {t(
-                      'admin.apps.edit.transcriptionDesc',
-                      'Transcribe uploaded audio, uploaded video, or a browser recording with a self-hosted transcription model (e.g. Voxtral) and render the result as a chat answer.'
-                    )}
-                  </p>
-                </div>
-                <div className="mt-5 md:col-span-2 md:mt-0">
-                  <div className="space-y-4">
-                    <div className="flex items-center">
-                      <input
-                        type="checkbox"
-                        checked={app.transcription?.enabled || false}
-                        onChange={e =>
-                          handleInputChange('transcription', {
-                            ...app.transcription,
-                            enabled: e.target.checked
-                          })
-                        }
-                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                      />
-                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
-                        {t('admin.apps.edit.enableTranscription', 'Enable transcription')}
-                      </label>
-                    </div>
-
-                    {app.transcription?.enabled && (
-                      <div className="space-y-4 pl-6">
-                        <div className="flex items-center">
-                          <input
-                            type="checkbox"
-                            checked={app.transcription?.defaultEnabled !== false}
-                            onChange={e =>
-                              handleInputChange('transcription', {
-                                ...app.transcription,
-                                defaultEnabled: e.target.checked
-                              })
-                            }
-                            className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                          />
-                          <label className="ml-2 block text-sm text-gray-700 dark:text-gray-300">
-                            {t(
-                              'admin.apps.edit.transcriptionDefaultEnabled',
-                              'On by default (users can toggle it per chat)'
-                            )}
-                          </label>
-                        </div>
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                            {t('admin.apps.edit.transcriptionModel', 'Transcription model')}
-                          </label>
-                          <select
-                            value={app.transcription?.modelId || ''}
-                            onChange={e =>
-                              handleInputChange('transcription', {
-                                ...app.transcription,
-                                modelId: e.target.value
-                              })
-                            }
-                            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600"
-                          >
-                            <option value="">
-                              {t('admin.apps.edit.selectTranscriptionModel', 'Select a model…')}
-                            </option>
-                            {transcriptionModels.map(m => (
-                              <option key={m.id} value={m.id}>
-                                {getLocalizedContent(m.name, currentLanguage) || m.id}
-                              </option>
-                            ))}
-                          </select>
-                          {transcriptionModels.length === 0 && (
-                            <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
-                              {t(
-                                'admin.apps.edit.noTranscriptionModels',
-                                'No transcription models configured. Add one under Admin → Models (model type "transcription").'
-                              )}
-                            </p>
-                          )}
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                            {t('admin.apps.edit.transcriptionInputs', 'Input sources')}
-                          </label>
-                          <div className="space-y-2">
-                            {[
-                              ['upload', t('admin.apps.edit.transcriptionUpload', 'Audio upload')],
-                              ['video', t('admin.apps.edit.transcriptionVideo', 'Video upload')],
-                              ['record', t('admin.apps.edit.transcriptionRecord', 'Record audio')]
-                            ].map(([key, label]) => (
-                              <div key={key} className="flex items-center">
-                                <input
-                                  type="checkbox"
-                                  checked={app.transcription?.inputs?.[key] !== false}
-                                  onChange={e =>
-                                    handleInputChange('transcription', {
-                                      ...app.transcription,
-                                      inputs: {
-                                        ...app.transcription?.inputs,
-                                        [key]: e.target.checked
-                                      }
-                                    })
-                                  }
-                                  className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                                />
-                                <label className="ml-2 block text-sm text-gray-700 dark:text-gray-300">
-                                  {label}
-                                </label>
-                              </div>
-                            ))}
-                          </div>
-                          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                            {t(
-                              'admin.apps.edit.transcriptionInputsHint',
-                              'Audio/video upload also requires the matching upload toggle under Upload Configuration.'
-                            )}
-                          </p>
-                        </div>
-
-                        <div className="flex items-center">
-                          <input
-                            type="checkbox"
-                            checked={app.transcription?.streaming !== false}
-                            onChange={e =>
-                              handleInputChange('transcription', {
-                                ...app.transcription,
-                                streaming: e.target.checked
-                              })
-                            }
-                            className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                          />
-                          <label className="ml-2 block text-sm text-gray-700 dark:text-gray-300">
-                            {t(
-                              'admin.apps.edit.transcriptionStreaming',
-                              'Stream transcript as it is produced'
-                            )}
-                          </label>
-                        </div>
-
-                        <div>
-                          <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
-                            {t(
-                              'admin.apps.edit.transcriptionMaxDuration',
-                              'Max duration (seconds)'
-                            )}
-                          </label>
-                          <input
-                            type="number"
-                            min="1"
-                            max="7200"
-                            value={app.transcription?.maxDurationSeconds || 900}
-                            onChange={e =>
-                              handleInputChange('transcription', {
-                                ...app.transcription,
-                                maxDurationSeconds: parseNumberOrUndefined(e.target.value, parseInt)
-                              })
-                            }
-                            className="mt-1 block w-24 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-xs dark:bg-gray-700 dark:border-gray-600"
-                          />
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
+            <TranscriptionSection
+              app={app}
+              onChange={handleInputChange}
+              t={t}
+              currentLanguage={currentLanguage}
+              transcriptionModels={transcriptionModels}
+              parseNumberOrUndefined={parseNumberOrUndefined}
+            />
 
             {/* Magic Prompt Configuration */}
             <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">

--- a/client/src/features/admin/components/app-form/TranscriptionSection.jsx
+++ b/client/src/features/admin/components/app-form/TranscriptionSection.jsx
@@ -1,0 +1,162 @@
+import { getLocalizedContent } from '../../../../utils/localizeContent';
+
+function TranscriptionSection({
+  app,
+  onChange,
+  t,
+  currentLanguage,
+  transcriptionModels,
+  parseNumberOrUndefined
+}) {
+  const handleTranscriptionChange = updates =>
+    onChange('transcription', { ...app.transcription, ...updates });
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.transcription', 'Transcription')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.apps.edit.transcriptionDesc',
+              'Transcribe uploaded audio, uploaded video, or a browser recording with a self-hosted transcription model (e.g. Voxtral) and render the result as a chat answer.'
+            )}
+          </p>
+        </div>
+        <div className="mt-5 md:col-span-2 md:mt-0">
+          <div className="space-y-4">
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                checked={app.transcription?.enabled || false}
+                onChange={e => handleTranscriptionChange({ enabled: e.target.checked })}
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+              />
+              <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                {t('admin.apps.edit.enableTranscription', 'Enable transcription')}
+              </label>
+            </div>
+
+            {app.transcription?.enabled && (
+              <div className="space-y-4 pl-6">
+                <div className="flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={app.transcription?.defaultEnabled !== false}
+                    onChange={e => handleTranscriptionChange({ defaultEnabled: e.target.checked })}
+                    className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+                  />
+                  <label className="ml-2 block text-sm text-gray-700 dark:text-gray-300">
+                    {t(
+                      'admin.apps.edit.transcriptionDefaultEnabled',
+                      'On by default (users can toggle it per chat)'
+                    )}
+                  </label>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {t('admin.apps.edit.transcriptionModel', 'Transcription model')}
+                  </label>
+                  <select
+                    value={app.transcription?.modelId || ''}
+                    onChange={e => handleTranscriptionChange({ modelId: e.target.value })}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm dark:bg-gray-700 dark:border-gray-600"
+                  >
+                    <option value="">
+                      {t('admin.apps.edit.selectTranscriptionModel', 'Select a model…')}
+                    </option>
+                    {transcriptionModels.map(m => (
+                      <option key={m.id} value={m.id}>
+                        {getLocalizedContent(m.name, currentLanguage) || m.id}
+                      </option>
+                    ))}
+                  </select>
+                  {transcriptionModels.length === 0 && (
+                    <p className="mt-1 text-xs text-amber-600 dark:text-amber-400">
+                      {t(
+                        'admin.apps.edit.noTranscriptionModels',
+                        'No transcription models configured. Add one under Admin → Models (model type "transcription").'
+                      )}
+                    </p>
+                  )}
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
+                    {t('admin.apps.edit.transcriptionInputs', 'Input sources')}
+                  </label>
+                  <div className="space-y-2">
+                    {[
+                      ['upload', t('admin.apps.edit.transcriptionUpload', 'Audio upload')],
+                      ['video', t('admin.apps.edit.transcriptionVideo', 'Video upload')],
+                      ['record', t('admin.apps.edit.transcriptionRecord', 'Record audio')]
+                    ].map(([key, label]) => (
+                      <div key={key} className="flex items-center">
+                        <input
+                          type="checkbox"
+                          checked={app.transcription?.inputs?.[key] !== false}
+                          onChange={e =>
+                            handleTranscriptionChange({
+                              inputs: { ...app.transcription?.inputs, [key]: e.target.checked }
+                            })
+                          }
+                          className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+                        />
+                        <label className="ml-2 block text-sm text-gray-700 dark:text-gray-300">
+                          {label}
+                        </label>
+                      </div>
+                    ))}
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {t(
+                      'admin.apps.edit.transcriptionInputsHint',
+                      'Audio/video upload also requires the matching upload toggle under Upload Configuration.'
+                    )}
+                  </p>
+                </div>
+
+                <div className="flex items-center">
+                  <input
+                    type="checkbox"
+                    checked={app.transcription?.streaming !== false}
+                    onChange={e => handleTranscriptionChange({ streaming: e.target.checked })}
+                    className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+                  />
+                  <label className="ml-2 block text-sm text-gray-700 dark:text-gray-300">
+                    {t(
+                      'admin.apps.edit.transcriptionStreaming',
+                      'Stream transcript as it is produced'
+                    )}
+                  </label>
+                </div>
+
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 dark:text-gray-300">
+                    {t('admin.apps.edit.transcriptionMaxDuration', 'Max duration (seconds)')}
+                  </label>
+                  <input
+                    type="number"
+                    min="1"
+                    max="7200"
+                    value={app.transcription?.maxDurationSeconds || 900}
+                    onChange={e =>
+                      handleTranscriptionChange({
+                        maxDurationSeconds: parseNumberOrUndefined(e.target.value, parseInt)
+                      })
+                    }
+                    className="mt-1 block w-24 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-xs dark:bg-gray-700 dark:border-gray-600"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default TranscriptionSection;


### PR DESCRIPTION
## Summary

Continues the incremental split of `AppFormEditor.jsx` tracked in #1781 ("Split the 2545-line AppFormEditor into section components with a shared nested-update helper"). This is a follow-up slice in the same spirit as the Upload (#1942), Variables (#2044), Starter Prompts (#2046), Tools/MCP/Workflows/Skills (#2048), PlatformFormEditor OIDC/JWT/LDAP (#2049), and Web Search/iAssistant (#2050) extractions — scoped to one more self-contained card that doesn't overlap any of those.

- Extracted the **Transcription** card (enable toggle, default-on toggle, transcription model picker, input-source checkboxes, streaming toggle, max-duration field) into a new `client/src/features/admin/components/app-form/TranscriptionSection.jsx`.
- The section only ever reads/writes its own slice of app state (`app.transcription`) via the existing `onChange` prop, so it's a fully self-contained `(app, onChange)` component per the pattern established by the prior extraction PRs. Internally it consolidates the repeated `{...app.transcription, field: value}` spread calls into one small local `handleTranscriptionChange(updates)` merge helper.
- `AppFormEditor.jsx` now imports and renders `<TranscriptionSection app={app} onChange={handleInputChange} t={t} currentLanguage={currentLanguage} transcriptionModels={transcriptionModels} parseNumberOrUndefined={parseNumberOrUndefined} />` in place of the ~173-line inline block; shrinks from 2902 → 2739 lines.

No behavior change is intended — JSX and logic were ported verbatim (same class names, same `t()` keys, same DOM structure, same default values).

Remaining sections of `AppFormEditor.jsx` (Basic Info, System Instructions, Iframe/Redirect, Sources, Settings Config, Export Config, Compare Mode, Input Mode) and `PlatformFormEditor.jsx`'s remaining Proxy/Local/NTLM/Debug settings blocks are left for further follow-up PRs against #1781.

## Test plan

- [x] `npx eslint` on changed/new files — 0 errors (pre-existing `jsx-a11y`/`@eslint-react` style warnings only, unchanged from before)
- [x] `npx prettier --write` — clean
- [x] `npx vite build` (client) — succeeds with no errors
- [x] Ran the dev server + client, logged in as the local admin, and exercised the extracted section end-to-end in a real browser on the "iHub Support Bot" app: toggled Enable transcription (revealed default-on/model-picker/input-sources/streaming/max-duration fields), unchecked "Stream transcript as it is produced", and changed Max duration to 600 — all fields updated live with zero console/page errors.

Part of #1781.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQDRLrC8SjCU1NxJytBDVB

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQDRLrC8SjCU1NxJytBDVB)_