### PR TITLE
feat(prompts): let users save their own prompts to the library

### DIFF
--- a/client/src/api/endpoints/prompts.js
+++ b/client/src/api/endpoints/prompts.js
@@ -37,3 +37,31 @@ export const generateMagicPrompt = async (input, options = {}) => {
     false
   );
 };
+
+// User-owned prompts (save-to-library, #1037/#1038). Not cached — always
+// user-specific and expected to change right after a create/edit/delete.
+export const fetchUserPrompts = async () => {
+  return handleApiResponse(() => apiClient.get('/user-prompts'), null, null, false);
+};
+
+export const createUserPrompt = async data => {
+  return handleApiResponse(() => apiClient.post('/user-prompts', data), null, null, false);
+};
+
+export const updateUserPrompt = async (promptId, data) => {
+  return handleApiResponse(
+    () => apiClient.put(`/user-prompts/${encodeURIComponent(promptId)}`, data),
+    null,
+    null,
+    false
+  );
+};
+
+export const deleteUserPrompt = async promptId => {
+  return handleApiResponse(
+    () => apiClient.delete(`/user-prompts/${encodeURIComponent(promptId)}`),
+    null,
+    null,
+    false
+  );
+};

--- a/client/src/features/prompts/components/UserPromptFormModal.jsx
+++ b/client/src/features/prompts/components/UserPromptFormModal.jsx
@@ -1,0 +1,167 @@
+import { useState } from 'react';
+import Icon from '../../../shared/components/Icon';
+
+/**
+ * Create/edit form for a user-owned prompt (save-to-library, #1037/#1038).
+ * Unlike admin-curated prompts, these are plain strings (no localization,
+ * variables, or output schema) — kept intentionally simple for v1.
+ */
+function UserPromptFormModal({ prompt, onClose, onSave, t }) {
+  const isEditing = Boolean(prompt);
+  const [name, setName] = useState(prompt?.name || '');
+  const [description, setDescription] = useState(prompt?.description || '');
+  const [promptText, setPromptText] = useState(prompt?.prompt || '');
+  const [visibility, setVisibility] = useState(prompt?.visibility || 'private');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async e => {
+    e.preventDefault();
+    if (!name.trim() || !promptText.trim()) {
+      setError(
+        t('pages.promptsList.userPrompts.validationError', 'Name and prompt text are required')
+      );
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave({
+        name: name.trim(),
+        description: description.trim(),
+        prompt: promptText.trim(),
+        visibility
+      });
+    } catch (err) {
+      setError(
+        err.userFriendlyMessage ||
+          err.message ||
+          t('pages.promptsList.userPrompts.saveError', 'Failed to save prompt')
+      );
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-lg w-full p-6 animate-fade-in max-h-[85vh] flex flex-col">
+        <div className="flex justify-between items-start mb-4">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100">
+            {isEditing
+              ? t('pages.promptsList.userPrompts.editTitle', 'Edit prompt')
+              : t('pages.promptsList.userPrompts.saveTitle', 'Save a new prompt')}
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label={t('common.cancel', 'Cancel')}
+            className="text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+          >
+            <Icon name="x" />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4 overflow-y-auto">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {t('pages.promptsList.userPrompts.nameLabel', 'Name')}
+            </label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              maxLength={200}
+              className="block w-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 rounded-lg text-sm px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder={t(
+                'pages.promptsList.userPrompts.namePlaceholder',
+                'e.g. Weekly summary'
+              )}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {t('pages.promptsList.userPrompts.descriptionLabel', 'Description (optional)')}
+            </label>
+            <input
+              type="text"
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              maxLength={2000}
+              className="block w-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 rounded-lg text-sm px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder={t(
+                'pages.promptsList.userPrompts.descriptionPlaceholder',
+                'What is this prompt for?'
+              )}
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {t('pages.promptsList.userPrompts.promptLabel', 'Prompt')}
+            </label>
+            <textarea
+              value={promptText}
+              onChange={e => setPromptText(e.target.value)}
+              maxLength={20000}
+              rows={6}
+              className="block w-full border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 rounded-lg text-sm px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+              placeholder={t(
+                'pages.promptsList.userPrompts.promptPlaceholder',
+                'Write your prompt text here...'
+              )}
+            />
+          </div>
+
+          <div>
+            <span className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              {t('pages.promptsList.userPrompts.visibilityLabel', 'Visibility')}
+            </span>
+            <div className="flex gap-4">
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                <input
+                  type="radio"
+                  name="visibility"
+                  value="private"
+                  checked={visibility === 'private'}
+                  onChange={() => setVisibility('private')}
+                />
+                {t('pages.promptsList.userPrompts.visibilityPrivate', 'Private (only me)')}
+              </label>
+              <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+                <input
+                  type="radio"
+                  name="visibility"
+                  value="shared"
+                  checked={visibility === 'shared'}
+                  onChange={() => setVisibility('shared')}
+                />
+                {t('pages.promptsList.userPrompts.visibilityShared', 'Shared (everyone)')}
+              </label>
+            </div>
+          </div>
+
+          {error && <p className="text-sm text-red-600 dark:text-red-400">{error}</p>}
+
+          <div className="flex justify-end gap-2 mt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+            >
+              {t('common.cancel', 'Cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50"
+            >
+              {saving ? t('common.saving', 'Saving...') : t('common.save', 'Save')}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export default UserPromptFormModal;

--- a/client/src/features/prompts/pages/PromptsList.jsx
+++ b/client/src/features/prompts/pages/PromptsList.jsx
@@ -1,20 +1,29 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link, useSearchParams } from 'react-router-dom';
-import { fetchPrompts } from '../../../api';
+import {
+  fetchPrompts,
+  fetchUserPrompts,
+  createUserPrompt,
+  updateUserPrompt,
+  deleteUserPrompt
+} from '../../../api';
 import LoadingSpinner from '../../../shared/components/LoadingSpinner';
 import Icon from '../../../shared/components/Icon';
 import PromptModal from '../components/PromptModal';
+import UserPromptFormModal from '../components/UserPromptFormModal';
 import { createFavoriteItemHelpers } from '../../../utils/favoriteItems';
 import { getRecentPromptIds, recordPromptUsage } from '../../../utils/recentPrompts';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import { highlightVariables } from '../../../utils/highlightVariables';
 import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
+import { useAuth } from '../../../shared/contexts/AuthContext';
 
 const ITEMS_PER_PAGE = 9;
 
 function PromptsList() {
   const { t, i18n } = useTranslation();
+  const { isAuthenticated } = useAuth();
   const [prompts, setPrompts] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -24,6 +33,9 @@ function PromptsList() {
   const [recentPromptIds, setRecentPromptIds] = useState([]);
   const [selectedPrompt, setSelectedPrompt] = useState(null);
   const [selectedCategory, setSelectedCategory] = useState('all');
+  const [showSaveModal, setShowSaveModal] = useState(false);
+  const [editingUserPrompt, setEditingUserPrompt] = useState(null);
+  const [deletingPromptId, setDeletingPromptId] = useState(null);
 
   // Create favorite prompts helpers
   const { getFavorites: getFavoritePrompts, toggleFavorite: toggleFavoritePrompt } =
@@ -69,29 +81,49 @@ function PromptsList() {
     setSortMethod(sortConfig.default || 'relevance');
   }, [sortConfig]);
 
-  useEffect(() => {
-    (async () => {
-      try {
-        const raw = await fetchPrompts();
-        const localized = (Array.isArray(raw) ? raw : []).map(p => ({
-          ...p,
-          name: getLocalizedContent(p.name, i18n.language),
-          prompt: getLocalizedContent(p.prompt, i18n.language),
-          description: getLocalizedContent(p.description, i18n.language)
-        }));
-        setPrompts(localized);
-        setFavoritePromptIds(getFavoritePrompts());
-        setRecentPromptIds(getRecentPromptIds());
-        setError(null);
-      } catch (err) {
-        console.error('Error loading prompts:', err);
-        setError(t('error.loadingFailed', 'Failed to load prompts'));
-      } finally {
-        setLoading(false);
-      }
-    })();
+  const loadPrompts = useCallback(async () => {
+    try {
+      const [raw, userRaw] = await Promise.all([
+        fetchPrompts(),
+        // User prompts require an authenticated (non-anonymous) session — skip the
+        // call entirely rather than let it 401 for anonymous/logged-out visitors.
+        isAuthenticated
+          ? fetchUserPrompts().catch(err => {
+              console.error('Error loading user prompts:', err);
+              return [];
+            })
+          : Promise.resolve([])
+      ]);
+      const localize = p => ({
+        ...p,
+        name: getLocalizedContent(p.name, i18n.language),
+        prompt: getLocalizedContent(p.prompt, i18n.language),
+        description: getLocalizedContent(p.description, i18n.language)
+      });
+      const localized = (Array.isArray(raw) ? raw : []).map(p => ({
+        ...localize(p),
+        isUserPrompt: false
+      }));
+      const localizedUser = (Array.isArray(userRaw) ? userRaw : []).map(p => ({
+        ...localize(p),
+        isUserPrompt: true
+      }));
+      setPrompts([...localizedUser, ...localized]);
+      setFavoritePromptIds(getFavoritePrompts());
+      setRecentPromptIds(getRecentPromptIds());
+      setError(null);
+    } catch (err) {
+      console.error('Error loading prompts:', err);
+      setError(t('error.loadingFailed', 'Failed to load prompts'));
+    } finally {
+      setLoading(false);
+    }
     // eslint-disable-next-line @eslint-react/exhaustive-deps
-  }, [t, i18n.language]);
+  }, [t, i18n.language, isAuthenticated]);
+
+  useEffect(() => {
+    loadPrompts();
+  }, [loadPrompts]);
 
   // Open modal if id parameter is present
   useEffect(() => {
@@ -195,6 +227,36 @@ function PromptsList() {
     setPage(0); // Reset to first page when category changes
   };
 
+  const handleSaveUserPrompt = async data => {
+    if (editingUserPrompt) {
+      await updateUserPrompt(editingUserPrompt.id, data);
+    } else {
+      await createUserPrompt(data);
+    }
+    setShowSaveModal(false);
+    setEditingUserPrompt(null);
+    await loadPrompts();
+  };
+
+  const handleEditUserPrompt = (e, prompt) => {
+    e.stopPropagation();
+    setEditingUserPrompt(prompt);
+    setShowSaveModal(true);
+  };
+
+  const handleDeleteUserPrompt = async (e, promptId) => {
+    e.stopPropagation();
+    try {
+      await deleteUserPrompt(promptId);
+      setDeletingPromptId(null);
+      if (selectedPrompt?.id === promptId) setSelectedPrompt(null);
+      await loadPrompts();
+    } catch (err) {
+      console.error('Error deleting prompt:', err);
+      setDeletingPromptId(null);
+    }
+  };
+
   if (loading) {
     return <LoadingSpinner message={t('app.loading')} />;
   }
@@ -218,9 +280,22 @@ function PromptsList() {
       <h1 className="text-3xl font-bold mb-2 text-gray-900 dark:text-gray-100">
         {t('pages.promptsList.title', 'Prompts')}
       </h1>
-      <p className="text-gray-600 dark:text-gray-400 mb-6">
+      <p className="text-gray-600 dark:text-gray-400 mb-4">
         {t('pages.promptsList.subtitle', 'Browse available prompts')}
       </p>
+
+      {isAuthenticated && (
+        <button
+          onClick={() => {
+            setEditingUserPrompt(null);
+            setShowSaveModal(true);
+          }}
+          className="mb-6 px-4 py-2 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 flex items-center gap-1.5"
+        >
+          <Icon name="plus" className="w-4 h-4" />
+          {t('pages.promptsList.userPrompts.saveNew', 'Save a new prompt')}
+        </button>
+      )}
 
       <div className="w-full max-w-md sm:max-w-lg lg:max-w-xl mb-8">
         <div className="flex flex-col sm:flex-row items-stretch gap-4">
@@ -373,6 +448,23 @@ function PromptsList() {
                             {t('common.promptSearch.appSpecific', 'app')}
                           </span>
                         )}
+                        {p.isUserPrompt && (
+                          <span
+                            className="ml-1 px-1.5 py-0.5 text-xs text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 rounded-full flex items-center gap-0.5"
+                            title={
+                              p.mine
+                                ? t('pages.promptsList.userPrompts.mine', 'Mine')
+                                : t('pages.promptsList.userPrompts.sharedByOther', 'Shared')
+                            }
+                          >
+                            {p.visibility === 'shared' && (
+                              <Icon name="users" size="sm" className="w-3 h-3" />
+                            )}
+                            {p.mine
+                              ? t('pages.promptsList.userPrompts.mine', 'Mine')
+                              : t('pages.promptsList.userPrompts.sharedByOther', 'Shared')}
+                          </span>
+                        )}
                       </h3>
                     </div>
                   </div>
@@ -427,6 +519,29 @@ function PromptsList() {
                         {t('pages.promptsList.useInApp', 'Open')}
                       </Link>
                     )}
+                    {p.mine && (
+                      <>
+                        <button
+                          onClick={e => handleEditUserPrompt(e, p)}
+                          className="px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 text-gray-600 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors flex items-center justify-center"
+                          aria-label={t('common.edit', 'Edit')}
+                          title={t('common.edit', 'Edit')}
+                        >
+                          <Icon name="pencil" size="sm" />
+                        </button>
+                        <button
+                          onClick={e => {
+                            e.stopPropagation();
+                            setDeletingPromptId(p.id);
+                          }}
+                          className="px-2 py-1.5 text-xs border border-gray-300 dark:border-gray-600 text-red-600 dark:text-red-400 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/30 transition-colors flex items-center justify-center"
+                          aria-label={t('common.delete', 'Delete')}
+                          title={t('common.delete', 'Delete')}
+                        >
+                          <Icon name="trash" size="sm" />
+                        </button>
+                      </>
+                    )}
                   </div>
                 </div>
                 <div className="absolute inset-0 rounded-xl border border-transparent group-hover:border-indigo-200 dark:group-hover:border-indigo-700 transition-colors pointer-events-none"></div>
@@ -476,6 +591,43 @@ function PromptsList() {
           }}
           t={t}
         />
+      )}
+      {showSaveModal && (
+        <UserPromptFormModal
+          prompt={editingUserPrompt}
+          onClose={() => {
+            setShowSaveModal(false);
+            setEditingUserPrompt(null);
+          }}
+          onSave={handleSaveUserPrompt}
+          t={t}
+        />
+      )}
+      {deletingPromptId && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg max-w-sm w-full p-6">
+            <p className="text-gray-900 dark:text-gray-100 mb-4">
+              {t(
+                'pages.promptsList.userPrompts.deleteConfirm',
+                'Delete this prompt? This cannot be undone.'
+              )}
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                onClick={() => setDeletingPromptId(null)}
+                className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700"
+              >
+                {t('common.cancel', 'Cancel')}
+              </button>
+              <button
+                onClick={e => handleDeleteUserPrompt(e, deletingPromptId)}
+                className="px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700"
+              >
+                {t('common.delete', 'Delete')}
+              </button>
+            </div>
+          </div>
+        </div>
       )}
     </div>
   );

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -171,3 +171,28 @@ The client UI shows prompts in the prompts library where users can search, filte
 ## Managing Prompts via Admin UI
 
 Prompts can also be created and edited through the admin panel at `/admin/prompts`. Changes made through the admin panel write directly to the corresponding file in `contents/prompts/`.
+
+## User-Owned Prompts (Save to Library)
+
+In addition to the admin-curated library above, any authenticated (non-anonymous) user can save
+their own prompts directly from the Prompts page (`/prompts`) via the "Save a new prompt" button.
+
+- Stored one file per prompt under `contents/data/user-prompts/<userId>/<promptId>.json` — separate
+  from the admin-curated `contents/prompts/` library and not subject to `contentAdminAuth`.
+- Each prompt is **private** (visible only to its owner) or **shared** (visible to every
+  authenticated user), chosen when saving. Owners can edit or delete their own prompts; shared
+  prompts from other users are read-only.
+- Every record tracks `ownerId`, `createdBy`/`createdAt`, and `lastModifiedBy`/`lastModifiedAt`.
+- User prompts are plain strings (no localization, `variables`, or `outputSchema`) — a deliberately
+  simpler shape than admin-curated prompts.
+- Gated behind the same `promptsLibrary` feature flag as `GET /api/prompts` (enabled by default).
+
+### API
+
+- `GET /api/user-prompts` — Returns the caller's own prompts plus every other user's `shared`
+  prompts. Each item includes `mine: true|false`.
+- `POST /api/user-prompts` — Creates a new prompt (`name`, `description?`, `prompt`, `visibility?`).
+- `PUT /api/user-prompts/:promptId` — Updates one of the caller's own prompts.
+- `DELETE /api/user-prompts/:promptId` — Deletes one of the caller's own prompts.
+
+All four endpoints require an authenticated, non-anonymous session.

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,5 +1,17 @@
 # Features — 5.5.0
 
+## Save Your Own Prompts to the Prompt Library
+
+Any signed-in user can now save a prompt directly to the Prompt Library (`/prompts`) instead of
+relying only on the admin-curated set.
+
+- New "Save a new prompt" button opens a simple form (name, description, prompt text, visibility).
+- Prompts can be **private** (only you) or **shared** (visible to every signed-in user); prompts
+  from other users show a "Shared" badge, your own show "Mine" and can be edited or deleted.
+- Every prompt tracks who created and last modified it, and when.
+- Anonymous sessions don't see the save button — this feature requires being signed in, and is
+  gated behind the existing Prompts Library feature flag.
+
 ## Agent Profile Editor No Longer Corrupts Shared State on Save
 
 Fixed a bug in the Agent Profile admin editor where saving could corrupt data shared across the

--- a/server/routes/userPromptsRoutes.js
+++ b/server/routes/userPromptsRoutes.js
@@ -1,0 +1,113 @@
+import { authenticatedOnly } from '../middleware/authRequired.js';
+import { requireFeature } from '../featureRegistry.js';
+import { buildServerPath } from '../utils/basePath.js';
+import { validateIdForPath } from '../utils/pathSecurity.js';
+import { userPromptInputSchema } from '../validators/userPromptInputSchema.js';
+import {
+  listOwnUserPrompts,
+  listSharedUserPrompts,
+  getUserPrompt,
+  createUserPrompt,
+  updateUserPrompt,
+  deleteUserPrompt
+} from '../utils/userPromptsStore.js';
+import { logAudit } from '../services/AuditLogService.js';
+import { sendInternalError, sendBadRequest, sendNotFound } from '../utils/responseHelpers.js';
+
+/**
+ * User-owned prompts: lets any authenticated (non-anonymous) user save their
+ * own prompts into the library, private by default or shared with everyone.
+ * Separate from the admin-curated contents/prompts/ library (server/routes/admin/prompts.js) —
+ * see #1037/#1038.
+ */
+export default function registerUserPromptsRoutes(app) {
+  const gate = [authenticatedOnly, requireFeature('promptsLibrary')];
+
+  app.get(buildServerPath('/api/user-prompts'), ...gate, async (req, res) => {
+    try {
+      const userId = req.user.id;
+      const [own, shared] = await Promise.all([
+        listOwnUserPrompts(userId),
+        listSharedUserPrompts(userId)
+      ]);
+      const prompts = [
+        ...own.map(p => ({ ...p, mine: true })),
+        ...shared.map(p => ({ ...p, mine: false }))
+      ];
+      res.json(prompts);
+    } catch (error) {
+      return sendInternalError(res, error, 'fetch user prompts');
+    }
+  });
+
+  app.post(buildServerPath('/api/user-prompts'), ...gate, async (req, res) => {
+    try {
+      const parsed = userPromptInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return sendBadRequest(res, parsed.error.errors.map(e => e.message).join('; '));
+      }
+      const record = await createUserPrompt(req.user.id, parsed.data);
+      await logAudit({
+        req,
+        action: 'create',
+        resource: 'user-prompt',
+        resourceId: record.id,
+        summary: `Saved user prompt ${record.id}`
+      });
+      res.json({ message: 'Prompt saved successfully', prompt: { ...record, mine: true } });
+    } catch (error) {
+      return sendInternalError(res, error, 'create user prompt');
+    }
+  });
+
+  app.put(buildServerPath('/api/user-prompts/:promptId'), ...gate, async (req, res) => {
+    try {
+      const { promptId } = req.params;
+      if (!validateIdForPath(promptId, 'prompt', res)) {
+        return;
+      }
+      const parsed = userPromptInputSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return sendBadRequest(res, parsed.error.errors.map(e => e.message).join('; '));
+      }
+      const updated = await updateUserPrompt(req.user.id, promptId, parsed.data);
+      if (!updated) {
+        return sendNotFound(res, 'Prompt');
+      }
+      await logAudit({
+        req,
+        action: 'update',
+        resource: 'user-prompt',
+        resourceId: promptId,
+        summary: `Updated user prompt ${promptId}`
+      });
+      res.json({ message: 'Prompt updated successfully', prompt: { ...updated, mine: true } });
+    } catch (error) {
+      return sendInternalError(res, error, 'update user prompt');
+    }
+  });
+
+  app.delete(buildServerPath('/api/user-prompts/:promptId'), ...gate, async (req, res) => {
+    try {
+      const { promptId } = req.params;
+      if (!validateIdForPath(promptId, 'prompt', res)) {
+        return;
+      }
+      const existing = await getUserPrompt(req.user.id, promptId);
+      if (!existing) {
+        return sendNotFound(res, 'Prompt');
+      }
+      await deleteUserPrompt(req.user.id, promptId);
+      await logAudit({
+        req,
+        action: 'delete',
+        resource: 'user-prompt',
+        resourceId: promptId,
+        summary: `Deleted user prompt ${promptId}`
+      });
+      res.json({ message: 'Prompt deleted successfully' });
+    } catch (error) {
+      return sendInternalError(res, error, 'delete user prompt');
+    }
+  });
+}

--- a/server/server.js
+++ b/server/server.js
@@ -22,6 +22,7 @@ import registerPageRoutes from './routes/pageRoutes.js';
 import registerRendererRoutes from './routes/rendererRoutes.js';
 import registerAppSessionStartRoute from './routes/appSessionRoutes.js';
 import registerMagicPromptRoutes from './routes/magicPromptRoutes.js';
+import registerUserPromptsRoutes from './routes/userPromptsRoutes.js';
 import registerShortLinkRoutes from './routes/shortLinkRoutes.js';
 import registerOpenAIProxyRoutes from './routes/openaiProxy.js';
 import registerAuthRoutes from './routes/auth.js';
@@ -461,6 +462,7 @@ if (cluster.isPrimary && workerCount > 1) {
   registerRendererRoutes(app);
   registerAppSessionStartRoute(app);
   registerMagicPromptRoutes(app);
+  registerUserPromptsRoutes(app);
   registerChatRoutes(app, {
     verifyApiKey,
     processMessageTemplates,

--- a/server/tests/userPromptsStore.test.js
+++ b/server/tests/userPromptsStore.test.js
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for userPromptsStore.js (per-user prompt CRUD, #1037/#1038).
+ * Exercises the real filesystem under a throwaway userId directory (cleaned
+ * up in afterAll) rather than mocking fs, since path-traversal safety is the
+ * behavior under test.
+ */
+import { promises as fs } from 'fs';
+import path from 'path';
+import { getRootDir } from '../pathUtils.js';
+import {
+  listOwnUserPrompts,
+  listSharedUserPrompts,
+  getUserPrompt,
+  createUserPrompt,
+  updateUserPrompt,
+  deleteUserPrompt
+} from '../utils/userPromptsStore.js';
+
+const OWNER_ID = `test-owner-${Date.now()}`;
+const OTHER_ID = `test-other-${Date.now()}`;
+
+function userDirPath(userId) {
+  return path.join(getRootDir(), 'contents', 'data', 'user-prompts', userId);
+}
+
+afterAll(async () => {
+  await fs.rm(userDirPath(OWNER_ID), { recursive: true, force: true });
+  await fs.rm(userDirPath(OTHER_ID), { recursive: true, force: true });
+});
+
+describe('userPromptsStore', () => {
+  test('createUserPrompt persists a record with ownership/audit fields', async () => {
+    const record = await createUserPrompt(OWNER_ID, {
+      name: 'My Prompt',
+      description: 'A test prompt',
+      prompt: 'Summarize: [content]',
+      visibility: 'private'
+    });
+
+    expect(record.id).toBeTruthy();
+    expect(record.ownerId).toBe(OWNER_ID);
+    expect(record.createdBy).toBe(OWNER_ID);
+    expect(record.lastModifiedBy).toBe(OWNER_ID);
+    expect(record.visibility).toBe('private');
+    expect(record.enabled).toBe(true);
+
+    const fetched = await getUserPrompt(OWNER_ID, record.id);
+    expect(fetched).toEqual(record);
+  });
+
+  test('listOwnUserPrompts returns only the owner’s prompts', async () => {
+    const own = await listOwnUserPrompts(OWNER_ID);
+    expect(own.length).toBeGreaterThanOrEqual(1);
+    expect(own.every(p => p.ownerId === OWNER_ID)).toBe(true);
+  });
+
+  test('private prompts are not returned by listSharedUserPrompts for other users', async () => {
+    const shared = await listSharedUserPrompts(OTHER_ID);
+    expect(shared.some(p => p.ownerId === OWNER_ID)).toBe(false);
+  });
+
+  test('shared prompts are visible to other users, private ones are not', async () => {
+    const sharedRecord = await createUserPrompt(OWNER_ID, {
+      name: 'Shared Prompt',
+      prompt: 'Translate: [content]',
+      visibility: 'shared'
+    });
+
+    const visibleToOther = await listSharedUserPrompts(OTHER_ID);
+    expect(visibleToOther.some(p => p.id === sharedRecord.id)).toBe(true);
+
+    // Excluding the owner's own id should never surface their own prompts,
+    // shared or not — the caller already gets those from listOwnUserPrompts.
+    const visibleToSelf = await listSharedUserPrompts(OWNER_ID);
+    expect(visibleToSelf.some(p => p.id === sharedRecord.id)).toBe(false);
+  });
+
+  test('updateUserPrompt mutates fields and bumps lastModified*, returns null for unknown id', async () => {
+    const record = await createUserPrompt(OWNER_ID, {
+      name: 'Before',
+      prompt: 'Before text',
+      visibility: 'private'
+    });
+
+    const updated = await updateUserPrompt(OWNER_ID, record.id, {
+      name: 'After',
+      prompt: 'After text',
+      visibility: 'shared'
+    });
+
+    expect(updated.name).toBe('After');
+    expect(updated.prompt).toBe('After text');
+    expect(updated.visibility).toBe('shared');
+    expect(updated.createdAt).toBe(record.createdAt);
+    expect(updated.lastModifiedAt >= record.lastModifiedAt).toBe(true);
+
+    const missing = await updateUserPrompt(OWNER_ID, 'does-not-exist', {
+      name: 'X',
+      prompt: 'Y'
+    });
+    expect(missing).toBeNull();
+  });
+
+  test('deleteUserPrompt removes the file and reports whether it existed', async () => {
+    const record = await createUserPrompt(OWNER_ID, {
+      name: 'To Delete',
+      prompt: 'Delete me'
+    });
+
+    const deleted = await deleteUserPrompt(OWNER_ID, record.id);
+    expect(deleted).toBe(true);
+
+    const afterDelete = await getUserPrompt(OWNER_ID, record.id);
+    expect(afterDelete).toBeNull();
+
+    const deleteAgain = await deleteUserPrompt(OWNER_ID, record.id);
+    expect(deleteAgain).toBe(false);
+  });
+
+  test('rejects promptId values that look like path traversal', async () => {
+    await expect(getUserPrompt(OWNER_ID, '../../etc/passwd')).rejects.toThrow('Invalid prompt id');
+    await expect(getUserPrompt(OWNER_ID, '..')).rejects.toThrow('Invalid prompt id');
+  });
+
+  test('rejects userId values that look like path traversal', async () => {
+    await expect(listOwnUserPrompts('..')).rejects.toThrow('Invalid user id');
+    await expect(listOwnUserPrompts('../../etc')).rejects.toThrow('Invalid user id');
+  });
+});

--- a/server/utils/userPromptsStore.js
+++ b/server/utils/userPromptsStore.js
@@ -1,0 +1,212 @@
+/**
+ * User Prompts Store
+ *
+ * Per-user prompt files under contents/data/user-prompts/<userId>/<promptId>.json,
+ * separate from the admin-curated contents/prompts/ library (which is scanned
+ * wholesale by promptsLoader.js and gated behind contentAdminAuth). One file
+ * per prompt, one directory per owning user.
+ *
+ * userId comes straight from req.user.id (local username, OIDC subject, LDAP
+ * username, or a proxy-auth header value) so it's treated as untrusted input:
+ * validated against the same safe-filename allowlist TokenStorageService.js
+ * uses for its per-user token files, then re-checked to stay inside its
+ * parent directory before any fs call.
+ */
+
+import { promises as fs } from 'fs';
+import path from 'path';
+import { randomUUID } from 'crypto';
+import { getRootDir } from '../pathUtils.js';
+import { atomicWriteJSON, atomicCreateJSON } from './atomicWrite.js';
+import { isValidId } from './pathSecurity.js';
+
+const USER_PROMPTS_DIR = 'data/user-prompts';
+const USER_ID_PATTERN = /^[A-Za-z0-9._@+-]+$/;
+
+function baseDir() {
+  return path.join(getRootDir(), 'contents', USER_PROMPTS_DIR);
+}
+
+function isSafeUserId(userId) {
+  return (
+    typeof userId === 'string' &&
+    userId.length > 0 &&
+    userId.length <= 256 &&
+    USER_ID_PATTERN.test(userId) &&
+    !/^\.+$/.test(userId) // reject "." / ".." even though the charset allows dots
+  );
+}
+
+/**
+ * Joins `segment` onto `base` and asserts the result still resolves inside
+ * `base`. Safe to call before `base`/the target exist on disk (unlike
+ * pathSecurity.js's resolveAndValidatePath, which requires an existing
+ * ancestor to realpath against).
+ */
+function resolveWithinBase(base, segment) {
+  const resolvedBase = path.resolve(base);
+  const candidate = path.resolve(resolvedBase, segment);
+  const baseWithSep = resolvedBase.endsWith(path.sep) ? resolvedBase : resolvedBase + path.sep;
+  if (candidate !== resolvedBase && !candidate.startsWith(baseWithSep)) {
+    throw new Error('Resolved user-prompt path escapes its base directory');
+  }
+  return candidate;
+}
+
+function userDir(userId) {
+  if (!isSafeUserId(userId)) {
+    throw new Error('Invalid user id');
+  }
+  return resolveWithinBase(baseDir(), userId);
+}
+
+function promptFilePath(userId, promptId) {
+  if (!isValidId(promptId)) {
+    throw new Error('Invalid prompt id');
+  }
+  return resolveWithinBase(userDir(userId), `${promptId}.json`);
+}
+
+async function readPromptFile(filePath) {
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    return JSON.parse(raw);
+  } catch (error) {
+    if (error.code === 'ENOENT') return null;
+    throw error;
+  }
+}
+
+/**
+ * @param {string} userId
+ * @returns {Promise<Array>} All prompts owned by userId (private + shared).
+ */
+export async function listOwnUserPrompts(userId) {
+  const dir = userDir(userId);
+  let entries;
+  try {
+    entries = await fs.readdir(dir);
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+  const prompts = [];
+  for (const entry of entries) {
+    if (!entry.endsWith('.json')) continue;
+    const record = await readPromptFile(path.join(dir, entry));
+    if (record) prompts.push(record);
+  }
+  return prompts;
+}
+
+/**
+ * Scans every other user's directory for prompts marked visibility: 'shared'.
+ * @param {string} excludeUserId - Owner to skip (their own prompts are listed via listOwnUserPrompts)
+ * @returns {Promise<Array>}
+ */
+export async function listSharedUserPrompts(excludeUserId) {
+  let userDirEntries;
+  try {
+    userDirEntries = await fs.readdir(baseDir(), { withFileTypes: true });
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    throw error;
+  }
+  const prompts = [];
+  for (const entry of userDirEntries) {
+    if (!entry.isDirectory() || entry.name === excludeUserId) continue;
+    if (!isSafeUserId(entry.name)) continue;
+    const dir = path.join(baseDir(), entry.name);
+    let files;
+    try {
+      files = await fs.readdir(dir);
+    } catch {
+      continue;
+    }
+    for (const file of files) {
+      if (!file.endsWith('.json')) continue;
+      const record = await readPromptFile(path.join(dir, file));
+      if (record && record.visibility === 'shared') {
+        prompts.push(record);
+      }
+    }
+  }
+  return prompts;
+}
+
+/**
+ * @param {string} userId - Owner directory to look in (only ever the caller's own)
+ * @param {string} promptId
+ * @returns {Promise<Object|null>}
+ */
+export async function getUserPrompt(userId, promptId) {
+  return readPromptFile(promptFilePath(userId, promptId));
+}
+
+/**
+ * @param {string} userId
+ * @param {{name:string, description?:string, prompt:string, category?:string, visibility?:string}} data
+ * @returns {Promise<Object>} The created record
+ */
+export async function createUserPrompt(userId, data) {
+  const dir = userDir(userId);
+  await fs.mkdir(dir, { recursive: true });
+  const id = randomUUID();
+  const now = new Date().toISOString();
+  const record = {
+    id,
+    ownerId: userId,
+    name: data.name,
+    description: data.description || '',
+    prompt: data.prompt,
+    category: data.category,
+    visibility: data.visibility || 'private',
+    enabled: true,
+    createdBy: userId,
+    createdAt: now,
+    lastModifiedBy: userId,
+    lastModifiedAt: now
+  };
+  await atomicCreateJSON(resolveWithinBase(dir, `${id}.json`), record);
+  return record;
+}
+
+/**
+ * @param {string} userId
+ * @param {string} promptId
+ * @param {{name:string, description?:string, prompt:string, category?:string, visibility?:string}} data
+ * @returns {Promise<Object|null>} The updated record, or null if it doesn't exist
+ */
+export async function updateUserPrompt(userId, promptId, data) {
+  const filePath = promptFilePath(userId, promptId);
+  const existing = await readPromptFile(filePath);
+  if (!existing) return null;
+  const updated = {
+    ...existing,
+    name: data.name,
+    description: data.description || '',
+    prompt: data.prompt,
+    category: data.category,
+    visibility: data.visibility || existing.visibility || 'private',
+    lastModifiedBy: userId,
+    lastModifiedAt: new Date().toISOString()
+  };
+  await atomicWriteJSON(filePath, updated);
+  return updated;
+}
+
+/**
+ * @param {string} userId
+ * @param {string} promptId
+ * @returns {Promise<boolean>} True if a file was deleted, false if it didn't exist
+ */
+export async function deleteUserPrompt(userId, promptId) {
+  const filePath = promptFilePath(userId, promptId);
+  try {
+    await fs.unlink(filePath);
+    return true;
+  } catch (error) {
+    if (error.code === 'ENOENT') return false;
+    throw error;
+  }
+}

--- a/server/validators/userPromptInputSchema.js
+++ b/server/validators/userPromptInputSchema.js
@@ -1,0 +1,17 @@
+import { z } from 'zod';
+
+/**
+ * Validates the create/update payload for a user-owned prompt (see
+ * server/utils/userPromptsStore.js). Deliberately simpler than
+ * promptConfigSchema.js: user prompts aren't localized and carry no
+ * variables/actions/outputSchema — those remain admin-curated-only for now.
+ */
+export const userPromptInputSchema = z
+  .object({
+    name: z.string().trim().min(1, 'Name is required').max(200, 'Name is too long'),
+    description: z.string().trim().max(2000, 'Description is too long').optional().default(''),
+    prompt: z.string().trim().min(1, 'Prompt text is required').max(20000, 'Prompt is too long'),
+    category: z.string().trim().max(100, 'Category is too long').optional(),
+    visibility: z.enum(['private', 'shared']).optional().default('private')
+  })
+  .strict();

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -36,6 +36,7 @@
     "cancel": "Abbrechen",
     "close": "Schließen",
     "save": "Speichern",
+    "saving": "Wird gespeichert...",
     "delete": "Löschen",
     "edit": "Bearbeiten",
     "loading": "Wird geladen...",
@@ -238,6 +239,25 @@
         "nameAsc": "Name A-Z",
         "nameDesc": "Name Z-A",
         "relevance": "Relevanz"
+      },
+      "userPrompts": {
+        "saveNew": "Neuen Prompt speichern",
+        "saveTitle": "Neuen Prompt speichern",
+        "editTitle": "Prompt bearbeiten",
+        "nameLabel": "Name",
+        "namePlaceholder": "z. B. Wochenzusammenfassung",
+        "descriptionLabel": "Beschreibung (optional)",
+        "descriptionPlaceholder": "Wofür ist dieser Prompt gedacht?",
+        "promptLabel": "Prompt",
+        "promptPlaceholder": "Prompt-Text hier eingeben...",
+        "visibilityLabel": "Sichtbarkeit",
+        "visibilityPrivate": "Privat (nur ich)",
+        "visibilityShared": "Geteilt (alle)",
+        "validationError": "Name und Prompt-Text sind erforderlich",
+        "saveError": "Prompt konnte nicht gespeichert werden",
+        "deleteConfirm": "Diesen Prompt löschen? Dies kann nicht rückgängig gemacht werden.",
+        "mine": "Meine",
+        "sharedByOther": "Geteilt"
       }
     },
     "notFound": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -36,6 +36,7 @@
     "cancel": "Cancel",
     "close": "Close",
     "save": "Save",
+    "saving": "Saving...",
     "delete": "Delete",
     "edit": "Edit",
     "loading": "Loading...",
@@ -225,6 +226,25 @@
         "nameAsc": "Name A-Z",
         "nameDesc": "Name Z-A",
         "relevance": "Relevance"
+      },
+      "userPrompts": {
+        "saveNew": "Save a new prompt",
+        "saveTitle": "Save a new prompt",
+        "editTitle": "Edit prompt",
+        "nameLabel": "Name",
+        "namePlaceholder": "e.g. Weekly summary",
+        "descriptionLabel": "Description (optional)",
+        "descriptionPlaceholder": "What is this prompt for?",
+        "promptLabel": "Prompt",
+        "promptPlaceholder": "Write your prompt text here...",
+        "visibilityLabel": "Visibility",
+        "visibilityPrivate": "Private (only me)",
+        "visibilityShared": "Shared (everyone)",
+        "validationError": "Name and prompt text are required",
+        "saveError": "Failed to save prompt",
+        "deleteConfirm": "Delete this prompt? This cannot be undone.",
+        "mine": "Mine",
+        "sharedByOther": "Shared"
       }
     },
     "notFound": {


### PR DESCRIPTION
## Summary

Closes #1037 ("Support to save a prompt to the prompt library"). Also covers the data-model half of
#1038 (owner, visibility, createdBy/lastModifiedBy tracking) — see scoping note below.

Today `contents/prompts/*.json` is exclusively an admin-curated resource. This adds a parallel,
user-owned layer: any authenticated (non-anonymous) user can save their own prompt directly from
the Prompts page, mark it **private** (only them) or **shared** (every authenticated user), and
edit/delete their own prompts later.

### Backend

- New `server/utils/userPromptsStore.js` — one JSON file per prompt under
  `contents/data/user-prompts/<userId>/<promptId>.json`, separate from the admin-curated library
  and not subject to `contentAdminAuth`. `userId` (an OIDC subject/local username/LDAP username/proxy
  header value) is treated as untrusted input — validated against the same safe-filename allowlist
  `TokenStorageService.js` already uses for its per-user token files, then re-checked to stay inside
  its parent directory before any fs call (mirrors that module's existing path-safety pattern).
- New `server/validators/userPromptInputSchema.js` — a small Zod schema for the create/update
  payload (name/description/prompt/category/visibility). Deliberately simpler than
  `promptConfigSchema.js`: no localization, variables, or output schema for v1.
- New `server/routes/userPromptsRoutes.js` — `GET/POST/PUT/DELETE /api/user-prompts`, gated behind
  `authenticatedOnly` (rejects anonymous sessions) and the existing `promptsLibrary` feature flag
  (already default-on, so no migration needed). `GET` returns the caller's own prompts plus every
  other user's `shared` prompts, each tagged `mine: true|false`. Ownership on update/delete is
  enforced by construction — the store only ever reads/writes inside the caller's own directory, so
  a `promptId` belonging to someone else's directory simply 404s.
- New `server/tests/userPromptsStore.test.js` — Jest tests covering create/list/update/delete,
  private-vs-shared visibility, and rejection of path-traversal-shaped `userId`/`promptId` values.

### Frontend

- New `client/src/features/prompts/components/UserPromptFormModal.jsx` — create/edit form
  (name/description/prompt/visibility).
- `client/src/features/prompts/pages/PromptsList.jsx` — new "Save a new prompt" button (hidden for
  anonymous sessions), own/shared user prompts merged into the existing grid with "Mine"/"Shared"
  badges, and edit/delete controls on the user's own prompt cards.
- `client/src/api/endpoints/prompts.js` — `fetchUserPrompts`/`createUserPrompt`/`updateUserPrompt`/
  `deleteUserPrompt`.
- New `en`/`de` translation strings under `pages.promptsList.userPrompts.*` and `common.saving`.

### Scoping notes (see `docs/prompts.md` for the full write-up)

- User prompts are **plain strings** (no localization/variables/outputSchema) — intentionally
  simpler than admin-curated prompts for v1.
- No admin moderation queue for `shared` prompts in this PR (an open question raised on #1037's
  implementation-plan comment) — flagging as a candidate follow-up, not blocking this slice.
- Anonymous sessions never see the save button and the API rejects them with 401, consistent with
  `authenticatedOnly` elsewhere in the codebase.

## Test plan

- [x] New unit tests (`server/tests/userPromptsStore.test.js`) — 8/8 passing, including
      path-traversal rejection for both `userId` and `promptId`.
- [x] `npx eslint` on all changed/new files — 0 errors (only pre-existing warnings elsewhere in
      `PromptsList.jsx` that predate this change).
- [x] `npx prettier --check` — clean.
- [x] Production client build (`vite build`) succeeds with no errors.
- [x] Server boots cleanly with the new route registered (`node server/server.js`, all 4 cluster
      workers ready, migrations unaffected).
- [x] Manually exercised the full CRUD lifecycle against a running dev server (logged in as the
      local admin per CLAUDE.md): create private → list → update to shared → delete → list empty
      again. Also verified: anonymous `GET /api/user-prompts` → 401; a path-traversal-shaped
      `promptId` on `DELETE` → 400; a request missing `name`/`prompt` → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGoQpnovDaVSVSGA9fsiyX


---
_Generated by [Claude Code](https://claude.ai/code/session_01KGoQpnovDaVSVSGA9fsiyX)_