### PR TITLE
Add SSE-based notification center for background job events (#1496)

### DIFF
--- a/client/src/api/endpoints/notifications.js
+++ b/client/src/api/endpoints/notifications.js
@@ -1,0 +1,22 @@
+import { apiClient } from '../client';
+import { handleApiResponse } from '../utils/requestHandler';
+
+export const fetchNotifications = async ({ limit, unreadOnly } = {}) => {
+  const params = {};
+  if (limit) params.limit = limit;
+  if (unreadOnly) params.unreadOnly = 'true';
+  return handleApiResponse(() => apiClient.get('/notifications', { params }), null, null, false);
+};
+
+export const markNotificationRead = async notificationId => {
+  return handleApiResponse(
+    () => apiClient.post(`/notifications/${notificationId}/read`),
+    null,
+    null,
+    false
+  );
+};
+
+export const markAllNotificationsRead = async () => {
+  return handleApiResponse(() => apiClient.post('/notifications/read-all'), null, null, false);
+};

--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -6,6 +6,7 @@ export * from './endpoints/prompts';
 export * from './endpoints/admin';
 export * from './endpoints/skills';
 export * from './endpoints/misc';
+export * from './endpoints/notifications';
 
 // Re-export utility functions
 export { clearApiCache, invalidateCacheByPattern } from './utils/cache';

--- a/client/src/features/notifications/components/NotificationBell.jsx
+++ b/client/src/features/notifications/components/NotificationBell.jsx
@@ -1,0 +1,64 @@
+import { useEffect, useRef, useState } from 'react';
+import { BellIcon } from '@heroicons/react/24/outline';
+import { useTranslation } from 'react-i18next';
+import useNotifications from '../hooks/useNotifications';
+import NotificationPanel from './NotificationPanel';
+
+/**
+ * Header bell + unread badge + dropdown panel. Only mounted when the
+ * 'notifications' feature flag is enabled and the user is authenticated.
+ */
+export default function NotificationBell() {
+  const { t } = useTranslation();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef(null);
+  const { notifications, unreadCount, markRead, markAllRead } = useNotifications({
+    enabled: true
+  });
+
+  useEffect(() => {
+    if (!open) return undefined;
+
+    const handleClickOutside = event => {
+      if (containerRef.current && !containerRef.current.contains(event.target)) {
+        setOpen(false);
+      }
+    };
+    const handleEscape = event => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        className="relative text-white/90 hover:text-white p-1"
+        onClick={() => setOpen(prev => !prev)}
+        aria-label={t('notifications.toggle', 'Notifications')}
+        aria-expanded={open}
+      >
+        <BellIcon className="h-5 w-5" />
+        {unreadCount > 0 && (
+          <span className="absolute -top-1 -right-1 bg-red-500 text-white text-[10px] leading-none rounded-full min-w-[16px] h-4 flex items-center justify-center px-1">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </span>
+        )}
+      </button>
+      {open && (
+        <NotificationPanel
+          notifications={notifications}
+          onMarkRead={markRead}
+          onMarkAllRead={markAllRead}
+        />
+      )}
+    </div>
+  );
+}

--- a/client/src/features/notifications/components/NotificationPanel.jsx
+++ b/client/src/features/notifications/components/NotificationPanel.jsx
@@ -1,0 +1,93 @@
+import { useTranslation } from 'react-i18next';
+
+function relativeTime(isoString, t) {
+  const diffMs = Date.now() - new Date(isoString).getTime();
+  const diffMin = Math.round(diffMs / 60000);
+  if (diffMin < 1) return t('notifications.justNow', 'Just now');
+  if (diffMin < 60) return t('notifications.minutesAgo', '{{count}}m ago', { count: diffMin });
+  const diffHr = Math.round(diffMin / 60);
+  if (diffHr < 24) return t('notifications.hoursAgo', '{{count}}h ago', { count: diffHr });
+  const diffDay = Math.round(diffHr / 24);
+  return t('notifications.daysAgo', '{{count}}d ago', { count: diffDay });
+}
+
+function describeNotification(notification, t) {
+  const toolType = notification.data?.toolType;
+  switch (notification.type) {
+    case 'job.completed':
+      return t('notifications.jobCompleted', '{{toolType}} job completed', {
+        toolType: toolType || t('notifications.job', 'Job')
+      });
+    case 'job.error':
+      return t('notifications.jobError', '{{toolType}} job failed', {
+        toolType: toolType || t('notifications.job', 'Job')
+      });
+    case 'job.cancelled':
+      return t('notifications.jobCancelled', '{{toolType}} job cancelled', {
+        toolType: toolType || t('notifications.job', 'Job')
+      });
+    default:
+      return notification.type;
+  }
+}
+
+export default function NotificationPanel({ notifications, onMarkRead, onMarkAllRead }) {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      className="absolute right-0 mt-2 w-80 max-h-96 overflow-y-auto bg-white dark:bg-gray-800 rounded-lg shadow-xl border border-gray-200 dark:border-gray-700 z-50"
+      role="dialog"
+      aria-label={t('notifications.panelLabel', 'Notifications')}
+    >
+      <div className="flex items-center justify-between px-4 py-2 border-b border-gray-200 dark:border-gray-700">
+        <span className="font-medium text-gray-900 dark:text-gray-100">
+          {t('notifications.title', 'Notifications')}
+        </span>
+        {notifications.length > 0 && (
+          <button
+            type="button"
+            className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline"
+            onClick={onMarkAllRead}
+          >
+            {t('notifications.markAllRead', 'Mark all read')}
+          </button>
+        )}
+      </div>
+
+      {notifications.length === 0 ? (
+        <div className="px-4 py-6 text-sm text-gray-500 dark:text-gray-400 text-center">
+          {t('notifications.empty', 'No notifications yet')}
+        </div>
+      ) : (
+        <ul>
+          {notifications.map(notification => (
+            <li key={notification.id}>
+              <button
+                type="button"
+                className={`w-full text-left px-4 py-3 text-sm border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700/50 flex items-start gap-2 ${
+                  notification.read ? 'opacity-60' : ''
+                }`}
+                onClick={() => {
+                  if (!notification.read) onMarkRead(notification.id);
+                }}
+              >
+                {!notification.read && (
+                  <span className="mt-1.5 w-2 h-2 rounded-full bg-indigo-600 flex-shrink-0" />
+                )}
+                <span className="flex-1">
+                  <span className="block text-gray-900 dark:text-gray-100">
+                    {describeNotification(notification, t)}
+                  </span>
+                  <span className="block text-xs text-gray-400 dark:text-gray-500">
+                    {relativeTime(notification.createdAt, t)}
+                  </span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/client/src/features/notifications/hooks/useNotifications.js
+++ b/client/src/features/notifications/hooks/useNotifications.js
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { buildApiUrl } from '../../../utils/runtimeBasePath';
+import { parseSseStream } from '../../../shared/utils/parseSseStream';
+import { fetchNotifications, markNotificationRead, markAllNotificationsRead } from '../../../api';
+
+/**
+ * Maintains the notification list + unread count for the current user,
+ * fed by an initial REST fetch and then live-updated over SSE.
+ *
+ * Uses fetch + ReadableStream (not native EventSource) so the same
+ * Authorization-header pattern as useEventSource.js works here too.
+ */
+export default function useNotifications({ enabled = true } = {}) {
+  const [notifications, setNotifications] = useState([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const abortControllerRef = useRef(null);
+
+  const getAuthHeaders = useCallback(() => {
+    const token = localStorage.getItem('authToken');
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  }, []);
+
+  const loadInitial = useCallback(async () => {
+    try {
+      const result = await fetchNotifications({ limit: 50 });
+      if (result) {
+        setNotifications(result.notifications || []);
+        setUnreadCount(result.unreadCount || 0);
+      }
+    } catch (err) {
+      console.warn('Failed to load notifications:', err);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    loadInitial();
+
+    const ac = new AbortController();
+    abortControllerRef.current = ac;
+
+    (async () => {
+      try {
+        const res = await fetch(buildApiUrl('notifications/stream'), {
+          method: 'GET',
+          headers: { Accept: 'text/event-stream', ...getAuthHeaders() },
+          credentials: 'include',
+          signal: ac.signal
+        });
+        if (!res.ok || !res.body) return;
+
+        await parseSseStream(
+          res.body,
+          (name, data) => {
+            if (name === 'notification' && data && data.id) {
+              setNotifications(prev => [data, ...prev].slice(0, 50));
+              setUnreadCount(prev => prev + 1);
+            }
+          },
+          ac.signal
+        );
+      } catch (err) {
+        if (err?.name !== 'AbortError') {
+          console.warn('Notifications stream error:', err);
+        }
+      }
+    })();
+
+    return () => {
+      ac.abort();
+      abortControllerRef.current = null;
+    };
+  }, [enabled, getAuthHeaders, loadInitial]);
+
+  const markRead = useCallback(async notificationId => {
+    let wasUnread = false;
+    setNotifications(prev =>
+      prev.map(n => {
+        if (n.id !== notificationId) return n;
+        wasUnread = !n.read;
+        return { ...n, read: true };
+      })
+    );
+    if (wasUnread) setUnreadCount(prev => Math.max(0, prev - 1));
+    try {
+      await markNotificationRead(notificationId);
+    } catch (err) {
+      console.warn('Failed to mark notification as read:', err);
+    }
+  }, []);
+
+  const markAllRead = useCallback(async () => {
+    setNotifications(prev => prev.map(n => ({ ...n, read: true })));
+    setUnreadCount(0);
+    try {
+      await markAllNotificationsRead();
+    } catch (err) {
+      console.warn('Failed to mark all notifications as read:', err);
+    }
+  }, []);
+
+  return { notifications, unreadCount, markRead, markAllRead, refresh: loadInitial };
+}

--- a/client/src/shared/components/Layout.jsx
+++ b/client/src/shared/components/Layout.jsx
@@ -10,6 +10,7 @@ import SmartSearch from './SmartSearch';
 import { updateSettingsFromUrl, saveIntegrationSettings } from '../../utils/integrationSettings';
 import Icon from './Icon';
 import UserAuthMenu from '../../features/auth/components/UserAuthMenu';
+import NotificationBell from '../../features/notifications/components/NotificationBell';
 import { useAuth } from '../contexts/AuthContext.jsx';
 import useFeatureFlags from '../hooks/useFeatureFlags';
 import { pathnameStartsWith, isActivePath } from '../../utils/pathUtils';
@@ -167,6 +168,9 @@ function Layout() {
               <div className="flex items-center space-x-2">
                 <DarkModeToggle />
                 {uiConfig?.header?.languageSelector?.enabled !== false && <LanguageSelector />}
+                {isAuthenticated && featureFlags.isEnabled('notifications', false) && (
+                  <NotificationBell />
+                )}
                 <UserAuthMenu />
                 <button
                   className="md:hidden text-white"

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -73,6 +73,7 @@
     - [Magic Prompt](magic-prompt-feature.md)
     - [Image Upload Feature](image-upload-feature.md)
     - [OCR Feature](ocr-feature.md)
+    - [Notification Center](notifications-feature.md)
     - [React Component Feature](react-component-feature.md)
     - [Agent Factory (V1)](agents.md)
     - [OpenAI-Compatible API](openai-compatible-api.md)

--- a/docs/notifications-feature.md
+++ b/docs/notifications-feature.md
@@ -1,0 +1,75 @@
+# Notification Center (Preview)
+
+A per-user, real-time notification bell that surfaces background job
+completion (and future event types) even if the user has navigated away
+from the tab that started the job.
+
+> **Status:** Preview feature, disabled by default (`features.notifications`).
+> Enable it under **Admin → Platform → Features** to try it out.
+
+## Why
+
+Background jobs (e.g. AI OCR via the Tools Service) only reported progress
+to a client that had an **open** `/jobs/:jobId/progress` SSE connection at
+the moment the job finished — closing the tab or navigating away silently
+lost the completion event. The notification center adds a small, durable
+record of terminal job events (`completed` / `error` / `cancelled`) that
+survives across page loads and multiple open tabs.
+
+## Scope (v1)
+
+This is intentionally a small, self-contained slice, not the full design
+sketched in the original feature request:
+
+- **Producer:** only background-job lifecycle events
+  (`job.completed` / `job.error` / `job.cancelled`), emitted once per job
+  from `server/routes/toolsService/jobStore.js`. Intermediate progress
+  ticks are **not** persisted as notifications — they're too frequent
+  (e.g. one per OCR page) to be useful in a notification list.
+- **Storage:** one JSON file per user under
+  `contents/data/notifications/<userId>.json`, capped at the 200 most
+  recent entries. This is **not** backed by PostgreSQL — durable,
+  multi-instance-safe storage is tracked separately (see
+  [`concepts/`](../concepts) for the PostgreSQL persistence work) and can
+  replace this store later without changing `NotificationService`'s API.
+- **Delivery:** a dedicated per-user SSE channel
+  (`GET /api/notifications/stream`, multiple tabs per user supported) plus
+  a REST list/mark-read API, so a client that missed the live push still
+  sees the notification on next load.
+- **UI:** a bell icon in the header (visible to authenticated users only)
+  with an unread-count badge and a dropdown panel. No toast/desktop
+  notifications and no admin-broadcast ("system announcement") producer
+  in this first slice.
+
+## Server
+
+| Endpoint | Description |
+| --- | --- |
+| `GET /api/notifications/stream` | SSE stream of new notifications for the authenticated user |
+| `GET /api/notifications` | List persisted notifications (`?limit=`, `?unreadOnly=true`) |
+| `POST /api/notifications/:id/read` | Mark one notification read |
+| `POST /api/notifications/read-all` | Mark all of a user's notifications read |
+
+Key modules:
+
+- `server/services/notifications/NotificationService.js` — in-process
+  event bus (`notify(userId, type, data)`); persists then broadcasts.
+- `server/services/notifications/NotificationStore.js` — per-user
+  JSON-file persistence.
+- `server/routes/notifications.js` — the four endpoints above, gated
+  behind `requireFeature('notifications')`.
+
+## Client
+
+- `client/src/features/notifications/hooks/useNotifications.js` — loads
+  the initial list via REST, then subscribes to the SSE stream.
+- `client/src/features/notifications/components/NotificationBell.jsx` /
+  `NotificationPanel.jsx` — header bell + dropdown, mounted in
+  `Layout.jsx` when the feature flag is enabled and the user is
+  authenticated.
+
+## Enabling
+
+1. Admin → Platform → Features → enable **Notifications**.
+2. Reload the app — authenticated users now see a bell icon in the
+   header.

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -487,3 +487,19 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Notification Center (Preview)
+
+A new bell icon in the header lets signed-in users see when a background job (for example an AI
+OCR job started via the Tools Service) finishes, fails, or is cancelled — even after they've
+navigated away from the tab that started it.
+
+- New **Notifications** feature flag (Admin → Platform → Features, disabled by default).
+- Live updates arrive over a per-user SSE stream and work across multiple open tabs; a REST list
+  also shows anything missed while the browser was closed, capped at the 200 most recent entries
+  per user.
+- v1 scope: only background-job completion/error/cancellation events are surfaced. Broader event
+  types (chat sharing, admin announcements) and durable multi-instance storage are tracked as
+  follow-up work.
+
+**Before using:** enable the **Notifications** feature under Admin → Platform → Features.

--- a/server/defaults/config/features.json
+++ b/server/defaults/config/features.json
@@ -2,5 +2,6 @@
   "skills": false,
   "workflows": false,
   "usageTracking": true,
-  "toolsService": false
+  "toolsService": false,
+  "notifications": false
 }

--- a/server/featureRegistry.js
+++ b/server/featureRegistry.js
@@ -155,6 +155,17 @@ export const featureRegistry = [
     category: 'preview',
     default: false,
     preview: true
+  },
+  {
+    id: 'notifications',
+    name: { en: 'Notifications', de: 'Benachrichtigungen' },
+    description: {
+      en: 'Real-time notification center (SSE) for background job progress and completion',
+      de: 'Echtzeit-Benachrichtigungszentrale (SSE) für Fortschritt und Abschluss von Hintergrundaufgaben'
+    },
+    category: 'preview',
+    default: false,
+    preview: true
   }
 ];
 

--- a/server/migrations/V078__add_notifications_feature_flag.js
+++ b/server/migrations/V078__add_notifications_feature_flag.js
@@ -1,0 +1,15 @@
+export const version = '078';
+export const description = 'add_notifications_feature_flag';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/features.json');
+}
+
+export async function up(ctx) {
+  const features = await ctx.readJson('config/features.json');
+
+  ctx.setDefault(features, 'notifications', false);
+
+  await ctx.writeJson('config/features.json', features);
+  ctx.log('Added notifications feature flag default (false)');
+}

--- a/server/routes/notifications.js
+++ b/server/routes/notifications.js
@@ -1,0 +1,119 @@
+/**
+ * Per-user real-time notification center (v1).
+ *
+ * GET  /api/notifications/stream    — SSE push channel, multi-tab per user
+ * GET  /api/notifications           — list persisted notifications
+ * POST /api/notifications/:id/read  — mark one notification read
+ * POST /api/notifications/read-all  — mark all notifications read
+ *
+ * Gated behind the 'notifications' preview feature flag (default off).
+ */
+import express from 'express';
+import { authRequired } from '../middleware/authRequired.js';
+import { requireFeature } from '../featureRegistry.js';
+import { buildApiPath } from '../utils/basePath.js';
+import notificationService from '../services/notifications/NotificationService.js';
+import {
+  listNotifications,
+  countUnread,
+  markRead,
+  markAllRead
+} from '../services/notifications/NotificationStore.js';
+import { sendNotFound } from '../utils/responseHelpers.js';
+import logger from '../utils/logger.js';
+
+const router = express.Router();
+
+// userId -> Set<res>. A user can have multiple open tabs, unlike the
+// single-pinned-entry shape createSseChannel (utils/sseChannel.js) assumes.
+const clientsByUser = new Map();
+
+// One shared listener fans out to whichever user's client set matches,
+// rather than attaching a new NotificationService listener per connection.
+notificationService.on('notification', notification => {
+  const clients = clientsByUser.get(notification.userId);
+  if (!clients || clients.size === 0) return;
+  const message = `event: notification\ndata: ${JSON.stringify(notification)}\n\n`;
+  for (const res of clients) {
+    try {
+      res.write(message);
+    } catch (error) {
+      logger.warn('Failed to write notification to SSE client', {
+        component: 'notificationsRoutes',
+        error: error.message
+      });
+    }
+  }
+});
+
+router.get('/stream', authRequired, requireFeature('notifications'), (req, res) => {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Authentication required' });
+
+  res.writeHead(200, {
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    Connection: 'keep-alive',
+    'X-Accel-Buffering': 'no'
+  });
+  res.write(`event: connected\ndata: ${JSON.stringify({ userId })}\n\n`);
+
+  let clients = clientsByUser.get(userId);
+  if (!clients) {
+    clients = new Set();
+    clientsByUser.set(userId, clients);
+  }
+  clients.add(res);
+
+  const heartbeat = setInterval(() => {
+    try {
+      res.write(': heartbeat\n\n');
+    } catch {
+      clearInterval(heartbeat);
+    }
+  }, 30000);
+
+  req.on('close', () => {
+    clearInterval(heartbeat);
+    const set = clientsByUser.get(userId);
+    if (set) {
+      set.delete(res);
+      if (set.size === 0) clientsByUser.delete(userId);
+    }
+  });
+});
+
+router.get('/', authRequired, requireFeature('notifications'), async (req, res) => {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Authentication required' });
+
+  const limit = Math.min(Math.max(parseInt(req.query.limit, 10) || 50, 1), 200);
+  const unreadOnly = req.query.unreadOnly === 'true';
+
+  const [notifications, unreadCount] = await Promise.all([
+    listNotifications(userId, { limit, unreadOnly }),
+    countUnread(userId)
+  ]);
+  res.json({ notifications, unreadCount });
+});
+
+router.post('/:id/read', authRequired, requireFeature('notifications'), async (req, res) => {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Authentication required' });
+
+  const changed = await markRead(userId, req.params.id);
+  if (!changed) return sendNotFound(res, 'Notification');
+  res.json({ success: true });
+});
+
+router.post('/read-all', authRequired, requireFeature('notifications'), async (req, res) => {
+  const userId = req.user?.id;
+  if (!userId) return res.status(401).json({ error: 'Authentication required' });
+
+  const changed = await markAllRead(userId);
+  res.json({ success: true, changed });
+});
+
+export default function registerNotificationRoutes(app) {
+  app.use(buildApiPath('/notifications'), router);
+}

--- a/server/routes/toolsService/jobStore.js
+++ b/server/routes/toolsService/jobStore.js
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import notificationService from '../../services/notifications/NotificationService.js';
 
 // In-memory job store
 const jobs = new Map();
@@ -126,4 +127,21 @@ export function notifyClients(job) {
   }
 
   job.clients = isTerminal ? [] : survivors;
+
+  // Only persist/broadcast a durable notification on terminal states — this
+  // survives even if the user closed the /progress SSE tab, unlike the
+  // per-tick progress events above. Intermediate progress ticks are not
+  // persisted: they're too frequent (e.g. one per OCR page) to be useful as
+  // a notification-center entry.
+  if (isTerminal && job.userId) {
+    notificationService
+      .notify(job.userId, `job.${job.status}`, {
+        jobId: job.id,
+        toolType: job.toolType,
+        error: job.error || null
+      })
+      .catch(() => {
+        // NotificationService already logs failures internally.
+      });
+  }
 }

--- a/server/server.js
+++ b/server/server.js
@@ -37,6 +37,7 @@ import { authRequired } from './middleware/authRequired.js';
 import { adminAuth } from './middleware/adminAuth.js';
 import { attachRealtimeTranscription } from './websocket/realtimeTranscription.js';
 import registerVoiceRoutes from './routes/voiceRoutes.js';
+import registerNotificationRoutes from './routes/notifications.js';
 import registerSetupRoutes from './routes/setup.js';
 import registerPwaRoutes from './routes/pwaRoutes.js';
 import registerThemeRoutes from './routes/themeRoutes.js';
@@ -475,6 +476,7 @@ if (cluster.isPrimary && workerCount > 1) {
   registerTriggerRoutes(app, { authRequired, adminAuth });
   registerAgentRoutes(app);
   registerVoiceRoutes(app);
+  registerNotificationRoutes(app);
   registerSetupRoutes(app);
 
   // --- Integration Routes ---

--- a/server/services/notifications/NotificationService.js
+++ b/server/services/notifications/NotificationService.js
@@ -1,0 +1,51 @@
+/**
+ * In-process notification bus.
+ *
+ * Deliberately NOT hooked into actionTracker.js's 'fire-sse' bus (server/sse.js) —
+ * that bus's contract is chat-progress events keyed by chatId, not general
+ * per-user notifications. This is a parallel, purpose-built emitter.
+ *
+ * `notify()` persists the notification (see NotificationStore.js) and then
+ * emits it for any live SSE listeners to forward to connected clients. This
+ * ordering means a client reconnecting after a notification fired still
+ * sees it via the REST list endpoint, even though it missed the live push.
+ */
+import { EventEmitter } from 'events';
+import { appendNotification } from './NotificationStore.js';
+import logger from '../../utils/logger.js';
+
+class NotificationService extends EventEmitter {
+  constructor() {
+    super();
+    // Many per-user SSE connections (often several tabs per user) attach
+    // concurrently — mirrors actionTracker.js's setMaxListeners(0).
+    this.setMaxListeners(0);
+  }
+
+  /**
+   * Persist and broadcast a notification for a user.
+   *
+   * @param {string} userId
+   * @param {string} type - e.g. 'job.started' | 'job.progress' | 'job.completed' | 'job.error'
+   * @param {object} [data]
+   * @returns {Promise<object|null>} The persisted notification, or null if userId is missing
+   */
+  async notify(userId, type, data = {}) {
+    if (!userId || !type) return null;
+    try {
+      const notification = await appendNotification(userId, type, data);
+      this.emit('notification', notification);
+      return notification;
+    } catch (error) {
+      logger.error('Failed to persist/broadcast notification', {
+        component: 'NotificationService',
+        userId,
+        type,
+        error: error.message
+      });
+      return null;
+    }
+  }
+}
+
+export default new NotificationService();

--- a/server/services/notifications/NotificationStore.js
+++ b/server/services/notifications/NotificationStore.js
@@ -1,0 +1,162 @@
+/**
+ * Per-user notification persistence.
+ *
+ * v1 scope: one JSON file per user under contents/data/notifications/<userId>.json,
+ * capped at MAX_NOTIFICATIONS_PER_USER entries. This is intentionally not the
+ * PostgreSQL-backed store described in #1499/#1490 — those don't exist yet.
+ * Swapping the implementation later (e.g. once a writable StorageProvider
+ * lands) should not require changes to NotificationService's call sites.
+ */
+import fs from 'fs/promises';
+import path from 'path';
+import crypto from 'crypto';
+import { getRootDir } from '../../pathUtils.js';
+import config from '../../config.js';
+import { atomicWriteJSON } from '../../utils/atomicWrite.js';
+import logger from '../../utils/logger.js';
+
+const NOTIFICATIONS_DIR = path.join(getRootDir(), config.CONTENTS_DIR, 'data', 'notifications');
+const MAX_NOTIFICATIONS_PER_USER = 200;
+
+/**
+ * Restrict userId to a safe filename component, mirroring
+ * TokenStorageService.js's `_assertSafeFilenameComponent` — user ids can be
+ * emails (contain '@', '.', '+'), so this is intentionally broader than
+ * pathSecurity.js's SAFE_ID_PATTERN, which rejects '@'.
+ */
+function assertSafeUserId(userId) {
+  if (typeof userId !== 'string' || userId.length === 0 || userId.length > 256) {
+    throw new Error('Invalid userId: must be a non-empty string up to 256 characters');
+  }
+  if (!/^[A-Za-z0-9._@+-]+$/.test(userId)) {
+    throw new Error('Invalid userId: contains characters outside the safe filename set');
+  }
+}
+
+function filePathForUser(userId) {
+  assertSafeUserId(userId);
+  const candidate = path.resolve(NOTIFICATIONS_DIR, `${userId}.json`);
+  const baseDir = path.resolve(NOTIFICATIONS_DIR) + path.sep;
+  if (!candidate.startsWith(baseDir)) {
+    throw new Error('Resolved notifications file path escapes its base directory');
+  }
+  return candidate;
+}
+
+// Per-user write locks so a read-modify-write (append/markRead) can't race
+// against another one for the same user. Separate users never contend.
+const writeLocks = new Map();
+function withUserWriteLock(userId, fn) {
+  const prev = writeLocks.get(userId) || Promise.resolve();
+  const run = prev.then(fn, fn);
+  // Store a non-rejecting continuation as the lock so a failed operation
+  // doesn't permanently wedge this user's future writes.
+  writeLocks.set(
+    userId,
+    run.catch(() => {})
+  );
+  return run;
+}
+
+async function readUserNotifications(userId) {
+  const filePath = filePathForUser(userId);
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch (error) {
+    if (error.code === 'ENOENT') return [];
+    logger.warn('Failed to read notifications file, treating as empty', {
+      component: 'NotificationStore',
+      userId,
+      error: error.message
+    });
+    return [];
+  }
+}
+
+async function writeUserNotifications(userId, notifications) {
+  const filePath = filePathForUser(userId);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await atomicWriteJSON(filePath, notifications);
+}
+
+/**
+ * Append a new notification for a user and persist it, capping the stored
+ * history at MAX_NOTIFICATIONS_PER_USER (oldest entries are dropped).
+ *
+ * @param {string} userId
+ * @param {string} type - e.g. 'job.started' | 'job.progress' | 'job.completed' | 'job.error'
+ * @param {object} [data] - Arbitrary event payload
+ * @returns {Promise<object>} The persisted notification
+ */
+export async function appendNotification(userId, type, data = {}) {
+  const notification = {
+    id: crypto.randomUUID(),
+    userId,
+    type,
+    data,
+    read: false,
+    createdAt: new Date().toISOString()
+  };
+
+  await withUserWriteLock(userId, async () => {
+    const existing = await readUserNotifications(userId);
+    const updated = [notification, ...existing].slice(0, MAX_NOTIFICATIONS_PER_USER);
+    await writeUserNotifications(userId, updated);
+  });
+
+  return notification;
+}
+
+/**
+ * List a user's notifications, most recent first.
+ *
+ * @param {string} userId
+ * @param {object} [options]
+ * @param {number} [options.limit=50]
+ * @param {boolean} [options.unreadOnly=false]
+ */
+export async function listNotifications(userId, { limit = 50, unreadOnly = false } = {}) {
+  const all = await readUserNotifications(userId);
+  const filtered = unreadOnly ? all.filter(n => !n.read) : all;
+  return filtered.slice(0, limit);
+}
+
+export async function countUnread(userId) {
+  const all = await readUserNotifications(userId);
+  return all.reduce((count, n) => (n.read ? count : count + 1), 0);
+}
+
+/**
+ * Mark a single notification as read. No-op (returns false) if not found.
+ */
+export async function markRead(userId, notificationId) {
+  return withUserWriteLock(userId, async () => {
+    const all = await readUserNotifications(userId);
+    const target = all.find(n => n.id === notificationId);
+    if (!target || target.read) return false;
+    target.read = true;
+    await writeUserNotifications(userId, all);
+    return true;
+  });
+}
+
+/**
+ * Mark all of a user's notifications as read.
+ * @returns {Promise<number>} Number of notifications flipped from unread to read.
+ */
+export async function markAllRead(userId) {
+  return withUserWriteLock(userId, async () => {
+    const all = await readUserNotifications(userId);
+    let changed = 0;
+    for (const n of all) {
+      if (!n.read) {
+        n.read = true;
+        changed += 1;
+      }
+    }
+    if (changed > 0) await writeUserNotifications(userId, all);
+    return changed;
+  });
+}

--- a/server/tests/NotificationStore.test.js
+++ b/server/tests/NotificationStore.test.js
@@ -1,0 +1,107 @@
+import { jest } from '@jest/globals';
+import os from 'os';
+import fsSync from 'fs';
+import fs from 'fs/promises';
+import path from 'path';
+
+/**
+ * Unit tests for NotificationStore.js — the per-user JSON-file notification
+ * persistence backing NotificationService (issue #1496, v1 scope).
+ *
+ * getRootDir() is mocked to point at a throwaway temp directory so these
+ * tests never touch the real contents/ tree. The temp dir must exist
+ * *before* the dynamic import below, since module-level code in
+ * NotificationStore.js calls getRootDir() at import time, ahead of any
+ * beforeAll/beforeEach hook.
+ */
+
+const tmpRoot = fsSync.mkdtempSync(path.join(os.tmpdir(), 'ihub-notifications-test-'));
+
+afterAll(async () => {
+  await fs.rm(tmpRoot, { recursive: true, force: true });
+});
+
+jest.unstable_mockModule('../pathUtils.js', () => ({
+  getRootDir: () => tmpRoot
+}));
+
+jest.unstable_mockModule('../config.js', () => ({
+  default: { CONTENTS_DIR: 'contents' }
+}));
+
+const { appendNotification, listNotifications, countUnread, markRead, markAllRead } =
+  await import('../services/notifications/NotificationStore.js');
+
+describe('NotificationStore', () => {
+  it('appends and lists notifications, most recent first', async () => {
+    const userId = 'user-a@example.com';
+    await appendNotification(userId, 'job.completed', { jobId: '1' });
+    await appendNotification(userId, 'job.error', { jobId: '2' });
+
+    const list = await listNotifications(userId);
+    expect(list).toHaveLength(2);
+    expect(list[0].type).toBe('job.error');
+    expect(list[1].type).toBe('job.completed');
+    expect(list[0].read).toBe(false);
+  });
+
+  it('scopes notifications per user', async () => {
+    const userA = 'user-b@example.com';
+    const userB = 'user-c@example.com';
+    await appendNotification(userA, 'job.completed', {});
+
+    expect(await listNotifications(userB)).toHaveLength(0);
+    expect(await listNotifications(userA)).toHaveLength(1);
+  });
+
+  it('marks a single notification read and updates unread count', async () => {
+    const userId = 'user-d@example.com';
+    const n1 = await appendNotification(userId, 'job.completed', {});
+    await appendNotification(userId, 'job.error', {});
+
+    expect(await countUnread(userId)).toBe(2);
+
+    const changed = await markRead(userId, n1.id);
+    expect(changed).toBe(true);
+    expect(await countUnread(userId)).toBe(1);
+
+    // Marking an already-read notification again is a no-op.
+    expect(await markRead(userId, n1.id)).toBe(false);
+  });
+
+  it('returns false when marking an unknown notification id as read', async () => {
+    const userId = 'user-e@example.com';
+    await appendNotification(userId, 'job.completed', {});
+    expect(await markRead(userId, 'does-not-exist')).toBe(false);
+  });
+
+  it('marks all notifications read in one call', async () => {
+    const userId = 'user-f@example.com';
+    await appendNotification(userId, 'job.completed', {});
+    await appendNotification(userId, 'job.error', {});
+
+    const changed = await markAllRead(userId);
+    expect(changed).toBe(2);
+    expect(await countUnread(userId)).toBe(0);
+
+    // Second call has nothing left to flip.
+    expect(await markAllRead(userId)).toBe(0);
+  });
+
+  it('rejects userIds with path-traversal characters', async () => {
+    await expect(appendNotification('../evil', 'job.completed', {})).rejects.toThrow();
+    await expect(appendNotification('foo/bar', 'job.completed', {})).rejects.toThrow();
+  });
+
+  it('caps stored notifications per user at 200', async () => {
+    const userId = 'user-cap@example.com';
+    for (let i = 0; i < 205; i++) {
+      await appendNotification(userId, 'job.completed', { i });
+    }
+    const list = await listNotifications(userId, { limit: 500 });
+    expect(list).toHaveLength(200);
+    // Most recent (i=204) should be first; oldest 5 (i=0..4) dropped.
+    expect(list[0].data.i).toBe(204);
+    expect(list[list.length - 1].data.i).toBe(5);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1496 (v1 slice — see scope notes below).

Adds a preview-gated, per-user real-time notification center. Today, background jobs (Tools Service, e.g. AI OCR) only report progress to a client with an **open** `/jobs/:jobId/progress` SSE connection — closing the tab or navigating away silently loses the completion event. This adds a small, durable record of terminal job events that survives across page loads and multiple open tabs.

- `server/services/notifications/NotificationService.js` — in-process event bus (`notify(userId, type, data)`); persists then broadcasts to any live SSE listeners.
- `server/services/notifications/NotificationStore.js` — per-user JSON-file persistence (`contents/data/notifications/<userId>.json`, capped at 200 entries/user).
- `server/routes/notifications.js` — `GET /api/notifications/stream` (SSE, multi-tab per user), `GET /api/notifications` (list), `POST /:id/read`, `POST /read-all`. Gated behind a new `notifications` feature flag (default off) + migration `V078`.
- `server/routes/toolsService/jobStore.js` — `notifyClients()` now also emits a notification on **terminal** job states only (`completed`/`error`/`cancelled`) — intermediate progress ticks are intentionally not persisted (too frequent, e.g. one per OCR page, to be a useful notification-list entry).
- `client/src/features/notifications/` — `useNotifications` hook (REST initial load + SSE live updates, same fetch+ReadableStream pattern as `useEventSource.js` for custom auth headers) and `NotificationBell`/`NotificationPanel` UI, mounted in `Layout.jsx`'s header for authenticated users when the flag is enabled.

### Deliberately out of scope for this slice (per the issue's own implementation-plan comment)

- **Durable, multi-instance storage** — the original design assumed PostgreSQL (#1490/#1499), which doesn't exist in this codebase yet. This ships a simple per-user JSON-file store behind the same `NotificationService.notify()` call sites, so swapping to a real DB later doesn't require touching producers.
- **Other event types** — only background-job lifecycle events are wired up. `chat.shared` (no such feature exists yet) and `system.announcement` (no admin broadcast UI) have no producer in this PR.
- **Toast/desktop notifications** — only the bell + panel; no `Notification` Web API integration.

Full write-up: `docs/notifications-feature.md`.

## Test plan

- [x] `npm run lint:fix && npm run format:fix` — clean on all changed files
- [x] New unit tests: `server/tests/NotificationStore.test.js` (append/list/scope-per-user/mark-read/mark-all-read/path-traversal-rejection/200-item cap) — all pass
- [x] Verified `server/routes/notifications.js`, `server/routes/toolsService/jobStore.js`, and `server/featureRegistry.js` import cleanly with no errors
- [ ] Manual end-to-end verification (start dev server, enable the feature flag, trigger an OCR job, confirm the bell updates) — not done in this session (no running dev environment with a configured OCR provider); would appreciate a manual smoke test before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A8KD83dJU7XCZx1GUDD1kk


---
_Generated by [Claude Code](https://claude.ai/code/session_01A8KD83dJU7XCZx1GUDD1kk)_