### PR TITLE
Restrict apps to specific integration surfaces (#1298)

### DIFF
--- a/client/src/api/endpoints/apps.js
+++ b/client/src/api/endpoints/apps.js
@@ -35,20 +35,20 @@ const escapeHtml = s =>
 
 // Apps
 export const fetchApps = async (options = {}) => {
-  const { language = null } = options;
+  const { language = null, surface = null } = options;
 
   return handleApiResponse(
-    () => apiClient.get('/apps', { params: { language } }),
+    () => apiClient.get('/apps', { params: { language, surface } }),
     null, // no client-side caching for apps list
     null
   );
 };
 
 export const fetchAppDetails = async (appId, options = {}) => {
-  const { language = null } = options;
+  const { language = null, surface = null } = options;
 
   return handleApiResponse(
-    () => apiClient.get(`/apps/${appId}`, { params: { language } }),
+    () => apiClient.get(`/apps/${appId}`, { params: { language, surface } }),
     null, // no client-side caching for app details
     null
   );

--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -28,6 +28,13 @@ function parseNumberOrUndefined(value, parser = parseFloat) {
   return Number.isFinite(n) ? n : undefined;
 }
 
+// Known integration surfaces an app can be restricted to. Free-form values are
+// still accepted by the server schema; this is just the set the admin UI offers.
+const INTEGRATION_SURFACE_OPTIONS = [
+  { id: 'web', labelKey: 'admin.apps.edit.integrationWeb', labelDefault: 'Web' },
+  { id: 'outlook', labelKey: 'admin.apps.edit.integrationOutlook', labelDefault: 'Outlook' }
+];
+
 /**
  * AppFormEditor - Form-based editor for app configuration
  * This component contains all the form fields for editing app configuration
@@ -302,6 +309,17 @@ function AppFormEditor({
     onChange(updatedApp);
   };
 
+  const handleIntegrationSurfaceToggle = surfaceId => {
+    const current = app.restrictToIntegrations || [];
+    const updated = current.includes(surfaceId)
+      ? current.filter(id => id !== surfaceId)
+      : [...current, surfaceId];
+    onChange({
+      ...app,
+      restrictToIntegrations: updated
+    });
+  };
+
   // Source handling functions
   const handleSourcesChange = selectedSourceIds => {
     const updatedApp = {
@@ -438,6 +456,34 @@ function AppFormEditor({
                         </option>
                       ))}
                   </select>
+                </div>
+
+                <div className="col-span-6 sm:col-span-3">
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {t('admin.apps.edit.restrictToIntegrations', 'Visible On')}
+                  </label>
+                  <div className="mt-2 space-y-2">
+                    {INTEGRATION_SURFACE_OPTIONS.map(surface => (
+                      <label
+                        key={surface.id}
+                        className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={(app.restrictToIntegrations || []).includes(surface.id)}
+                          onChange={() => handleIntegrationSurfaceToggle(surface.id)}
+                          className="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                        />
+                        {t(surface.labelKey, surface.labelDefault)}
+                      </label>
+                    ))}
+                  </div>
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {t(
+                      'admin.apps.edit.restrictToIntegrationsHint',
+                      'Leave all unchecked to show this app on every surface. Check specific surfaces to hide it everywhere else.'
+                    )}
+                  </p>
                 </div>
 
                 <div className="col-span-6">

--- a/client/src/features/office/components/OfficeApp.jsx
+++ b/client/src/features/office/components/OfficeApp.jsx
@@ -79,6 +79,7 @@ function SelectPage({ user, onLogout, onSelect }) {
             header={<ChatHeader title="Select App" showCheckmark={false} menuItems={menuItems} />}
             favorites={favorites}
             onToggleFavorite={handleToggleFavorite}
+            surface="outlook"
           />
         </div>
       </div>

--- a/client/src/features/office/components/OfficeChatPanel.jsx
+++ b/client/src/features/office/components/OfficeChatPanel.jsx
@@ -472,7 +472,7 @@ function OfficeChatPanel({ authData, selectedApp, setSelectedApp, onLogout }) {
   );
 
   const handleOpenSelector = useCallback(() => {
-    fetchApps()
+    fetchApps({ surface: 'outlook' })
       .then(data => {
         if (Array.isArray(data)) setSelectorItems(data);
         setIsSelectorOpen(true);

--- a/client/src/shared/components/AppListPanel.jsx
+++ b/client/src/shared/components/AppListPanel.jsx
@@ -17,6 +17,8 @@ import Icon from './Icon';
  * @param {React.ReactNode} [header] - Optional header node rendered above the list
  * @param {string[]} [favorites] - Optional list of favorited app IDs (enables favorite UI)
  * @param {Function} [onToggleFavorite] - Called as (event, appId) when the star is clicked
+ * @param {string} [surface] - Integration surface to request (e.g. 'outlook'); apps
+ *   restricted to other surfaces via `restrictToIntegrations` are excluded server-side
  */
 function AppListPanel({
   onSelect,
@@ -24,7 +26,8 @@ function AppListPanel({
   showSearch = 'auto',
   header,
   favorites,
-  onToggleFavorite
+  onToggleFavorite,
+  surface
 }) {
   const { t } = useTranslation();
   const [apps, setApps] = useState([]);
@@ -33,13 +36,13 @@ function AppListPanel({
   const [favoritesOnly, setFavoritesOnly] = useState(false);
 
   useEffect(() => {
-    fetchApps()
+    fetchApps({ surface })
       .then(data => {
         if (Array.isArray(data)) setApps(data);
       })
       .catch(() => {})
       .finally(() => setIsLoading(false));
-  }, []);
+  }, [surface]);
 
   const shouldShowSearch = showSearch === 'auto' ? apps.length > 6 : showSearch === true;
   const favoriteIds = favorites || [];

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -531,6 +531,7 @@ Each app is defined with the following essential properties:
 | `order`                 | Number  | Optional. Display order in the app list                                                                                  |
 | `enabled`               | Boolean | Optional. Whether the app is enabled. Default: `true`                                                                    |
 | `category`              | String  | Optional. Category label for grouping apps in the UI                                                                     |
+| `restrictToIntegrations`| Array   | Optional. Array of integration surface names (e.g. `["outlook"]`) the app is visible on. Leave empty/unset to show the app everywhere. See [Restricting Apps to Specific Integrations](#restricting-apps-to-specific-integrations) below |
 | `preferredModel`        | String  | Optional. Default AI model to use with this app. If omitted, uses the model marked as default in `models.json`          |
 | `preferredOutputFormat` | String  | Optional. Format for AI responses (`markdown`, `text`, `json`, `html`)                                                   |
 | `preferredStyle`        | String  | Optional. Style guidance for AI responses (normal, professional, creative, academic)                                     |
@@ -555,6 +556,20 @@ Each app is defined with the following essential properties:
 | `parentId`              | String  | Optional. ID of the parent app to inherit configuration from                                                             |
 | `inheritanceLevel`      | Number  | Optional. Depth of the inheritance chain                                                                                 |
 | `overriddenFields`      | Array   | Optional. Fields that have been explicitly overridden from the parent app                                                |
+
+### Restricting Apps to Specific Integrations
+
+By default, an app is visible everywhere it's referenced — the main web app, the Outlook add-in, etc. Set `restrictToIntegrations` to a non-empty array to instead show the app **only** on the listed surfaces, hiding it everywhere else (including direct navigation to the app's URL from another surface):
+
+```json
+"restrictToIntegrations": ["outlook"]
+```
+
+- Omit the field, or leave the array empty, to keep the app visible everywhere (the default).
+- Known surface values used by this codebase: `"web"`, `"outlook"`. Other integrations can use their own surface string as long as the client passes it via `?surface=` when calling `GET /api/apps`.
+- This is orthogonal to an OAuth client's `allowedApps` allow-list (see [Outlook Add-in guide](outlook-add-in.md#step-5--optional-restrict-what-the-add-in-can-access)) — an app must pass both checks to be visible.
+- Configurable in the admin app editor under **Visible On**.
+
 ### Advanced Configuration Options
 
 Apps can include additional configuration for user inputs and prompt formatting:

--- a/docs/outlook-add-in.md
+++ b/docs/outlook-add-in.md
@@ -126,6 +126,8 @@ Semantics, in short:
 
 The full design is in [OAuth Client Permission Filter for Authorization Code Flow](../concepts/2026-04-21%20OAuth%20Client%20Permission%20Filter%20for%20Authorization%20Code%20Flow.md).
 
+**App-level alternative.** The allow-list above is configured per OAuth client and scopes what *that client's* tokens can see. If instead you want a specific app to appear **only** in Outlook (and be hidden from the regular web app) — or vice versa — set `restrictToIntegrations: ["outlook"]` on the app itself in the app editor's **Visible On** field (or directly in the app's JSON config). Leave it empty/unset to keep the app visible everywhere, which is the default. Both mechanisms compose: an app must pass both its own `restrictToIntegrations` check and the OAuth client's allow-list to be visible.
+
 ---
 
 ## Step 6 — Verify the rollout

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -473,6 +473,19 @@ route groups that previously relied only on the coarse URL-derived fallback: **T
 - No admin action required — existing audit log filtering, retention, and CSV export apply to
   these new entries automatically.
 
+## Restrict an App to a Specific Integration Surface
+
+The App Editor now has a **Visible On** option, so admins can maintain a single app definition
+that only appears on a specific surface (for example, the Outlook add-in) instead of duplicating
+near-identical apps for web vs. Outlook.
+
+- Leave all surfaces unchecked to keep the app visible everywhere — this is the default and
+  matches today's behavior for every existing app.
+- Check a specific surface (e.g. **Outlook**) to hide the app from every other surface, including
+  direct navigation to its URL.
+- The Outlook add-in now requests apps for the `outlook` surface automatically; no add-in
+  configuration is required.
+
 ## No More Silent Empty Answers from Gemini (Web Search Off)
 
 Chatting with a Gemini model while web search is turned off (for example the **Web Chat** app) could

--- a/server/configCache.js
+++ b/server/configCache.js
@@ -8,6 +8,7 @@ import { loadAllTools } from './toolsLoader.js';
 import {
   resolveGroupInheritance,
   filterResourcesByPermissions,
+  filterAppsBySurface,
   isAnonymousAccessAllowed
 } from './utils/authorization.js';
 import { loadTools } from './toolLoader.js';
@@ -1573,7 +1574,7 @@ class ConfigCache {
    * @param {Object} platformConfig - Platform configuration
    * @returns {Promise<Object>} Filtered apps with user-specific ETag
    */
-  async getAppsForUser(user, platformConfig) {
+  async getAppsForUser(user, platformConfig, { surface } = {}) {
     // Get all apps from cache
     let { data: apps = [], etag: appsEtag } = this.getApps();
 
@@ -1583,6 +1584,9 @@ class ConfigCache {
 
     const originalAppsCount = apps.length;
     let userSpecificEtag = appsEtag;
+
+    // Apply integration-surface visibility filtering (e.g. an app restricted to 'outlook')
+    apps = filterAppsBySurface(apps, surface);
 
     // Apply filtering based on user permissions
     if (user && user.permissions) {

--- a/server/routes/generalRoutes.js
+++ b/server/routes/generalRoutes.js
@@ -1,5 +1,9 @@
 import configCache from '../configCache.js';
-import { enhanceUserWithPermissions, isAnonymousAccessAllowed } from '../utils/authorization.js';
+import {
+  enhanceUserWithPermissions,
+  isAnonymousAccessAllowed,
+  isAppVisibleForSurface
+} from '../utils/authorization.js';
 import { authRequired, appAccessRequired } from '../middleware/authRequired.js';
 import { buildServerPath, getRelativeRequestPath } from '../utils/basePath.js';
 import {
@@ -175,10 +179,15 @@ export default function registerGeneralRoutes(app, { getLocalizedError }) {
         req.user = enhanceUserWithPermissions(null, authConfig, platformConfig);
       }
 
+      // Requesting integration surface (e.g. 'outlook' for the Office add-in);
+      // defaults to 'web' so apps restricted to other surfaces are hidden here.
+      const surface = typeof req.query.surface === 'string' ? req.query.surface : 'web';
+
       // Use centralized method to get filtered apps with user-specific ETag
       const { data: apps, etag: userSpecificEtag } = await configCache.getAppsForUser(
         req.user,
-        platformConfig
+        platformConfig,
+        { surface }
       );
 
       if (!apps) {
@@ -343,6 +352,13 @@ export default function registerGeneralRoutes(app, { getLocalizedError }) {
         }
         const appData = apps.find(a => a.id === appId);
         if (!appData) {
+          const errorMessage = await getLocalizedError('appNotFound', {}, language);
+          return sendErrorResponse(res, 404, errorMessage);
+        }
+
+        // Hide apps that aren't restricted to the requesting integration surface
+        const surface = typeof req.query.surface === 'string' ? req.query.surface : 'web';
+        if (!isAppVisibleForSurface(appData, surface)) {
           const errorMessage = await getLocalizedError('appNotFound', {}, language);
           return sendErrorResponse(res, 404, errorMessage);
         }

--- a/server/utils/authorization.js
+++ b/server/utils/authorization.js
@@ -454,6 +454,37 @@ export function applyOAuthClientFilter(permissions, user) {
 }
 
 /**
+ * Whether an app is visible on a given integration surface (e.g. 'web', 'outlook').
+ *
+ * `app.restrictToIntegrations` is an app-config-declared allow-list of surfaces the
+ * app should appear on. Absent/empty means "visible everywhere" (default, matches
+ * today's behavior). If the caller doesn't know/pass a surface, the restriction is
+ * not enforced, so internal callers that aren't UI-surface-aware are unaffected.
+ *
+ * @param {Object} app - App config object.
+ * @param {string} [surface] - The requesting surface (e.g. 'web', 'outlook').
+ * @returns {boolean}
+ */
+export function isAppVisibleForSurface(app, surface) {
+  const restriction = app?.restrictToIntegrations;
+  if (!Array.isArray(restriction) || restriction.length === 0) return true;
+  if (!surface) return true;
+  return restriction.includes(surface);
+}
+
+/**
+ * Filter a list of apps down to those visible on the given integration surface.
+ * @param {Array} apps - Apps to filter.
+ * @param {string} [surface] - The requesting surface.
+ * @returns {Array}
+ */
+export function filterAppsBySurface(apps, surface) {
+  if (!Array.isArray(apps)) return [];
+  if (!surface) return apps;
+  return apps.filter(app => isAppVisibleForSurface(app, surface));
+}
+
+/**
  * Filter resources based on user permissions
  * @param {Array} resources - Array of resources to filter
  * @param {Set} allowedResources - Set of allowed resource IDs

--- a/server/validators/appConfigSchema.js
+++ b/server/validators/appConfigSchema.js
@@ -412,6 +412,10 @@ const baseAppConfigSchema = z.object({
   category: z.string().optional(),
   enabled: z.boolean().optional().default(true),
 
+  // Integration surface visibility - absent/empty means visible everywhere.
+  // Non-empty restricts the app to only the listed surfaces (e.g. 'web', 'outlook').
+  restrictToIntegrations: z.array(z.string()).optional(),
+
   // Tool-specific configurations
   iassistant: iAssistantConfigSchema,
 


### PR DESCRIPTION
## Summary

Closes #1298. Lets an admin declare which integration surfaces an app should be visible on (e.g. `outlook`), instead of maintaining near-duplicate app configs for web vs. Outlook. Absent/empty means "visible everywhere" — no behavior change for any existing app.

- **Schema**: `server/validators/appConfigSchema.js` — new optional `restrictToIntegrations: string[]` field on the app config.
- **Enforcement**: new `isAppVisibleForSurface`/`filterAppsBySurface` helpers in `server/utils/authorization.js`. `configCache.getAppsForUser(user, platformConfig, { surface })` filters the app list by surface. `GET /api/apps` and `GET /api/apps/:appId` (`server/routes/generalRoutes.js`) accept a `?surface=` query param (defaults to `web`); the single-app route hard-404s when the app is restricted away from the requesting surface, matching the "only accessible there" framing in the issue. Callers that don't pass a `surface` (e.g. the MCP permissions check) are unaffected — filtering is skipped entirely without one.
- **Client**: `fetchApps`/`fetchAppDetails` (`client/src/api/endpoints/apps.js`) accept a `surface` option. The Outlook add-in (`OfficeChatPanel.jsx`, `OfficeApp.jsx` via `AppListPanel.jsx`) now requests `surface: 'outlook'`.
- **Admin UI**: new "Visible On" checkbox group in the App Editor (`AppFormEditor.jsx`), next to Category.
- **Docs**: `docs/apps.md` (new field + dedicated section) and `docs/outlook-add-in.md` (relationship to the existing OAuth-client `allowedApps` allow-list — both must pass, composing as an intersection).
- Changelog entry added under `docs/releases/5.5.0/features.md`.

### Scope decisions (per the issue's own open questions)
- Surface vocabulary kept open (`z.array(z.string())`, not a hard enum) with `web`/`outlook` as the only surfaces the admin UI currently offers — matches what actually exists in this codebase today (no live Teams/browser-extension app list wiring found to hook up yet).
- Surface detection is an explicit `?surface=` query param, not OAuth-client inference — simpler and works for both OAuth and session-based access.
- Hard exclusion (404 on direct single-app fetch), not just hidden from the list grid, per the issue's "only accessible there" framing.
- Composes with the existing OAuth-client `allowedApps` allow-list as an intersection (both must permit).

## Test plan

- [x] `npx eslint --fix` / `npx prettier --write` on all changed files — no new errors, only pre-existing warnings.
- [x] Validated the new Zod field accepts/rejects the right shapes (`safeParse` with no field, `["outlook"]`, and an invalid non-array value).
- [x] Unit-style checks of `isAppVisibleForSurface`/`filterAppsBySurface` (default surface, explicit surface, `undefined` surface skips filtering).
- [x] End-to-end against a running dev server: temporarily set `restrictToIntegrations: ["outlook"]` on the bundled `chat` app and confirmed `GET /api/apps` excludes it by default, includes it with `?surface=outlook`, and `GET /api/apps/:appId` 404s / 200s accordingly. Reverted the test config afterward.
- [ ] Manual admin-UI verification of the new "Visible On" checkboxes in a browser (not run in this session — no browser available here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6zxUynZdtEebP15P54aQB

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6zxUynZdtEebP15P54aQB)_