### PR TITLE
Extract Magic Prompt, Export, and Compare Mode sections from AppFormEditor (#1781)

### DIFF
--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -10,6 +10,9 @@ import ResourceSelector from './ResourceSelector';
 import Icon from '../../../shared/components/Icon';
 import IconPicker from '../../../shared/components/IconPicker';
 import MimeTypeSelector from './MimeTypeSelector';
+import MagicPromptSection from './app-form/MagicPromptSection';
+import ExportConfigSection from './app-form/ExportConfigSection';
+import CompareModeSection from './app-form/CompareModeSection';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import {
   validateWithSchema,
@@ -2323,189 +2326,13 @@ function AppFormEditor({
             </div>
 
             {/* Magic Prompt Configuration */}
-            <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-              <div className="md:grid md:grid-cols-3 md:gap-6">
-                <div className="md:col-span-1">
-                  <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                    {t('admin.apps.edit.magicPrompt', 'Magic Prompt')}
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    {t('admin.apps.edit.magicPromptDesc', 'AI-powered prompt enhancement feature')}
-                  </p>
-                </div>
-                <div className="mt-5 md:col-span-2 md:mt-0">
-                  <div className="space-y-4">
-                    <div className="flex items-center">
-                      <input
-                        type="checkbox"
-                        checked={app.features?.magicPrompt?.enabled || false}
-                        onChange={e =>
-                          handleInputChange('features', {
-                            ...app.features,
-                            magicPrompt: { ...app.features?.magicPrompt, enabled: e.target.checked }
-                          })
-                        }
-                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                      />
-                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
-                        {t('admin.apps.edit.enableMagicPrompt', 'Enable Magic Prompt')}
-                      </label>
-                    </div>
-
-                    {app.features?.magicPrompt?.enabled && (
-                      <div className="space-y-4 pl-6">
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                            {t('admin.apps.edit.magicPromptModel', 'Magic Prompt Model')}
-                          </label>
-                          <select
-                            value={app.features?.magicPrompt?.model || ''}
-                            onChange={e =>
-                              handleInputChange('features', {
-                                ...app.features,
-                                magicPrompt: {
-                                  ...app.features?.magicPrompt,
-                                  model: e.target.value || undefined
-                                }
-                              })
-                            }
-                            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                          >
-                            <option value="">
-                              {t('admin.apps.edit.selectModel', 'Select model...')}
-                            </option>
-                            {availableModels.map(model => (
-                              <option key={model.id} value={model.id}>
-                                {getLocalizedContent(model.name, currentLanguage)}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-
-                        <div>
-                          <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                            {t(
-                              'admin.apps.edit.magicPromptInstructions',
-                              'Magic Prompt Instructions'
-                            )}
-                          </label>
-                          <textarea
-                            value={
-                              app.features?.magicPrompt?.prompt ||
-                              'You are a helpful assistant that improves user prompts to be more specific and effective. Improve this prompt: {{prompt}}'
-                            }
-                            onChange={e =>
-                              handleInputChange('features', {
-                                ...app.features,
-                                magicPrompt: {
-                                  ...app.features?.magicPrompt,
-                                  prompt: e.target.value
-                                }
-                              })
-                            }
-                            rows={3}
-                            className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
-                            placeholder="Enter instructions for the magic prompt feature..."
-                          />
-                          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
-                            {t(
-                              'admin.apps.edit.magicPromptPlaceholder',
-                              "Use {{prompt}} to reference the user's original prompt"
-                            )}
-                          </p>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
+            <MagicPromptSection app={app} onChange={onChange} availableModels={availableModels} />
 
             {/* Export Configuration */}
-            <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-              <div className="md:grid md:grid-cols-3 md:gap-6">
-                <div className="md:col-span-1">
-                  <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                    {t('admin.apps.edit.export', 'Export')}
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    {t(
-                      'admin.apps.edit.exportDesc',
-                      'Control whether users can export conversations from this app'
-                    )}
-                  </p>
-                </div>
-                <div className="mt-5 md:col-span-2 md:mt-0">
-                  <div className="space-y-4">
-                    <div className="flex items-center">
-                      <input
-                        type="checkbox"
-                        checked={app.features?.export !== false}
-                        onChange={e =>
-                          handleInputChange('features', {
-                            ...app.features,
-                            export: e.target.checked
-                          })
-                        }
-                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                      />
-                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
-                        {t('admin.apps.edit.enableExport', 'Enable Export')}
-                      </label>
-                    </div>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
-                      {t(
-                        'admin.apps.edit.exportNote',
-                        'When disabled, users cannot export conversations in any format (JSON, Markdown, PDF, etc.). The platform-level export setting must also be enabled for export to work.'
-                      )}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <ExportConfigSection app={app} onChange={onChange} />
 
             {/* Compare Mode Configuration */}
-            <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-              <div className="md:grid md:grid-cols-3 md:gap-6">
-                <div className="md:col-span-1">
-                  <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                    {t('admin.apps.edit.compareMode', 'Compare Mode')}
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    {t(
-                      'admin.apps.edit.compareModeDesc',
-                      'Allow users to query two models simultaneously and compare their responses side-by-side'
-                    )}
-                  </p>
-                </div>
-                <div className="mt-5 md:col-span-2 md:mt-0">
-                  <div className="space-y-4">
-                    <div className="flex items-center">
-                      <input
-                        type="checkbox"
-                        checked={app.features?.compareMode?.enabled !== false}
-                        onChange={e =>
-                          handleInputChange('features', {
-                            ...app.features,
-                            compareMode: { ...app.features?.compareMode, enabled: e.target.checked }
-                          })
-                        }
-                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                      />
-                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
-                        {t('admin.apps.edit.enableCompareMode', 'Enable Compare Mode')}
-                      </label>
-                    </div>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
-                      {t(
-                        'admin.apps.edit.compareModeNote',
-                        'When enabled, users can activate compare mode to send their input to two different models and view the responses side-by-side. The platform-level compare mode feature must also be enabled for this to work.'
-                      )}
-                    </p>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <CompareModeSection app={app} onChange={onChange} />
 
             {/* Input Mode & Microphone Configuration */}
             <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">

--- a/client/src/features/admin/components/app-form/CompareModeSection.jsx
+++ b/client/src/features/admin/components/app-form/CompareModeSection.jsx
@@ -1,0 +1,59 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * CompareModeSection - Compare Mode toggle card for the App form.
+ * Extracted from AppFormEditor.jsx (see #1781) as a self-contained slice:
+ * only ever reads/writes `app.features.compareMode` via the passed-in onChange.
+ */
+function CompareModeSection({ app, onChange }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.compareMode', 'Compare Mode')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.apps.edit.compareModeDesc',
+              'Allow users to query two models simultaneously and compare their responses side-by-side'
+            )}
+          </p>
+        </div>
+        <div className="mt-5 md:col-span-2 md:mt-0">
+          <div className="space-y-4">
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                checked={app.features?.compareMode?.enabled !== false}
+                onChange={e =>
+                  onChange({
+                    ...app,
+                    features: {
+                      ...app.features,
+                      compareMode: { ...app.features?.compareMode, enabled: e.target.checked }
+                    }
+                  })
+                }
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+              />
+              <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                {t('admin.apps.edit.enableCompareMode', 'Enable Compare Mode')}
+              </label>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {t(
+                'admin.apps.edit.compareModeNote',
+                'When enabled, users can activate compare mode to send their input to two different models and view the responses side-by-side. The platform-level compare mode feature must also be enabled for this to work.'
+              )}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default CompareModeSection;

--- a/client/src/features/admin/components/app-form/ExportConfigSection.jsx
+++ b/client/src/features/admin/components/app-form/ExportConfigSection.jsx
@@ -1,0 +1,56 @@
+import { useTranslation } from 'react-i18next';
+
+/**
+ * ExportConfigSection - Conversation export toggle card for the App form.
+ * Extracted from AppFormEditor.jsx (see #1781) as a self-contained slice:
+ * only ever reads/writes `app.features.export` via the passed-in onChange.
+ */
+function ExportConfigSection({ app, onChange }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.export', 'Export')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.apps.edit.exportDesc',
+              'Control whether users can export conversations from this app'
+            )}
+          </p>
+        </div>
+        <div className="mt-5 md:col-span-2 md:mt-0">
+          <div className="space-y-4">
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                checked={app.features?.export !== false}
+                onChange={e =>
+                  onChange({
+                    ...app,
+                    features: { ...app.features, export: e.target.checked }
+                  })
+                }
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+              />
+              <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                {t('admin.apps.edit.enableExport', 'Enable Export')}
+              </label>
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {t(
+                'admin.apps.edit.exportNote',
+                'When disabled, users cannot export conversations in any format (JSON, Markdown, PDF, etc.). The platform-level export setting must also be enabled for export to work.'
+              )}
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ExportConfigSection;

--- a/client/src/features/admin/components/app-form/MagicPromptSection.jsx
+++ b/client/src/features/admin/components/app-form/MagicPromptSection.jsx
@@ -1,0 +1,99 @@
+import { useTranslation } from 'react-i18next';
+import { getLocalizedContent } from '../../../../utils/localizeContent';
+
+/**
+ * MagicPromptSection - Magic Prompt (AI-powered prompt enhancement) configuration
+ * card for the App form. Extracted from AppFormEditor.jsx (see #1781) as a
+ * self-contained slice: only ever reads/writes `app.features.magicPrompt` via
+ * the passed-in onChange.
+ */
+function MagicPromptSection({ app, onChange, availableModels = [] }) {
+  const { t, i18n } = useTranslation();
+  const currentLanguage = i18n.language;
+
+  const handleMagicPromptChange = updates => {
+    onChange({
+      ...app,
+      features: {
+        ...app.features,
+        magicPrompt: { ...app.features?.magicPrompt, ...updates }
+      }
+    });
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.magicPrompt', 'Magic Prompt')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t('admin.apps.edit.magicPromptDesc', 'AI-powered prompt enhancement feature')}
+          </p>
+        </div>
+        <div className="mt-5 md:col-span-2 md:mt-0">
+          <div className="space-y-4">
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                checked={app.features?.magicPrompt?.enabled || false}
+                onChange={e => handleMagicPromptChange({ enabled: e.target.checked })}
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+              />
+              <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                {t('admin.apps.edit.enableMagicPrompt', 'Enable Magic Prompt')}
+              </label>
+            </div>
+
+            {app.features?.magicPrompt?.enabled && (
+              <div className="space-y-4 pl-6">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {t('admin.apps.edit.magicPromptModel', 'Magic Prompt Model')}
+                  </label>
+                  <select
+                    value={app.features?.magicPrompt?.model || ''}
+                    onChange={e => handleMagicPromptChange({ model: e.target.value || undefined })}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                  >
+                    <option value="">{t('admin.apps.edit.selectModel', 'Select model...')}</option>
+                    {availableModels.map(model => (
+                      <option key={model.id} value={model.id}>
+                        {getLocalizedContent(model.name, currentLanguage)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {t('admin.apps.edit.magicPromptInstructions', 'Magic Prompt Instructions')}
+                  </label>
+                  <textarea
+                    value={
+                      app.features?.magicPrompt?.prompt ||
+                      'You are a helpful assistant that improves user prompts to be more specific and effective. Improve this prompt: {{prompt}}'
+                    }
+                    onChange={e => handleMagicPromptChange({ prompt: e.target.value })}
+                    rows={3}
+                    className="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm"
+                    placeholder="Enter instructions for the magic prompt feature..."
+                  />
+                  <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+                    {t(
+                      'admin.apps.edit.magicPromptPlaceholder',
+                      "Use {{prompt}} to reference the user's original prompt"
+                    )}
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MagicPromptSection;


### PR DESCRIPTION
## Summary

Follow-up to #1781 ("Split the 2545-line AppFormEditor into section components with a shared nested-update helper"), continuing the series of small extraction PRs already landed/opened against it (#1942, #2044, #2046, #2048, #2049, #2050, #2051, #2054).

Extracts the three remaining `app.features`-scoped configuration cards from `AppFormEditor.jsx` into standalone components under `client/src/features/admin/components/app-form/`:

- `MagicPromptSection.jsx` — AI-powered prompt enhancement config (`app.features.magicPrompt`)
- `ExportConfigSection.jsx` — conversation export toggle (`app.features.export`)
- `CompareModeSection.jsx` — side-by-side model comparison toggle (`app.features.compareMode`)

Each component receives `(app, onChange)` and owns its own local update handler, following the same convention established by the prior PRs in this series (e.g. `WebSearchSection.jsx`, `IAssistantSection.jsx`). Pure extraction — no behavior change intended.

`AppFormEditor.jsx` shrinks from 2,905 to 2,729 lines.

Remaining unclaimed sections per the issue's tracking comments: Basic Info, System Instructions, Sources Configuration, Settings Configuration, Input Mode & Microphone — left for further follow-up PRs against #1781.

## Test plan

- [x] `npm run lint:fix && npm run format:fix` — no new errors (10 pre-existing warnings unrelated to this change)
- [x] `npx vite build` — production build succeeds
- [x] Verified end-to-end in a running dev server (local admin login, App editor for a chat-type app): enabled Magic Prompt, filled in the model dropdown and instructions textarea, toggled Export and Compare Mode — all three sections render identically to before and update independently without clobbering each other's state, zero console errors

Closes-nothing (this is a partial, incremental slice of #1781 — the issue stays open for the remaining sections).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VV7T2u24HZjQah4oaQf1HZ)_