### PR TITLE
Extract System Instructions, Sources, and Settings sections from AppFormEditor (#1781)

### DIFF
--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -5,11 +5,13 @@ import ToolsSelector from '../../../shared/components/ToolsSelector';
 import McpToolsSelector from './McpToolsSelector';
 import SkillsSelector from '../../../shared/components/SkillsSelector';
 import WorkflowsSelector from '../../../shared/components/WorkflowsSelector';
-import SourcePicker from './SourcePicker';
 import ResourceSelector from './ResourceSelector';
 import Icon from '../../../shared/components/Icon';
 import IconPicker from '../../../shared/components/IconPicker';
 import MimeTypeSelector from './MimeTypeSelector';
+import SystemInstructionsSection from './app-form/SystemInstructionsSection';
+import SourcesConfigSection from './app-form/SourcesConfigSection';
+import SettingsConfigSection from './app-form/SettingsConfigSection';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import {
   validateWithSchema,
@@ -298,15 +300,6 @@ function AppFormEditor({
     const updatedApp = {
       ...app,
       allowedModels: selectedModelIds
-    };
-    onChange(updatedApp);
-  };
-
-  // Source handling functions
-  const handleSourcesChange = selectedSourceIds => {
-    const updatedApp = {
-      ...app,
-      sources: selectedSourceIds
     };
     onChange(updatedApp);
   };
@@ -666,63 +659,12 @@ function AppFormEditor({
         {(app.type === 'chat' || !app.type) && (
           <>
             {/* System Instructions - Only for chat apps */}
-            <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-              <div className="md:grid md:grid-cols-3 md:gap-6">
-                <div className="md:col-span-1">
-                  <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                    {t('admin.apps.edit.systemInstructions', 'System Instructions')}
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    {t(
-                      'admin.apps.edit.systemInstructionsDesc',
-                      'System prompts that define the app behavior'
-                    )}
-                  </p>
-                </div>
-                <div className="mt-5 md:col-span-2 md:mt-0">
-                  <DynamicLanguageEditor
-                    label={
-                      <span>
-                        {t('admin.apps.edit.systemInstructions', 'System Instructions')}
-                        <span className="text-red-500 ml-1">*</span>
-                      </span>
-                    }
-                    value={app.system || {}}
-                    onChange={value => handleLocalizedChange('system', value)}
-                    type="textarea"
-                    placeholder={{
-                      en: 'Enter system instructions in English',
-                      de: 'Systeminstruktionen auf Deutsch eingeben'
-                    }}
-                    className="mb-6"
-                    error={validationErrors.system}
-                    name="system"
-                  />
-
-                  <DynamicLanguageEditor
-                    label={t('admin.apps.edit.messagePlaceholder', 'Message Placeholder')}
-                    value={app.messagePlaceholder || {}}
-                    onChange={value => handleLocalizedChange('messagePlaceholder', value)}
-                    placeholder={{
-                      en: 'Enter message placeholder in English',
-                      de: 'Nachrichtenplatzhalter auf Deutsch eingeben'
-                    }}
-                    className="mb-6"
-                  />
-
-                  <DynamicLanguageEditor
-                    label={t('admin.apps.edit.prompt', 'Prompt Template')}
-                    value={app.prompt || {}}
-                    onChange={value => handleLocalizedChange('prompt', value)}
-                    type="textarea"
-                    placeholder={{
-                      en: 'Enter prompt template in English',
-                      de: 'Prompt-Vorlage auf Deutsch eingeben'
-                    }}
-                  />
-                </div>
-              </div>
-            </div>
+            <SystemInstructionsSection
+              app={app}
+              onChange={onChange}
+              t={t}
+              validationErrors={validationErrors}
+            />
           </>
         )}
 
@@ -2711,187 +2653,10 @@ function AppFormEditor({
             </div>
 
             {/* Sources Configuration - Only show if sources feature is enabled */}
-            {isSourcesEnabled && (
-              <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-                <div className="md:grid md:grid-cols-3 md:gap-6">
-                  <div className="md:col-span-1">
-                    <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                      {t('admin.apps.edit.sources', 'Sources Configuration')}
-                    </h3>
-                    <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                      {t(
-                        'admin.apps.edit.sourcesDesc',
-                        'Configure data sources that provide content to this app'
-                      )}
-                    </p>
-                  </div>
-                  <div className="mt-5 md:col-span-2 md:mt-0">
-                    <div className="space-y-6">
-                      {/* Source References */}
-                      <div>
-                        <p className="text-sm text-gray-600 mb-4">
-                          {t(
-                            'admin.apps.edit.sourcesDesc',
-                            'Select data sources configured in the admin interface to provide content to this app'
-                          )}
-                        </p>
-                        <SourcePicker
-                          value={app.sources || []}
-                          onChange={handleSourcesChange}
-                          allowMultiple={true}
-                          className="mb-4"
-                        />
-                      </div>
-
-                      {/* Sources Summary */}
-                      {app.sources && app.sources.length > 0 && (
-                        <div className="bg-blue-50 border border-blue-200 rounded-md p-4">
-                          <div className="flex">
-                            <div className="flex-shrink-0">
-                              <Icon name="information-circle" className="h-5 w-5 text-blue-400" />
-                            </div>
-                            <div className="ml-3">
-                              <h3 className="text-sm font-medium text-blue-800">
-                                {t('admin.apps.edit.sourcesConfigured', 'Sources Configured')}
-                              </h3>
-                              <div className="mt-2 text-sm text-blue-700">
-                                <p>
-                                  {t(
-                                    'admin.apps.edit.sourcesCount',
-                                    'This app has {{count}} source(s) configured:',
-                                    { count: app.sources.length }
-                                  )}
-                                </p>
-                                <ul className="list-disc list-inside mt-1 space-y-1">
-                                  {app.sources.map((sourceId, index) => (
-                                    <li key={`source-${index}`}>
-                                      <span className="font-mono text-xs bg-blue-100 px-1 rounded">
-                                        {sourceId}
-                                      </span>
-                                    </li>
-                                  ))}
-                                </ul>
-                                <p className="mt-2 text-xs">
-                                  {t(
-                                    'admin.apps.edit.sourcesUsage',
-                                    'Sources will be loaded and their content made available via {{sources}} template in system prompts.'
-                                  )}
-                                </p>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-            )}
+            {isSourcesEnabled && <SourcesConfigSection app={app} onChange={onChange} t={t} />}
 
             {/* Settings Configuration */}
-            <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
-              <div className="md:grid md:grid-cols-3 md:gap-6">
-                <div className="md:col-span-1">
-                  <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
-                    {t('admin.apps.edit.settings', 'User Settings')}
-                  </h3>
-                  <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                    {t('admin.apps.edit.settingsDesc', 'Configure which settings users can modify')}
-                  </p>
-                </div>
-                <div className="mt-5 md:col-span-2 md:mt-0">
-                  <div className="space-y-4">
-                    <div className="flex items-center">
-                      <input
-                        type="checkbox"
-                        checked={app.settings?.model?.enabled !== false}
-                        onChange={e =>
-                          handleInputChange('settings', {
-                            ...app.settings,
-                            model: { enabled: e.target.checked }
-                          })
-                        }
-                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                      />
-                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
-                        {t('admin.apps.edit.enableModelSelection', 'Enable Model Selection')}
-                      </label>
-                    </div>
-
-                    <div className="flex items-center">
-                      <input
-                        type="checkbox"
-                        checked={app.settings?.temperature?.enabled !== false}
-                        onChange={e =>
-                          handleInputChange('settings', {
-                            ...app.settings,
-                            temperature: { enabled: e.target.checked }
-                          })
-                        }
-                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                      />
-                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
-                        {t(
-                          'admin.apps.edit.enableTemperatureControl',
-                          'Enable Temperature Control'
-                        )}
-                      </label>
-                    </div>
-
-                    <div className="flex items-center">
-                      <input
-                        type="checkbox"
-                        checked={app.settings?.outputFormat?.enabled !== false}
-                        onChange={e =>
-                          handleInputChange('settings', {
-                            ...app.settings,
-                            outputFormat: { enabled: e.target.checked }
-                          })
-                        }
-                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                      />
-                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
-                        {t('admin.apps.edit.enableOutputFormat', 'Enable Output Format Selection')}
-                      </label>
-                    </div>
-
-                    <div className="flex items-center">
-                      <input
-                        type="checkbox"
-                        checked={app.settings?.chatHistory?.enabled !== false}
-                        onChange={e =>
-                          handleInputChange('settings', {
-                            ...app.settings,
-                            chatHistory: { enabled: e.target.checked }
-                          })
-                        }
-                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                      />
-                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
-                        {t('admin.apps.edit.enableChatHistory', 'Enable Chat History Control')}
-                      </label>
-                    </div>
-
-                    <div className="flex items-center">
-                      <input
-                        type="checkbox"
-                        checked={app.settings?.style?.enabled !== false}
-                        onChange={e =>
-                          handleInputChange('settings', {
-                            ...app.settings,
-                            style: { enabled: e.target.checked }
-                          })
-                        }
-                        className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
-                      />
-                      <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
-                        {t('admin.apps.edit.enableStyleControl', 'Enable Style Control')}
-                      </label>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            <SettingsConfigSection app={app} onChange={onChange} t={t} />
           </>
         )}
       </div>

--- a/client/src/features/admin/components/app-form/SettingsConfigSection.jsx
+++ b/client/src/features/admin/components/app-form/SettingsConfigSection.jsx
@@ -1,0 +1,97 @@
+/**
+ * SettingsConfigSection - Toggles controlling which per-chat settings end
+ * users are allowed to change, extracted from AppFormEditor.
+ *
+ * @component
+ */
+function SettingsConfigSection({ app, onChange, t }) {
+  const handleSettingChange = (key, enabled) => {
+    onChange({
+      ...app,
+      settings: {
+        ...app.settings,
+        [key]: { enabled }
+      }
+    });
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.settings', 'User Settings')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t('admin.apps.edit.settingsDesc', 'Configure which settings users can modify')}
+          </p>
+        </div>
+        <div className="mt-5 md:col-span-2 md:mt-0">
+          <div className="space-y-4">
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                checked={app.settings?.model?.enabled !== false}
+                onChange={e => handleSettingChange('model', e.target.checked)}
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+              />
+              <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                {t('admin.apps.edit.enableModelSelection', 'Enable Model Selection')}
+              </label>
+            </div>
+
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                checked={app.settings?.temperature?.enabled !== false}
+                onChange={e => handleSettingChange('temperature', e.target.checked)}
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+              />
+              <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                {t('admin.apps.edit.enableTemperatureControl', 'Enable Temperature Control')}
+              </label>
+            </div>
+
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                checked={app.settings?.outputFormat?.enabled !== false}
+                onChange={e => handleSettingChange('outputFormat', e.target.checked)}
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+              />
+              <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                {t('admin.apps.edit.enableOutputFormat', 'Enable Output Format Selection')}
+              </label>
+            </div>
+
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                checked={app.settings?.chatHistory?.enabled !== false}
+                onChange={e => handleSettingChange('chatHistory', e.target.checked)}
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+              />
+              <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                {t('admin.apps.edit.enableChatHistory', 'Enable Chat History Control')}
+              </label>
+            </div>
+
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                checked={app.settings?.style?.enabled !== false}
+                onChange={e => handleSettingChange('style', e.target.checked)}
+                className="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 dark:border-gray-600 rounded"
+              />
+              <label className="ml-2 block text-sm text-gray-900 dark:text-gray-100">
+                {t('admin.apps.edit.enableStyleControl', 'Enable Style Control')}
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SettingsConfigSection;

--- a/client/src/features/admin/components/app-form/SourcesConfigSection.jsx
+++ b/client/src/features/admin/components/app-form/SourcesConfigSection.jsx
@@ -1,0 +1,99 @@
+import Icon from '../../../../shared/components/Icon';
+import SourcePicker from '../SourcePicker';
+
+/**
+ * SourcesConfigSection - Data source selection card for chat apps, extracted
+ * from AppFormEditor. Only rendered when the sources feature flag is enabled
+ * (checked by the caller).
+ *
+ * @component
+ */
+function SourcesConfigSection({ app, onChange, t }) {
+  const handleSourcesChange = selectedSourceIds => {
+    onChange({
+      ...app,
+      sources: selectedSourceIds
+    });
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.sources', 'Sources Configuration')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.apps.edit.sourcesDesc',
+              'Configure data sources that provide content to this app'
+            )}
+          </p>
+        </div>
+        <div className="mt-5 md:col-span-2 md:mt-0">
+          <div className="space-y-6">
+            {/* Source References */}
+            <div>
+              <p className="text-sm text-gray-600 mb-4">
+                {t(
+                  'admin.apps.edit.sourcesDesc',
+                  'Select data sources configured in the admin interface to provide content to this app'
+                )}
+              </p>
+              <SourcePicker
+                value={app.sources || []}
+                onChange={handleSourcesChange}
+                allowMultiple={true}
+                className="mb-4"
+              />
+            </div>
+
+            {/* Sources Summary */}
+            {app.sources && app.sources.length > 0 && (
+              <div className="bg-blue-50 border border-blue-200 rounded-md p-4">
+                <div className="flex">
+                  <div className="flex-shrink-0">
+                    <Icon name="information-circle" className="h-5 w-5 text-blue-400" />
+                  </div>
+                  <div className="ml-3">
+                    <h3 className="text-sm font-medium text-blue-800">
+                      {t('admin.apps.edit.sourcesConfigured', 'Sources Configured')}
+                    </h3>
+                    <div className="mt-2 text-sm text-blue-700">
+                      <p>
+                        {t(
+                          'admin.apps.edit.sourcesCount',
+                          'This app has {{count}} source(s) configured:',
+                          {
+                            count: app.sources.length
+                          }
+                        )}
+                      </p>
+                      <ul className="list-disc list-inside mt-1 space-y-1">
+                        {app.sources.map((sourceId, index) => (
+                          <li key={`source-${index}`}>
+                            <span className="font-mono text-xs bg-blue-100 px-1 rounded">
+                              {sourceId}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                      <p className="mt-2 text-xs">
+                        {t(
+                          'admin.apps.edit.sourcesUsage',
+                          'Sources will be loaded and their content made available via {{sources}} template in system prompts.'
+                        )}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SourcesConfigSection;

--- a/client/src/features/admin/components/app-form/SystemInstructionsSection.jsx
+++ b/client/src/features/admin/components/app-form/SystemInstructionsSection.jsx
@@ -1,0 +1,78 @@
+import DynamicLanguageEditor from '../../../../shared/components/DynamicLanguageEditor';
+
+/**
+ * SystemInstructionsSection - System prompt, message placeholder and prompt template
+ * editor for chat apps, extracted from AppFormEditor.
+ *
+ * @component
+ */
+function SystemInstructionsSection({ app, onChange, t, validationErrors = {} }) {
+  const handleLocalizedChange = (field, value) => {
+    onChange({
+      ...app,
+      [field]: value
+    });
+  };
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.systemInstructions', 'System Instructions')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.apps.edit.systemInstructionsDesc',
+              'System prompts that define the app behavior'
+            )}
+          </p>
+        </div>
+        <div className="mt-5 md:col-span-2 md:mt-0">
+          <DynamicLanguageEditor
+            label={
+              <span>
+                {t('admin.apps.edit.systemInstructions', 'System Instructions')}
+                <span className="text-red-500 ml-1">*</span>
+              </span>
+            }
+            value={app.system || {}}
+            onChange={value => handleLocalizedChange('system', value)}
+            type="textarea"
+            placeholder={{
+              en: 'Enter system instructions in English',
+              de: 'Systeminstruktionen auf Deutsch eingeben'
+            }}
+            className="mb-6"
+            error={validationErrors.system}
+            name="system"
+          />
+
+          <DynamicLanguageEditor
+            label={t('admin.apps.edit.messagePlaceholder', 'Message Placeholder')}
+            value={app.messagePlaceholder || {}}
+            onChange={value => handleLocalizedChange('messagePlaceholder', value)}
+            placeholder={{
+              en: 'Enter message placeholder in English',
+              de: 'Nachrichtenplatzhalter auf Deutsch eingeben'
+            }}
+            className="mb-6"
+          />
+
+          <DynamicLanguageEditor
+            label={t('admin.apps.edit.prompt', 'Prompt Template')}
+            value={app.prompt || {}}
+            onChange={value => handleLocalizedChange('prompt', value)}
+            type="textarea"
+            placeholder={{
+              en: 'Enter prompt template in English',
+              de: 'Prompt-Vorlage auf Deutsch eingeben'
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default SystemInstructionsSection;


### PR DESCRIPTION
## Summary

Follow-up to #1781 ("Split the 2545-line AppFormEditor into section components with a shared nested-update helper"), continuing the series of small extraction PRs already opened against it (#1942, #2044, #2046, #2048, #2049, #2050, #2051, #2054, #2060).

Extracts three of the remaining unclaimed sections (per the issue's own tracking comments: Basic Info, System Instructions, Sources Configuration, Settings Configuration, Input Mode & Microphone) from `AppFormEditor.jsx` into standalone components under `client/src/features/admin/components/app-form/`:

- `SystemInstructionsSection.jsx` — system prompt, message placeholder, and prompt template editors for chat apps
- `SourcesConfigSection.jsx` — data source picker + sources-configured summary card (only rendered when the sources feature flag is enabled, gated by the caller as before)
- `SettingsConfigSection.jsx` — per-chat settings toggles (model selection, temperature control, output format, chat history, style)

Each component receives `(app, onChange, t)` and owns its own local update handler, following the same convention established by the prior PRs in this series (e.g. `WebSearchSection.jsx`, `MagicPromptSection.jsx`). Pure extraction — no behavior change intended. The now-unused `handleSourcesChange` helper and `SourcePicker` import were removed from `AppFormEditor.jsx` since their only remaining call site moved into `SourcesConfigSection.jsx`.

`AppFormEditor.jsx` shrinks from 2,902 to 2,667 lines.

Remaining unclaimed sections: Basic Info, Input Mode & Microphone — left for further follow-up PRs against #1781.

## Test plan

- [x] `npx eslint` on all changed/new files — 0 errors (pre-existing warnings elsewhere in `AppFormEditor.jsx` untouched)
- [x] `npx prettier --write` — clean
- [x] `npx vite build` (client) — succeeds with no errors
- [x] Verified end-to-end against a running dev server (local admin login, App editor for an existing chat app): confirmed the System Instructions, Sources Configuration, and User Settings cards render identically to before, edited the system-instructions textarea, toggled a settings checkbox, and confirmed the sources summary still lists all configured sources — zero console errors


---
_Generated by [Claude Code](https://claude.ai/code/session_015JHjRaHuEWiRku8QGt26yX)_