### PR TITLE
fix(workflow): thread nativeWebSearch into executeLLMWithTools

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -31,6 +31,19 @@ existing native-search behavior already available for Gemini and GPT models.
   now resolved directly from the app/workflow configuration and passed straight to the model
   provider.
 
+## Agent Workflows No Longer Crash on Their First Prompt Step
+
+Fixed a regression introduced with the native web search rework above that caused agent workflows
+to fail as soon as they reached a prompt step, with the error `Agent execution failed:
+nativeWebSearch is not defined`.
+
+- Every workflow with a prompt/agent node was affected, whether or not the node used web search;
+  the failure surfaced on the first such step (for example, the Stellungnahmen review workflows
+  failed at their `refine-decision` step).
+- Workflows now run their prompt steps normally again, and the native web search directive is
+  correctly applied on steps that request it.
+- No configuration changes are required.
+
 ## iHub Support Bot Can Now Answer Questions About the Platform
 
 The bundled **iHub Support Bot** app now references the built-in iHub Documentation source, so it

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -534,7 +534,11 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
         tools,
         config,
         context: contextForLLM,
-        nodeId: node.id
+        nodeId: node.id,
+        // Provider-native search directive resolved above. It's computed in
+        // execute() but consumed inside the tool loop, so it must be threaded
+        // through explicitly — it is NOT in executeLLMWithTools's scope.
+        nativeWebSearch
       });
 
       // Finalise the step transcript with timing + outcome.
@@ -1392,7 +1396,15 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
    * @returns {Promise<Object>} Final response with content
    * @private
    */
-  async executeLLMWithTools({ model, messages, tools, config, context, nodeId }) {
+  async executeLLMWithTools({
+    model,
+    messages,
+    tools,
+    config,
+    context,
+    nodeId,
+    nativeWebSearch = null
+  }) {
     // Budget-driven continuation (Claude Code TOKEN_BUDGET analog). The agent
     // runs as long as the task and budget require, rather than a fixed count.
     // `maxToolRoundsPerNode` is a safety backstop above the token budget; the

--- a/server/tests/workflow-native-websearch-threading.test.js
+++ b/server/tests/workflow-native-websearch-threading.test.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * Regression test for the `nativeWebSearch is not defined` workflow crash.
+ *
+ * The websearch refactor (commit b397934) moved native-search resolution into
+ * `execute()`, where it computes a local `nativeWebSearch` directive, then
+ * referenced that same name inside `executeLLMWithTools()` — a separate method
+ * whose scope never contained it. Because the reference sits in the tool loop's
+ * first iteration (`nativeWebSearch: !forceFinish ? nativeWebSearch : null`,
+ * with `forceFinish` starting false), EVERY prompt node threw
+ * `ReferenceError: nativeWebSearch is not defined` the moment it reached the
+ * LLM call — surfacing as "Node <id> failed: Agent execution failed:
+ * nativeWebSearch is not defined" (the stellungnahmen workflow hit it on its
+ * first prompt node, `refine-decision`).
+ *
+ * The fix threads `nativeWebSearch` into `executeLLMWithTools()` as an
+ * explicit parameter. These tests verify the loop no longer throws and that the
+ * directive is forwarded verbatim to the adapter request options.
+ *
+ * Run directly: `node server/tests/workflow-native-websearch-threading.test.js`.
+ */
+
+import { PromptNodeExecutor } from '../services/workflow/executors/PromptNodeExecutor.js';
+
+let failures = 0;
+function check(label, cond, details) {
+  if (!cond) failures += 1;
+  console.log(`${cond ? '✅' : '❌'} ${label}`);
+  if (!cond && details) console.log(`   ${details}`);
+}
+
+// A minimal llmHelper stub: passes API-key verification and returns a
+// tool-less response so the loop breaks after a single iteration. It records
+// the options the executor forwarded so we can assert on nativeWebSearch.
+function makeExecutor() {
+  const captured = { calls: [] };
+  const llmHelper = {
+    verifyApiKey: async () => ({ success: true, apiKey: 'test-key' }),
+    executeStreamingRequest: async ({ options }) => {
+      captured.calls.push(options);
+      return { content: 'done', finishReason: 'stop' };
+    }
+  };
+  const executor = new PromptNodeExecutor({ llmHelper });
+  return { executor, captured };
+}
+
+const baseArgs = {
+  model: { id: 'test-model', provider: 'anthropic', maxOutputTokens: 4096 },
+  messages: [{ role: 'user', content: 'hello' }],
+  tools: [],
+  config: {},
+  context: {},
+  nodeId: 'refine-decision'
+};
+
+console.log('🧪 executeLLMWithTools threads nativeWebSearch instead of throwing\n');
+
+// 1. The exact regression: an Anthropic native-search directive must reach the
+//    adapter, and the call must not throw a ReferenceError.
+{
+  const { executor, captured } = makeExecutor();
+  const directive = { provider: 'anthropic' };
+  let threw = null;
+  let result = null;
+  try {
+    result = await executor.executeLLMWithTools({ ...baseArgs, nativeWebSearch: directive });
+  } catch (e) {
+    threw = e;
+  }
+  check(
+    'does not throw (previously ReferenceError: nativeWebSearch)',
+    threw === null,
+    threw?.message
+  );
+  check('returns the model content', result?.content === 'done');
+  check(
+    'forwards the nativeWebSearch directive to the adapter options',
+    captured.calls.length === 1 &&
+      JSON.stringify(captured.calls[0]?.nativeWebSearch) === JSON.stringify(directive),
+    `got ${JSON.stringify(captured.calls[0]?.nativeWebSearch)}`
+  );
+}
+
+// 2. Omitting nativeWebSearch (a node without web search, like refine-decision)
+//    must default to null — never undefined-that-throws.
+{
+  const { executor, captured } = makeExecutor();
+  let threw = null;
+  try {
+    await executor.executeLLMWithTools({ ...baseArgs });
+  } catch (e) {
+    threw = e;
+  }
+  check('does not throw when nativeWebSearch is omitted', threw === null, threw?.message);
+  check(
+    'defaults nativeWebSearch to null in adapter options',
+    captured.calls[0]?.nativeWebSearch === null,
+    `got ${JSON.stringify(captured.calls[0]?.nativeWebSearch)}`
+  );
+}
+
+console.log(`\n${failures === 0 ? '✅ all passed' : `❌ ${failures} failed`}`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## Summary

Fixes agent workflows crashing on their first prompt step with:

```
Workflow failed: Node refine-decision failed: Agent execution failed: nativeWebSearch is not defined
```

The native web search refactor (`b397934`, finalizes #1881) resolves a `nativeWebSearch` directive inside `PromptNodeExecutor.execute()`, but then **references that same local inside the separate `executeLLMWithTools()` method**, whose scope never contained it:

```js
// PromptNodeExecutor.execute()  — nativeWebSearch is a local here (line ~327)
let nativeWebSearch = null;
...
const response = await this.executeLLMWithTools({ model, messages, tools, config, context, nodeId });

// PromptNodeExecutor.executeLLMWithTools()  — different method scope
nativeWebSearch: !forceFinish ? nativeWebSearch : null,   // ← ReferenceError
```

Because that reference sits in the tool loop's first iteration and `forceFinish` starts `false`, the `nativeWebSearch` branch of the ternary is always evaluated — so **every workflow prompt/agent node** threw `ReferenceError: nativeWebSearch is not defined` the instant it reached the LLM call, regardless of whether the node used web search. The Stellungnahmen review workflows hit it on their first prompt node, `refine-decision` (the earlier `transform` / `query-plan` / `corpus-search` nodes use different executors and never reach this method).

## Fix

Thread `nativeWebSearch` into `executeLLMWithTools()` as an explicit parameter (defaulting to `null` so nodes without web search degrade gracefully), and pass it from the `execute()` call site.

## Changes

- `server/services/workflow/executors/PromptNodeExecutor.js` — add `nativeWebSearch = null` to the `executeLLMWithTools()` parameters and forward it from the `execute()` call site.
- `server/tests/workflow-native-websearch-threading.test.js` — new regression test. It reproduces the exact `nativeWebSearch is not defined` error against the unfixed method and verifies the directive is forwarded verbatim to the adapter request options (and defaults to `null` when omitted).
- `docs/releases/5.5.0/features.md` — changelog entry for the fix.

## Test plan

- [x] New regression test passes with the fix and fails (with the exact original `ReferenceError`) when the parameter is reverted.
- [x] `native-web-search.test.js` (23 tests), `workflow-llm-retry.test.js`, `workflow-model-resolution.test.js` — pass.
- [x] `eslint` + `prettier` on changed files — clean (only a pre-existing unrelated `fullMatch` warning in untouched code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y7z5zexQnQxuWmdZHw5un5)_