### PR TITLE
feat(ui): admin-configurable error & empty-state page messages

### DIFF
--- a/client/src/features/admin/components/ErrorPagesCustomization.jsx
+++ b/client/src/features/admin/components/ErrorPagesCustomization.jsx
@@ -1,0 +1,144 @@
+import DynamicLanguageEditor from '../../../shared/components/DynamicLanguageEditor';
+
+// Declarative description of every editable error / empty-state screen.
+// Each field maps to a localized `{ en, de, ... }` object under
+// `errorPages.<pageKey>.<fieldKey>` in ui.json. Any unset value falls back to
+// the bundled i18n string, so leaving a field empty keeps the default text.
+const ERROR_PAGES = [
+  {
+    key: 'generic',
+    labelKey: 'admin.ui.errorPages.generic',
+    labelDefault: 'Generic Error',
+    descKey: 'admin.ui.errorPages.genericDesc',
+    descDefault: 'Shown by the application error boundary when an unexpected error occurs.',
+    fields: [
+      { key: 'title', type: 'text' },
+      { key: 'description', type: 'textarea' }
+    ]
+  },
+  {
+    key: 'notFound',
+    labelKey: 'admin.ui.errorPages.notFound',
+    labelDefault: 'Not Found (404)',
+    descKey: 'admin.ui.errorPages.notFoundDesc',
+    descDefault: 'Shown when a page or resource cannot be found.',
+    fields: [
+      { key: 'title', type: 'text' },
+      { key: 'message', type: 'textarea' }
+    ]
+  },
+  {
+    key: 'serverError',
+    labelKey: 'admin.ui.errorPages.serverError',
+    labelDefault: 'Server Error (500)',
+    descKey: 'admin.ui.errorPages.serverErrorDesc',
+    descDefault: 'Shown when the server returns an internal error.',
+    fields: [
+      { key: 'title', type: 'text' },
+      { key: 'message', type: 'textarea' },
+      { key: 'subtitle', type: 'textarea' }
+    ]
+  },
+  {
+    key: 'forbidden',
+    labelKey: 'admin.ui.errorPages.forbidden',
+    labelDefault: 'Forbidden (403)',
+    descKey: 'admin.ui.errorPages.forbiddenDesc',
+    descDefault: 'Shown when access to a resource is not allowed.',
+    fields: [
+      { key: 'title', type: 'text' },
+      { key: 'message', type: 'textarea' }
+    ]
+  },
+  {
+    key: 'unauthorized',
+    labelKey: 'admin.ui.errorPages.unauthorized',
+    labelDefault: 'Unauthorized (401)',
+    descKey: 'admin.ui.errorPages.unauthorizedDesc',
+    descDefault: 'Shown when the user is not authenticated / lacks permission.',
+    fields: [
+      { key: 'title', type: 'text' },
+      { key: 'message', type: 'textarea' }
+    ]
+  },
+  {
+    key: 'noApps',
+    labelKey: 'admin.ui.errorPages.noApps',
+    labelDefault: 'No Apps Available',
+    descKey: 'admin.ui.errorPages.noAppsDesc',
+    descDefault: 'Shown on the apps list when the server returns no applications.',
+    fields: [
+      { key: 'title', type: 'text' },
+      { key: 'message', type: 'textarea' }
+    ]
+  }
+];
+
+const FIELD_LABELS = {
+  title: { key: 'admin.ui.errorPages.field.title', default: 'Title' },
+  message: { key: 'admin.ui.errorPages.field.message', default: 'Message' },
+  description: { key: 'admin.ui.errorPages.field.description', default: 'Description' },
+  subtitle: { key: 'admin.ui.errorPages.field.subtitle', default: 'Subtitle' }
+};
+
+function ErrorPagesCustomization({ config, onUpdate, t }) {
+  const errorPages = config || {};
+
+  const updateField = (pageKey, fieldKey, value) => {
+    onUpdate({
+      [pageKey]: {
+        ...(errorPages[pageKey] || {}),
+        [fieldKey]: value
+      }
+    });
+  };
+
+  return (
+    <div className="p-6 space-y-8">
+      <div>
+        <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">
+          {t('admin.ui.errorPages.title', 'Error & Empty-State Messages')}
+        </h3>
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          {t(
+            'admin.ui.errorPages.subtitle',
+            'Customize the localized text shown on error and empty-state screens. Leave a field empty to use the built-in default text.'
+          )}
+        </p>
+      </div>
+
+      {ERROR_PAGES.map(page => (
+        <fieldset
+          key={page.key}
+          className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 space-y-4"
+        >
+          <legend className="px-2 text-sm font-semibold text-gray-900 dark:text-gray-100">
+            {t(page.labelKey, page.labelDefault)}
+          </legend>
+          <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">
+            {t(page.descKey, page.descDefault)}
+          </p>
+
+          {page.fields.map(field => {
+            const fieldLabel = FIELD_LABELS[field.key];
+            return (
+              <DynamicLanguageEditor
+                key={field.key}
+                label={t(fieldLabel.key, fieldLabel.default)}
+                value={errorPages[page.key]?.[field.key] || {}}
+                onChange={value => updateField(page.key, field.key, value)}
+                type={field.type}
+                placeholder={{
+                  en: `${t(fieldLabel.key, fieldLabel.default)} (en)`,
+                  de: `${t(fieldLabel.key, fieldLabel.default)} (de)`
+                }}
+              />
+            );
+          })}
+        </fieldset>
+      ))}
+    </div>
+  );
+}
+
+export default ErrorPagesCustomization;

--- a/client/src/features/admin/pages/AdminUICustomization.jsx
+++ b/client/src/features/admin/pages/AdminUICustomization.jsx
@@ -6,6 +6,7 @@ import AssetManager from '../components/AssetManager';
 import StyleEditor from '../components/StyleEditor';
 import ContentEditor from '../components/ContentEditor';
 import PwaCustomization from '../components/PwaCustomization';
+import ErrorPagesCustomization from '../components/ErrorPagesCustomization';
 import { makeAdminApiCall } from '../../../api/adminApi';
 import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
 
@@ -116,6 +117,7 @@ function AdminUICustomization() {
     { id: 'assets', label: t('admin.ui.tabs.assets', 'Assets'), icon: '🖼️' },
     { id: 'styles', label: t('admin.ui.tabs.styles', 'Styles'), icon: '🎯' },
     { id: 'content', label: t('admin.ui.tabs.content', 'Content'), icon: '📝' },
+    { id: 'errorPages', label: t('admin.ui.tabs.errorPages', 'Error Pages'), icon: '⚠️' },
     { id: 'pwa', label: t('admin.ui.tabs.pwa', 'PWA'), icon: '📱' }
   ];
 
@@ -292,6 +294,13 @@ function AdminUICustomization() {
           {activeTab === 'assets' && <AssetManager t={t} />}
           {activeTab === 'styles' && <StyleEditor config={config} onUpdate={setConfig} t={t} />}
           {activeTab === 'content' && <ContentEditor config={config} onUpdate={setConfig} t={t} />}
+          {activeTab === 'errorPages' && (
+            <ErrorPagesCustomization
+              config={config.errorPages || {}}
+              onUpdate={updates => updateConfig('errorPages', updates)}
+              t={t}
+            />
+          )}
           {activeTab === 'pwa' && (
             <PwaCustomization
               config={config.pwa || {}}

--- a/client/src/features/apps/pages/AppsList.jsx
+++ b/client/src/features/apps/pages/AppsList.jsx
@@ -452,13 +452,16 @@ function AppsList() {
 
   // Always show debugging info when no apps are available
   if (apps.length === 0) {
+    const noAppsConfig = uiConfig?.errorPages?.noApps;
     return (
       <div className="text-center py-12">
         <div className="text-yellow-500 mb-4">
-          {t('error.noAppsAvailable', 'No apps available from server')}
+          {getLocalizedContent(noAppsConfig?.title, currentLanguage) ||
+            t('error.noAppsAvailable', 'No apps available from server')}
         </div>
         <p className="mb-4">
-          {t('error.checkServer', 'Check if the server is running and returning data correctly.')}
+          {getLocalizedContent(noAppsConfig?.message, currentLanguage) ||
+            t('error.checkServer', 'Check if the server is running and returning data correctly.')}
         </p>
         <button
           className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"

--- a/client/src/pages/error/Forbidden.jsx
+++ b/client/src/pages/error/Forbidden.jsx
@@ -1,17 +1,26 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../shared/components/Icon';
+import { useUIConfig } from '../../shared/contexts/UIConfigContext';
+import { getLocalizedContent } from '../../utils/localizeContent';
 
 export default function Forbidden() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const { uiConfig } = useUIConfig();
+  const cfg = uiConfig?.errorPages?.forbidden;
+  const lang = i18n.language;
+
   return (
     <div className="flex flex-col items-center justify-center py-12">
       <div className="text-indigo-600 mb-4">
         <Icon name="ban" size="2xl" className="w-24 h-24" />
       </div>
-      <h1 className="text-4xl font-bold mb-2">{t('errors.forbidden.title', 'Forbidden')}</h1>
+      <h1 className="text-4xl font-bold mb-2">
+        {getLocalizedContent(cfg?.title, lang) || t('errors.forbidden.title', 'Forbidden')}
+      </h1>
       <p className="text-xl mb-6 text-center">
-        {t('errors.forbidden.message', 'Access to this resource is forbidden.')}
+        {getLocalizedContent(cfg?.message, lang) ||
+          t('errors.forbidden.message', 'Access to this resource is forbidden.')}
       </p>
       <Link
         to="/"

--- a/client/src/pages/error/NotFound.jsx
+++ b/client/src/pages/error/NotFound.jsx
@@ -1,9 +1,14 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../shared/components/Icon';
+import { useUIConfig } from '../../shared/contexts/UIConfigContext';
+import { getLocalizedContent } from '../../utils/localizeContent';
 
 export default function NotFound() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const { uiConfig } = useUIConfig();
+  const cfg = uiConfig?.errorPages?.notFound;
+  const lang = i18n.language;
 
   return (
     <div className="flex flex-col items-center justify-center py-12">
@@ -11,9 +16,12 @@ export default function NotFound() {
         <Icon name="face-frown" size="2xl" className="w-24 h-24" />
       </div>
       <h1 className="text-4xl font-bold mb-2">404</h1>
-      <p className="text-xl mb-6">{t('errors.notFound.title', 'Page Not Found')}</p>
+      <p className="text-xl mb-6">
+        {getLocalizedContent(cfg?.title, lang) || t('errors.notFound.title', 'Page Not Found')}
+      </p>
       <p className="text-gray-600 mb-8 text-center max-w-md">
-        {t('errors.notFound.message', "We couldn't find the page you're looking for.")}
+        {getLocalizedContent(cfg?.message, lang) ||
+          t('errors.notFound.message', "We couldn't find the page you're looking for.")}
       </p>
       <Link
         to="/"

--- a/client/src/pages/error/ServerError.jsx
+++ b/client/src/pages/error/ServerError.jsx
@@ -1,20 +1,30 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../shared/components/Icon';
+import { useUIConfig } from '../../shared/contexts/UIConfigContext';
+import { getLocalizedContent } from '../../utils/localizeContent';
 
 export default function ServerError() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const { uiConfig } = useUIConfig();
+  const cfg = uiConfig?.errorPages?.serverError;
+  const lang = i18n.language;
+
   return (
     <div className="flex flex-col items-center justify-center py-12">
       <div className="text-indigo-600 mb-4">
         <Icon name="exclamation-triangle" size="2xl" className="w-24 h-24" />
       </div>
-      <h1 className="text-4xl font-bold mb-2">{t('errors.serverError.title', 'Server Error')}</h1>
+      <h1 className="text-4xl font-bold mb-2">
+        {getLocalizedContent(cfg?.title, lang) || t('errors.serverError.title', 'Server Error')}
+      </h1>
       <p className="text-xl mb-2 text-center">
-        {t('errors.serverError.message', 'Something went wrong on our end.')}
+        {getLocalizedContent(cfg?.message, lang) ||
+          t('errors.serverError.message', 'Something went wrong on our end.')}
       </p>
       <p className="text-gray-600 mb-8 text-center">
-        {t('errors.serverError.subtitle', 'Please try again later.')}
+        {getLocalizedContent(cfg?.subtitle, lang) ||
+          t('errors.serverError.subtitle', 'Please try again later.')}
       </p>
       <Link
         to="/"

--- a/client/src/pages/error/Unauthorized.jsx
+++ b/client/src/pages/error/Unauthorized.jsx
@@ -1,17 +1,26 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../shared/components/Icon';
+import { useUIConfig } from '../../shared/contexts/UIConfigContext';
+import { getLocalizedContent } from '../../utils/localizeContent';
 
 export default function Unauthorized() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const { uiConfig } = useUIConfig();
+  const cfg = uiConfig?.errorPages?.unauthorized;
+  const lang = i18n.language;
+
   return (
     <div className="flex flex-col items-center justify-center py-12">
       <div className="text-indigo-600 mb-4">
         <Icon name="lock" size="2xl" className="w-24 h-24" />
       </div>
-      <h1 className="text-4xl font-bold mb-2">{t('errors.unauthorized.title', 'Unauthorized')}</h1>
+      <h1 className="text-4xl font-bold mb-2">
+        {getLocalizedContent(cfg?.title, lang) || t('errors.unauthorized.title', 'Unauthorized')}
+      </h1>
       <p className="text-xl mb-6 text-center">
-        {t('errors.unauthorized.message', "You don't have permission to access this page.")}
+        {getLocalizedContent(cfg?.message, lang) ||
+          t('errors.unauthorized.message', "You don't have permission to access this page.")}
       </p>
       <Link
         to="/"

--- a/client/src/shared/components/ErrorBoundary.jsx
+++ b/client/src/shared/components/ErrorBoundary.jsx
@@ -4,6 +4,8 @@ import { Navigate } from 'react-router-dom';
 import Icon from './Icon';
 import { buildPath } from '../../utils/runtimeBasePath';
 import { isChunkLoadError } from '../../utils/lazyWithRetry';
+import { getLocalizedContent } from '../../utils/localizeContent';
+import { readCachedErrorPagesConfig } from '../../utils/errorPagesCache';
 
 // Error boundary wrapper component
 class ErrorBoundaryComponent extends Component {
@@ -52,7 +54,7 @@ class ErrorBoundaryComponent extends Component {
 
 // Error fallback display component with reset capability and translation
 function ErrorFallback({ error, resetErrorBoundary }) {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
   const chunkError = isChunkLoadError(error);
 
   if (error?.status === 401) {
@@ -65,16 +67,23 @@ function ErrorFallback({ error, resetErrorBoundary }) {
     return <Navigate to="/server-error" replace />;
   }
 
+  // Admin-configurable messages for the generic error screen. This boundary is
+  // mounted above UIConfigProvider, so we read a cached snapshot from
+  // localStorage rather than context; any unset value falls back to i18n.
+  const generic = readCachedErrorPagesConfig().generic || {};
+  const lang = i18n.language;
+
   const title = chunkError
     ? t('error.chunkLoadTitle', 'Page failed to load')
-    : t('error.title', 'Something went wrong');
+    : getLocalizedContent(generic.title, lang) || t('error.title', 'Something went wrong');
 
   const description = chunkError
     ? t(
         'error.chunkLoadDescription',
         'A required resource could not be loaded. This may be due to a network issue or an application update.'
       )
-    : t(
+    : getLocalizedContent(generic.description, lang) ||
+      t(
         'error.description',
         'An unexpected error occurred in the application. The development team has been notified.'
       );

--- a/client/src/shared/contexts/UIConfigContext.jsx
+++ b/client/src/shared/contexts/UIConfigContext.jsx
@@ -1,6 +1,7 @@
 import { createContext, useState, useContext, useEffect } from 'react';
 import { fetchUIConfig } from '../../api';
 import { buildPath, buildAssetUrl } from '../../utils/runtimeBasePath';
+import { cacheErrorPagesConfig } from '../../utils/errorPagesCache';
 
 // Default header color as a fallback if config is not loaded
 const FALLBACK_COLOR = '#4f46e5'; // indigo-600
@@ -45,6 +46,14 @@ export function UIConfigProvider({ children }) {
   useEffect(() => {
     fetchUiConfig();
   }, []);
+
+  // Cache error-page messages so the context-less generic ErrorBoundary
+  // (mounted above this provider) can still render admin-configured text.
+  // Guard on null so a not-yet-loaded config doesn't wipe a prior snapshot.
+  useEffect(() => {
+    if (uiConfig === null) return;
+    cacheErrorPagesConfig(uiConfig.errorPages);
+  }, [uiConfig]);
 
   // Set header color based on UI config
   useEffect(() => {

--- a/client/src/utils/errorPagesCache.js
+++ b/client/src/utils/errorPagesCache.js
@@ -1,0 +1,44 @@
+/**
+ * Small persistence helper for the admin-configurable error-page messages.
+ *
+ * The generic ErrorBoundary is mounted *above* UIConfigProvider, so it cannot
+ * read the `errorPages` config through the React context (the provider may be
+ * the very thing that failed). To still let admins customize the generic error
+ * screen, UIConfigProvider writes the latest `errorPages` block to localStorage
+ * whenever the UI config loads, and the ErrorBoundary reads that cached
+ * snapshot as a best-effort source. When nothing is cached, callers fall back
+ * to the bundled i18n strings.
+ */
+const ERROR_PAGES_CACHE_KEY = 'ihub-error-pages-config';
+
+/**
+ * Persist the errorPages config so the context-less ErrorBoundary can use it.
+ * @param {object|null|undefined} errorPages
+ */
+export function cacheErrorPagesConfig(errorPages) {
+  try {
+    if (errorPages && typeof errorPages === 'object') {
+      localStorage.setItem(ERROR_PAGES_CACHE_KEY, JSON.stringify(errorPages));
+    } else {
+      localStorage.removeItem(ERROR_PAGES_CACHE_KEY);
+    }
+  } catch {
+    // localStorage may be unavailable (private mode, quota) — ignore.
+  }
+}
+
+/**
+ * Read the cached errorPages config. Returns an empty object when nothing is
+ * cached or the value cannot be parsed.
+ * @returns {object}
+ */
+export function readCachedErrorPagesConfig() {
+  try {
+    const raw = localStorage.getItem(ERROR_PAGES_CACHE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -500,3 +500,18 @@ is now both prevented and, if it still happens, reported clearly instead of show
   ("The AI model returned an incomplete response… please try sending your message again") rather
   than a silent blank reply.
 - No admin action is required — the fix takes effect automatically on upgrade.
+
+## Customizable Error & Empty-State Messages
+
+Admins can now reword the text shown on error and empty-state screens per language, directly from
+the admin panel — no code change or redeploy required. This is useful for branded deployments that
+need tenant-specific wording, a support contact, or a different tone.
+
+- Covers the generic error screen, the 404 / 500 / 403 / 401 pages, and the "no apps available"
+  state on the apps list.
+- Edit under **Admin → UI Customization → Error Pages**. Each screen has its own title and message
+  fields, with the standard multi-language editor (add languages, auto-translate).
+- Every field is optional — leave one empty to keep the built-in default text. Existing
+  installations get the current wording seeded automatically so there's nothing to fill in unless
+  you want to change it.
+- No admin action is required on upgrade; a migration adds the editable defaults for you.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -176,6 +176,70 @@ Setting `enabled` to `false` will completely remove the disclaimer from the appl
 
 **Note:** If `link` is not provided, the hint will be displayed as non-clickable text. If `hint` is not provided, a default hint text will be shown.
 
+### Error & Empty-State Messages
+
+The `errorPages` section lets administrators customize the localized text shown on the
+application's error and empty-state screens. This covers the generic error boundary, the HTTP
+error pages (404 / 500 / 403 / 401), and the "no apps available" state on the apps list.
+
+Every field is a localized object (`{ "en": "…", "de": "…", … }`) and is **optional**. When a
+field is left empty or omitted, the screen falls back to the built-in translation — so behavior is
+unchanged until you fill something in.
+
+```json
+"errorPages": {
+  "generic": {
+    "title": { "en": "Something went wrong", "de": "Etwas ist schiefgelaufen" },
+    "description": {
+      "en": "An unexpected error occurred in the application. The development team has been notified.",
+      "de": "Ein unerwarteter Fehler ist in der Anwendung aufgetreten. Das Entwicklungsteam wurde benachrichtigt."
+    }
+  },
+  "notFound": {
+    "title": { "en": "Page Not Found", "de": "Seite nicht gefunden" },
+    "message": { "en": "We couldn't find the page you're looking for.", "de": "Die gesuchte Seite konnte nicht gefunden werden." }
+  },
+  "serverError": {
+    "title": { "en": "Server Error", "de": "Serverfehler" },
+    "message": { "en": "Something went wrong on our end.", "de": "Auf unserer Seite ist etwas schiefgelaufen." },
+    "subtitle": { "en": "Please try again later.", "de": "Bitte versuchen Sie es später erneut." }
+  },
+  "forbidden": {
+    "title": { "en": "Forbidden", "de": "Zugriff verweigert" },
+    "message": { "en": "Access to this resource is forbidden.", "de": "Der Zugriff auf diese Ressource ist nicht erlaubt." }
+  },
+  "unauthorized": {
+    "title": { "en": "Unauthorized", "de": "Nicht autorisiert" },
+    "message": { "en": "You don't have permission to access this page.", "de": "Sie haben keine Berechtigung, auf diese Seite zuzugreifen." }
+  },
+  "noApps": {
+    "title": { "en": "No apps available from server", "de": "Keine Apps vom Server verfügbar" },
+    "message": { "en": "Check if the server is running and returning data correctly.", "de": "Prüfen Sie, ob der Server läuft und Daten korrekt zurückgibt." }
+  }
+}
+```
+
+| Screen         | Fields                       | Where it appears                                                    |
+| -------------- | ---------------------------- | ------------------------------------------------------------------ |
+| `generic`      | `title`, `description`       | Application error boundary — shown when an unexpected error occurs  |
+| `notFound`     | `title`, `message`           | 404 page                                                           |
+| `serverError`  | `title`, `message`, `subtitle` | 500 page                                                         |
+| `forbidden`    | `title`, `message`           | 403 page                                                           |
+| `unauthorized` | `title`, `message`           | 401 page                                                           |
+| `noApps`       | `title`, `message`           | Apps list, when the server returns no applications                 |
+
+**Editing in the admin panel:** Go to **Admin → UI Customization → Error Pages**. Each screen has
+its own group of fields, and every field uses the multi-language editor (add/remove languages,
+auto-translate). Click **Save Changes** to apply — no restart is needed.
+
+**Action buttons** (e.g. "Return Home", "Retry", "Go Back") are not part of `errorPages`; they
+remain controlled by the application's bundled translations.
+
+> **Note on the generic error boundary:** because it renders above the UI-config provider (the
+> provider itself may be what failed), the generic screen reads its text from a snapshot cached in
+> the browser after the last successful config load. The first time a user visits after a config
+> change, the generic screen may briefly use the bundled defaults until the new config is cached.
+
 ### Icons Configuration
 
 The `icons` section allows overriding which icon is used for certain UI elements. Icon names can

--- a/examples/config/ui.json
+++ b/examples/config/ui.json
@@ -105,6 +105,72 @@
     },
     "link": "/pages/disclaimer"
   },
+  "errorPages": {
+    "generic": {
+      "title": {
+        "en": "Something went wrong",
+        "de": "Etwas ist schiefgelaufen"
+      },
+      "description": {
+        "en": "An unexpected error occurred in the application. The development team has been notified.",
+        "de": "Ein unerwarteter Fehler ist in der Anwendung aufgetreten. Das Entwicklungsteam wurde benachrichtigt."
+      }
+    },
+    "notFound": {
+      "title": {
+        "en": "Page Not Found",
+        "de": "Seite nicht gefunden"
+      },
+      "message": {
+        "en": "We couldn't find the page you're looking for.",
+        "de": "Die gesuchte Seite konnte nicht gefunden werden."
+      }
+    },
+    "serverError": {
+      "title": {
+        "en": "Server Error",
+        "de": "Serverfehler"
+      },
+      "message": {
+        "en": "Something went wrong on our end.",
+        "de": "Auf unserer Seite ist etwas schiefgelaufen."
+      },
+      "subtitle": {
+        "en": "Please try again later.",
+        "de": "Bitte versuchen Sie es später erneut."
+      }
+    },
+    "forbidden": {
+      "title": {
+        "en": "Forbidden",
+        "de": "Zugriff verweigert"
+      },
+      "message": {
+        "en": "Access to this resource is forbidden.",
+        "de": "Der Zugriff auf diese Ressource ist nicht erlaubt."
+      }
+    },
+    "unauthorized": {
+      "title": {
+        "en": "Unauthorized",
+        "de": "Nicht autorisiert"
+      },
+      "message": {
+        "en": "You don't have permission to access this page.",
+        "de": "Sie haben keine Berechtigung, auf diese Seite zuzugreifen."
+      }
+    },
+    "noApps": {
+      "title": {
+        "en": "No apps available from server",
+        "de": "Keine Apps vom Server verfügbar"
+      },
+      "message": {
+        "en": "Check if the server is running and returning data correctly.",
+        "de": "Prüfen Sie, ob der Server läuft und Daten korrekt zurückgibt."
+      }
+    }
+  },
   "widget": {
     "defaultApp": "faq-bot",
     "title": {

--- a/server/defaults/config/ui.json
+++ b/server/defaults/config/ui.json
@@ -105,6 +105,72 @@
       "de": "iHub nutzt KI und kann Fehler machen. Bitte überprüfe die Ergebnisse sorgfältig."
     }
   },
+  "errorPages": {
+    "generic": {
+      "title": {
+        "en": "Something went wrong",
+        "de": "Etwas ist schiefgelaufen"
+      },
+      "description": {
+        "en": "An unexpected error occurred in the application. The development team has been notified.",
+        "de": "Ein unerwarteter Fehler ist in der Anwendung aufgetreten. Das Entwicklungsteam wurde benachrichtigt."
+      }
+    },
+    "notFound": {
+      "title": {
+        "en": "Page Not Found",
+        "de": "Seite nicht gefunden"
+      },
+      "message": {
+        "en": "We couldn't find the page you're looking for.",
+        "de": "Die gesuchte Seite konnte nicht gefunden werden."
+      }
+    },
+    "serverError": {
+      "title": {
+        "en": "Server Error",
+        "de": "Serverfehler"
+      },
+      "message": {
+        "en": "Something went wrong on our end.",
+        "de": "Auf unserer Seite ist etwas schiefgelaufen."
+      },
+      "subtitle": {
+        "en": "Please try again later.",
+        "de": "Bitte versuchen Sie es später erneut."
+      }
+    },
+    "forbidden": {
+      "title": {
+        "en": "Forbidden",
+        "de": "Zugriff verweigert"
+      },
+      "message": {
+        "en": "Access to this resource is forbidden.",
+        "de": "Der Zugriff auf diese Ressource ist nicht erlaubt."
+      }
+    },
+    "unauthorized": {
+      "title": {
+        "en": "Unauthorized",
+        "de": "Nicht autorisiert"
+      },
+      "message": {
+        "en": "You don't have permission to access this page.",
+        "de": "Sie haben keine Berechtigung, auf diese Seite zuzugreifen."
+      }
+    },
+    "noApps": {
+      "title": {
+        "en": "No apps available from server",
+        "de": "Keine Apps vom Server verfügbar"
+      },
+      "message": {
+        "en": "Check if the server is running and returning data correctly.",
+        "de": "Prüfen Sie, ob der Server läuft und Daten korrekt zurückgibt."
+      }
+    }
+  },
   "appsList": {
     "title": {
       "en": "iHub Apps",

--- a/server/migrations/V078__add_error_page_messages.js
+++ b/server/migrations/V078__add_error_page_messages.js
@@ -1,0 +1,92 @@
+/**
+ * Migration V078 — Add error-page messages section to ui.json
+ *
+ * Seeds the `errorPages` top-level section into existing ui.json configs so
+ * administrators can customize the localized text shown on error and
+ * empty-state screens (generic error boundary, 404, 500, 403, 401, and the
+ * "no apps available" state).
+ *
+ * Each field is a localized `{ en, de, ... }` object and is only added when
+ * missing, so any value an admin has already set is preserved. Screens fall
+ * back to their bundled i18n strings whenever a field is left unset, so this
+ * migration does not change existing behavior — it just exposes the defaults
+ * for editing.
+ */
+
+export const version = '078';
+export const description = 'Add error-page messages section to ui.json';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/ui.json');
+}
+
+export async function up(ctx) {
+  const ui = await ctx.readJson('config/ui.json');
+
+  // Generic error boundary
+  ctx.setDefault(ui, 'errorPages.generic.title', {
+    en: 'Something went wrong',
+    de: 'Etwas ist schiefgelaufen'
+  });
+  ctx.setDefault(ui, 'errorPages.generic.description', {
+    en: 'An unexpected error occurred in the application. The development team has been notified.',
+    de: 'Ein unerwarteter Fehler ist in der Anwendung aufgetreten. Das Entwicklungsteam wurde benachrichtigt.'
+  });
+
+  // Not Found (404)
+  ctx.setDefault(ui, 'errorPages.notFound.title', {
+    en: 'Page Not Found',
+    de: 'Seite nicht gefunden'
+  });
+  ctx.setDefault(ui, 'errorPages.notFound.message', {
+    en: "We couldn't find the page you're looking for.",
+    de: 'Die gesuchte Seite konnte nicht gefunden werden.'
+  });
+
+  // Server Error (500)
+  ctx.setDefault(ui, 'errorPages.serverError.title', {
+    en: 'Server Error',
+    de: 'Serverfehler'
+  });
+  ctx.setDefault(ui, 'errorPages.serverError.message', {
+    en: 'Something went wrong on our end.',
+    de: 'Auf unserer Seite ist etwas schiefgelaufen.'
+  });
+  ctx.setDefault(ui, 'errorPages.serverError.subtitle', {
+    en: 'Please try again later.',
+    de: 'Bitte versuchen Sie es später erneut.'
+  });
+
+  // Forbidden (403)
+  ctx.setDefault(ui, 'errorPages.forbidden.title', {
+    en: 'Forbidden',
+    de: 'Zugriff verweigert'
+  });
+  ctx.setDefault(ui, 'errorPages.forbidden.message', {
+    en: 'Access to this resource is forbidden.',
+    de: 'Der Zugriff auf diese Ressource ist nicht erlaubt.'
+  });
+
+  // Unauthorized (401)
+  ctx.setDefault(ui, 'errorPages.unauthorized.title', {
+    en: 'Unauthorized',
+    de: 'Nicht autorisiert'
+  });
+  ctx.setDefault(ui, 'errorPages.unauthorized.message', {
+    en: "You don't have permission to access this page.",
+    de: 'Sie haben keine Berechtigung, auf diese Seite zuzugreifen.'
+  });
+
+  // No apps available (apps list empty state)
+  ctx.setDefault(ui, 'errorPages.noApps.title', {
+    en: 'No apps available from server',
+    de: 'Keine Apps vom Server verfügbar'
+  });
+  ctx.setDefault(ui, 'errorPages.noApps.message', {
+    en: 'Check if the server is running and returning data correctly.',
+    de: 'Prüfen Sie, ob der Server läuft und Daten korrekt zurückgibt.'
+  });
+
+  await ctx.writeJson('config/ui.json', ui);
+  ctx.log('Applied error-page message defaults');
+}

--- a/server/routes/admin/ui.js
+++ b/server/routes/admin/ui.js
@@ -407,5 +407,18 @@ export default function registerAdminUIRoutes(app) {
         throw new Error('pwa.shortName must be a string');
       }
     }
+
+    // Validate errorPages section if present. Each screen is an object of
+    // localized `{ lang: value }` fields; unset fields fall back to i18n.
+    if (config.errorPages !== undefined) {
+      if (typeof config.errorPages !== 'object' || Array.isArray(config.errorPages)) {
+        throw new Error('errorPages section must be an object');
+      }
+      for (const [pageKey, page] of Object.entries(config.errorPages)) {
+        if (page !== null && (typeof page !== 'object' || Array.isArray(page))) {
+          throw new Error(`errorPages.${pageKey} must be an object`);
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Implements #2070 — lets administrators customize the localized text shown on error and empty-state screens directly from the admin UI, with any unset value falling back to the current built-in translations.

Covered screens:
- Generic error boundary (unexpected app errors)
- **404** Not Found, **500** Server Error, **403** Forbidden, **401** Unauthorized
- The "no apps available" empty state on the apps list

## How it works

Follows the existing `disclaimer` pattern: a new top-level `errorPages` block lives in `ui.json`, is served raw by `/api/configs/ui`, reaches the client through `useUIConfig()`, and is rendered with `getLocalizedContent(value, lang) || t('fallback.key')`. No new API endpoints — the admin save flow already round-trips the whole `ui.json`.

Every field is optional. When empty/unset, the screen uses the bundled i18n default, so behavior is unchanged until an admin fills something in.

### Config shape (`ui.json`)

```jsonc
"errorPages": {
  "generic":      { "title": {…}, "description": {…} },
  "notFound":     { "title": {…}, "message": {…} },
  "serverError":  { "title": {…}, "message": {…}, "subtitle": {…} },
  "forbidden":    { "title": {…}, "message": {…} },
  "unauthorized": { "title": {…}, "message": {…} },
  "noApps":       { "title": {…}, "message": {…} }
}
```

### Generic ErrorBoundary special case

`ErrorBoundary` is mounted **above** `UIConfigProvider`, so it cannot use `useUIConfig()` (the provider may be the thing that failed). `UIConfigProvider` now caches `errorPages` to `localStorage` on each successful config load, and the boundary reads that snapshot (falling back to i18n when nothing is cached).

## Changes

| Area | Files |
|---|---|
| Config defaults | `server/defaults/config/ui.json`, `examples/config/ui.json` |
| Migration | `server/migrations/V078__add_error_page_messages.js` (new) |
| Server validation | `server/routes/admin/ui.js` (`validateUIConfig`) |
| Client consumption | `client/src/pages/error/{NotFound,ServerError,Forbidden,Unauthorized}.jsx`, `client/src/features/apps/pages/AppsList.jsx`, `client/src/shared/components/ErrorBoundary.jsx` |
| Cache helper | `client/src/utils/errorPagesCache.js` (new) + `UIConfigContext.jsx` |
| Admin UI | `client/src/features/admin/pages/AdminUICustomization.jsx`, `client/src/features/admin/components/ErrorPagesCustomization.jsx` (new) |
| Docs | `docs/ui.md`, changelog `docs/releases/5.5.0/features.md` |

## Design decisions

- **Fallback semantics:** admin value overrides, empty/unset ⇒ bundled i18n default (fully backward compatible).
- **Action button labels** ("Return Home", "Retry", "Go Back") remain on i18n — only title/message/description/subtitle are configurable.
- **Admin editor labels** use inline `t()` defaults, consistent with the rest of the admin UI section (no `admin.ui.*` keys exist in the i18n JSON today).
- **Bonus fix:** seeded German defaults improve the German error pages, which previously fell back to English because the `de` i18n bundle is missing the `errors.*` keys.

## Verification

- ✅ Server boots; migration `V078` applies and `contents/config/ui.json` gets the `errorPages` section (verified all six screens + German text present).
- ✅ Migration is non-destructive — a pre-set `notFound.title` is preserved while missing fields are seeded.
- ✅ `npm run build` (client) succeeds.
- ✅ ESLint: 0 errors on changed files; Prettier clean.

Closes #2070

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZpixFPwUow6Gm9Wn3yims)_