### PR TITLE
feat(admin): use searchable group pickers in authentication settings

### DIFF
--- a/client/src/features/admin/components/GroupMultiSelect.jsx
+++ b/client/src/features/admin/components/GroupMultiSelect.jsx
@@ -25,6 +25,7 @@ import Icon from '../../../shared/components/Icon';
  * @param {string} [props.emptyMessage] - Message shown when nothing is selected
  * @param {boolean} [props.allowCustom=true] - Allow adding names that are not known groups
  * @param {boolean} [props.warnOnCustom=true] - Visually flag entries that are not defined groups
+ * @param {boolean} [props.multiple=true] - Allow multiple selections; when false, a new selection replaces the current one
  * @param {boolean} [props.disabled=false] - Disable the control
  */
 function GroupMultiSelect({
@@ -38,6 +39,7 @@ function GroupMultiSelect({
   emptyMessage,
   allowCustom = true,
   warnOnCustom = true,
+  multiple = true,
   disabled = false
 }) {
   const { t } = useTranslation();
@@ -122,7 +124,8 @@ function GroupMultiSelect({
       setActiveIndex(-1);
       return;
     }
-    commit([...selected, val]);
+    // In single-select mode a new selection replaces the current one.
+    commit(multiple ? [...selected, val] : [val]);
   };
 
   // Add by raw term: prefer the canonical id of a matching known group.

--- a/client/src/features/admin/components/PlatformFormEditor.jsx
+++ b/client/src/features/admin/components/PlatformFormEditor.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
 import { CredentialRefSelect } from './OpenApiToolEditor';
+import GroupMultiSelect from './GroupMultiSelect';
 
 // OIDC Provider Templates
 const OIDC_PROVIDER_TEMPLATES = {
@@ -67,7 +68,7 @@ const OIDC_PROVIDER_TEMPLATES = {
 /**
  * PlatformFormEditor - Form-based editor for platform configuration
  */
-function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
+function PlatformFormEditor({ value: config, onChange, onValidationChange, availableGroups = [] }) {
   const { t } = useTranslation();
   const [showProviderModal, setShowProviderModal] = useState(false);
 
@@ -509,47 +510,42 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
         </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Authenticated Groups
-            </label>
-            <input
-              type="text"
-              value={config.auth?.authenticatedGroup || ''}
-              onChange={e => updateNestedConfig('auth', 'authenticatedGroup', e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              placeholder="authenticated"
+            <GroupMultiSelect
+              id="auth-authenticated-group"
+              label={t('admin.auth.groups.authenticatedLabel', 'Authenticated Group')}
+              multiple={false}
+              allowCustom={false}
+              availableGroups={availableGroups}
+              value={config.auth?.authenticatedGroup ? [config.auth.authenticatedGroup] : []}
+              onChange={next =>
+                updateNestedConfig('auth', 'authenticatedGroup', next[next.length - 1] || '')
+              }
+              placeholder={t('admin.auth.groups.searchPlaceholder', 'Search groups…')}
+              emptyMessage={t('admin.auth.groups.emptySingle', 'No group selected yet')}
+              helpText={t(
+                'admin.auth.groups.authenticatedHelp',
+                'Internal group automatically assigned to all authenticated users'
+              )}
             />
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              Group automatically assigned to all authenticated users
-            </p>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              Anonymous Groups
-            </label>
-            <input
-              type="text"
+            <GroupMultiSelect
+              id="anonymous-default-groups"
+              label={t('admin.auth.groups.anonymousLabel', 'Anonymous Groups')}
+              allowCustom={false}
+              availableGroups={availableGroups}
               value={
                 Array.isArray(config.anonymousAuth?.defaultGroups)
-                  ? config.anonymousAuth.defaultGroups.join(', ')
-                  : ''
+                  ? config.anonymousAuth.defaultGroups
+                  : []
               }
-              onChange={e =>
-                updateNestedConfig(
-                  'anonymousAuth',
-                  'defaultGroups',
-                  e.target.value
-                    .split(',')
-                    .map(g => g.trim())
-                    .filter(g => g)
-                )
-              }
-              className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-              placeholder="anonymous, guest"
+              onChange={next => updateNestedConfig('anonymousAuth', 'defaultGroups', next)}
+              placeholder={t('admin.auth.groups.searchPlaceholder', 'Search groups…')}
+              helpText={t(
+                'admin.auth.groups.anonymousHelp',
+                'Internal groups assigned to users who access without authentication'
+              )}
             />
-            <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-              Groups assigned to users who access without authentication (comma-separated)
-            </p>
           </div>
         </div>
       </div>
@@ -981,24 +977,18 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
                       />
                     </div>
                     <div className="md:col-span-2">
-                      <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                        Default Groups (comma-separated)
-                      </label>
-                      <input
-                        type="text"
-                        placeholder="google-users, external-users"
-                        value={provider.defaultGroups ? provider.defaultGroups.join(', ') : ''}
-                        onChange={e =>
-                          updateOidcProvider(
-                            index,
-                            'defaultGroups',
-                            e.target.value
-                              .split(',')
-                              .map(s => s.trim())
-                              .filter(s => s)
-                          )
-                        }
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                      <GroupMultiSelect
+                        id={`oidc-default-groups-${index}`}
+                        label={t('admin.auth.groups.defaultLabel', 'Default Groups')}
+                        allowCustom={false}
+                        availableGroups={availableGroups}
+                        value={Array.isArray(provider.defaultGroups) ? provider.defaultGroups : []}
+                        onChange={next => updateOidcProvider(index, 'defaultGroups', next)}
+                        placeholder={t('admin.auth.groups.searchPlaceholder', 'Search groups…')}
+                        helpText={t(
+                          'admin.auth.groups.oidcHelp',
+                          'Internal groups automatically assigned to users authenticating with this provider'
+                        )}
                       />
                     </div>
                     <div>
@@ -1263,30 +1253,19 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
                 </div>
 
                 <div className="md:col-span-2">
-                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                    Default Groups (comma-separated)
-                  </label>
-                  <input
-                    type="text"
-                    value={
-                      Array.isArray(provider.defaultGroups) ? provider.defaultGroups.join(', ') : ''
-                    }
-                    onChange={e =>
-                      updateLdapProvider(
-                        index,
-                        'defaultGroups',
-                        e.target.value
-                          .split(',')
-                          .map(g => g.trim())
-                          .filter(g => g)
-                      )
-                    }
-                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    placeholder="ldap-users, employees"
+                  <GroupMultiSelect
+                    id={`ldap-default-groups-${index}`}
+                    label={t('admin.auth.groups.defaultLabel', 'Default Groups')}
+                    allowCustom={false}
+                    availableGroups={availableGroups}
+                    value={Array.isArray(provider.defaultGroups) ? provider.defaultGroups : []}
+                    onChange={next => updateLdapProvider(index, 'defaultGroups', next)}
+                    placeholder={t('admin.auth.groups.searchPlaceholder', 'Search groups…')}
+                    helpText={t(
+                      'admin.auth.groups.ldapHelp',
+                      'Internal groups automatically assigned to LDAP users'
+                    )}
                   />
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                    Groups automatically assigned to LDAP users
-                  </p>
                 </div>
 
                 <div className="md:col-span-2">
@@ -1422,32 +1401,21 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange }) {
               </p>
             </div>
             <div className="md:col-span-2">
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-                Default Groups (comma-separated)
-              </label>
-              <input
-                type="text"
+              <GroupMultiSelect
+                id="ntlm-default-groups"
+                label={t('admin.auth.groups.defaultLabel', 'Default Groups')}
+                allowCustom={false}
+                availableGroups={availableGroups}
                 value={
-                  Array.isArray(config.ntlmAuth?.defaultGroups)
-                    ? config.ntlmAuth.defaultGroups.join(', ')
-                    : ''
+                  Array.isArray(config.ntlmAuth?.defaultGroups) ? config.ntlmAuth.defaultGroups : []
                 }
-                onChange={e =>
-                  updateNestedConfig(
-                    'ntlmAuth',
-                    'defaultGroups',
-                    e.target.value
-                      .split(',')
-                      .map(g => g.trim())
-                      .filter(g => g)
-                  )
-                }
-                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                placeholder="ntlm-users, domain-users"
+                onChange={next => updateNestedConfig('ntlmAuth', 'defaultGroups', next)}
+                placeholder={t('admin.auth.groups.searchPlaceholder', 'Search groups…')}
+                helpText={t(
+                  'admin.auth.groups.ntlmHelp',
+                  'Internal groups automatically assigned to NTLM authenticated users'
+                )}
               />
-              <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                Groups automatically assigned to NTLM authenticated users
-              </p>
             </div>
             <div>
               <label className="flex items-center">

--- a/client/src/features/admin/pages/AdminAuthPage.jsx
+++ b/client/src/features/admin/pages/AdminAuthPage.jsx
@@ -15,6 +15,7 @@ function AdminAuthPage() {
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
   const [jsonSchema, setJsonSchema] = useState(null);
+  const [availableGroups, setAvailableGroups] = useState([]);
   const [config, setConfig] = useState({
     auth: {
       mode: 'proxy',
@@ -85,6 +86,7 @@ function AdminAuthPage() {
   useEffect(() => {
     loadConfiguration();
     loadSchema();
+    loadGroups();
   }, []);
 
   const loadSchema = async () => {
@@ -93,6 +95,16 @@ function AdminAuthPage() {
       setJsonSchema(schema);
     } catch (error) {
       console.error('Failed to load platform schema:', error);
+    }
+  };
+
+  const loadGroups = async () => {
+    try {
+      const response = await makeAdminApiCall('/admin/groups');
+      const groups = response.data?.groups || {};
+      setAvailableGroups(Object.values(groups));
+    } catch (error) {
+      console.error('Failed to load groups:', error);
     }
   };
 
@@ -231,6 +243,7 @@ function AdminAuthPage() {
           value={config}
           onChange={handleDataChange}
           formComponent={PlatformFormEditor}
+          formProps={{ availableGroups }}
           jsonSchema={jsonSchema}
           title={t('admin.auth.configuration', 'Authentication Configuration')}
         />

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,5 +1,17 @@
 # Features — 5.5.0
 
+## Authentication Admin Now Uses Searchable Group Pickers
+
+The default-group fields in Authentication settings are now searchable group selectors instead of
+free-text inputs, so admins pick from real, defined groups and can no longer introduce typos that
+silently grant no permissions.
+
+- Applies to all default-group fields: the authenticated-users group, anonymous-access groups, and
+  the default groups for each OIDC, LDAP, and NTLM provider.
+- Each field shows the defined groups with their names and descriptions and filters as you type.
+- Any group value that no longer matches a defined group is still shown but visibly flagged, so
+  existing configurations remain visible and can be corrected rather than being dropped.
+
 ## Agent Profile Editor No Longer Corrupts Shared State on Save
 
 Fixed a bug in the Agent Profile admin editor where saving could corrupt data shared across the

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -906,6 +906,18 @@
       "builtInSystem": "Integriertes Benutzername/Passwort-System",
       "anonymousAccess": "Anonymer Zugriff",
       "defaultGroups": "Standardgruppen",
+      "groups": {
+        "authenticatedLabel": "Authentifizierte Gruppe",
+        "authenticatedHelp": "Interne Gruppe, die automatisch allen authentifizierten Benutzern zugewiesen wird",
+        "anonymousLabel": "Anonyme Gruppen",
+        "anonymousHelp": "Interne Gruppen, die Benutzern ohne Authentifizierung zugewiesen werden",
+        "defaultLabel": "Standardgruppen",
+        "oidcHelp": "Interne Gruppen, die Benutzern bei der Authentifizierung über diesen Anbieter automatisch zugewiesen werden",
+        "ldapHelp": "Interne Gruppen, die LDAP-Benutzern automatisch zugewiesen werden",
+        "ntlmHelp": "Interne Gruppen, die über NTLM authentifizierten Benutzern automatisch zugewiesen werden",
+        "searchPlaceholder": "Gruppen suchen…",
+        "emptySingle": "Noch keine Gruppe ausgewählt"
+      },
       "jwtProviders": "JWT-Anbieter",
       "noOidcProviders": "Keine OIDC-Anbieter konfiguriert",
       "addProvider": "Fügen Sie einen Anbieter hinzu, um OIDC-Authentifizierung zu aktivieren",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -654,6 +654,18 @@
       "builtInSystem": "Built-in username/password system",
       "anonymousAccess": "Anonymous Access",
       "defaultGroups": "Default Groups",
+      "groups": {
+        "authenticatedLabel": "Authenticated Group",
+        "authenticatedHelp": "Internal group automatically assigned to all authenticated users",
+        "anonymousLabel": "Anonymous Groups",
+        "anonymousHelp": "Internal groups assigned to users who access without authentication",
+        "defaultLabel": "Default Groups",
+        "oidcHelp": "Internal groups automatically assigned to users authenticating with this provider",
+        "ldapHelp": "Internal groups automatically assigned to LDAP users",
+        "ntlmHelp": "Internal groups automatically assigned to NTLM authenticated users",
+        "searchPlaceholder": "Search groups…",
+        "emptySingle": "No group selected yet"
+      },
       "jwtProviders": "JWT Providers",
       "noOidcProviders": "No OIDC providers configured",
       "addProvider": "Add a provider to enable OIDC authentication",


### PR DESCRIPTION
## Summary

Closes #2067.

Replaces the free-text default-group inputs in the **Authentication** admin with the existing searchable `GroupMultiSelect` component, so admins pick from valid, defined groups instead of typing raw ids that can silently grant no permissions.

## What changed

- **`AdminAuthPage.jsx`** — fetches groups from `GET /admin/groups` and passes them to the form via `DualModeEditor`'s `formProps` (mirrors the existing pattern in `AdminUserEditPage`).
- **`PlatformFormEditor.jsx`** — wires `GroupMultiSelect` into all five default-group fields:
  | Field | Shape | Mode |
  |---|---|---|
  | `auth.authenticatedGroup` | single string | single-select |
  | `anonymousAuth.defaultGroups` | `string[]` | multi-select |
  | OIDC provider `defaultGroups` | `string[]` | multi-select |
  | LDAP provider `defaultGroups` | `string[]` | multi-select |
  | `ntlmAuth.defaultGroups` | `string[]` | multi-select |
- **`GroupMultiSelect.jsx`** — gains an optional `multiple` prop (default `true`); when `false`, a new selection replaces the current one, supporting the single-string `authenticatedGroup` field without a breaking config change.
- **i18n** (`en.json`, `de.json`) — new localized labels and help text under `admin.auth.groups`.
- **Changelog** — entry added to `docs/releases/5.5.0/features.md`.

## Design decisions

- `allowCustom={false}` on all five fields: these hold **internal** group ids assigned to users (external group *names* are matched via a group's `mappings`, configured on the Groups side). Restricting to defined groups matches the issue intent.
- `warnOnCustom` (default `true`) is kept so any pre-existing value that no longer matches a defined group still renders — visibly flagged — rather than being silently dropped. Backward compatible.
- Non-group fields (OIDC `scope`/`groupsAttribute`, proxy `groupsHeader`) are left untouched.
- Raw-JSON mode remains available via `DualModeEditor` for power users.

## Verification

Ran the app end-to-end (dev server + Playwright, logged in as local admin):

- All five selectors render as searchable comboboxes; the authenticated-group field is single-select.
- The dropdown lists defined groups with names + descriptions and filters as you type (e.g. "admin" → Admins, Content Admins).
- Existing config values resolve to their display names (`authenticated` → "Authenticated", `anonymous` → "Anonymous").
- A pre-existing invalid value (`nonexistent-group`) on an OIDC provider still renders, flagged, alongside the valid `users` chip — confirming graceful handling of stale ids.
- `npm run lint` (errors only) and `prettier --check` pass on all changed files; client build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fobrh1cmFBPyM3sG5c1cMY)_