### PR TITLE
fix(auth): repair and consolidate authentication debug logging

### DIFF
--- a/client/src/features/admin/components/PlatformFormEditor.jsx
+++ b/client/src/features/admin/components/PlatformFormEditor.jsx
@@ -275,32 +275,6 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange, avail
     });
   };
 
-  const updateAuthDebugConfig = (field, value) => {
-    onChange({
-      ...config,
-      authDebug: {
-        ...config.authDebug,
-        [field]: value
-      }
-    });
-  };
-
-  const updateAuthDebugProvider = (provider, field, value) => {
-    onChange({
-      ...config,
-      authDebug: {
-        ...config.authDebug,
-        providers: {
-          ...config.authDebug?.providers,
-          [provider]: {
-            ...config.authDebug?.providers?.[provider],
-            [field]: value
-          }
-        }
-      }
-    });
-  };
-
   if (!config) {
     return (
       <div className="p-8 text-center text-gray-500">
@@ -1532,129 +1506,24 @@ function PlatformFormEditor({ value: config, onChange, onValidationChange, avail
         </div>
       )}
 
-      {/* Authentication Debug Settings */}
-      <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <div className="mb-4">
-          <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Debug Settings</h3>
-          <p className="text-sm text-gray-600 mt-1">
-            Enable detailed logging for authentication providers to troubleshoot issues.
-            <span className="text-amber-600 font-medium ml-1">
-              Warning: This may log sensitive information.
-            </span>
-          </p>
-        </div>
-
-        <div className="space-y-4">
-          <div className="flex items-start space-x-3">
-            <div className="flex items-center h-5">
-              <input
-                type="checkbox"
-                checked={config.authDebug?.enabled || false}
-                onChange={e => updateAuthDebugConfig('enabled', e.target.checked)}
-                className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-              />
-            </div>
-            <div className="flex-1">
-              <label className="text-sm font-medium text-gray-900">
-                Enable Authentication Debug Logging
-              </label>
-              <p className="text-xs text-gray-500 dark:text-gray-400">
-                Log authentication events, token exchanges, and user information for troubleshooting
-              </p>
-            </div>
+      {/* Authentication Debug Settings — consolidated onto the Logging page */}
+      <div className="bg-blue-50 dark:bg-blue-900/20 rounded-lg border border-blue-200 dark:border-blue-800 p-4">
+        <div className="flex items-start">
+          <Icon
+            name="information-circle"
+            className="h-5 w-5 mr-2 text-blue-600 dark:text-blue-400 flex-shrink-0 mt-0.5"
+          />
+          <div className="text-sm text-blue-800 dark:text-blue-300">
+            <p className="font-medium">
+              {t('admin.auth.debugMovedTitle', 'Authentication debug logging moved')}
+            </p>
+            <p className="mt-1 text-xs">
+              {t(
+                'admin.auth.debugMovedHelp',
+                'All authentication debug settings (OIDC/LDAP/NTLM tracing, token masking, raw data) now live in one place: Platform → Logging → Authentication Debug Logging.'
+              )}
+            </p>
           </div>
-
-          {config.authDebug?.enabled && (
-            <div className="ml-6 space-y-4 pl-4 border-l-2 border-gray-200">
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label className="flex items-center">
-                    <input
-                      type="checkbox"
-                      checked={config.authDebug?.maskTokens !== false}
-                      onChange={e => updateAuthDebugConfig('maskTokens', e.target.checked)}
-                      className="mr-2 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                    />
-                    <span className="text-sm font-medium text-gray-700">Mask Tokens</span>
-                  </label>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-6">
-                    Hide sensitive parts of access tokens and secrets
-                  </p>
-                </div>
-
-                <div>
-                  <label className="flex items-center">
-                    <input
-                      type="checkbox"
-                      checked={config.authDebug?.redactPasswords !== false}
-                      onChange={e => updateAuthDebugConfig('redactPasswords', e.target.checked)}
-                      className="mr-2 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                    />
-                    <span className="text-sm font-medium text-gray-700">Redact Passwords</span>
-                  </label>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-6">
-                    Remove passwords and credentials from logs
-                  </p>
-                </div>
-
-                <div>
-                  <label className="flex items-center">
-                    <input
-                      type="checkbox"
-                      checked={config.authDebug?.consoleLogging || false}
-                      onChange={e => updateAuthDebugConfig('consoleLogging', e.target.checked)}
-                      className="mr-2 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                    />
-                    <span className="text-sm font-medium text-gray-700">Console Logging</span>
-                  </label>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-6">
-                    Also output debug logs to console
-                  </p>
-                </div>
-
-                <div>
-                  <label className="flex items-center">
-                    <input
-                      type="checkbox"
-                      checked={config.authDebug?.includeRawData || false}
-                      onChange={e => updateAuthDebugConfig('includeRawData', e.target.checked)}
-                      className="mr-2 h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                    />
-                    <span className="text-sm font-medium text-gray-700">Include Raw Data</span>
-                  </label>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1 ml-6">
-                    Include unsanitized raw data (security risk)
-                  </p>
-                </div>
-              </div>
-
-              {/* Provider-specific settings */}
-              <div className="pt-4 border-t border-gray-200">
-                <h4 className="text-sm font-medium text-gray-900 mb-3">Provider Settings</h4>
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
-                  {['oidc', 'local', 'proxy', 'ldap', 'ntlm'].map(provider => (
-                    <div key={provider} className="flex items-center space-x-2">
-                      <input
-                        type="checkbox"
-                        id={`debug-${provider}`}
-                        checked={config.authDebug?.providers?.[provider]?.enabled !== false}
-                        onChange={e =>
-                          updateAuthDebugProvider(provider, 'enabled', e.target.checked)
-                        }
-                        className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-                      />
-                      <label htmlFor={`debug-${provider}`} className="text-sm text-gray-700">
-                        {provider.toUpperCase()}
-                      </label>
-                    </div>
-                  ))}
-                </div>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-2">
-                  Enable debug logging per authentication provider
-                </p>
-              </div>
-            </div>
-          )}
         </div>
       </div>
 

--- a/client/src/features/admin/pages/AdminAuthPage.jsx
+++ b/client/src/features/admin/pages/AdminAuthPage.jsx
@@ -56,31 +56,9 @@ function AdminAuthPage() {
       defaultGroups: [],
       sessionTimeoutMinutes: 480,
       generateJwtToken: true
-    },
-    authDebug: {
-      enabled: false,
-      maskTokens: true,
-      redactPasswords: true,
-      consoleLogging: false,
-      includeRawData: false,
-      providers: {
-        oidc: {
-          enabled: true
-        },
-        local: {
-          enabled: true
-        },
-        proxy: {
-          enabled: true
-        },
-        ldap: {
-          enabled: true
-        },
-        ntlm: {
-          enabled: true
-        }
-      }
     }
+    // Authentication debug logging is configured on the Logging page
+    // (Platform → Logging) under the canonical `auth.debug` key.
   });
 
   useEffect(() => {

--- a/client/src/features/admin/pages/AdminLoggingPage.jsx
+++ b/client/src/features/admin/pages/AdminLoggingPage.jsx
@@ -40,7 +40,6 @@ function AdminLoggingPage() {
     enabled: false,
     maskTokens: true,
     redactPasswords: true,
-    consoleLogging: false,
     includeRawData: false,
     providers: {
       oidc: { enabled: true },
@@ -238,12 +237,14 @@ function AdminLoggingPage() {
         }
       });
 
-      // Load platform config for authDebug
+      // Load platform config for auth debug settings. The canonical location is
+      // `auth.debug` (what the server reads); merge over defaults so any fields
+      // an older config omits keep sensible values.
       const platformResponse = await makeAdminApiCall('/admin/configs/platform', {
         method: 'GET'
       });
-      if (platformResponse.data?.authDebug) {
-        setAuthDebugConfig(platformResponse.data.authDebug);
+      if (platformResponse.data?.auth?.debug) {
+        setAuthDebugConfig(prev => ({ ...prev, ...platformResponse.data.auth.debug }));
       }
 
       // Load audit-log settings (anonymizeIp lives under `audit.*`, the
@@ -303,8 +304,10 @@ function AdminLoggingPage() {
       });
       const platformConfig = platformResponse.data;
 
-      // Update authDebug section
-      platformConfig.authDebug = authDebugConfig;
+      // Persist under the canonical `auth.debug` key that the server reads.
+      // The platform save route merges the whole `auth` object, so keep the
+      // rest of the auth config intact.
+      platformConfig.auth = { ...platformConfig.auth, debug: authDebugConfig };
 
       // Save back
       await makeAdminApiCall('/admin/configs/platform', {
@@ -811,10 +814,16 @@ function AdminLoggingPage() {
 
         {/* Authentication Debug Logging */}
         <div className="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-4 flex items-center">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2 flex items-center">
             <Icon name="ShieldCheckIcon" className="w-5 h-5 mr-2 text-blue-500" />
             {t('admin.logging.authDebugSection', 'Authentication Debug Logging')}
           </h2>
+          <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            {t(
+              'admin.logging.authDebugDescription',
+              'The single place to trace authentication flows — OIDC redirects, token exchange, group mapping, NTLM handshakes. Traces are written at the "info" level, so they appear at the default log level without any further changes and take effect immediately (no restart needed).'
+            )}
+          </p>
 
           <div className="space-y-4">
             <label className="flex items-center">
@@ -862,39 +871,30 @@ function AdminLoggingPage() {
                   </span>
                 </label>
 
-                <label className="flex items-center">
-                  <input
-                    type="checkbox"
-                    checked={authDebugConfig.consoleLogging || false}
-                    onChange={e =>
-                      setAuthDebugConfig(prev => ({
-                        ...prev,
-                        consoleLogging: e.target.checked
-                      }))
-                    }
-                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  <span className="ml-2 text-sm text-gray-700 dark:text-gray-300">
-                    {t('admin.logging.consoleLogging', 'Enable console logging')}
-                  </span>
-                </label>
-
-                <label className="flex items-center">
-                  <input
-                    type="checkbox"
-                    checked={authDebugConfig.includeRawData || false}
-                    onChange={e =>
-                      setAuthDebugConfig(prev => ({
-                        ...prev,
-                        includeRawData: e.target.checked
-                      }))
-                    }
-                    className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                  />
-                  <span className="ml-2 text-sm text-gray-700 dark:text-gray-300">
-                    {t('admin.logging.includeRawData', 'Include raw authentication data')}
-                  </span>
-                </label>
+                <div>
+                  <label className="flex items-center">
+                    <input
+                      type="checkbox"
+                      checked={authDebugConfig.includeRawData || false}
+                      onChange={e =>
+                        setAuthDebugConfig(prev => ({
+                          ...prev,
+                          includeRawData: e.target.checked
+                        }))
+                      }
+                      className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                    />
+                    <span className="ml-2 text-sm text-gray-700 dark:text-gray-300">
+                      {t('admin.logging.includeRawData', 'Include raw authentication data')}
+                    </span>
+                  </label>
+                  <p className="text-xs text-amber-600 dark:text-amber-400 mt-1 ml-6">
+                    {t(
+                      'admin.logging.includeRawDataWarning',
+                      'Security risk: logs the full user-info payload and access tokens. Leave off unless actively debugging; disable again afterwards.'
+                    )}
+                  </p>
+                </div>
 
                 {/* Provider-specific debug settings */}
                 <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
@@ -1005,7 +1005,7 @@ function AdminLoggingPage() {
                 <li>
                   {t(
                     'admin.logging.note5',
-                    'Authentication debug logging is separate and requires restart'
+                    'Authentication debug logging applies immediately (no restart) and its traces are emitted at the "info" level, so they show at the default log level'
                   )}
                 </li>
               </ul>

--- a/concepts/2026-07-15 Auth Debug Logging Fix.md
+++ b/concepts/2026-07-15 Auth Debug Logging Fix.md
@@ -1,0 +1,74 @@
+# Authentication Debug Logging Fix
+
+**Date:** 2026-07-15
+**Issue:** [#2068](https://github.com/intrafind/ihub-apps/issues/2068) — Debug Logging for Authentication broken
+
+## Problem
+
+Admins could not reliably enable authentication debug logging to diagnose OIDC
+redirect issues, token exchange, and group mapping. The controls were spread
+across multiple admin pages, and the main toggle silently did nothing.
+
+## Root cause
+
+1. **Config key mismatch (the "broken").** The admin UI and shipped examples
+   wrote a **top-level `authDebug`** block, but the server only ever read
+   **`auth.debug`** (`authDebugService`, `platformConfigSchema`). Worse, the
+   `POST /api/admin/configs/platform` merge only whitelists specific top-level
+   keys and `authDebug` was not among them, so the value was never even
+   persisted by that route.
+2. **Two gates in two places.** Even with `auth.debug.enabled = true`, most
+   OIDC events were logged at Winston level `debug`, which the default
+   `logging.level: info` suppresses. Admins had to *also* lower the global log
+   level in a different UI section.
+3. **Dead flags.** `includeRawData` was never consulted (the raw access token
+   log fired unconditionally), and `consoleLogging` was not in the schema and
+   read nowhere.
+4. **Component filter could hide auth logs.** `logging.components` filtering,
+   when enabled without the auth components in the list, silently dropped auth
+   logs. `components` was also missing from the logging schema.
+5. **Fragmentation.** Auth-debug controls appeared on both the Logging page and
+   the Authentication page, `ntlmAuth.debug` was a third standalone switch, and
+   the UI wrongly claimed a restart was required.
+
+## Fix
+
+- **Standardize on `auth.debug`** (the key the code/schema already use). The UI
+  now reads/writes `auth.debug`; the platform-save merge persists it because the
+  whole `auth` object is whitelisted.
+- **Single toggle is sufficient.** `authDebugService.log()` now emits
+  informational traces at `info` (errors/warnings keep their severity), so they
+  appear at the default log level with no second switch. Applies immediately —
+  the platform-config cache is refreshed on save.
+- **`includeRawData` now works.** Raw access-token and full user-info logs are
+  gated behind it (default off), and `sanitizeData` only bypasses masking when
+  it is explicitly on. The core logger still redacts known-sensitive keys as a
+  defense-in-depth safety net.
+- **`consoleLogging` removed** from the UI, examples, and defaults (Winston owns
+  the console transport).
+- **Component filter never hides auth logs** while `auth.debug.enabled` is true;
+  `components` added to the logging schema.
+- **NTLM unified.** `ntlmAuth.debug` still works, and NTLM tracing now also
+  responds to the central `auth.debug` toggle (`providers.ntlm`).
+- **UI consolidated** onto the Logging page; the Authentication page now points
+  there. The misleading "requires restart" note is corrected.
+- **Migration `V079`** moves any existing top-level `authDebug` → `auth.debug`
+  and drops the dead `consoleLogging` flag, preserving admin settings.
+
+## Security posture (defaults)
+
+- `maskTokens: true`, `redactPasswords: true`, `includeRawData: false`.
+- Enabling `includeRawData` is a deliberate, documented risk and should be
+  turned off again after debugging.
+
+## Files touched
+
+- `server/utils/authDebugService.js` — emit level, `includeRawData`, `isRawDataEnabled`
+- `server/utils/logger.js` — auth components bypass component filter when debug on
+- `server/middleware/oidcAuth.js` — gate raw token / user-info logs
+- `server/middleware/ntlmAuth.js` — honor central `auth.debug` toggle
+- `server/validators/platformConfigSchema.js` — add `logging.components`
+- `server/migrations/V079__migrate_auth_debug_key.js` — key migration
+- `server/defaults/config/platform.json`, `examples/config/platform.json`
+- `client/.../AdminLoggingPage.jsx`, `PlatformFormEditor.jsx`, `AdminAuthPage.jsx`
+- `docs/platform.md`

--- a/docs/platform.md
+++ b/docs/platform.md
@@ -685,34 +685,53 @@ Windows NTLM/Kerberos authentication for domain-joined environments.
 
 For detailed setup instructions see [LDAP/NTLM Authentication](ldap-ntlm-authentication.md).
 
-### **authDebug**
-Authentication debugging and logging configuration.
+### **auth.debug**
+Authentication debug logging configuration. This lives under the `auth` block
+(`auth.debug`) and is edited from the admin UI at **Platform → Logging →
+Authentication Debug Logging** — the single place for all auth tracing.
 
 ```json
 {
-  "authDebug": {
-    "enabled": false,
-    "maskTokens": true,
-    "redactPasswords": true,
-    "consoleLogging": false,
-    "includeRawData": false,
-    "providers": {
-      "oidc": { "enabled": true },
-      "local": { "enabled": true },
-      "proxy": { "enabled": true },
-      "ldap": { "enabled": true },
-      "ntlm": { "enabled": true }
+  "auth": {
+    "debug": {
+      "enabled": false,
+      "maskTokens": true,
+      "redactPasswords": true,
+      "includeRawData": false,
+      "providers": {
+        "oidc": { "enabled": true },
+        "local": { "enabled": true },
+        "proxy": { "enabled": true },
+        "ldap": { "enabled": true },
+        "ntlm": { "enabled": true }
+      }
     }
   }
 }
 ```
 
-- **enabled** (boolean) – Enable authentication debugging. Default: `false`
+- **enabled** (boolean) – Enable authentication debug logging. Default: `false`.
+  Traces are emitted at the `info` level, so they appear at the default
+  `logging.level` without any further change, and the toggle applies immediately
+  (no server restart required).
 - **maskTokens** (boolean) – Mask sensitive tokens in logs. Default: `true`
 - **redactPasswords** (boolean) – Redact passwords from logs. Default: `true`
-- **consoleLogging** (boolean) – Enable console logging. Default: `false`
-- **includeRawData** (boolean) – Include raw authentication data. Default: `false`
-- **providers** (object) – Per-provider debugging settings
+- **includeRawData** (boolean) – Log the full, unsanitized user-info payload and
+  raw access token for the OIDC flow. **Security risk** — leave `false` (default)
+  and only enable while actively debugging. The core logger still redacts
+  well-known sensitive keys as a safety net.
+- **providers** (object) – Per-provider toggles (`oidc`, `local`, `proxy`,
+  `ldap`, `ntlm`). Each defaults to enabled when global debug is on.
+
+> **Migration note:** earlier releases wrote a top-level `authDebug` key that the
+> server never read, so the toggle silently did nothing. The value is moved to
+> `auth.debug` automatically on upgrade (migration `V079`), and the dead
+> `consoleLogging` flag is dropped (Winston owns the console transport).
+
+> **NTLM:** the standalone `ntlmAuth.debug` flag still works, and NTLM tracing is
+> now also driven by `auth.debug` (`providers.ntlm`), so a single toggle covers
+> it. When component filtering (`logging.components`) is active, authentication
+> components are never filtered out while `auth.debug.enabled` is `true`.
 
 ## Environment Variables
 

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -538,3 +538,20 @@ need tenant-specific wording, a support contact, or a different tone.
   installations get the current wording seeded automatically so there's nothing to fill in unless
   you want to change it.
 - No admin action is required on upgrade; a migration adds the editable defaults for you.
+
+## Authentication Debug Logging — Fixed and Consolidated
+
+Enabling authentication debug logging now actually works, and all of its controls live in one
+place. Admins can trace OIDC redirects, token exchange, group mapping, and NTLM handshakes to
+diagnose sign-in problems.
+
+- Configure it under **Admin → Platform → Logging → Authentication Debug Logging**. The
+  Authentication page now points here instead of offering a second, disconnected copy.
+- Turning it on is sufficient on its own — traces are written at the `info` level, so they appear
+  at the default log level without also lowering the global log level, and the change applies
+  immediately (no server restart).
+- The **Include raw authentication data** option (off by default) is clearly marked as a security
+  risk; leave it off unless you are actively debugging, and turn it off again afterward.
+- The obsolete "Console logging" toggle was removed (the logger already manages console output).
+- No admin action is required on upgrade: a migration moves any previously saved setting to its new
+  location so your configuration is preserved.

--- a/examples/config/platform.json
+++ b/examples/config/platform.json
@@ -80,14 +80,13 @@
     "mode": "oidc",
     "authenticatedGroup": "authenticated",
     "sessionTimeoutMinutes": 480,
-    "jwtSecret": "${JWT_SECRET}"
-  },
-  "authDebug": {
-    "enabled": true,
-    "consoleLogging": true,
-    "includeRawData": true,
-    "maskTokens": false,
-    "redactPasswords": false
+    "jwtSecret": "${JWT_SECRET}",
+    "debug": {
+      "enabled": true,
+      "includeRawData": true,
+      "maskTokens": false,
+      "redactPasswords": false
+    }
   },
   "anonymousAuth": {
     "enabled": true,

--- a/server/defaults/config/platform.json
+++ b/server/defaults/config/platform.json
@@ -99,7 +99,20 @@
   "auth": {
     "mode": "local",
     "authenticatedGroup": "authenticated",
-    "sessionTimeoutMinutes": 480
+    "sessionTimeoutMinutes": 480,
+    "debug": {
+      "enabled": false,
+      "maskTokens": true,
+      "redactPasswords": true,
+      "includeRawData": false,
+      "providers": {
+        "oidc": { "enabled": true },
+        "local": { "enabled": true },
+        "proxy": { "enabled": true },
+        "ldap": { "enabled": true },
+        "ntlm": { "enabled": true }
+      }
+    }
   },
   "oauth": {
     "enabled": {

--- a/server/middleware/ntlmAuth.js
+++ b/server/middleware/ntlmAuth.js
@@ -6,6 +6,7 @@ import { generateJwt } from '../utils/tokenService.js';
 import { validateAndPersistExternalUser } from '../utils/userManager.js';
 import { getLdapProviderByName, lookupLdapGroupsForUser } from './ldapAuth.js';
 import logger from '../utils/logger.js';
+import authDebugService from '../utils/authDebugService.js';
 import { getAuthCookieOptions } from '../utils/cookieSettings.js';
 
 /**
@@ -31,11 +32,16 @@ function createNtlmMiddleware(ntlmConfig = {}) {
     credentialService.tryResolveSecret(ntlmConfig.domainControllerPasswordRef) ||
     process.env.NTLM_LDAP_PASSWORD;
 
+  // NTLM tracing is driven either by the provider-local `ntlmAuth.debug` flag or
+  // by the central authentication-debug toggle (auth.debug), so admins can turn
+  // it on from the single Logging page without a second, NTLM-only switch.
+  const ntlmDebug = ntlmConfig.debug === true || authDebugService.isDebugEnabled('ntlm');
+
   // express-ntlm calls this for every internal step (negotiate, bind, parse).
-  // When ntlmConfig.debug is true, forward each line to our logger so admins can
+  // When NTLM debug is on, forward each line to our logger so admins can
   // see exactly where the handshake is failing — particularly important for
   // diagnosing 403 responses from the AD SASL bind step.
-  const debugFn = ntlmConfig.debug
+  const debugFn = ntlmDebug
     ? (...args) => {
         // First arg is the prefix ("[express-ntlm]"); strip it so we don't double-tag.
         const [, ...rest] = args;
@@ -166,7 +172,7 @@ function createNtlmMiddleware(ntlmConfig = {}) {
     getGroups: options.getGroups,
     ldapBindUserConfigured: !!options.domaincontrolleruser,
     ldapBindPasswordConfigured: !!options.domaincontrollerpassword,
-    debugMode: !!ntlmConfig.debug,
+    debugMode: ntlmDebug,
     challengeScheme: ntlmConfig.type === 'negotiate' ? 'Negotiate' : 'NTLM',
     tlsOptions: tlsOptionsSummary
   });
@@ -200,8 +206,14 @@ function createNtlmMiddleware(ntlmConfig = {}) {
  * @returns {Function} Express middleware instance
  */
 function getNtlmMiddleware(ntlmConfig) {
-  // Check if config changed, if so, recreate middleware
-  const configHash = JSON.stringify(ntlmConfig);
+  // Check if config changed, if so, recreate middleware. The central auth-debug
+  // toggle also feeds NTLM tracing, so fold it into the hash — otherwise
+  // flipping auth.debug wouldn't take effect until the NTLM config itself
+  // changed or the server restarted.
+  const configHash = JSON.stringify({
+    ...ntlmConfig,
+    __authDebug: authDebugService.isDebugEnabled('ntlm')
+  });
   if (!ntlmMiddlewareInstance || ntlmMiddlewareConfig !== configHash) {
     ntlmMiddlewareInstance = createNtlmMiddleware(ntlmConfig);
     ntlmMiddlewareConfig = configHash;

--- a/server/middleware/oidcAuth.js
+++ b/server/middleware/oidcAuth.js
@@ -79,17 +79,22 @@ export function configureOidcProviders() {
           const sessionId = authDebugService.generateSessionId();
 
           try {
-            //log access token itself if includeRawdata is enabled
-            authDebugService.log(
-              'oidc',
-              'debug',
-              'raw_access_token',
-              {
-                provider: provider.name,
-                accessToken
-              },
-              sessionId
-            );
+            // Log the access token itself only when the admin explicitly
+            // opted into raw data (default off). sanitizeData leaves it
+            // unmasked in that mode; the core logger still redacts the
+            // token-named key as a safety net.
+            if (authDebugService.isRawDataEnabled('oidc')) {
+              authDebugService.log(
+                'oidc',
+                'debug',
+                'raw_access_token',
+                {
+                  provider: provider.name,
+                  accessToken
+                },
+                sessionId
+              );
+            }
 
             authDebugService.log(
               'oidc',
@@ -174,17 +179,19 @@ export function configureOidcProviders() {
               );
             }
 
-            // Log user info if includeRawData is enabled
-            authDebugService.log(
-              'oidc',
-              'debug',
-              'raw_user_info',
-              {
-                provider: provider.name,
-                userInfo: JSON.stringify(userInfo, null, 2)
-              },
-              sessionId
-            );
+            // Log the full user-info payload only when raw data is enabled.
+            if (authDebugService.isRawDataEnabled('oidc')) {
+              authDebugService.log(
+                'oidc',
+                'debug',
+                'raw_user_info',
+                {
+                  provider: provider.name,
+                  userInfo: JSON.stringify(userInfo, null, 2)
+                },
+                sessionId
+              );
+            }
 
             // Normalize user data from OIDC provider
             const oidcUser = normalizeOidcUser(userInfo, provider, sessionId);

--- a/server/migrations/V079__migrate_auth_debug_key.js
+++ b/server/migrations/V079__migrate_auth_debug_key.js
@@ -1,0 +1,68 @@
+/**
+ * Migration V079 — Consolidate the authentication-debug config key
+ *
+ * Authentication debug logging was broken by a config key mismatch: the admin
+ * UI and the shipped examples wrote a top-level `authDebug` block, while the
+ * server (authDebugService, platformConfigSchema) only ever read `auth.debug`.
+ * As a result the toggle silently did nothing.
+ *
+ * This migration moves any existing top-level `authDebug` into `auth.debug` so
+ * installs that had configured it keep their setting, and drops the dead
+ * `consoleLogging` flag (it was never wired to anything — Winston owns the
+ * console transport).
+ *
+ * The admin's intent lived in the top-level `authDebug` key (that is what the
+ * old UI persisted), so its values win over any stale `auth.debug` values.
+ * Installs that never touched auth debug have no `authDebug` key and this
+ * migration is a no-op for them.
+ */
+export const version = '079';
+export const description = 'migrate_auth_debug_key';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  const legacy = platform.authDebug;
+  if (!legacy || typeof legacy !== 'object' || Array.isArray(legacy)) {
+    // Nothing to migrate. Still strip a stray dead flag if it slipped into the
+    // canonical location somehow.
+    if (platform.auth?.debug && 'consoleLogging' in platform.auth.debug) {
+      delete platform.auth.debug.consoleLogging;
+      await ctx.writeJson('config/platform.json', platform);
+      ctx.log('Removed dead consoleLogging flag from auth.debug');
+      return;
+    }
+    ctx.log('No top-level authDebug key found; nothing to migrate');
+    return;
+  }
+
+  // The dead flag never controlled anything — do not carry it forward.
+  delete legacy.consoleLogging;
+
+  platform.auth = platform.auth || {};
+  const existing =
+    platform.auth.debug &&
+    typeof platform.auth.debug === 'object' &&
+    !Array.isArray(platform.auth.debug)
+      ? platform.auth.debug
+      : {};
+
+  // Merge providers shallowly with the same "legacy wins" precedence.
+  const mergedProviders = { ...(existing.providers || {}), ...(legacy.providers || {}) };
+
+  platform.auth.debug = {
+    ...existing,
+    ...legacy,
+    ...(Object.keys(mergedProviders).length > 0 ? { providers: mergedProviders } : {})
+  };
+  delete platform.auth.debug.consoleLogging;
+
+  delete platform.authDebug;
+
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Migrated top-level authDebug → auth.debug and dropped dead consoleLogging flag');
+}

--- a/server/utils/authDebugService.js
+++ b/server/utils/authDebugService.js
@@ -44,7 +44,24 @@ class AuthDebugService {
   }
 
   /**
-   * Log authentication event
+   * Whether unsanitized raw payloads (raw tokens, full user-info claims) may be
+   * logged. Guarded by both the debug toggle and the explicit, security-gated
+   * `includeRawData` flag (default false).
+   */
+  isRawDataEnabled(provider = null) {
+    if (!this.isDebugEnabled(provider)) return false;
+    return this.getDebugConfig(provider).includeRawData === true;
+  }
+
+  /**
+   * Log authentication event.
+   *
+   * Auth debug is an explicit, self-contained opt-in — when it is enabled the
+   * admin wants to see these traces. Winston's global `logging.level` (default
+   * `info`) would otherwise swallow anything emitted at `debug`, forcing admins
+   * to flip a second, separate switch. To make the single toggle sufficient we
+   * emit informational traces at `info`; genuine warnings/errors keep their
+   * severity so they still surface in production logs.
    */
   log(provider, level, event, data = {}, sessionId = null) {
     if (!this.isDebugEnabled(provider)) return;
@@ -53,28 +70,17 @@ class AuthDebugService {
     const sanitizedData = this.sanitizeData(data, config);
 
     const logEntry = {
+      authDebug: true,
       provider,
       event,
       sessionId,
       ...sanitizedData
     };
 
-    // Log via Winston based on level
-    switch (level) {
-      case 'error':
-        logger.error(event, { component: 'AuthService', ...logEntry });
-        break;
-      case 'warn':
-        logger.warn(event, { component: 'AuthService', ...logEntry });
-        break;
-      case 'info':
-        logger.info(event, { component: 'AuthService', ...logEntry });
-        break;
-      case 'debug':
-      default:
-        logger.debug(event, { component: 'AuthService', ...logEntry });
-        break;
-    }
+    // Map non-error/warn levels up to `info` so they clear the default global
+    // log level without the admin also having to lower `logging.level`.
+    const effectiveLevel = level === 'error' ? 'error' : level === 'warn' ? 'warn' : 'info';
+    logger[effectiveLevel](event, { component: 'AuthService', ...logEntry });
   }
 
   /**
@@ -82,6 +88,12 @@ class AuthDebugService {
    */
   sanitizeData(data, config = {}) {
     if (!data || typeof data !== 'object') return data;
+
+    // When the admin has explicitly opted into raw data, bypass service-level
+    // masking so the actual claims/tokens are visible for troubleshooting. The
+    // core logger (utils/logger.js) still redacts known-sensitive keys as a
+    // defense-in-depth safety net, so this stays a deliberate, bounded risk.
+    if (config.includeRawData === true) return { ...data };
 
     const sanitized = { ...data };
     const maskTokens = config.maskTokens !== false; // Default to true

--- a/server/utils/logger.js
+++ b/server/utils/logger.js
@@ -115,6 +115,41 @@ function getComponentFilter() {
   }
 }
 
+// Components that emit authentication traces. When auth debug is explicitly
+// enabled these must never be suppressed by component filtering — otherwise the
+// single auth-debug toggle would silently do nothing whenever an admin has a
+// component filter active that happens to exclude them.
+const AUTH_COMPONENTS = new Set([
+  'AuthService',
+  'OidcAuth',
+  'NtlmAuth',
+  'JwtAuth',
+  'LdapAuth',
+  'LdapGroupLookup',
+  'ProxyAuth',
+  'TeamsAuth',
+  'McpAuth',
+  'Authorization',
+  'Auth',
+  'EntraService'
+]);
+
+/**
+ * Whether authentication debug logging is enabled in platform config.
+ * @returns {boolean}
+ */
+function isAuthDebugEnabled() {
+  try {
+    if (configCacheRef) {
+      const platformConfig = configCacheRef.getPlatform();
+      return platformConfig?.auth?.debug?.enabled === true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Custom filter format to filter logs by component
  */
@@ -133,6 +168,12 @@ const componentFilterFormat = winston.format(info => {
 
   // If log has a component and it's in the filter list, allow it
   if (info.component && componentFilter.filter.includes(info.component)) {
+    return info;
+  }
+
+  // Never let component filtering hide authentication logs while auth debug is
+  // switched on, so the single toggle reliably surfaces auth traces.
+  if (info.component && AUTH_COMPONENTS.has(info.component) && isAuthDebugEnabled()) {
     return info;
   }
 

--- a/server/validators/platformConfigSchema.js
+++ b/server/validators/platformConfigSchema.js
@@ -84,6 +84,16 @@ const loggingSchema = z.object({
       maxFiles: z.number().default(5)
     })
     .default({}),
+  // Optional per-component filtering (read by utils/logger.js). When enabled
+  // with a non-empty filter list, only logs from the listed components are
+  // emitted — except authentication components, which are always allowed
+  // through while auth.debug is enabled so the auth-debug toggle keeps working.
+  components: z
+    .object({
+      enabled: z.boolean().default(false),
+      filter: z.array(z.string()).default([])
+    })
+    .default({}),
   anonymizeIp: ipAnonymizationSchema
 });
 


### PR DESCRIPTION
Fixes #2068

## Problem

Authentication debug logging silently did nothing, and its controls were spread across multiple admin pages, so admins had no reliable way to trace OIDC redirects, token exchange, or group mapping.

## Root causes (from code investigation)

- **Config key mismatch (the "broken").** The admin UI and shipped examples wrote a top-level `authDebug` block, but the server only ever reads `auth.debug` (`authDebugService`, `platformConfigSchema`). Worse, the `POST /api/admin/configs/platform` merge only whitelists specific top-level keys and `authDebug` was **not** among them — so the value was never even persisted by that route.
- **Two gates in two places.** Even with `auth.debug.enabled = true`, most OIDC events were logged at winston level `debug`, which the default `logging.level: info` suppresses — so admins also had to lower the global level in a different UI section.
- **Dead flags.** `includeRawData` was never consulted (the raw access token was logged unconditionally); `consoleLogging` was read nowhere and absent from the schema.
- **Component filter could hide auth logs.** `logging.components` filtering silently dropped auth logs when the auth components weren't in the list; `components` was also missing from the schema.
- **Fragmentation.** Auth-debug controls appeared on both the Logging and Authentication pages, `ntlmAuth.debug` was a third standalone switch, and the UI wrongly claimed a restart was required.

## Changes

- **Standardize on `auth.debug`.** The UI now reads/writes `auth.debug` (persisted via the whitelisted `auth` object) and it applies immediately — the platform-config cache is refreshed on save.
- **Single toggle is sufficient.** `authDebugService.log()` emits informational traces at `info` when enabled (errors/warnings keep their severity), so they appear at the default log level with no second switch.
- **`includeRawData` now works.** Raw access-token and full user-info logs are gated behind it (default off); `sanitizeData` bypasses masking only when it is explicitly on. The core logger still redacts known-sensitive keys as a defense-in-depth safety net.
- **Component filter never hides auth logs** while `auth.debug.enabled` is true; `logging.components` added to the schema.
- **NTLM unified.** `ntlmAuth.debug` still works, and NTLM tracing now also responds to the central `auth.debug` toggle (`providers.ntlm`).
- **`consoleLogging` removed** from the UI, examples, and defaults (winston owns the console transport).
- **UI consolidated** onto the Logging page; the Authentication page points there. The misleading "requires restart" note is corrected; a security warning is added to `includeRawData`.
- **Migration `V079`** moves any existing top-level `authDebug` → `auth.debug` and drops the dead `consoleLogging` flag, preserving admin settings.
- Docs (`docs/platform.md`), concept doc, and changelog (`5.5.0`) updated.

## Security posture (defaults unchanged)

`maskTokens: true`, `redactPasswords: true`, `includeRawData: false`. Enabling raw data is a deliberate, clearly-labeled risk.

## Verification

- **V079 migration** — standalone harness across 4 scenarios (legacy present, both present → legacy wins, no legacy, stray `consoleLogging`): all assertions pass.
- **authDebugService** — 7 assertions: disabled → silent; enabled → `debug` event emitted at `info` with `authDebug` marker; error/warn severity preserved; token masking default; `includeRawData` bypass; `isRawDataEnabled` requires the toggle; per-provider disable.
- **Logger component filter** — auth components pass when `auth.debug` on, non-auth components still filtered.
- **Server boot** — starts cleanly; migration run complete (applied 69, skipped 4, **failed 0**); V079 applied; resulting config has correct `auth.debug` and no stale `authDebug`.
- `eslint --fix` (0 errors) and Prettier run on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014hvoMgbBhH7JTHsdbKRAxq)_