### PR TITLE
fix(chat): prevent server crash when cancelling a workflow on disconnect

### DIFF
--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,5 +1,16 @@
 # Features — 5.5.0
 
+## Cancelling a Workflow No Longer Crashes the Server
+
+Fixed a crash where stopping or cancelling a running workflow at the moment the chat connection
+dropped could take down the entire server for all users.
+
+- Previously, if the browser's connection closed while a workflow was being cancelled, the stop
+  handler tried to close an already-removed connection and threw an unhandled error, exiting the
+  server process.
+- The stop endpoint now safely handles a connection that has already disconnected, so cancelling a
+  workflow always completes cleanly.
+
 ## Authentication Admin Now Uses Searchable Group Pickers
 
 The default-group fields in Authentication settings are now searchable group selectors instead of

--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -1009,10 +1009,29 @@ export default function registerSessionRoutes(
           }
         }
 
+        // Re-read the client after the awaits above: cancelling the workflow
+        // yields the event loop, and the SSE connection can close in that gap
+        // (its req.on('close') handler deletes the entry from `clients`). The
+        // top-of-handler clients.has() check is therefore stale here, so guard
+        // against a now-missing entry instead of dereferencing undefined — an
+        // unguarded client.response.end() throws a TypeError that crashes the
+        // whole process as an unhandled rejection on Node >= 15.
         const client = clients.get(chatId);
         actionTracker.trackDisconnected(chatId, { message: 'Chat stream stopped by client' });
-        client.response.end();
-        clients.delete(chatId);
+        if (client) {
+          try {
+            client.response.end();
+          } catch (error) {
+            // The socket may already be dead (write-after-end on an already
+            // destroyed stream). We're tearing it down anyway, so just log.
+            logger.warn('Error ending client response on stop', {
+              component: 'sessionRoutes',
+              chatId,
+              error: error?.message || String(error)
+            });
+          }
+          clients.delete(chatId);
+        }
         logger.info('Chat stream stopped', { component: 'sessionRoutes', chatId });
         return res.status(200).json({ success: true, message: 'Chat stream stopped' });
       }


### PR DESCRIPTION
## Summary

A customer reported that starting/cancelling a workflow crashed the entire server (`Application exited with error code 1`). The crash:

```
file:///.../server/routes/chat/sessionRoutes.js:1014
        client.response.end();
        ^
TypeError: Cannot read properties of undefined (reading 'response')
Node.js v24.18.0
Server process exited with code 1
```

## Root cause

`POST /api/apps/:appId/chat/:chatId/stop` is a **check-then-act (TOCTOU) race**:

1. The handler guards with `clients.has(chatId)` → `true`.
2. It then `await`s `workflowExec.engine.cancel(...)`, which **yields the event loop** while the workflow tears down (~28ms in the customer's logs).
3. During that await the browser's SSE connection closes. The `req.on('close')` handler in `sseChannel.js` runs `clients.delete(chatId)`, removing the entry.
4. On resume, `clients.get(chatId)` returns `undefined`, and the unconditional `client.response.end()` throws a `TypeError`.
5. The throw inside the `async` handler becomes an **unhandled promise rejection**, which crashes the process by default on **Node ≥ 15** (customer runs Node 24) — taking the server down for *all* users, not just the one who cancelled.

The customer's log timeline confirms it exactly: `Client disconnected` / `SSE connection closed` at `.034Z` (mid-cancel), then `Cancelled workflow` at `.061Z`, then the crash.

## Fix

- Re-read the client after the awaits and **guard against a missing entry** before dereferencing it.
- Wrap `response.end()` in `try/catch` to tolerate an already-dead socket (mirrors the existing pattern in `sweepInactiveClients`).
- The endpoint still returns `200 { success: true }` — cancellation succeeded; the disconnected client simply no longer needs its stream ended.

## Testing

- `node --check` passes; Prettier clean.
- Manual reasoning against the reported log timeline; the guarded path handles the exact interleaving that crashed.

## Changelog

Added an entry to `docs/releases/5.5.0/features.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BFf53KBvKX772GiUUgs2MK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFf53KBvKX772GiUUgs2MK)_