### PR TITLE
fix(client): prevent browser auto-translation from crashing the app

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,7 +1,18 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" translate="no">
   <head>
     <meta charset="UTF-8" />
+    <!--
+      Disable browser auto-translation (Google/Chrome Translate, Edge, etc.).
+      iHub Apps ships its own i18n system, so browser translation is redundant.
+      More importantly, in-place translation rewrites/wraps the DOM text nodes
+      that React holds references to; React's reconciler then fails with
+      "NotFoundError: Failed to execute 'insertBefore' on 'Node'" (and similar
+      removeChild errors) and the whole app crashes to the error boundary.
+      This is most visible on a fresh install, which defaults to the English UI
+      and is therefore auto-translated by non-English browsers. See React #11538.
+    -->
+    <meta name="google" content="notranslate" />
     <script>
       // Dynamically set base tag for proper asset loading when deployed at subpath
       // This logic is aligned with client/src/utils/runtimeBasePath.js

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -645,3 +645,18 @@ diagnose sign-in problems.
 - The obsolete "Console logging" toggle was removed (the logger already manages console output).
 - No admin action is required on upgrade: a migration moves any previously saved setting to its new
   location so your configuration is preserved.
+
+## Fixed App Crash Caused by Browser Auto-Translation
+
+Fixed a crash where the entire app would fail to load with a generic "Something went wrong" error
+on browsers configured to automatically translate pages (for example, Chrome or Edge on a German,
+French, or other non-English system).
+
+- The symptom was an unexpected-error screen showing `NotFoundError: Failed to execute
+  'insertBefore' on 'Node'`, often in the browser's own translated wording rather than iHub's.
+- It was most visible right after a fresh installation, because a new install starts in English
+  and a non-English browser would offer to auto-translate it.
+- iHub Apps already ships its own language switcher, so browser translation was both redundant and
+  the source of the crash. The application now instructs browsers not to auto-translate its pages;
+  users should continue to switch languages using the in-app language selector.
+- No admin action is required on upgrade.


### PR DESCRIPTION
## Summary

A customer reported the whole app crashing to the generic error screen with:

> `NotFoundError: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.`

This is the well-known React + browser-translation crash ([facebook/react#11538](https://github.com/facebook/react/issues/11538)). Browsers with auto-translation enabled (Chrome/Edge Translate on a non-English system) rewrite and wrap the DOM **text nodes that React holds references to**. When React's reconciler later inserts/removes a sibling, the reference node is gone and it throws `insertBefore` / `removeChild` `NotFoundError`, taking down the entire app via the error boundary.

## Why it looked like a "fresh installation" issue

A fresh install defaults to the **English** UI (`<html lang="en">`), so a non-English browser offers to auto-translate it — and does. The screenshot confirms the browser (not the app) produced the German: the error-boundary text was machine-translated and does **not** match the app's own `de.json`:

| Element | App's `de.json` | Screenshot (browser translation) |
|---|---|---|
| "Try Again" | `Erneut versuchen` | `Versuchen Sie es erneut` |
| description | `Ein unerwarteter Fehler ist … Das **Entwicklungsteam** …` | `In der Anwendung ist ein … Das **Entwicklerteam** …` |

Those mismatches prove the app was running in English and the browser was translating on top of it.

## Fix

iHub Apps already ships its own i18n / language switcher, so browser translation is redundant **and** the source of the crash. Disable browser auto-translation for the app:

- `translate="no"` on `<html>` — the HTML standard, honored by Chrome/Edge/Firefox. It's a static attribute, so the dynamic `document.documentElement.lang` updates in `i18nService` don't affect it.
- `<meta name="google" content="notranslate" />` — Google/Chrome belt-and-suspenders.

Users continue switching languages with the in-app selector as before. No admin action required on upgrade.

## Changes

- `client/index.html` — add `translate="no"` + `notranslate` meta (with an explanatory comment).
- `docs/releases/5.5.0/features.md` — changelog entry for the admin changelog.

## Testing

- `npx prettier --check` passes on both changed files.
- Manual verification: on a German-locale browser with auto-translate enabled, the English UI no longer offers/performs translation, so React's reconciler is no longer corrupted and the app loads normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015a3uhH1v7FDiCKnUaYQsPF)_