### PR TITLE
Make the MCP gateway connectable from Claude: OAuth discovery, dynamic client registration, one-page activation

### DIFF
--- a/client/src/features/admin/pages/AdminMcpGatewayPage.jsx
+++ b/client/src/features/admin/pages/AdminMcpGatewayPage.jsx
@@ -64,6 +64,9 @@ function AdminMcpGatewayPage() {
   const gateway = platform?.mcpServer || {};
   const expose = gateway.expose || {};
   const transports = gateway.transports || {};
+  const oauth = platform?.oauth || {};
+  const oauthAuthzEnabled = !!oauth.enabled?.authz;
+  const dcrEnabled = !!oauth.dcr?.enabled;
 
   const update = patch => {
     setPlatform(prev => ({
@@ -79,6 +82,39 @@ function AdminMcpGatewayPage() {
           : prev?.mcpServer?.transports
       }
     }));
+  };
+
+  const setOauthAuthz = enabled => {
+    setPlatform(prev => {
+      const prevOauth = prev?.oauth || {};
+      return {
+        ...prev,
+        oauth: {
+          ...prevOauth,
+          enabled: {
+            ...(prevOauth.enabled || {}),
+            authz: enabled,
+            // Enabling the authorization server for MCP also needs the client
+            // store and the authorization_code + refresh_token grants.
+            ...(enabled ? { clients: true } : {})
+          },
+          ...(enabled ? { authorizationCodeEnabled: true, refreshTokenEnabled: true } : {})
+        }
+      };
+    });
+  };
+
+  const setDcr = enabled => {
+    setPlatform(prev => {
+      const prevOauth = prev?.oauth || {};
+      return {
+        ...prev,
+        oauth: {
+          ...prevOauth,
+          dcr: { ...(prevOauth.dcr || {}), enabled }
+        }
+      };
+    });
   };
 
   const save = async () => {
@@ -158,6 +194,46 @@ function AdminMcpGatewayPage() {
               'Show the OAuth consent screen on authorization_code flow before issuing an MCP-scoped access token.'
             )}
           />
+        </section>
+
+        <section className="bg-white dark:bg-gray-800 shadow rounded-lg p-6">
+          <h2 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">
+            {t('admin.mcp.gateway.authSection', 'Authentication')}
+          </h2>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">
+            {t(
+              'admin.mcp.gateway.authSectionDesc',
+              'The MCP gateway only accepts OAuth bearer tokens issued by the built-in authorization server. It must be enabled for any MCP client to connect.'
+            )}
+          </p>
+          {gateway.enabled && !oauthAuthzEnabled && (
+            <div className="mb-3 p-3 rounded-md border bg-amber-50 dark:bg-amber-900/30 border-amber-200 dark:border-amber-800 text-amber-800 dark:text-amber-300 text-sm">
+              {t(
+                'admin.mcp.gateway.oauthWarning',
+                'The gateway is enabled but the OAuth authorization server is off — MCP clients cannot obtain a token. Enable it below.'
+              )}
+            </div>
+          )}
+          <div className="divide-y divide-gray-200 dark:divide-gray-700">
+            <Toggle
+              checked={oauthAuthzEnabled}
+              onChange={setOauthAuthz}
+              label={t('admin.mcp.gateway.oauthToggle', 'OAuth authorization server')}
+              description={t(
+                'admin.mcp.gateway.oauthToggleDesc',
+                'Serves /api/oauth/authorize and /api/oauth/token. Enabling this also switches on OAuth client management and the authorization_code + refresh_token grants. A server restart is required after enabling it for the first time.'
+              )}
+            />
+            <Toggle
+              checked={dcrEnabled}
+              onChange={setDcr}
+              label={t('admin.mcp.gateway.dcrToggle', 'Dynamic client registration (RFC 7591)')}
+              description={t(
+                'admin.mcp.gateway.dcrToggleDesc',
+                'Lets MCP clients such as Claude register their OAuth client automatically at /api/oauth/register — no manual client setup needed. Registered clients always go through user sign-in and consent, and only receive identity + mcp:* scopes.'
+              )}
+            />
+          </div>
         </section>
 
         <section className="bg-white dark:bg-gray-800 shadow rounded-lg p-6 space-y-4">
@@ -297,11 +373,22 @@ function AdminMcpGatewayPage() {
                 {(gateway.publicUrl || window.location.origin).replace(/\/$/, '')}/mcp/.well-known
               </code>
             </p>
-            <p className="text-xs text-blue-700 dark:text-blue-300">
+            <p className="text-xs text-blue-700 dark:text-blue-300 mb-2">
               {t(
                 'admin.mcp.gateway.connectionHint',
                 'Authenticate with an OAuth client (see /admin/oauth/clients) that grants the relevant mcp:* scopes.'
               )}
+            </p>
+            <p className="text-xs text-blue-700 dark:text-blue-300">
+              {dcrEnabled
+                ? t(
+                    'admin.mcp.gateway.claudeHintDcr',
+                    'Claude: Settings → Connectors → Add custom connector, then paste the endpoint URL above. Claude registers its OAuth client automatically; users sign in to iHub and consent to the requested mcp:* scopes.'
+                  )
+                : t(
+                    'admin.mcp.gateway.claudeHintManual',
+                    'Claude: Settings → Connectors → Add custom connector, then paste the endpoint URL above and enter the client ID/secret of an OAuth client you created under /admin/oauth/clients (grant types authorization_code + refresh_token, redirect URI https://claude.ai/api/mcp/auth_callback, plus the desired mcp:* scopes). Enable dynamic client registration above to skip the manual client setup.'
+                  )}
             </p>
           </section>
         )}

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -312,7 +312,8 @@ curl https://ihub.example.com/.well-known/openid-configuration
 
 curl https://ihub.example.com/.well-known/oauth-authorization-server
 # RFC 8414 alias of the same document — MCP clients try this path first;
-# includes registration_endpoint when DCR is enabled
+# includes registration_endpoint when DCR and the authorization server
+# are both enabled
 
 curl https://ihub.example.com/.well-known/oauth-protected-resource/mcp
 # RFC 9728 — names the authorization server + scopes protecting /mcp

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -133,8 +133,25 @@ tool definition and forwards to `McpClientManager.callTool`, which:
 
 ### Enabling the gateway
 
-Set `platform.mcpServer.enabled: true` (Admin → MCP gateway) and the
-endpoint goes live at:
+The gateway needs **two** things switched on (both on Admin → MCP gateway):
+
+1. `platform.mcpServer.enabled: true` — mounts the `/mcp` endpoints.
+2. `platform.oauth.enabled.authz: true` — the OAuth authorization server.
+   The gateway accepts **only** OAuth bearer tokens, so without this no
+   client can ever authenticate. The admin page's *OAuth authorization
+   server* toggle sets this together with `oauth.enabled.clients`,
+   `oauth.authorizationCodeEnabled` and `oauth.refreshTokenEnabled`.
+
+Optionally enable `platform.oauth.dcr.enabled: true` (*Dynamic client
+registration* toggle) so MCP clients such as Claude can register their
+OAuth client automatically instead of an admin creating one by hand.
+
+> ⚠️ **Restart required:** the OAuth session middleware is mounted at
+> startup. After enabling the OAuth authorization server for the first
+> time, restart the server — otherwise the consent flow has no session
+> store and authorization fails.
+
+With the gateway enabled the endpoints go live at:
 
 ```
 POST   /mcp           # Streamable HTTP (canonical)
@@ -170,6 +187,49 @@ Two grant flows produce valid tokens:
 
 Both flows use the **same** authorization server and the **same**
 permission machinery (`enhanceUserWithPermissions`).
+
+#### How an MCP client bootstraps auth (discovery chain)
+
+MCP clients discover everything from a single unauthenticated probe:
+
+1. `POST /mcp` without a token → `401` with
+   `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource/mcp"`.
+2. The client fetches that **protected resource metadata** (RFC 9728) —
+   it names the authorization server and the supported `mcp:*` scopes.
+3. The client fetches `/.well-known/oauth-authorization-server`
+   (RFC 8414; same document as `/.well-known/openid-configuration`) —
+   it lists the authorize/token endpoints, PKCE support, and (when DCR
+   is enabled) the `registration_endpoint`.
+4. With DCR enabled the client `POST`s `/api/oauth/register` (RFC 7591)
+   and receives a `client_id` — no manual client setup.
+5. Authorization Code + PKCE runs as usual: the user signs in, consents
+   to the `mcp:*` scopes, and the client exchanges the code for tokens.
+
+#### Dynamic Client Registration (RFC 7591)
+
+`POST /api/oauth/register` is available when
+`platform.oauth.dcr.enabled: true`. It is unauthenticated (that is how
+the MCP client ecosystem uses DCR), so the policy is deliberately narrow:
+
+- Only `authorization_code` (+ `refresh_token`) grants can be registered —
+  `client_credentials` service accounts still require an admin.
+- Redirect URIs must be `https`, loopback `http`, or a private-use native
+  app scheme; dangerous schemes are rejected.
+- Grantable scopes are limited to identity scopes + `mcp:*`
+  (override with `platform.oauth.dcr.allowedScopes`).
+- Registered clients are never trusted and always require user consent.
+- `platform.oauth.dcr.maxClients` (default 100) caps auto-registered
+  clients; the shared `/api/oauth` rate limiter applies.
+- Clients registering `token_endpoint_auth_method: "none"` become public
+  PKCE clients; `client_secret_post/basic` yields a confidential client
+  whose secret is returned once in the registration response.
+
+Auto-registered clients appear in **Admin → OAuth clients** like any
+other client and can be narrowed (`allowedApps`, `allowedGroups`, …),
+suspended, or deleted there.
+
+If DCR stays disabled, create the client manually at
+`/admin/oauth/clients` and configure its id/secret in the MCP client.
 
 ### Scopes
 
@@ -250,6 +310,14 @@ Unauthenticated metadata endpoints help MCP-aware clients auto-configure:
 curl https://ihub.example.com/.well-known/openid-configuration
 # advertises mcp_endpoint + mcp:* scopes when gateway is enabled
 
+curl https://ihub.example.com/.well-known/oauth-authorization-server
+# RFC 8414 alias of the same document — MCP clients try this path first;
+# includes registration_endpoint when DCR is enabled
+
+curl https://ihub.example.com/.well-known/oauth-protected-resource/mcp
+# RFC 9728 — names the authorization server + scopes protecting /mcp
+# (also referenced by the 401 WWW-Authenticate challenge on /mcp)
+
 curl https://ihub.example.com/mcp/.well-known
 # MCP-specific metadata: issuer, mcp_endpoint, transports, scopes_supported,
 # oauth_authorization_server link
@@ -272,22 +340,49 @@ a set `MCP_SERVER_URL` into the new `mcpServers.json` as a server with
 the migration runs, the env var is ignored — manage the server via
 `/admin/mcp/servers` instead.
 
-## Connecting Claude Desktop / Cursor
+## Connecting Claude (claude.ai / Claude Desktop)
 
-(Worked example follows once gateway is enabled and an OAuth client with
-`grant_types: ["authorization_code"]` plus the appropriate `mcp:*` scopes
-is registered.)
+Checklist on the iHub side (all on **Admin → MCP gateway**):
 
-1. Register an OAuth client at `/admin/oauth/clients`:
-   - `grant_types`: `["authorization_code", "refresh_token"]`
-   - `redirectUris`: include the client's redirect URI
-   - `scopes`: include the desired `mcp:*` scopes
-2. In the client, add iHub as an MCP server with auto-discovery URL
-   `https://your-ihub/.well-known/openid-configuration`.
-3. The client redirects the user through iHub's authorization endpoint,
-   the user signs in via whichever mode is configured, reviews the
-   requested `mcp:*` scopes, and consents.
-4. Subsequent MCP calls run as that user with full group permissions.
+1. Enable the MCP gateway.
+2. Enable the OAuth authorization server (restart once after first enable).
+3. Enable Dynamic client registration.
+4. If iHub runs behind a proxy, set the **Public URL** so discovery
+   metadata advertises the externally reachable address. iHub must be
+   reachable over HTTPS for claude.ai.
+
+Then in Claude: **Settings → Connectors → Add custom connector** and
+paste `https://your-ihub/mcp`. Claude walks the discovery chain,
+registers itself via DCR, and sends the user through iHub's sign-in and
+consent screen. Subsequent MCP calls run as that user with their normal
+group permissions.
+
+Without DCR, create the OAuth client manually at `/admin/oauth/clients`:
+
+- `grant_types`: `["authorization_code", "refresh_token"]`
+- `redirectUris`: `["https://claude.ai/api/mcp/auth_callback"]`
+- `scopes`: the desired `mcp:*` scopes (plus `openid profile email`)
+
+and enter its client id/secret in Claude's connector advanced settings.
+
+Other MCP clients (Cursor, VS Code, custom agents) follow the same
+pattern — point them at `https://your-ihub/mcp`; clients that only take
+a discovery URL can use
+`https://your-ihub/.well-known/openid-configuration`.
+
+Troubleshooting:
+
+- `401 mcp_disabled` / hard 404 on `/mcp` → gateway not enabled.
+- `400 OAuth is not enabled on this server` from
+  `/api/oauth/authorize` or `/api/oauth/token` →
+  `oauth.enabled.authz` is still false.
+- Client fails right after registration → DCR disabled
+  (`/api/oauth/register` is a hard 404 while off) and no manual client
+  configured.
+- Consent screen loops or CSRF errors → server was not restarted after
+  enabling OAuth (session middleware missing).
+- `403 insufficient_scope` on `/mcp` → the token carries no `mcp:*`
+  scope; check the scopes on the OAuth client and re-authorize.
 
 ## Agent-to-Agent (A2A) endpoint — experimental
 

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -718,6 +718,8 @@ standard OAuth discovery — including automatic client registration.
   (`oauth.dcr.maxClients`, default 100), and only the authorization-code flow can be registered.
 - The consent screen now explains `mcp:*` scopes in plain language, and clients that omit the
   `scope` parameter receive their registered scopes instead of a token the gateway would reject.
+- Fixed the MCP gateway settings not saving at all: the platform config endpoint reported success
+  while discarding the gateway section, so every toggle on the page reverted on reload.
 - To connect Claude: enable the three toggles, then add `https://your-ihub/mcp` under
   **Settings → Connectors → Add custom connector** in Claude.
 

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -697,3 +697,29 @@ French, or other non-English system).
   the source of the crash. The application now instructs browsers not to auto-translate its pages;
   users should continue to switch languages using the in-app language selector.
 - No admin action is required on upgrade.
+
+## Connect Claude and Other MCP Clients Without Manual OAuth Setup
+
+The MCP gateway can now be activated end-to-end from **Admin → MCP gateway**, and MCP clients such
+as Claude (claude.ai custom connectors, Claude Desktop), Cursor, and VS Code can connect through
+standard OAuth discovery — including automatic client registration.
+
+- The MCP gateway page now includes an **Authentication** section: one toggle enables the OAuth
+  authorization server (previously this had to be edited in `platform.json` by hand, which left
+  the gateway unusable), and a second toggle enables **Dynamic client registration (RFC 7591)** so
+  MCP clients create their OAuth client automatically at `/api/oauth/register` — no manual client
+  setup needed. A warning appears if the gateway is on but OAuth is off.
+- New standard discovery endpoints: `/.well-known/oauth-authorization-server` (RFC 8414) and
+  `/.well-known/oauth-protected-resource` (RFC 9728). Unauthenticated requests to `/mcp` now
+  return the `resource_metadata` challenge that MCP clients use to bootstrap authentication.
+- Auto-registered clients are never trusted: users always sign in and consent to the requested
+  `mcp:*` scopes, and the clients can be reviewed, restricted, or removed under
+  **Admin → OAuth clients**. Registration is rate-limited and capped
+  (`oauth.dcr.maxClients`, default 100), and only the authorization-code flow can be registered.
+- The consent screen now explains `mcp:*` scopes in plain language, and clients that omit the
+  `scope` parameter receive their registered scopes instead of a token the gateway would reject.
+- To connect Claude: enable the three toggles, then add `https://your-ihub/mcp` under
+  **Settings → Connectors → Add custom connector** in Claude.
+
+**Note:** after enabling the OAuth authorization server for the first time, restart the server
+once so the OAuth session middleware is mounted.

--- a/server/defaults/config/platform.json
+++ b/server/defaults/config/platform.json
@@ -128,7 +128,28 @@
     "refreshTokenEnabled": false,
     "refreshTokenExpirationDays": 30,
     "consentRequired": true,
-    "consentMemoryDays": 90
+    "consentMemoryDays": 90,
+    "dcr": {
+      "enabled": false,
+      "maxClients": 100
+    }
+  },
+  "mcpServer": {
+    "enabled": false,
+    "requireConsent": true,
+    "publicUrl": "",
+    "transports": {
+      "streamableHttp": { "enabled": true },
+      "sse": { "enabled": true }
+    },
+    "a2a": { "enabled": false },
+    "expose": {
+      "tools": true,
+      "apps": true,
+      "workflows": true,
+      "resources": false
+    },
+    "defaultScopes": ["mcp:tools:read", "mcp:tools:call"]
   },
   "anonymousAuth": {
     "enabled": true,

--- a/server/middleware/mcpAuth.js
+++ b/server/middleware/mcpAuth.js
@@ -2,8 +2,35 @@ import { verifyOAuthToken } from '../utils/oauthTokenService.js';
 import { loadOAuthClients, findClientById } from '../utils/oauthClientManager.js';
 import { enhanceUserWithPermissions } from '../utils/authorization.js';
 import { hasAnyScope, MCP_METHOD_SCOPES, MCP_SCOPES } from '../services/mcp/scopes.js';
+import { buildServerPath } from '../utils/basePath.js';
 import configCache from '../configCache.js';
 import logger from '../utils/logger.js';
+
+/**
+ * Resolve the URL of the RFC 9728 protected-resource metadata document.
+ * Advertised in the 401 WWW-Authenticate challenge so MCP clients can
+ * discover the authorization server (MCP auth spec, 2025-06-18).
+ *
+ * @param {import('express').Request} req - Express request object
+ * @returns {string} Absolute URL of /.well-known/oauth-protected-resource
+ */
+function resourceMetadataUrl(req) {
+  const mcpConfig = (configCache.getPlatform() || {}).mcpServer || {};
+  let base;
+  if (mcpConfig.publicUrl) {
+    // publicUrl points at the app base (possibly with a subpath); the
+    // well-known document lives at the host root per RFC 9728.
+    try {
+      base = new URL(mcpConfig.publicUrl).origin;
+    } catch {
+      base = mcpConfig.publicUrl.replace(/\/$/, '');
+    }
+  } else {
+    const protocol = req.protocol || (req.secure ? 'https' : 'http');
+    base = `${protocol}://${req.get('host')}`;
+  }
+  return `${base}/.well-known/oauth-protected-resource${buildServerPath('/mcp')}`;
+}
 
 /**
  * Bearer-token middleware for the MCP gateway (`/mcp` and `/mcp/sse`).
@@ -22,7 +49,7 @@ export default async function mcpAuth(req, res, next) {
   const mcpConfig = platform.mcpServer || {};
 
   if (!mcpConfig.enabled) {
-    return sendUnauthorized(res, 'mcp_disabled', 'MCP gateway is not enabled on this server');
+    return sendUnauthorized(req, res, 'mcp_disabled', 'MCP gateway is not enabled on this server');
   }
 
   // The MCP authorization model is OAuth-only — even if the platform allows
@@ -30,13 +57,13 @@ export default async function mcpAuth(req, res, next) {
   // bearer token.
   const authHeader = req.headers.authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return sendUnauthorized(res, 'missing_token', 'Bearer token required');
+    return sendUnauthorized(req, res, 'missing_token', 'Bearer token required');
   }
 
   const token = authHeader.substring(7).trim();
   const decoded = verifyOAuthToken(token);
   if (!decoded) {
-    return sendUnauthorized(res, 'invalid_token', 'Token is invalid or expired');
+    return sendUnauthorized(req, res, 'invalid_token', 'Token is invalid or expired');
   }
 
   // Look up the OAuth client. Required for both auth_code (per-client
@@ -62,7 +89,7 @@ export default async function mcpAuth(req, res, next) {
   }
 
   if (!client || !client.active) {
-    return sendUnauthorized(res, 'invalid_client', 'OAuth client not found or suspended');
+    return sendUnauthorized(req, res, 'invalid_client', 'OAuth client not found or suspended');
   }
 
   // Build req.user with shape identical to jwtAuth (so downstream filtering
@@ -102,13 +129,17 @@ export default async function mcpAuth(req, res, next) {
     };
   } else {
     // Reject any non-OAuth token — only OAuth-issued tokens are valid for MCP.
-    return sendUnauthorized(res, 'invalid_token', 'Only OAuth tokens are accepted on /mcp');
+    return sendUnauthorized(req, res, 'invalid_token', 'Only OAuth tokens are accepted on /mcp');
   }
 
   // Enforce that the token bears at least one MCP scope. Method-level scope
   // checks (e.g. tools/call requires mcp:tools:call) are applied in the
   // McpServerService dispatch.
   if (!hasAnyScope(user.scopes, Object.values(MCP_SCOPES))) {
+    res.setHeader(
+      'WWW-Authenticate',
+      `Bearer realm="ihub-mcp", error="insufficient_scope", resource_metadata="${resourceMetadataUrl(req)}"`
+    );
     return sendError(res, 403, 'insufficient_scope', 'Token does not carry any mcp:* scopes');
   }
 
@@ -127,8 +158,15 @@ export default async function mcpAuth(req, res, next) {
   next();
 }
 
-function sendUnauthorized(res, error, description) {
-  res.setHeader('WWW-Authenticate', 'Bearer realm="ihub-mcp"');
+function sendUnauthorized(req, res, error, description) {
+  // The resource_metadata parameter (RFC 9728 §5.1) tells MCP clients where
+  // to find the protected-resource metadata, which in turn points at the
+  // OAuth authorization server — this is how Claude & co. bootstrap the
+  // whole auth flow from a single 401.
+  res.setHeader(
+    'WWW-Authenticate',
+    `Bearer realm="ihub-mcp", resource_metadata="${resourceMetadataUrl(req)}"`
+  );
   res.status(401).json({ error, error_description: description });
 }
 

--- a/server/middleware/mcpAuth.js
+++ b/server/middleware/mcpAuth.js
@@ -16,16 +16,20 @@ import logger from '../utils/logger.js';
  */
 function resourceMetadataUrl(req) {
   const mcpConfig = (configCache.getPlatform() || {}).mcpServer || {};
-  let base;
+  let base = null;
   if (mcpConfig.publicUrl) {
     // publicUrl points at the app base (possibly with a subpath); the
     // well-known document lives at the host root per RFC 9728.
     try {
       base = new URL(mcpConfig.publicUrl).origin;
     } catch {
-      base = mcpConfig.publicUrl.replace(/\/$/, '');
+      // Misconfigured (non-absolute) publicUrl — fall through to the
+      // request-derived origin so the challenge always carries an
+      // absolute URL.
+      base = null;
     }
-  } else {
+  }
+  if (!base) {
     const protocol = req.protocol || (req.secure ? 'https' : 'http');
     base = `${protocol}://${req.get('host')}`;
   }

--- a/server/migrations/V080__add_mcp_gateway_oauth_defaults.js
+++ b/server/migrations/V080__add_mcp_gateway_oauth_defaults.js
@@ -1,0 +1,35 @@
+export const version = '080';
+export const description = 'add_mcp_gateway_oauth_defaults';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+/**
+ * Seed defaults for the MCP gateway (platform.mcpServer) and OAuth dynamic
+ * client registration (platform.oauth.dcr) so both sections exist with
+ * explicit values and show up correctly in the admin UI. All values are
+ * conservative (gateway off, DCR off) and setDefault never overwrites
+ * anything an admin has already configured.
+ */
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  ctx.setDefault(platform, 'mcpServer.enabled', false);
+  ctx.setDefault(platform, 'mcpServer.requireConsent', true);
+  ctx.setDefault(platform, 'mcpServer.publicUrl', '');
+  ctx.setDefault(platform, 'mcpServer.transports.streamableHttp.enabled', true);
+  ctx.setDefault(platform, 'mcpServer.transports.sse.enabled', true);
+  ctx.setDefault(platform, 'mcpServer.a2a.enabled', false);
+  ctx.setDefault(platform, 'mcpServer.expose.tools', true);
+  ctx.setDefault(platform, 'mcpServer.expose.apps', true);
+  ctx.setDefault(platform, 'mcpServer.expose.workflows', true);
+  ctx.setDefault(platform, 'mcpServer.expose.resources', false);
+  ctx.setDefault(platform, 'mcpServer.defaultScopes', ['mcp:tools:read', 'mcp:tools:call']);
+
+  ctx.setDefault(platform, 'oauth.dcr.enabled', false);
+  ctx.setDefault(platform, 'oauth.dcr.maxClients', 100);
+
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Added mcpServer gateway defaults and oauth.dcr defaults');
+}

--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -310,6 +310,12 @@ export default function registerAdminConfigRoutes(app) {
         ntlmAuth: newConfig.ntlmAuth || existingConfig.ntlmAuth,
         authorization: newConfig.authorization || existingConfig.authorization,
         oauth: newConfig.oauth || existingConfig.oauth,
+        // MCP gateway (Admin → MCP gateway) is edited through this generic
+        // endpoint rather than a dedicated route, so it must be listed here —
+        // otherwise the spread of existingConfig silently wins and the saved
+        // toggles revert on the next load.
+        mcpServer:
+          newConfig.mcpServer !== undefined ? newConfig.mcpServer : existingConfig.mcpServer,
         jira: newConfig.jira || existingConfig.jira,
         cloudStorage: newConfig.cloudStorage || existingConfig.cloudStorage,
         iFinder: newConfig.iFinder || existingConfig.iFinder,

--- a/server/routes/mcpServer.js
+++ b/server/routes/mcpServer.js
@@ -200,6 +200,7 @@ export default function registerMcpServerRoutes(app) {
   // Unauthenticated metadata endpoint; safe to expose.
   app.get(buildServerPath('/mcp/.well-known'), enabledCheck, (req, res) => {
     const cfg = gatewayConfig();
+    const oauthCfg = (configCache.getPlatform() || {}).oauth || {};
     let baseUrl =
       cfg.publicUrl ||
       `${req.protocol || (req.secure ? 'https' : 'http')}://${req.get('host')}${buildServerPath('')}`;
@@ -241,7 +242,10 @@ export default function registerMcpServerRoutes(app) {
         : ['mcp:tools:read', 'mcp:tools:call'],
       oauth_authorization_server: `${baseUrl}/.well-known/oauth-authorization-server`,
       oauth_protected_resource: `${baseUrl}/.well-known/oauth-protected-resource`,
-      ...((configCache.getPlatform() || {}).oauth?.dcr?.enabled
+      // Advertised only when /api/oauth/register would actually accept a
+      // registration — it hard-404s unless DCR and the authorization server
+      // are both enabled.
+      ...(oauthCfg?.dcr?.enabled && oauthCfg?.enabled?.authz
         ? { registration_endpoint: `${baseUrl}/api/oauth/register` }
         : {})
     });

--- a/server/routes/mcpServer.js
+++ b/server/routes/mcpServer.js
@@ -239,7 +239,11 @@ export default function registerMcpServerRoutes(app) {
       default_scopes: Array.isArray(cfg.defaultScopes)
         ? cfg.defaultScopes
         : ['mcp:tools:read', 'mcp:tools:call'],
-      oauth_authorization_server: `${baseUrl}/.well-known/oauth-authorization-server`
+      oauth_authorization_server: `${baseUrl}/.well-known/oauth-authorization-server`,
+      oauth_protected_resource: `${baseUrl}/.well-known/oauth-protected-resource`,
+      ...((configCache.getPlatform() || {}).oauth?.dcr?.enabled
+        ? { registration_endpoint: `${baseUrl}/api/oauth/register` }
+        : {})
     });
   });
 

--- a/server/routes/oauthAuthorize.js
+++ b/server/routes/oauthAuthorize.js
@@ -101,7 +101,12 @@ function renderConsentScreen({ client, scopes, csrfToken, oauthParams, baseUrl, 
     openid: 'Verify your identity',
     profile: 'Access your name and profile information',
     email: 'Access your email address',
-    offline_access: 'Access resources when you are not actively using the app (refresh tokens)'
+    offline_access: 'Access resources when you are not actively using the app (refresh tokens)',
+    'mcp:tools:read': 'List the iHub tools available to you',
+    'mcp:tools:call': 'Run iHub tools on your behalf',
+    'mcp:apps:invoke': 'Run iHub apps on your behalf',
+    'mcp:workflows:run': 'Run iHub workflows on your behalf',
+    'mcp:resources:read': 'Read iHub sources and skills available to you'
   };
 
   const scopeItems = scopes
@@ -314,8 +319,14 @@ export default function registerOAuthAuthorizeRoutes(app) {
         }
       }
 
-      // Parse requested scopes; default to "openid" when absent
-      const requestedScopes = scope ? scope.split(' ').filter(Boolean) : ['openid'];
+      // Parse requested scopes. When the request carries no scope parameter,
+      // fall back to the client's registered scopes (RFC 6749 §3.3 pre-defined
+      // default) — MCP clients that skip the parameter still need their mcp:*
+      // scopes on the token or the gateway rejects it — and to "openid" for
+      // clients registered without scopes.
+      const requestedScopes = scope
+        ? scope.split(' ').filter(Boolean)
+        : (Array.isArray(client.scopes) && client.scopes.length > 0 && client.scopes) || ['openid'];
 
       // Check if user is authenticated via the authToken JWT cookie
       const token = req.cookies?.authToken;
@@ -335,7 +346,7 @@ export default function registerOAuthAuthorizeRoutes(app) {
             response_type,
             client_id,
             redirect_uri,
-            scope: scope || 'openid',
+            scope: requestedScopes.join(' '),
             state: state || '',
             code_challenge: code_challenge || '',
             code_challenge_method: code_challenge_method || '',
@@ -444,7 +455,7 @@ export default function registerOAuthAuthorizeRoutes(app) {
         req.session.oauthParams = {
           client_id,
           redirect_uri,
-          scope: scope || 'openid',
+          scope: requestedScopes.join(' '),
           state: state || '',
           code_challenge: code_challenge || '',
           code_challenge_method: code_challenge_method || '',
@@ -467,7 +478,7 @@ export default function registerOAuthAuthorizeRoutes(app) {
           client_id,
           redirect_uri,
           state: state || '',
-          scope: scope || 'openid',
+          scope: requestedScopes.join(' '),
           nonce: nonce || ''
         },
         baseUrl,

--- a/server/routes/oauthRegister.js
+++ b/server/routes/oauthRegister.js
@@ -1,0 +1,190 @@
+import { createOAuthClient, loadOAuthClients } from '../utils/oauthClientManager.js';
+import { validateRegistrationRequest } from '../utils/dcrValidation.js';
+import { buildServerPath } from '../utils/basePath.js';
+import configCache from '../configCache.js';
+import logger from '../utils/logger.js';
+
+/**
+ * OAuth 2.0 Dynamic Client Registration (RFC 7591).
+ *
+ * MCP-aware clients (Claude, Claude Desktop, Cursor, VS Code, …) discover the
+ * registration_endpoint from /.well-known/oauth-authorization-server and
+ * self-register before running the authorization_code + PKCE flow. Without
+ * this endpoint every user would have to manually create an OAuth client in
+ * the admin UI and paste its id/secret into their MCP client.
+ *
+ * Registration is unauthenticated by design (that is how the MCP client
+ * ecosystem uses DCR), so the policy is intentionally narrow — see
+ * dcrValidation.js — and the endpoint is:
+ *   - opt-in via platform.oauth.dcr.enabled (default false),
+ *   - rate-limited by the shared /api/oauth limiter,
+ *   - capped at platform.oauth.dcr.maxClients auto-registered clients.
+ *
+ * Registered clients always require user consent (consentRequired: true) and
+ * are never trusted, so a user must still sign in and approve the requested
+ * mcp:* scopes before any token is issued.
+ */
+export default function registerOAuthRegisterRoutes(app) {
+  /**
+   * @swagger
+   * /api/oauth/register:
+   *   post:
+   *     summary: OAuth 2.0 Dynamic Client Registration endpoint (RFC 7591)
+   *     description: |
+   *       Registers a new OAuth client for the authorization_code + PKCE flow.
+   *       Only available when platform.oauth.dcr.enabled is true.
+   *     tags:
+   *       - OAuth
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - redirect_uris
+   *             properties:
+   *               redirect_uris:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *               client_name:
+   *                 type: string
+   *               grant_types:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *               response_types:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *               token_endpoint_auth_method:
+   *                 type: string
+   *                 enum: [none, client_secret_post, client_secret_basic]
+   *               scope:
+   *                 type: string
+   *     responses:
+   *       201:
+   *         description: Client registered
+   *       400:
+   *         description: Invalid client metadata
+   *       404:
+   *         description: Dynamic client registration is not enabled
+   */
+  app.post(buildServerPath('/api/oauth/register'), async (req, res) => {
+    try {
+      const platform = configCache.getPlatform() || {};
+      const oauthConfig = platform.oauth || {};
+      const dcrConfig = oauthConfig.dcr || {};
+
+      // Hard-404 while disabled, matching the MCP gateway posture — probing
+      // must not reveal whether the feature exists.
+      if (!oauthConfig.enabled?.authz || dcrConfig.enabled !== true) {
+        return res.status(404).json({
+          error: 'not_found',
+          error_description: 'Dynamic client registration is not enabled'
+        });
+      }
+
+      const validation = validateRegistrationRequest(req.body, {
+        allowedScopes: dcrConfig.allowedScopes
+      });
+      if (!validation.ok) {
+        return res
+          .status(400)
+          .json({ error: validation.error, error_description: validation.errorDescription });
+      }
+
+      const clientsFilePath = oauthConfig.clientsFile || 'contents/config/oauth-clients.json';
+
+      // Cap the number of auto-registered clients so an unauthenticated
+      // caller cannot grow the client store unboundedly.
+      const maxClients = Number.isInteger(dcrConfig.maxClients) ? dcrConfig.maxClients : 100;
+      const clientsConfig = loadOAuthClients(clientsFilePath);
+      if (clientsConfig?.metadata?.error) {
+        return res.status(503).json({
+          error: 'service_unavailable',
+          error_description: 'OAuth client store unavailable'
+        });
+      }
+      const dcrClientCount = Object.values(clientsConfig.clients || {}).filter(
+        c => c?.metadata?.dcr === true
+      ).length;
+      if (dcrClientCount >= maxClients) {
+        logger.warn('[OAuth DCR] Registration rejected — client limit reached', {
+          component: 'OAuthRegister',
+          dcrClientCount,
+          maxClients
+        });
+        return res.status(400).json({
+          error: 'invalid_client_metadata',
+          error_description:
+            'Dynamic client registration limit reached — ask an administrator to remove unused clients'
+        });
+      }
+
+      const meta = validation.clientMetadata;
+      const isPublic = meta.tokenEndpointAuthMethod === 'none';
+
+      const created = await createOAuthClient(
+        {
+          name: meta.name,
+          description: 'Dynamically registered client (RFC 7591)',
+          clientType: isPublic ? 'public' : 'confidential',
+          grantTypes: meta.grantTypes,
+          redirectUris: meta.redirectUris,
+          scopes: meta.scopes,
+          consentRequired: true,
+          trusted: false,
+          tokenExpirationMinutes: oauthConfig.defaultTokenExpirationMinutes || 60,
+          metadata: {
+            dcr: true,
+            tokenEndpointAuthMethod: meta.tokenEndpointAuthMethod,
+            ...(meta.softwareId ? { softwareId: meta.softwareId } : {}),
+            ...(meta.softwareVersion ? { softwareVersion: meta.softwareVersion } : {})
+          }
+        },
+        clientsFilePath,
+        'dcr'
+      );
+
+      logger.info('[OAuth DCR] Client registered', {
+        component: 'OAuthRegister',
+        clientId: created.clientId,
+        clientName: meta.name,
+        clientType: isPublic ? 'public' : 'confidential',
+        scopes: meta.scopes,
+        ip: req.ip
+      });
+
+      // RFC 7591 §3.2.1 response. The plaintext secret is only returned for
+      // confidential clients and only in this one response.
+      const response = {
+        client_id: created.clientId,
+        client_id_issued_at: Math.floor(Date.parse(created.createdAt) / 1000),
+        client_name: meta.name,
+        redirect_uris: meta.redirectUris,
+        grant_types: meta.grantTypes,
+        response_types: ['code'],
+        token_endpoint_auth_method: meta.tokenEndpointAuthMethod,
+        scope: meta.scopes.join(' ')
+      };
+      if (!isPublic) {
+        response.client_secret = created.clientSecret;
+        response.client_secret_expires_at = 0;
+      }
+
+      res.status(201).json(response);
+    } catch (error) {
+      logger.error('[OAuth DCR] Registration endpoint error', {
+        component: 'OAuthRegister',
+        error: error.message,
+        stack: error.stack
+      });
+      res.status(500).json({
+        error: 'server_error',
+        error_description: 'An internal error occurred'
+      });
+    }
+  });
+}

--- a/server/routes/wellKnown.js
+++ b/server/routes/wellKnown.js
@@ -47,6 +47,108 @@ async function pemToJwk(publicKeyPem) {
   }
 }
 
+/**
+ * Build the authorization-server discovery document served at both
+ * /.well-known/openid-configuration (OIDC Discovery 1.0) and
+ * /.well-known/oauth-authorization-server (RFC 8414). MCP clients such as
+ * Claude try the RFC 8414 path first, so both must resolve to the same
+ * metadata.
+ *
+ * @param {import('express').Request} req - Express request object
+ * @returns {Object} Discovery metadata document
+ */
+function buildAuthServerMetadata(req) {
+  const baseUrl = getBaseUrl(req);
+  const platform = configCache.getPlatform() || {};
+  const algorithm = getJwtAlgorithm();
+
+  // Use configured issuer or fall back to dynamic base URL.
+  // OIDC spec (RFC 8414 §2) requires issuer to be a URL starting with https:// or http://.
+  const oauthConfig = platform.oauth || {};
+  const issuer =
+    oauthConfig.issuer && oauthConfig.issuer.startsWith('http') ? oauthConfig.issuer : baseUrl;
+
+  const mcpConfig = platform.mcpServer || {};
+  const mcpScopes = mcpConfig.enabled
+    ? [
+        'mcp:tools:read',
+        'mcp:tools:call',
+        'mcp:apps:invoke',
+        'mcp:workflows:run',
+        'mcp:resources:read'
+      ]
+    : [];
+
+  return {
+    issuer,
+    jwks_uri: `${baseUrl}/.well-known/jwks.json`,
+    authorization_endpoint: `${baseUrl}/api/oauth/authorize`,
+    token_endpoint: `${baseUrl}/api/oauth/token`,
+    userinfo_endpoint: `${baseUrl}/api/oauth/userinfo`,
+    revocation_endpoint: `${baseUrl}/api/oauth/revoke`,
+    end_session_endpoint: `${baseUrl}/api/oauth/logout`,
+    // RFC 7591 Dynamic Client Registration — advertised only when the admin
+    // has enabled DCR so MCP clients (Claude, Cursor, …) can self-register.
+    ...(oauthConfig.dcr?.enabled ? { registration_endpoint: `${baseUrl}/api/oauth/register` } : {}),
+    response_types_supported: ['code'],
+    subject_types_supported: ['public'],
+    id_token_signing_alg_values_supported: [algorithm],
+    // 'none' covers public PKCE clients (RFC 8414 §2) — the token endpoint
+    // accepts secret-less clients with clientType 'public'.
+    token_endpoint_auth_methods_supported: ['client_secret_post', 'client_secret_basic', 'none'],
+    grant_types_supported: ['client_credentials', 'authorization_code', 'refresh_token'],
+    scopes_supported: ['openid', 'profile', 'email', 'offline_access', ...mcpScopes],
+    code_challenge_methods_supported: ['S256'],
+    claims_supported: ['sub', 'name', 'email', 'groups', 'iss', 'aud', 'exp', 'iat', 'nonce'],
+    request_parameter_supported: false,
+    request_uri_parameter_supported: false,
+    // Non-standard but useful for MCP-aware clients: advertise the gateway
+    // endpoint so an agent can auto-discover it from the well-known URL.
+    ...(mcpConfig.enabled
+      ? {
+          mcp_endpoint: mcpConfig.publicUrl
+            ? `${mcpConfig.publicUrl.replace(/\/$/, '')}/mcp`
+            : `${baseUrl}/mcp`
+        }
+      : {})
+  };
+}
+
+/**
+ * Build the OAuth Protected Resource Metadata document (RFC 9728) for the
+ * MCP gateway. MCP clients resolve this from the `resource_metadata`
+ * parameter of the gateway's 401 WWW-Authenticate challenge to find out
+ * which authorization server protects /mcp and which scopes to request.
+ *
+ * @param {import('express').Request} req - Express request object
+ * @returns {Object} Protected resource metadata document
+ */
+function buildProtectedResourceMetadata(req) {
+  const baseUrl = getBaseUrl(req);
+  const platform = configCache.getPlatform() || {};
+  const oauthConfig = platform.oauth || {};
+  const mcpConfig = platform.mcpServer || {};
+
+  const issuer =
+    oauthConfig.issuer && oauthConfig.issuer.startsWith('http') ? oauthConfig.issuer : baseUrl;
+  const publicBase = mcpConfig.publicUrl ? mcpConfig.publicUrl.replace(/\/$/, '') : baseUrl;
+
+  return {
+    resource: `${publicBase}/mcp`,
+    authorization_servers: [issuer],
+    bearer_methods_supported: ['header'],
+    scopes_supported: [
+      'mcp:tools:read',
+      'mcp:tools:call',
+      'mcp:apps:invoke',
+      'mcp:workflows:run',
+      'mcp:resources:read'
+    ],
+    resource_name: 'iHub Apps MCP gateway',
+    resource_documentation: `${publicBase}/mcp/.well-known`
+  };
+}
+
 export default function registerWellKnownRoutes(app) {
   /**
    * @swagger
@@ -93,62 +195,11 @@ export default function registerWellKnownRoutes(app) {
    */
   app.get('/.well-known/openid-configuration', (req, res) => {
     try {
-      const baseUrl = getBaseUrl(req);
-      const platform = configCache.getPlatform() || {};
-      const algorithm = getJwtAlgorithm();
-
-      // Use configured issuer or fall back to dynamic base URL.
-      // OIDC spec (RFC 8414 §2) requires issuer to be a URL starting with https:// or http://.
-      const oauthConfig = platform.oauth || {};
-      const issuer =
-        oauthConfig.issuer && oauthConfig.issuer.startsWith('http') ? oauthConfig.issuer : baseUrl;
-
-      const mcpConfig = platform.mcpServer || {};
-      const mcpScopes = mcpConfig.enabled
-        ? [
-            'mcp:tools:read',
-            'mcp:tools:call',
-            'mcp:apps:invoke',
-            'mcp:workflows:run',
-            'mcp:resources:read'
-          ]
-        : [];
-
-      // Build OpenID Connect Discovery response.
-      // Fields follow the OIDC Discovery specification (OpenID Connect Discovery 1.0).
-      const discovery = {
-        issuer,
-        jwks_uri: `${baseUrl}/.well-known/jwks.json`,
-        authorization_endpoint: `${baseUrl}/api/oauth/authorize`,
-        token_endpoint: `${baseUrl}/api/oauth/token`,
-        userinfo_endpoint: `${baseUrl}/api/oauth/userinfo`,
-        revocation_endpoint: `${baseUrl}/api/oauth/revoke`,
-        end_session_endpoint: `${baseUrl}/api/oauth/logout`,
-        response_types_supported: ['code'],
-        subject_types_supported: ['public'],
-        id_token_signing_alg_values_supported: [algorithm],
-        token_endpoint_auth_methods_supported: ['client_secret_post', 'client_secret_basic'],
-        grant_types_supported: ['client_credentials', 'authorization_code', 'refresh_token'],
-        scopes_supported: ['openid', 'profile', 'email', 'offline_access', ...mcpScopes],
-        code_challenge_methods_supported: ['S256'],
-        claims_supported: ['sub', 'name', 'email', 'groups', 'iss', 'aud', 'exp', 'iat', 'nonce'],
-        request_parameter_supported: false,
-        request_uri_parameter_supported: false,
-        // Non-standard but useful for MCP-aware clients: advertise the gateway
-        // endpoint so an agent can auto-discover it from the well-known URL.
-        ...(mcpConfig.enabled
-          ? {
-              mcp_endpoint: mcpConfig.publicUrl
-                ? `${mcpConfig.publicUrl.replace(/\/$/, '')}/mcp`
-                : `${baseUrl}/mcp`
-            }
-          : {})
-      };
+      const discovery = buildAuthServerMetadata(req);
 
       logger.info('Served OpenID Connect Discovery', {
         component: 'WellKnown',
-        algorithm,
-        baseUrl
+        issuer: discovery.issuer
       });
 
       res.json(discovery);
@@ -156,6 +207,80 @@ export default function registerWellKnownRoutes(app) {
       return sendInternalError(res, error, 'serve OpenID Connect Discovery');
     }
   });
+
+  /**
+   * @swagger
+   * /.well-known/oauth-authorization-server:
+   *   get:
+   *     summary: OAuth 2.0 Authorization Server Metadata (RFC 8414)
+   *     description: |
+   *       Same metadata document as /.well-known/openid-configuration. MCP
+   *       clients (Claude, Cursor, VS Code, …) resolve this path first when
+   *       discovering how to authenticate against the MCP gateway.
+   *     tags:
+   *       - Well-Known
+   *     responses:
+   *       200:
+   *         description: Authorization server metadata
+   */
+  const authServerMetadataHandler = (req, res) => {
+    try {
+      const discovery = buildAuthServerMetadata(req);
+
+      logger.info('Served OAuth Authorization Server Metadata', {
+        component: 'WellKnown',
+        issuer: discovery.issuer
+      });
+
+      res.json(discovery);
+    } catch (error) {
+      return sendInternalError(res, error, 'serve OAuth Authorization Server Metadata');
+    }
+  };
+
+  app.get('/.well-known/oauth-authorization-server', authServerMetadataHandler);
+  // RFC 8414 §3.1 inserts the well-known segment between host and issuer
+  // path, so subpath deployments are queried with the issuer path appended.
+  app.get('/.well-known/oauth-authorization-server/{*issuerPath}', authServerMetadataHandler);
+
+  /**
+   * @swagger
+   * /.well-known/oauth-protected-resource:
+   *   get:
+   *     summary: OAuth 2.0 Protected Resource Metadata (RFC 9728)
+   *     description: |
+   *       Describes the MCP gateway resource (/mcp) — which authorization
+   *       server protects it and which scopes it understands. Served only
+   *       while the MCP gateway is enabled; 404 otherwise so a disabled
+   *       gateway stays invisible. Also registered with the /mcp path suffix
+   *       because RFC 9728 §3.1 inserts the well-known segment between host
+   *       and resource path.
+   *     tags:
+   *       - Well-Known
+   *     responses:
+   *       200:
+   *         description: Protected resource metadata
+   *       404:
+   *         description: MCP gateway is not enabled
+   */
+  const protectedResourceHandler = (req, res) => {
+    try {
+      const platform = configCache.getPlatform() || {};
+      if (platform.mcpServer?.enabled !== true) {
+        return res
+          .status(404)
+          .json({ error: 'not_found', error_description: 'MCP gateway is not enabled' });
+      }
+      res.json(buildProtectedResourceMetadata(req));
+    } catch (error) {
+      return sendInternalError(res, error, 'serve OAuth Protected Resource Metadata');
+    }
+  };
+
+  app.get('/.well-known/oauth-protected-resource', protectedResourceHandler);
+  // RFC 9728 §3.1 appends the resource path (/mcp, or <subpath>/mcp when the
+  // app is deployed under a prefix) after the well-known segment.
+  app.get('/.well-known/oauth-protected-resource/{*resourcePath}', protectedResourceHandler);
 
   /**
    * @swagger

--- a/server/routes/wellKnown.js
+++ b/server/routes/wellKnown.js
@@ -87,9 +87,13 @@ function buildAuthServerMetadata(req) {
     userinfo_endpoint: `${baseUrl}/api/oauth/userinfo`,
     revocation_endpoint: `${baseUrl}/api/oauth/revoke`,
     end_session_endpoint: `${baseUrl}/api/oauth/logout`,
-    // RFC 7591 Dynamic Client Registration — advertised only when the admin
-    // has enabled DCR so MCP clients (Claude, Cursor, …) can self-register.
-    ...(oauthConfig.dcr?.enabled ? { registration_endpoint: `${baseUrl}/api/oauth/register` } : {}),
+    // RFC 7591 Dynamic Client Registration — advertised only when DCR *and*
+    // the authorization server are enabled, since /api/oauth/register
+    // hard-404s unless both are on (advertising it earlier would send MCP
+    // clients into a guaranteed registration failure).
+    ...(oauthConfig.dcr?.enabled && oauthConfig.enabled?.authz
+      ? { registration_endpoint: `${baseUrl}/api/oauth/register` }
+      : {}),
     response_types_supported: ['code'],
     subject_types_supported: ['public'],
     id_token_signing_alg_values_supported: [algorithm],

--- a/server/server.js
+++ b/server/server.js
@@ -27,6 +27,7 @@ import registerOpenAIProxyRoutes from './routes/openaiProxy.js';
 import registerAuthRoutes from './routes/auth.js';
 import registerOAuthRoutes from './routes/oauth.js';
 import registerOAuthAuthorizeRoutes from './routes/oauthAuthorize.js';
+import registerOAuthRegisterRoutes from './routes/oauthRegister.js';
 import registerWellKnownRoutes from './routes/wellKnown.js';
 import registerMcpServerRoutes from './routes/mcpServer.js';
 import registerSwaggerRoutes from './routes/swagger.js';
@@ -451,6 +452,7 @@ if (cluster.isPrimary && workerCount > 1) {
   registerAuthRoutes(app);
   registerOAuthRoutes(app);
   registerOAuthAuthorizeRoutes(app);
+  registerOAuthRegisterRoutes(app);
   registerWellKnownRoutes(app);
   registerMcpServerRoutes(app);
   registerGeneralRoutes(app, { getLocalizedError });

--- a/server/services/mcp/McpServerService.js
+++ b/server/services/mcp/McpServerService.js
@@ -1,4 +1,8 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  ListToolsRequestSchema,
+  ListResourcesRequestSchema
+} from '@modelcontextprotocol/sdk/types.js';
 import { z } from 'zod';
 import configCache from '../../configCache.js';
 import { loadConfiguredTools, runTool } from '../../toolLoader.js';
@@ -299,6 +303,22 @@ export async function buildMcpServer({ user, platform }) {
         }
       );
     }
+  }
+
+  // ---- Empty-registry fallbacks --------------------------------------------
+  // The SDK only installs its tools/list and resources/list handlers when at
+  // least one tool/resource was registered; with zero registrations a client
+  // gets JSON-RPC -32601 "Method not found", which MCP clients (Claude,
+  // Cursor) surface as a connection error. Since the registry is fixed after
+  // build, install explicit empty-list handlers instead.
+  if (Object.keys(server._registeredTools || {}).length === 0) {
+    server.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+  }
+  if (
+    Object.keys(server._registeredResources || {}).length === 0 &&
+    Object.keys(server._registeredResourceTemplates || {}).length === 0
+  ) {
+    server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));
   }
 
   // ---- Audit hook on every dispatch ---------------------------------------

--- a/server/services/mcp/McpServerService.js
+++ b/server/services/mcp/McpServerService.js
@@ -140,6 +140,19 @@ export async function buildMcpServer({ user, platform }) {
     { capabilities: { tools: { listChanged: false }, resources: { listChanged: false } } }
   );
 
+  // Local registration counters — used below to install empty-list fallback
+  // handlers without reaching into SDK-private fields.
+  let registeredToolCount = 0;
+  let registeredResourceCount = 0;
+  const registerTool = (...args) => {
+    server.registerTool(...args);
+    registeredToolCount += 1;
+  };
+  const registerResource = (...args) => {
+    server.registerResource(...args);
+    registeredResourceCount += 1;
+  };
+
   // ---- Tools (iHub-native, local-only) ------------------------------------
   // loadConfiguredTools excludes outbound MCP-discovered tools so the gateway
   // never re-proxies another server's tools to inbound callers.
@@ -148,7 +161,7 @@ export async function buildMcpServer({ user, platform }) {
     const tools = await loadConfiguredTools(platform?.defaultLanguage || 'en');
     for (const tool of tools) {
       if (!isToolAllowed(tool, expose, visibleToolIds)) continue;
-      server.registerTool(
+      registerTool(
         tool.id,
         {
           description: typeof tool.description === 'string' ? tool.description : '',
@@ -185,7 +198,7 @@ export async function buildMcpServer({ user, platform }) {
     const { data: apps = [] } = configCache.getApps();
     for (const app of apps) {
       if (!isAppAllowed(app, user, expose)) continue;
-      server.registerTool(
+      registerTool(
         buildAppToolName(app.id),
         {
           description:
@@ -230,7 +243,7 @@ export async function buildMcpServer({ user, platform }) {
     for (const wf of workflows) {
       if (!isWorkflowAllowed(wf, user, expose)) continue;
       const paramsSchema = buildWorkflowMcpParams(wf);
-      server.registerTool(
+      registerTool(
         buildWorkflowToolName(wf.id),
         {
           description:
@@ -272,7 +285,7 @@ export async function buildMcpServer({ user, platform }) {
     for (const r of resources) {
       // registerResource binds a single URI to a read callback. The SDK's
       // `resources/list` is served from the union of registered entries.
-      server.registerResource(
+      registerResource(
         r.name,
         r.uri,
         { description: r.description, mimeType: r.mimeType },
@@ -311,13 +324,10 @@ export async function buildMcpServer({ user, platform }) {
   // gets JSON-RPC -32601 "Method not found", which MCP clients (Claude,
   // Cursor) surface as a connection error. Since the registry is fixed after
   // build, install explicit empty-list handlers instead.
-  if (Object.keys(server._registeredTools || {}).length === 0) {
+  if (registeredToolCount === 0) {
     server.server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
   }
-  if (
-    Object.keys(server._registeredResources || {}).length === 0 &&
-    Object.keys(server._registeredResourceTemplates || {}).length === 0
-  ) {
+  if (registeredResourceCount === 0) {
     server.server.setRequestHandler(ListResourcesRequestSchema, async () => ({ resources: [] }));
   }
 

--- a/server/tests/admin-platform-config-merge.test.js
+++ b/server/tests/admin-platform-config-merge.test.js
@@ -1,0 +1,181 @@
+/**
+ * Regression tests for the platform config save path.
+ *
+ * POST /api/admin/configs/platform rebuilds the file from an explicit
+ * allowlist of sections spread over `...existingConfig`. Any section missing
+ * from that allowlist is silently dropped from the request: the endpoint
+ * answers 200 while the on-disk value stays as it was, so the admin UI
+ * appears to save and then reverts on reload.
+ *
+ * `mcpServer` (Admin → MCP gateway) is edited through this generic endpoint
+ * rather than a dedicated route, so it must round-trip.
+ *
+ * Note: The repo's source is native ESM, so this file uses
+ * `jest.unstable_mockModule` + dynamic imports. Run with
+ * `NODE_OPTIONS=--experimental-vm-modules`.
+ */
+
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+const state = { rootDir: null };
+
+jest.unstable_mockModule('../pathUtils.js', () => ({
+  getRootDir: () => state.rootDir
+}));
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: {
+    refreshCacheEntry: async () => {},
+    getPlatform: () => ({})
+  }
+}));
+
+jest.unstable_mockModule('../middleware/adminAuth.js', () => ({
+  adminAuth: (req, res, next) => next()
+}));
+
+jest.unstable_mockModule('../middleware/oidcAuth.js', () => ({
+  reconfigureOidcProviders: () => {}
+}));
+
+jest.unstable_mockModule('../services/TokenStorageService.js', () => ({
+  default: {
+    isEncrypted: () => false,
+    encryptString: v => v,
+    decryptString: v => v
+  }
+}));
+
+jest.unstable_mockModule('../websocket/realtimeTranscription.js', () => ({
+  testRealtimeConnection: async () => ({ ok: true })
+}));
+
+jest.unstable_mockModule('../services/AuditLogService.js', () => ({
+  logAudit: async () => {}
+}));
+
+jest.unstable_mockModule('../services/ChangeHistoryService.js', () => ({
+  saveSnapshot: async () => {}
+}));
+
+const { default: registerAdminConfigRoutes } = await import('../routes/admin/configs.js');
+
+function createTestApp() {
+  const app = express();
+  app.use(express.json());
+  app.use((req, res, next) => {
+    req.user = { id: 'admin-user', username: 'admin', groups: ['admin'] };
+    next();
+  });
+  registerAdminConfigRoutes(app);
+  return app;
+}
+
+const platformPath = () => path.join(state.rootDir, 'contents', 'config', 'platform.json');
+
+async function readPlatform() {
+  return JSON.parse(await fs.readFile(platformPath(), 'utf8'));
+}
+
+describe('POST /api/admin/configs/platform section persistence', () => {
+  beforeEach(async () => {
+    state.rootDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ihub-platform-cfg-'));
+    await fs.mkdir(path.join(state.rootDir, 'contents', 'config'), { recursive: true });
+    await fs.writeFile(
+      platformPath(),
+      JSON.stringify(
+        {
+          auth: { mode: 'local' },
+          oauth: { enabled: { authz: false, clients: false } },
+          mcpServer: {
+            enabled: false,
+            requireConsent: true,
+            expose: { tools: true, apps: true, workflows: true, resources: false }
+          }
+        },
+        null,
+        2
+      )
+    );
+  });
+
+  afterEach(async () => {
+    await fs.rm(state.rootDir, { recursive: true, force: true });
+  });
+
+  test('persists mcpServer.enabled instead of silently keeping the on-disk value', async () => {
+    const app = createTestApp();
+    const existing = await readPlatform();
+
+    const response = await request(app)
+      .post('/api/admin/configs/platform')
+      .send({ ...existing, mcpServer: { ...existing.mcpServer, enabled: true } });
+
+    expect(response.status).toBe(200);
+    // The actual regression: a 200 with the old value still on disk.
+    expect((await readPlatform()).mcpServer.enabled).toBe(true);
+  });
+
+  test('persists nested mcpServer fields (expose / publicUrl)', async () => {
+    const app = createTestApp();
+    const existing = await readPlatform();
+
+    await request(app)
+      .post('/api/admin/configs/platform')
+      .send({
+        ...existing,
+        mcpServer: {
+          ...existing.mcpServer,
+          enabled: true,
+          publicUrl: 'https://ihub.example.com',
+          expose: { ...existing.mcpServer.expose, resources: true }
+        }
+      });
+
+    const saved = await readPlatform();
+    expect(saved.mcpServer.publicUrl).toBe('https://ihub.example.com');
+    expect(saved.mcpServer.expose.resources).toBe(true);
+    expect(saved.mcpServer.expose.tools).toBe(true);
+  });
+
+  test('keeps the existing mcpServer section when the request omits it', async () => {
+    const app = createTestApp();
+    const { mcpServer: _omitted, ...withoutGateway } = await readPlatform();
+
+    await request(app).post('/api/admin/configs/platform').send(withoutGateway);
+
+    const saved = await readPlatform();
+    expect(saved.mcpServer).toBeDefined();
+    expect(saved.mcpServer.enabled).toBe(false);
+    expect(saved.mcpServer.requireConsent).toBe(true);
+  });
+
+  test('persists the oauth section alongside the gateway (single save from the MCP page)', async () => {
+    const app = createTestApp();
+    const existing = await readPlatform();
+
+    await request(app)
+      .post('/api/admin/configs/platform')
+      .send({
+        ...existing,
+        mcpServer: { ...existing.mcpServer, enabled: true },
+        oauth: {
+          ...existing.oauth,
+          enabled: { authz: true, clients: true },
+          authorizationCodeEnabled: true,
+          refreshTokenEnabled: true,
+          dcr: { enabled: true, maxClients: 100 }
+        }
+      });
+
+    const saved = await readPlatform();
+    expect(saved.mcpServer.enabled).toBe(true);
+    expect(saved.oauth.enabled.authz).toBe(true);
+    expect(saved.oauth.dcr.enabled).toBe(true);
+  });
+});

--- a/server/tests/oauth-dcr-validation.test.js
+++ b/server/tests/oauth-dcr-validation.test.js
@@ -36,6 +36,21 @@ describe('DCR redirect URI validation', () => {
     }
   });
 
+  it('rejects known network schemes that are not app callbacks', () => {
+    for (const uri of [
+      'ftp://evil.example.com/cb',
+      'ws://evil.example.com/cb',
+      'wss://evil.example.com/cb',
+      'mailto:attacker@example.com',
+      'ssh://evil.example.com/cb',
+      'ldap://evil.example.com/cb',
+      'intent://cb#Intent;end',
+      'chrome-extension://abcdef/cb'
+    ]) {
+      expect(validateRedirectUri(uri).ok).toBe(false);
+    }
+  });
+
   it('rejects URIs with fragments', () => {
     expect(validateRedirectUri('https://example.com/cb#frag').ok).toBe(false);
   });

--- a/server/tests/oauth-dcr-validation.test.js
+++ b/server/tests/oauth-dcr-validation.test.js
@@ -1,0 +1,139 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  validateRedirectUri,
+  validateRegistrationRequest,
+  DCR_DEFAULT_ALLOWED_SCOPES
+} from '../utils/dcrValidation.js';
+
+describe('DCR redirect URI validation', () => {
+  it('accepts https URIs', () => {
+    expect(validateRedirectUri('https://claude.ai/api/mcp/auth_callback').ok).toBe(true);
+  });
+
+  it('accepts loopback http URIs', () => {
+    expect(validateRedirectUri('http://localhost:3334/callback').ok).toBe(true);
+    expect(validateRedirectUri('http://127.0.0.1:8080/cb').ok).toBe(true);
+    expect(validateRedirectUri('http://[::1]:8080/cb').ok).toBe(true);
+  });
+
+  it('rejects non-loopback http URIs', () => {
+    expect(validateRedirectUri('http://evil.example.com/cb').ok).toBe(false);
+  });
+
+  it('accepts private-use native app schemes', () => {
+    expect(validateRedirectUri('cursor://anysphere.cursor-mcp/oauth/callback').ok).toBe(true);
+  });
+
+  it('rejects dangerous schemes', () => {
+    for (const uri of [
+      'javascript:alert(1)',
+      'data:text/html,x',
+      'file:///etc/passwd',
+      'vbscript:x',
+      'about:blank'
+    ]) {
+      expect(validateRedirectUri(uri).ok).toBe(false);
+    }
+  });
+
+  it('rejects URIs with fragments', () => {
+    expect(validateRedirectUri('https://example.com/cb#frag').ok).toBe(false);
+  });
+
+  it('rejects non-string and malformed values', () => {
+    expect(validateRedirectUri(null).ok).toBe(false);
+    expect(validateRedirectUri('').ok).toBe(false);
+    expect(validateRedirectUri('not a uri').ok).toBe(false);
+    expect(validateRedirectUri('x'.repeat(2001)).ok).toBe(false);
+  });
+});
+
+describe('DCR registration request validation', () => {
+  const minimal = { redirect_uris: ['https://claude.ai/api/mcp/auth_callback'] };
+
+  it('accepts a minimal Claude-style registration with sane defaults', () => {
+    const result = validateRegistrationRequest(minimal);
+    expect(result.ok).toBe(true);
+    expect(result.clientMetadata.name).toBe('MCP Client');
+    expect(result.clientMetadata.grantTypes).toEqual(['authorization_code', 'refresh_token']);
+    expect(result.clientMetadata.tokenEndpointAuthMethod).toBe('none');
+    expect(result.clientMetadata.scopes).toEqual([...DCR_DEFAULT_ALLOWED_SCOPES]);
+  });
+
+  it('requires redirect_uris', () => {
+    expect(validateRegistrationRequest({}).ok).toBe(false);
+    expect(validateRegistrationRequest({ redirect_uris: [] }).ok).toBe(false);
+    const tooMany = { redirect_uris: Array(11).fill('https://example.com/cb') };
+    expect(validateRegistrationRequest(tooMany).ok).toBe(false);
+  });
+
+  it('rejects non-object bodies', () => {
+    expect(validateRegistrationRequest(null).ok).toBe(false);
+    expect(validateRegistrationRequest([]).ok).toBe(false);
+    expect(validateRegistrationRequest('x').ok).toBe(false);
+  });
+
+  it('rejects the client_credentials grant', () => {
+    const result = validateRegistrationRequest({
+      ...minimal,
+      grant_types: ['client_credentials']
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('invalid_client_metadata');
+  });
+
+  it('requires authorization_code in grant_types', () => {
+    const result = validateRegistrationRequest({ ...minimal, grant_types: ['refresh_token'] });
+    expect(result.ok).toBe(false);
+  });
+
+  it('rejects unsupported response types', () => {
+    expect(validateRegistrationRequest({ ...minimal, response_types: ['token'] }).ok).toBe(false);
+    expect(validateRegistrationRequest({ ...minimal, response_types: ['code'] }).ok).toBe(true);
+  });
+
+  it('rejects unsupported token endpoint auth methods', () => {
+    expect(
+      validateRegistrationRequest({ ...minimal, token_endpoint_auth_method: 'private_key_jwt' }).ok
+    ).toBe(false);
+    const confidential = validateRegistrationRequest({
+      ...minimal,
+      token_endpoint_auth_method: 'client_secret_post'
+    });
+    expect(confidential.ok).toBe(true);
+    expect(confidential.clientMetadata.tokenEndpointAuthMethod).toBe('client_secret_post');
+  });
+
+  it('filters requested scopes against the allowlist', () => {
+    const result = validateRegistrationRequest({
+      ...minimal,
+      scope: 'openid mcp:tools:call admin:everything'
+    });
+    expect(result.ok).toBe(true);
+    expect(result.clientMetadata.scopes).toEqual(['openid', 'mcp:tools:call']);
+  });
+
+  it('rejects a scope request with no grantable scopes', () => {
+    const result = validateRegistrationRequest({ ...minimal, scope: 'admin:everything' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('invalid_client_metadata');
+  });
+
+  it('honors a custom scope allowlist', () => {
+    const result = validateRegistrationRequest(
+      { ...minimal, scope: 'openid mcp:tools:call' },
+      { allowedScopes: ['openid'] }
+    );
+    expect(result.ok).toBe(true);
+    expect(result.clientMetadata.scopes).toEqual(['openid']);
+  });
+
+  it('sanitizes the client name', () => {
+    const result = validateRegistrationRequest({
+      ...minimal,
+      client_name: '  Claude\x00\x1f Desktop  '
+    });
+    expect(result.ok).toBe(true);
+    expect(result.clientMetadata.name).toBe('Claude Desktop');
+  });
+});

--- a/server/utils/dcrValidation.js
+++ b/server/utils/dcrValidation.js
@@ -29,13 +29,36 @@ export const DCR_ALLOWED_AUTH_METHODS = Object.freeze([
   'client_secret_basic'
 ]);
 
-const DANGEROUS_SCHEMES = new Set([
+// Schemes that must never be redirect targets: script/local-content schemes
+// (XSS vectors) plus well-known network/navigation schemes that are not
+// app-callback schemes. Anything else that is neither https nor loopback
+// http is treated as a private-use native-app scheme (RFC 8252 §7.1) — a
+// positive allowlist is impossible since every native MCP client picks its
+// own scheme (cursor://…, vscode://…, com.example.app://…).
+const DENIED_SCHEMES = new Set([
   'javascript:',
   'data:',
   'file:',
   'vbscript:',
   'blob:',
-  'about:'
+  'about:',
+  'ftp:',
+  'ftps:',
+  'sftp:',
+  'ws:',
+  'wss:',
+  'mailto:',
+  'tel:',
+  'ssh:',
+  'telnet:',
+  'smb:',
+  'ldap:',
+  'ldaps:',
+  'gopher:',
+  'intent:',
+  'chrome:',
+  'chrome-extension:',
+  'moz-extension:'
 ]);
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
 
@@ -70,7 +93,7 @@ export function validateRedirectUri(uri) {
   }
 
   const scheme = parsed.protocol;
-  if (DANGEROUS_SCHEMES.has(scheme)) {
+  if (DENIED_SCHEMES.has(scheme)) {
     return { ok: false, reason: `redirect URI scheme not allowed: ${scheme}` };
   }
 
@@ -86,12 +109,11 @@ export function validateRedirectUri(uri) {
     return { ok: false, reason: 'http redirect URIs are only allowed for loopback addresses' };
   }
 
-  // Private-use URI scheme for native apps (RFC 8252 §7.1), e.g. cursor://…
-  if (/^[a-z][a-z0-9+.-]*:$/i.test(scheme)) {
-    return { ok: true };
-  }
-
-  return { ok: false, reason: `redirect URI scheme not allowed: ${scheme}` };
+  // Anything else is treated as a private-use URI scheme for native apps
+  // (RFC 8252 §7.1), e.g. cursor://…, vscode://…. Note that DCR necessarily
+  // allows arbitrary attacker-controlled https targets too — the mandatory
+  // user consent screen, not the scheme, is the actual authorization gate.
+  return { ok: true };
 }
 
 /**

--- a/server/utils/dcrValidation.js
+++ b/server/utils/dcrValidation.js
@@ -1,0 +1,258 @@
+import { MCP_SCOPE_LIST } from '../services/mcp/scopes.js';
+
+/**
+ * Validation for RFC 7591 Dynamic Client Registration requests.
+ *
+ * Kept free of Express/config dependencies so the security-relevant rules are
+ * unit-testable in isolation. The policy is deliberately narrower than the
+ * RFC allows:
+ *   - only the authorization_code (+ refresh_token) grant can be registered —
+ *     client_credentials service accounts must be created by an admin,
+ *   - redirect URIs must be https, loopback http, or a private-use scheme
+ *     (RFC 8252 native apps); dangerous schemes are always rejected,
+ *   - grantable scopes are limited to an allowlist (identity + mcp:*).
+ */
+
+export const DCR_DEFAULT_ALLOWED_SCOPES = Object.freeze([
+  'openid',
+  'profile',
+  'email',
+  'offline_access',
+  ...MCP_SCOPE_LIST
+]);
+
+export const DCR_ALLOWED_GRANT_TYPES = Object.freeze(['authorization_code', 'refresh_token']);
+
+export const DCR_ALLOWED_AUTH_METHODS = Object.freeze([
+  'none',
+  'client_secret_post',
+  'client_secret_basic'
+]);
+
+const DANGEROUS_SCHEMES = new Set([
+  'javascript:',
+  'data:',
+  'file:',
+  'vbscript:',
+  'blob:',
+  'about:'
+]);
+const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
+
+const MAX_REDIRECT_URIS = 10;
+const MAX_URI_LENGTH = 2000;
+const MAX_NAME_LENGTH = 100;
+const MAX_SCOPE_LENGTH = 500;
+
+/**
+ * Validate a single redirect URI against the DCR policy.
+ *
+ * @param {*} uri - Candidate redirect URI
+ * @returns {{ ok: boolean, reason?: string }} Validation result
+ */
+export function validateRedirectUri(uri) {
+  if (typeof uri !== 'string' || uri.length === 0) {
+    return { ok: false, reason: 'redirect URI must be a non-empty string' };
+  }
+  if (uri.length > MAX_URI_LENGTH) {
+    return { ok: false, reason: `redirect URI exceeds ${MAX_URI_LENGTH} characters` };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return { ok: false, reason: `redirect URI is not a valid URI: ${uri}` };
+  }
+
+  if (parsed.hash) {
+    return { ok: false, reason: 'redirect URI must not contain a fragment' };
+  }
+
+  const scheme = parsed.protocol;
+  if (DANGEROUS_SCHEMES.has(scheme)) {
+    return { ok: false, reason: `redirect URI scheme not allowed: ${scheme}` };
+  }
+
+  if (scheme === 'https:') {
+    return { ok: true };
+  }
+
+  if (scheme === 'http:') {
+    // Plain http is only acceptable for loopback redirects (RFC 8252 §7.3).
+    if (LOOPBACK_HOSTS.has(parsed.hostname)) {
+      return { ok: true };
+    }
+    return { ok: false, reason: 'http redirect URIs are only allowed for loopback addresses' };
+  }
+
+  // Private-use URI scheme for native apps (RFC 8252 §7.1), e.g. cursor://…
+  if (/^[a-z][a-z0-9+.-]*:$/i.test(scheme)) {
+    return { ok: true };
+  }
+
+  return { ok: false, reason: `redirect URI scheme not allowed: ${scheme}` };
+}
+
+/**
+ * Strip control characters and clamp length for display strings taken from
+ * an unauthenticated registration request.
+ *
+ * @param {*} value - Raw input value
+ * @param {number} maxLength - Maximum length to keep
+ * @returns {string} Sanitized string ('' when not a string)
+ */
+function sanitizeDisplayString(value, maxLength) {
+  if (typeof value !== 'string') return '';
+
+  return value
+    .replace(/[\x00-\x1f\x7f]/g, '')
+    .trim()
+    .substring(0, maxLength);
+}
+
+/**
+ * Validate an RFC 7591 registration request body and derive the client data
+ * to store.
+ *
+ * @param {Object} body - Parsed JSON request body
+ * @param {Object} [options] - Policy options
+ * @param {Array<string>} [options.allowedScopes] - Scope allowlist override
+ * @returns {{ ok: false, error: string, errorDescription: string } |
+ *           { ok: true, clientMetadata: Object }} Validation outcome; on
+ *           success `clientMetadata` carries the normalized registration
+ *           values (name, redirectUris, grantTypes, tokenEndpointAuthMethod,
+ *           scopes, softwareId, softwareVersion).
+ */
+export function validateRegistrationRequest(body, options = {}) {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return {
+      ok: false,
+      error: 'invalid_client_metadata',
+      errorDescription: 'Request body must be a JSON object'
+    };
+  }
+
+  // --- redirect_uris (required) ---
+  const redirectUris = body.redirect_uris;
+  if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
+    return {
+      ok: false,
+      error: 'invalid_redirect_uri',
+      errorDescription: 'redirect_uris is required and must be a non-empty array'
+    };
+  }
+  if (redirectUris.length > MAX_REDIRECT_URIS) {
+    return {
+      ok: false,
+      error: 'invalid_redirect_uri',
+      errorDescription: `At most ${MAX_REDIRECT_URIS} redirect URIs are allowed`
+    };
+  }
+  for (const uri of redirectUris) {
+    const result = validateRedirectUri(uri);
+    if (!result.ok) {
+      return { ok: false, error: 'invalid_redirect_uri', errorDescription: result.reason };
+    }
+  }
+
+  // --- grant_types ---
+  let grantTypes = [...DCR_ALLOWED_GRANT_TYPES];
+  if (body.grant_types !== undefined) {
+    if (!Array.isArray(body.grant_types) || body.grant_types.length === 0) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        errorDescription: 'grant_types must be a non-empty array'
+      };
+    }
+    const invalid = body.grant_types.filter(g => !DCR_ALLOWED_GRANT_TYPES.includes(g));
+    if (invalid.length > 0) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        errorDescription: `Unsupported grant types for dynamic registration: ${invalid.join(', ')}`
+      };
+    }
+    if (!body.grant_types.includes('authorization_code')) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        errorDescription: 'Dynamically registered clients must use the authorization_code grant'
+      };
+    }
+    grantTypes = [...new Set(body.grant_types)];
+  }
+
+  // --- response_types ---
+  if (body.response_types !== undefined) {
+    if (
+      !Array.isArray(body.response_types) ||
+      body.response_types.some(r => r !== 'code') ||
+      body.response_types.length === 0
+    ) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        errorDescription: 'Only the "code" response type is supported'
+      };
+    }
+  }
+
+  // --- token_endpoint_auth_method ---
+  let tokenEndpointAuthMethod = 'none';
+  if (body.token_endpoint_auth_method !== undefined) {
+    if (!DCR_ALLOWED_AUTH_METHODS.includes(body.token_endpoint_auth_method)) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        errorDescription: `Unsupported token_endpoint_auth_method. Supported: ${DCR_ALLOWED_AUTH_METHODS.join(', ')}`
+      };
+    }
+    tokenEndpointAuthMethod = body.token_endpoint_auth_method;
+  }
+
+  // --- scope ---
+  const allowedScopes =
+    Array.isArray(options.allowedScopes) && options.allowedScopes.length > 0
+      ? options.allowedScopes
+      : DCR_DEFAULT_ALLOWED_SCOPES;
+
+  let scopes = [...allowedScopes];
+  if (body.scope !== undefined) {
+    if (typeof body.scope !== 'string' || body.scope.length > MAX_SCOPE_LENGTH) {
+      return {
+        ok: false,
+        error: 'invalid_client_metadata',
+        errorDescription: 'scope must be a space-separated string'
+      };
+    }
+    const requested = body.scope.split(' ').filter(Boolean);
+    if (requested.length > 0) {
+      const granted = requested.filter(s => allowedScopes.includes(s));
+      if (granted.length === 0) {
+        return {
+          ok: false,
+          error: 'invalid_client_metadata',
+          errorDescription: `None of the requested scopes are grantable. Grantable scopes: ${allowedScopes.join(' ')}`
+        };
+      }
+      scopes = granted;
+    }
+  }
+
+  const name = sanitizeDisplayString(body.client_name, MAX_NAME_LENGTH) || 'MCP Client';
+
+  return {
+    ok: true,
+    clientMetadata: {
+      name,
+      redirectUris,
+      grantTypes,
+      tokenEndpointAuthMethod,
+      scopes,
+      softwareId: sanitizeDisplayString(body.software_id, MAX_NAME_LENGTH),
+      softwareVersion: sanitizeDisplayString(body.software_version, MAX_NAME_LENGTH)
+    }
+  };
+}

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1661,7 +1661,16 @@
         "exposeWorkflowsDesc": "Erfordert Scope mcp:workflows:run",
         "exposeResources": "Ressourcen",
         "exposeResourcesDesc": "Quellen / Skills als MCP-Ressourcen (resources/list + resources/read). Erfordert Scope mcp:resources:read.",
-        "connection": "Verbindungsbeispiele"
+        "connection": "Verbindungsbeispiele",
+        "authSection": "Authentifizierung",
+        "authSectionDesc": "Das MCP-Gateway akzeptiert ausschließlich OAuth-Bearer-Token des integrierten Autorisierungsservers. Dieser muss aktiviert sein, damit sich MCP-Clients verbinden können.",
+        "oauthWarning": "Das Gateway ist aktiviert, aber der OAuth-Autorisierungsserver ist aus — MCP-Clients können kein Token erhalten. Bitte unten aktivieren.",
+        "oauthToggle": "OAuth-Autorisierungsserver",
+        "oauthToggleDesc": "Stellt /api/oauth/authorize und /api/oauth/token bereit. Beim Aktivieren werden auch die OAuth-Client-Verwaltung sowie die Grants authorization_code + refresh_token eingeschaltet. Nach dem erstmaligen Aktivieren ist ein Server-Neustart erforderlich.",
+        "dcrToggle": "Dynamische Client-Registrierung (RFC 7591)",
+        "dcrToggleDesc": "Erlaubt MCP-Clients wie Claude, ihren OAuth-Client automatisch unter /api/oauth/register zu registrieren — keine manuelle Client-Einrichtung nötig. Registrierte Clients durchlaufen immer Anmeldung und Zustimmung der Nutzenden und erhalten nur Identitäts- und mcp:*-Scopes.",
+        "claudeHintDcr": "Claude: Einstellungen → Connectors → Benutzerdefinierten Connector hinzufügen, dann die obige Endpoint-URL einfügen. Claude registriert seinen OAuth-Client automatisch; Nutzende melden sich bei iHub an und stimmen den angeforderten mcp:*-Scopes zu.",
+        "claudeHintManual": "Claude: Einstellungen → Connectors → Benutzerdefinierten Connector hinzufügen, dann die obige Endpoint-URL einfügen und Client-ID/Secret eines unter /admin/oauth/clients angelegten OAuth-Clients eintragen (Grant-Typen authorization_code + refresh_token, Redirect-URI https://claude.ai/api/mcp/auth_callback sowie die gewünschten mcp:*-Scopes). Aktivieren Sie oben die dynamische Client-Registrierung, um die manuelle Einrichtung zu überspringen."
       }
     },
     "telemetry": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1409,7 +1409,16 @@
         "exposeWorkflowsDesc": "Requires scope mcp:workflows:run",
         "exposeResources": "Resources",
         "exposeResourcesDesc": "Sources / skills surfaced as MCP resources (resources/list + resources/read). Requires scope mcp:resources:read.",
-        "connection": "Connection examples"
+        "connection": "Connection examples",
+        "authSection": "Authentication",
+        "authSectionDesc": "The MCP gateway only accepts OAuth bearer tokens issued by the built-in authorization server. It must be enabled for any MCP client to connect.",
+        "oauthWarning": "The gateway is enabled but the OAuth authorization server is off — MCP clients cannot obtain a token. Enable it below.",
+        "oauthToggle": "OAuth authorization server",
+        "oauthToggleDesc": "Serves /api/oauth/authorize and /api/oauth/token. Enabling this also switches on OAuth client management and the authorization_code + refresh_token grants. A server restart is required after enabling it for the first time.",
+        "dcrToggle": "Dynamic client registration (RFC 7591)",
+        "dcrToggleDesc": "Lets MCP clients such as Claude register their OAuth client automatically at /api/oauth/register — no manual client setup needed. Registered clients always go through user sign-in and consent, and only receive identity + mcp:* scopes.",
+        "claudeHintDcr": "Claude: Settings → Connectors → Add custom connector, then paste the endpoint URL above. Claude registers its OAuth client automatically; users sign in to iHub and consent to the requested mcp:* scopes.",
+        "claudeHintManual": "Claude: Settings → Connectors → Add custom connector, then paste the endpoint URL above and enter the client ID/secret of an OAuth client you created under /admin/oauth/clients (grant types authorization_code + refresh_token, redirect URI https://claude.ai/api/mcp/auth_callback, plus the desired mcp:* scopes). Enable dynamic client registration above to skip the manual client setup."
       }
     },
     "telemetry": {


### PR DESCRIPTION
## Problem

Activating the MCP gateway so iHub can be used from Claude was not possible end-to-end:

1. **The gateway settings could not be saved at all.** `POST /api/admin/configs/platform` rebuilds `platform.json` from an explicit allowlist of sections spread over `...existingConfig`, and `mcpServer` was not in that allowlist — so the request's gateway settings were discarded while the endpoint answered 200. Every toggle on the MCP gateway page reverted on the next page load.
2. The **Admin → MCP gateway** page only set `mcpServer.enabled`, while the OAuth authorization server (`oauth.enabled.authz`) — the *only* accepted auth on `/mcp` — stayed off. Every `/api/oauth/authorize` / `/api/oauth/token` call then failed with "OAuth is not enabled on this server".
3. The OAuth discovery surface required by MCP clients was missing: `/.well-known/oauth-authorization-server` was advertised by `/mcp/.well-known` but never implemented (404), there was no RFC 9728 protected-resource metadata, and the 401 challenge on `/mcp` lacked the `resource_metadata` pointer.
4. There was no dynamic client registration, so every user would have to manually create an OAuth client and copy its credentials into their MCP client.

## Changes

### Server

- **Config save fix**: added `mcpServer` to the platform-config merge allowlist so the gateway section actually persists (omitting it in a request still preserves the existing section). This affected the MCP gateway page as shipped in 5.4.0, not just the new toggles.
- **RFC 8414**: `/.well-known/oauth-authorization-server` now serves the same document as `/.well-known/openid-configuration` (shared builder), including `registration_endpoint` when DCR *and* the authorization server are enabled, and `"none"` in `token_endpoint_auth_methods_supported` for public PKCE clients. Path-suffix variants are handled for subpath deployments.
- **RFC 9728**: new `/.well-known/oauth-protected-resource[/mcp]` describing the gateway resource, its authorization server, and the `mcp:*` scopes. Hard-404 while the gateway is disabled.
- **MCP auth spec (2025-06-18)**: 401/403 responses from `/mcp` now carry `WWW-Authenticate: Bearer realm="ihub-mcp", resource_metadata="…/.well-known/oauth-protected-resource/mcp"` so clients can bootstrap the flow from a single probe. Falls back to the request-derived origin if `publicUrl` is not an absolute URL.
- **RFC 7591 DCR**: new `POST /api/oauth/register` (opt-in via `oauth.dcr.enabled`, default off) that auto-creates OAuth clients. Deliberately narrow policy (`server/utils/dcrValidation.js`): `authorization_code` (+`refresh_token`) only — no self-registered service accounts; redirect URIs restricted to https / loopback http / private-use native schemes with script and known network schemes rejected; scope allowlist (identity + `mcp:*`, overridable via `oauth.dcr.allowedScopes`); consent always required, never trusted; capped by `oauth.dcr.maxClients` (default 100); covered by the existing `/api/oauth` rate limiter. Registered clients are manageable in Admin → OAuth clients like any other.
- **Scope fallback**: an authorize request without a `scope` parameter now defaults to the client's registered scopes (RFC 6749 §3.3) instead of bare `openid`, and the consent form carries the resolved scopes — previously such tokens were rejected by the gateway with `insufficient_scope`.
- **Empty registry fix**: `tools/list` / `resources/list` return empty lists instead of JSON-RPC `-32601` when a caller's filtered registry is empty (the SDK installs those handlers lazily on first registration). Tracked via local registration counters, not SDK-private fields.
- **Consent screen** now describes `mcp:*` scopes in plain language.
- **Migration V080** seeds `mcpServer` and `oauth.dcr` defaults (all conservative/off); `server/defaults/config/platform.json` updated for fresh installs.

### Admin UI

- MCP gateway page gains an **Authentication** section: a toggle for the OAuth authorization server (also enables the client store and the auth-code + refresh grants, with a restart hint), a toggle for dynamic client registration, and a warning banner when the gateway is on but OAuth is off. Connection examples now include Claude instructions (with and without DCR). i18n added for en/de.

### Docs & tests

- `docs/mcp-integration.md`: activation checklist, discovery-chain walkthrough, DCR policy, Claude connection guide, troubleshooting table.
- Changelog entry in `docs/releases/5.5.0/features.md`.
- 19 new Jest tests for the DCR validation policy and 4 for the platform-config save path; existing MCP suites pass (92 total across the related suites).

## Verification

Full flow verified against a locally booted server: unauthenticated `POST /mcp` → 401 with `resource_metadata` → RFC 8414/9728 documents served → DCR registration (201, public PKCE client) → local login → consent screen → code + PKCE token exchange (with refresh token) → `initialize` + `tools/list` over `/mcp` returning the user's 14 permitted tools. Also verified:

- the Claude-style variant that omits the `scope` parameter,
- the empty-registry case returning `[]` instead of an error,
- the admin save round-trip (`enabled: false` → POST → 200 → `true` on disk, `/mcp` switching from 404 to a 401 challenge), with the save-path tests confirmed to fail when the fix is reverted,
- discovery under a simulated subpath deployment (`X-Forwarded-Prefix: /ihub`), where both the path-appended and origin-root well-known forms return consistent metadata,
- `registration_endpoint` being advertised only when DCR and the authorization server are both on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbVgGvDnU9WVLfao1h8zXQ