### PR TITLE
Fix MCP gateway rejecting every request after a successful OAuth login

### DIFF
--- a/client/src/features/admin/pages/AdminMcpGatewayPage.jsx
+++ b/client/src/features/admin/pages/AdminMcpGatewayPage.jsx
@@ -264,7 +264,9 @@ function AdminMcpGatewayPage() {
               checked={transports.streamableHttp?.enabled !== false}
               onChange={v =>
                 update({
-                  transports: { streamableHttp: { enabled: v } }
+                  transports: {
+                    streamableHttp: { ...(transports.streamableHttp || {}), enabled: v }
+                  }
                 })
               }
               label={t(
@@ -274,6 +276,21 @@ function AdminMcpGatewayPage() {
               description={t(
                 'admin.mcp.gateway.transportStreamableHttpDesc',
                 'Canonical MCP HTTP transport per spec 2025-03-26+. Supports session resumption via Mcp-Session-Id + Last-Event-ID.'
+              )}
+            />
+            <Toggle
+              checked={transports.streamableHttp?.stateless === true}
+              onChange={v =>
+                update({
+                  transports: {
+                    streamableHttp: { ...(transports.streamableHttp || {}), stateless: v }
+                  }
+                })
+              }
+              label={t('admin.mcp.gateway.transportStateless', 'Stateless mode')}
+              description={t(
+                'admin.mcp.gateway.transportStatelessDesc',
+                'Handle every Streamable HTTP request independently instead of keeping MCP sessions in memory. Enable when iHub runs behind a load balancer that spreads requests across several pods, where a session opened on one pod is unknown to the next. Trade-off: no server-initiated SSE stream.'
               )}
             />
             <Toggle

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -293,14 +293,54 @@ callers with the matching scope.
 
 ### Session model
 
-The gateway is stateful: an `initialize` request receives a session id,
-echoed by the client on subsequent requests as `Mcp-Session-Id`. A
-session is bound to the authenticating user; subsequent requests on the
-same session with a token belonging to a *different* user are rejected
-with 403 to prevent resource leakage between concurrent OAuth clients.
+By default the gateway is stateful: an `initialize` request receives a
+session id, echoed by the client on subsequent requests as
+`Mcp-Session-Id`. A session is bound to the authenticating user;
+subsequent requests on the same session with a token belonging to a
+*different* user are rejected with 403 to prevent resource leakage
+between concurrent OAuth clients.
 
 `DELETE /mcp` (with `Mcp-Session-Id` header) tears down a session
-cleanly. SSE keepalive + reconnect is handled by the SDK.
+cleanly — only the user who opened the session may terminate it. SSE
+keepalive + reconnect is handled by the SDK. Sessions the client
+abandons without a `DELETE` are swept after an hour of inactivity.
+
+Requests the gateway cannot map to a live session get the status the MCP
+spec prescribes, so clients can recover on their own:
+
+| Situation | Response |
+| --- | --- |
+| `Mcp-Session-Id` is unknown, expired, or was opened elsewhere | `404` `Session not found` — the client starts a new session with a fresh `initialize` |
+| POST that is not `initialize` and carries no session id | `400 Bad Request: Mcp-Session-Id header is required` |
+| `GET /mcp` outside a session | `405 Method Not Allowed` — there is no server-initiated SSE stream to attach to |
+
+#### Stateless mode (load-balanced deployments)
+
+Session state lives in the worker's process memory. The sticky cluster
+router keeps a client on the same worker within one instance, but if
+iHub is deployed as several replicas behind a load balancer, a session
+opened on one replica is unknown to the next and the client has to
+re-initialize on every request.
+
+For that topology enable **stateless mode**
+(Admin → MCP gateway → Transports, or
+`platform.mcpServer.transports.streamableHttp.stateless: true`):
+
+```json
+{
+  "mcpServer": {
+    "transports": {
+      "streamableHttp": { "enabled": true, "stateless": true }
+    }
+  }
+}
+```
+
+Every request then builds its own short-lived MCP server, no session id
+is issued, and no affinity is required. Trade-off: `GET /mcp` answers
+`405`, so the server cannot push notifications to the client. The
+gateway does not use server-initiated messages today, and MCP clients
+treat the `405` as "this server has no push channel".
 
 ### Discovery
 
@@ -384,6 +424,17 @@ Troubleshooting:
   enabling OAuth (session middleware missing).
 - `403 insufficient_scope` on `/mcp` → the token carries no `mcp:*`
   scope; check the scopes on the OAuth client and re-authorize.
+- Sign-in and consent succeed but the client still reports it cannot
+  connect, and `/mcp` answers `404 Session not found` on every request →
+  requests are not landing on the process that holds the session. Enable
+  stateless mode (see [Stateless mode](#stateless-mode-load-balanced-deployments))
+  or configure session affinity on the load balancer.
+- `400 Bad Request: Mcp-Session-Id header is required` → the client sent
+  a non-`initialize` request without a session id; it never completed
+  (or lost) the handshake.
+
+Every rejection the transport makes is logged under the `McpGateway`
+component, so `npm run logs` shows the reason a client was turned away.
 
 ## Agent-to-Agent (A2A) endpoint — experimental
 

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -725,3 +725,27 @@ standard OAuth discovery — including automatic client registration.
 
 **Note:** after enabling the OAuth authorization server for the first time, restart the server
 once so the OAuth session middleware is mounted.
+
+## MCP clients can connect reliably after sign-in
+
+Fixed the MCP gateway rejecting every request that followed a successful OAuth login, which left
+clients such as the Claude Code CLI stuck at "could not connect" even though the browser consent
+step had completed.
+
+- Requests the gateway cannot match to a live session now get the status the MCP spec prescribes,
+  so clients recover on their own: an unknown or expired `Mcp-Session-Id` returns
+  `404 Session not found` (the client simply opens a new session), and `GET /mcp` outside a session
+  returns `405`. Previously all of these returned `400 Bad Request: Server not initialized`, which
+  MCP clients treat as a fatal protocol error.
+- The session is registered the moment the handshake is accepted, closing a window in which a
+  client already held its session id but the gateway did not yet recognise it.
+- New **Stateless mode** toggle under **Admin → MCP gateway → Transports** for installations that
+  run several load-balanced replicas. Each request is then served independently, so no session
+  affinity is required. Trade-off: no server-initiated SSE stream (the gateway does not use one).
+- Every request the gateway turns away is now logged under the `McpGateway` component with the
+  reason, and abandoned sessions are released after an hour instead of being held for the lifetime
+  of the process.
+- Only the user who opened a session can terminate it via `DELETE /mcp`.
+- Authorization-code tokens no longer log a misleading `JWT verification failed — jwt audience
+  invalid` warning on every MCP request; those tokens are audience-scoped to their OAuth client by
+  design and were always being accepted.

--- a/server/defaults/config/platform.json
+++ b/server/defaults/config/platform.json
@@ -139,7 +139,7 @@
     "requireConsent": true,
     "publicUrl": "",
     "transports": {
-      "streamableHttp": { "enabled": true },
+      "streamableHttp": { "enabled": true, "stateless": false },
       "sse": { "enabled": true }
     },
     "a2a": { "enabled": false },

--- a/server/migrations/V081__add_mcp_streamable_http_stateless.js
+++ b/server/migrations/V081__add_mcp_streamable_http_stateless.js
@@ -1,0 +1,25 @@
+export const version = '081';
+export const description = 'add_mcp_streamable_http_stateless';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+/**
+ * Seed `mcpServer.transports.streamableHttp.stateless` so the option shows up
+ * with an explicit value in the admin UI.
+ *
+ * Default `false` keeps the existing stateful behaviour (MCP sessions held in
+ * worker memory, which the sticky cluster router already routes consistently).
+ * Operators running iHub as several load-balanced replicas should turn it on:
+ * a session opened on one replica is unknown to the next, and the client then
+ * has to re-initialize on every request.
+ */
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  ctx.setDefault(platform, 'mcpServer.transports.streamableHttp.stateless', false);
+
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Added mcpServer.transports.streamableHttp.stateless default');
+}

--- a/server/routes/mcpServer.js
+++ b/server/routes/mcpServer.js
@@ -18,14 +18,29 @@ import logger from '../utils/logger.js';
  *   GET  /mcp/sse       — Legacy SSE transport (back-compat)
  *   POST /mcp/messages  — Legacy SSE client→server messages
  *
- * Sessions are stateful: an MCP `initialize` request receives a session id
- * that the client echoes back via `Mcp-Session-Id` on subsequent requests.
- * Stateful sessions keep the in-memory `McpServer` registry alive across
- * requests so tool callbacks stay bound to the same authenticated user.
+ * Sessions are stateful by default: an MCP `initialize` request receives a
+ * session id that the client echoes back via `Mcp-Session-Id` on subsequent
+ * requests. Stateful sessions keep the in-memory `McpServer` registry alive
+ * across requests so tool callbacks stay bound to the same authenticated user.
+ *
+ * Because that registry lives in the worker's process memory, stateful mode
+ * needs the client to keep landing on the same worker/replica (the sticky
+ * cluster router in `clusterSticky.js` handles the multi-worker case). Behind a
+ * load balancer that fans out across pods, set
+ * `platform.mcpServer.transports.streamableHttp.stateless = true` — every
+ * request then builds its own short-lived transport and no session id is
+ * issued, so no affinity is required.
  */
 
-// Map<sessionId, { transport, server, userId }>
+// Map<sessionId, { transport, server, userId, lastSeen }>
 const sessions = new Map();
+
+// Sessions are dropped after this much inactivity. MCP clients hold a session
+// for the lifetime of their connection, so the window is generous; the sweep
+// exists so abandoned sessions (client killed, network dropped without a
+// DELETE) cannot pile up McpServer instances for the life of the process.
+const SESSION_IDLE_TTL_MS = 60 * 60 * 1000;
+const SESSION_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 
 function gatewayEnabled() {
   const platform = configCache.getPlatform() || {};
@@ -36,11 +51,9 @@ function gatewayConfig() {
   return (configCache.getPlatform() || {}).mcpServer || {};
 }
 
-async function destroySession(sessionId) {
-  const s = sessions.get(sessionId);
-  if (!s) return;
+async function closeServer(server, sessionId) {
   try {
-    await s.server.close();
+    await server.close();
   } catch (err) {
     logger.warn('Error closing MCP gateway server', {
       component: 'McpGateway',
@@ -48,10 +61,62 @@ async function destroySession(sessionId) {
       error: err.message
     });
   }
+}
+
+async function destroySession(sessionId) {
+  const s = sessions.get(sessionId);
+  if (!s) return;
+  // Delete first: closing the transport fires onclose, which calls back into
+  // destroySession. Removing the entry up front makes that re-entry a no-op.
   sessions.delete(sessionId);
+  await closeServer(s.server, sessionId);
+}
+
+/**
+ * Drop sessions whose client has gone away without sending DELETE.
+ */
+function sweepIdleSessions() {
+  const cutoff = Date.now() - SESSION_IDLE_TTL_MS;
+  for (const [sessionId, entry] of sessions) {
+    if (entry.lastSeen > cutoff) continue;
+    logger.info('Expiring idle MCP session', {
+      component: 'McpGateway',
+      sessionId,
+      idleMs: Date.now() - entry.lastSeen
+    });
+    destroySession(sessionId).catch(() => {});
+  }
+}
+
+/**
+ * Reply with a JSON-RPC error envelope at a specific HTTP status.
+ * Matches the shape the MCP SDK's own transport-level errors use so clients
+ * parse gateway-level rejections the same way.
+ */
+function sendRpcError(res, status, code, message, headers = {}) {
+  for (const [name, value] of Object.entries(headers)) {
+    res.setHeader(name, value);
+  }
+  return res.status(status).json({
+    jsonrpc: '2.0',
+    error: { code, message },
+    id: null
+  });
+}
+
+/**
+ * True when the (already parsed) POST body is an MCP `initialize` request —
+ * the only message allowed to open a new session.
+ */
+function isInitializeRequestBody(body) {
+  const messages = Array.isArray(body) ? body : [body];
+  return messages.some(msg => msg && typeof msg === 'object' && msg.method === 'initialize');
 }
 
 export default function registerMcpServerRoutes(app) {
+  // unref() so the sweep timer never keeps the process alive on shutdown.
+  setInterval(sweepIdleSessions, SESSION_SWEEP_INTERVAL_MS).unref();
+
   const enabledCheck = (req, res, next) => {
     if (!gatewayEnabled()) {
       return res
@@ -62,6 +127,63 @@ export default function registerMcpServerRoutes(app) {
   };
 
   // ---- Streamable HTTP transport ----------------------------------------
+
+  /**
+   * Build a transport + per-user McpServer pair. In stateful mode the session
+   * is registered from the SDK's `onsessioninitialized` callback, which fires
+   * while the initialize request is still being handled — registering after
+   * `handleRequest()` resolves would leave a window in which the client has
+   * already received its session id but the gateway has not stored it yet, and
+   * the client's very next request would be rejected as unknown.
+   */
+  async function createTransport(req, { stateless }) {
+    const platform = configCache.getPlatform() || {};
+    const server = await buildMcpServer({ user: req.user, platform });
+    const entry = { transport: null, server, userId: req.user.id, lastSeen: Date.now() };
+
+    const transport = new StreamableHTTPServerTransport({
+      // `undefined` puts the SDK transport in stateless mode: no session id is
+      // issued and no session validation is performed.
+      sessionIdGenerator: stateless ? undefined : () => randomUUID(),
+      ...(stateless
+        ? {}
+        : {
+            onsessioninitialized: id => {
+              entry.lastSeen = Date.now();
+              sessions.set(id, entry);
+              logger.debug('MCP session opened', {
+                component: 'McpGateway',
+                sessionId: id,
+                userId: req.user.id
+              });
+            }
+          })
+    });
+
+    // Without this, transport-level rejections (bad Accept header, unsupported
+    // protocol version, malformed JSON-RPC) are returned to the client but
+    // never logged, which makes a failing client impossible to diagnose from
+    // the server side.
+    transport.onerror = err => {
+      logger.warn('MCP gateway transport rejected request', {
+        component: 'McpGateway',
+        userId: req.user?.id,
+        method: req.method,
+        sessionId: req.headers['mcp-session-id'] || null,
+        error: err?.message
+      });
+    };
+    if (!stateless) {
+      transport.onclose = () => {
+        if (transport.sessionId) destroySession(transport.sessionId);
+      };
+    }
+
+    await server.connect(transport);
+    entry.transport = transport;
+    return entry;
+  }
+
   const streamableHttpHandler = async (req, res) => {
     const cfg = gatewayConfig();
     if (cfg.transports?.streamableHttp?.enabled === false) {
@@ -70,8 +192,70 @@ export default function registerMcpServerRoutes(app) {
         .json({ error: 'not_found', error_description: 'Streamable HTTP transport disabled' });
     }
 
+    const stateless = cfg.transports?.streamableHttp?.stateless === true;
     const sessionId = req.headers['mcp-session-id'];
+
+    if (stateless) {
+      // One transport per request: nothing is kept in process memory, so the
+      // gateway works behind a load balancer without session affinity.
+      let entry;
+      try {
+        entry = await createTransport(req, { stateless: true });
+      } catch (err) {
+        logger.error('MCP gateway failed to build stateless server', {
+          component: 'McpGateway',
+          error: err.message
+        });
+        return sendRpcError(res, 500, -32603, 'Failed to initialise MCP server');
+      }
+      if (req.method === 'GET') {
+        // The standalone server→client SSE stream needs a session to belong
+        // to. Declining it with 405 is explicitly allowed by the spec and MCP
+        // clients treat it as "this server has no push channel".
+        await closeServer(entry.server, null);
+        return sendRpcError(
+          res,
+          405,
+          -32000,
+          'Method Not Allowed: this gateway runs in stateless mode and offers no server-initiated SSE stream',
+          { Allow: 'POST, DELETE' }
+        );
+      }
+      try {
+        await entry.transport.handleRequest(req, res, req.body);
+      } catch (err) {
+        logger.error('MCP gateway streamable HTTP handler failed', {
+          component: 'McpGateway',
+          error: err.message,
+          stack: err.stack
+        });
+        if (!res.headersSent) {
+          res.status(500).json({ error: 'internal_error', error_description: err.message });
+        }
+      } finally {
+        await closeServer(entry.server, null);
+      }
+      return;
+    }
+
     let entry = sessionId ? sessions.get(sessionId) : null;
+    let isNewSession = false;
+
+    if (sessionId && !entry) {
+      // Unknown session: expired, terminated, or opened on another worker /
+      // replica. The spec requires 404 here so the client knows to start a new
+      // session with a fresh `initialize`. Handing the request to a brand-new
+      // transport instead (as this used to) makes the SDK answer
+      // 400 "Server not initialized", which clients treat as a fatal protocol
+      // error — the connection never recovers.
+      logger.info('MCP session not found — asking client to re-initialize', {
+        component: 'McpGateway',
+        sessionId,
+        userId: req.user.id,
+        method: req.method
+      });
+      return sendRpcError(res, 404, -32001, 'Session not found');
+    }
 
     // Bind transport to authenticated user. Re-authenticating on every request
     // (rather than only at initialize) ensures token revocation takes effect
@@ -90,27 +274,38 @@ export default function registerMcpServerRoutes(app) {
     }
 
     if (!entry) {
-      const platform = configCache.getPlatform() || {};
-      const server = await buildMcpServer({ user: req.user, platform });
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID()
-      });
-      transport.onclose = () => {
-        if (transport.sessionId) destroySession(transport.sessionId);
-      };
-      await server.connect(transport);
-      // Session id is assigned after the first request the transport handles
-      // (per MCP spec). We register into the map once the id is known.
-      entry = { transport, server, userId: req.user.id };
+      // No session id at all. Only `initialize` may open one; anything else
+      // gets a targeted error instead of an McpServer that would be built,
+      // rejected by the SDK and then leaked.
+      if (req.method === 'GET') {
+        return sendRpcError(
+          res,
+          405,
+          -32000,
+          'Method Not Allowed: open a session with an initialize request before requesting the SSE stream',
+          { Allow: 'POST, DELETE' }
+        );
+      }
+      if (!isInitializeRequestBody(req.body)) {
+        return sendRpcError(res, 400, -32000, 'Bad Request: Mcp-Session-Id header is required');
+      }
+      try {
+        entry = await createTransport(req, { stateless: false });
+        isNewSession = true;
+      } catch (err) {
+        logger.error('MCP gateway failed to build server', {
+          component: 'McpGateway',
+          error: err.message
+        });
+        return sendRpcError(res, 500, -32603, 'Failed to initialise MCP server');
+      }
     }
+
+    entry.lastSeen = Date.now();
 
     try {
       await entry.transport.handleRequest(req, res, req.body);
-      // Register the session after handleRequest so we have the assigned id.
-      const id = entry.transport.sessionId;
-      if (id && !sessions.has(id)) {
-        sessions.set(id, entry);
-      }
+      entry.lastSeen = Date.now();
     } catch (err) {
       logger.error('MCP gateway streamable HTTP handler failed', {
         component: 'McpGateway',
@@ -119,6 +314,15 @@ export default function registerMcpServerRoutes(app) {
       });
       if (!res.headersSent) {
         res.status(500).json({ error: 'internal_error', error_description: err.message });
+      }
+    } finally {
+      // The transport only registers the session once it has accepted an
+      // initialize request. If it rejected the request instead (bad Accept
+      // header, malformed JSON-RPC, …) the server we just built is orphaned —
+      // release it rather than leaving it for the GC-less sessions map.
+      const assignedId = entry.transport.sessionId;
+      if (isNewSession && (!assignedId || !sessions.has(assignedId))) {
+        await closeServer(entry.server, assignedId || null);
       }
     }
   };
@@ -132,7 +336,22 @@ export default function registerMcpServerRoutes(app) {
   app.get(buildServerPath('/mcp'), enabledCheck, mcpAuth, streamableHttpHandler);
   app.delete(buildServerPath('/mcp'), enabledCheck, mcpAuth, async (req, res) => {
     const sessionId = req.headers['mcp-session-id'];
-    if (sessionId) await destroySession(sessionId);
+    const entry = sessionId ? sessions.get(sessionId) : null;
+    // Termination is idempotent: an already-gone session is still "terminated".
+    if (entry) {
+      if (entry.userId !== req.user.id) {
+        logger.warn('MCP session termination refused — session belongs to another user', {
+          component: 'McpGateway',
+          sessionId,
+          tokenUser: req.user.id,
+          sessionUser: entry.userId
+        });
+        return res
+          .status(403)
+          .json({ error: 'forbidden', error_description: 'Session belongs to a different user' });
+      }
+      await destroySession(sessionId);
+    }
     res.status(204).end();
   });
 

--- a/server/routes/mcpServer.js
+++ b/server/routes/mcpServer.js
@@ -179,7 +179,15 @@ export default function registerMcpServerRoutes(app) {
       };
     }
 
-    await server.connect(transport);
+    try {
+      await server.connect(transport);
+    } catch (err) {
+      // The server is fully built by this point; if wiring the transport to it
+      // fails there is nothing left holding a reference, so release it here
+      // rather than leaving it to accumulate behind the caller's 500.
+      await closeServer(server, null);
+      throw err;
+    }
     entry.transport = transport;
     return entry;
   }

--- a/server/tests/mcp-gateway-sessions.test.js
+++ b/server/tests/mcp-gateway-sessions.test.js
@@ -193,6 +193,24 @@ describe('MCP gateway session handling', () => {
     expect(buildMcpServer).toHaveBeenCalledTimes(1);
   });
 
+  it('releases the McpServer when wiring the transport to it fails', async () => {
+    // buildMcpServer succeeded, so something holds real resources; failing to
+    // connect must not leave it dangling behind the 500.
+    const close = jest.fn();
+    buildMcpServer.mockResolvedValue({
+      connect: jest.fn().mockRejectedValue(new Error('adapter init failed')),
+      close
+    });
+
+    const res = await request(makeApp())
+      .post('/mcp')
+      .set('Accept', 'application/json, text/event-stream')
+      .send(INITIALIZE);
+
+    expect(res.status).toBe(500);
+    expect(close).toHaveBeenCalled();
+  });
+
   it('refuses to terminate a session owned by another user', async () => {
     buildMcpServer.mockResolvedValue({ connect: jest.fn(), close: jest.fn() });
     nextSessionId = '55555555-5555-5555-5555-555555555555';

--- a/server/tests/mcp-gateway-sessions.test.js
+++ b/server/tests/mcp-gateway-sessions.test.js
@@ -1,0 +1,223 @@
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import express from 'express';
+import request from 'supertest';
+
+/**
+ * Session-handling contract of the Streamable HTTP gateway (routes/mcpServer.js).
+ *
+ * The MCP spec is specific about how a server answers a request it cannot map
+ * to a live session, and clients depend on those exact statuses to recover:
+ *   - unknown / expired session id  -> 404, client opens a new session
+ *   - non-initialize POST, no id    -> 400, client must initialize first
+ *   - GET without a session         -> 405, server offers no push stream
+ *
+ * Before this was fixed the gateway silently built a fresh, uninitialized
+ * transport for all three cases, so the SDK answered 400 "Server not
+ * initialized" every time. Clients treat that as a fatal protocol error, which
+ * is why an MCP client could authenticate successfully and still never connect.
+ */
+
+const buildMcpServer = jest.fn();
+
+jest.unstable_mockModule('../services/mcp/McpServerService.js', () => ({
+  buildMcpServer
+}));
+
+let currentUserId = 'user-1';
+
+jest.unstable_mockModule('../middleware/mcpAuth.js', () => ({
+  default: (req, res, next) => {
+    req.user = { id: currentUserId, scopes: ['mcp:tools:read'] };
+    next();
+  },
+  MCP_METHOD_SCOPES: {}
+}));
+
+const platform = {
+  mcpServer: {
+    enabled: true,
+    transports: { streamableHttp: { enabled: true }, sse: { enabled: false } }
+  }
+};
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: { getPlatform: () => platform }
+}));
+
+// Stand in for the SDK transport so the tests can inspect the options the
+// gateway constructs it with, and drive the session lifecycle deterministically.
+const transports = [];
+// The id the fake transport hands out when it accepts an initialize request.
+let nextSessionId = 'session-1';
+
+class FakeStreamableHTTPServerTransport {
+  constructor(options) {
+    this.options = options;
+    this.sessionId = undefined;
+    this.handleRequest = jest.fn(async (req, res, body) => {
+      // Mirror the real SDK: on initialize, assign the id and fire the
+      // onsessioninitialized callback *while still handling the request*.
+      if (body?.method === 'initialize' && options.sessionIdGenerator) {
+        this.sessionId = nextSessionId;
+        await options.onsessioninitialized?.(this.sessionId);
+      }
+      res.status(200).json({ handled: true, session: this.sessionId ?? null });
+    });
+    transports.push(this);
+  }
+}
+
+jest.unstable_mockModule('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
+  StreamableHTTPServerTransport: FakeStreamableHTTPServerTransport
+}));
+
+const { default: registerMcpServerRoutes } = await import('../routes/mcpServer.js');
+
+function makeApp() {
+  const app = express();
+  registerMcpServerRoutes(app);
+  return app;
+}
+
+const INITIALIZE = {
+  jsonrpc: '2.0',
+  id: 0,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2025-06-18',
+    capabilities: {},
+    clientInfo: { name: 't', version: '1' }
+  }
+};
+
+describe('MCP gateway session handling', () => {
+  beforeEach(() => {
+    buildMcpServer.mockReset();
+    transports.length = 0;
+    platform.mcpServer.transports.streamableHttp.stateless = false;
+  });
+
+  it('answers 404 Session not found for an unknown session id', async () => {
+    const res = await request(makeApp())
+      .post('/mcp')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('mcp-session-id', '11111111-1111-1111-1111-111111111111')
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    expect(res.status).toBe(404);
+    expect(res.body.error.code).toBe(-32001);
+    expect(res.body.error.message).toMatch(/Session not found/);
+    // No McpServer should be built for a request that cannot be served.
+    expect(buildMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('answers 400 with the session-header hint for a non-initialize POST', async () => {
+    const res = await request(makeApp())
+      .post('/mcp')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error.message).toMatch(/Mcp-Session-Id header is required/);
+    expect(buildMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('answers 405 for GET without a session instead of a confusing 400', async () => {
+    const res = await request(makeApp()).get('/mcp').set('Accept', 'text/event-stream');
+
+    expect(res.status).toBe(405);
+    expect(res.headers.allow).toBe('POST, DELETE');
+    expect(buildMcpServer).not.toHaveBeenCalled();
+  });
+
+  it('answers 405 for GET in stateless mode', async () => {
+    platform.mcpServer.transports.streamableHttp.stateless = true;
+    const close = jest.fn();
+    buildMcpServer.mockResolvedValue({ connect: jest.fn(), close });
+
+    const res = await request(makeApp()).get('/mcp').set('Accept', 'text/event-stream');
+
+    expect(res.status).toBe(405);
+    // The per-request server must be released, not leaked.
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('serves any POST in stateless mode, with no session id and no session state', async () => {
+    platform.mcpServer.transports.streamableHttp.stateless = true;
+    const close = jest.fn();
+    buildMcpServer.mockResolvedValue({ connect: jest.fn(), close });
+
+    // A session id from some other replica must not make the request fail.
+    const res = await request(makeApp())
+      .post('/mcp')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('mcp-session-id', '33333333-3333-3333-3333-333333333333')
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    expect(res.status).toBe(200);
+    expect(transports).toHaveLength(1);
+    // Stateless: the SDK transport must not generate session ids.
+    expect(transports[0].options.sessionIdGenerator).toBeUndefined();
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('registers the session from onsessioninitialized, before the client can use it', async () => {
+    // The SDK fires onsessioninitialized while the initialize request is still
+    // being handled. Registering after handleRequest() resolves instead leaves a
+    // window in which the client already holds its session id but the gateway
+    // does not know it yet — and the client's very next request 404s.
+    buildMcpServer.mockResolvedValue({ connect: jest.fn(), close: jest.fn() });
+    nextSessionId = '44444444-4444-4444-4444-444444444444';
+    const app = makeApp();
+
+    const init = await request(app)
+      .post('/mcp')
+      .set('Accept', 'application/json, text/event-stream')
+      .send(INITIALIZE);
+    expect(init.status).toBe(200);
+
+    expect(transports).toHaveLength(1);
+    expect(typeof transports[0].options.onsessioninitialized).toBe('function');
+    expect(typeof transports[0].options.sessionIdGenerator).toBe('function');
+
+    // The session the callback registered is routable — no 404.
+    const followUp = await request(app)
+      .post('/mcp')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('mcp-session-id', nextSessionId)
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    expect(followUp.status).toBe(200);
+    // Reused the existing transport rather than building a second server.
+    expect(transports).toHaveLength(1);
+    expect(buildMcpServer).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses to terminate a session owned by another user', async () => {
+    buildMcpServer.mockResolvedValue({ connect: jest.fn(), close: jest.fn() });
+    nextSessionId = '55555555-5555-5555-5555-555555555555';
+    const app = makeApp();
+
+    await request(app)
+      .post('/mcp')
+      .set('Accept', 'application/json, text/event-stream')
+      .send(INITIALIZE);
+
+    // mcpAuth is stubbed to authenticate whoever currentUserId names, so switch
+    // identity to simulate a session that belongs to somebody else.
+    currentUserId = 'someone-else';
+    try {
+      const res = await request(app).delete('/mcp').set('mcp-session-id', nextSessionId);
+      expect(res.status).toBe(403);
+    } finally {
+      currentUserId = 'user-1';
+    }
+  });
+
+  it('treats terminating an unknown session as a no-op', async () => {
+    const res = await request(makeApp())
+      .delete('/mcp')
+      .set('mcp-session-id', '66666666-6666-6666-6666-666666666666');
+    expect(res.status).toBe(204);
+  });
+});

--- a/server/utils/oauthTokenService.js
+++ b/server/utils/oauthTokenService.js
@@ -89,20 +89,23 @@ export function generateOAuthToken(client, options = {}) {
  */
 export function verifyOAuthToken(token) {
   try {
-    // First try standard verification (audience: 'ihub-apps', covers client_credentials)
-    let decoded = verifyJwt(token);
+    // Authorization-code tokens are audience-scoped to the OAuth client that
+    // requested them, everything else uses the platform audience. Peek at the
+    // (still unverified) claims to pick the expected audience up front —
+    // verifying with the wrong one first works, but logs a
+    // "jwt audience invalid" warning on every single authorization-code
+    // request, which reads like an auth failure when it is not.
+    const peeked = decodeJwt(token);
+    const claims = peeked?.payload;
+    const expectedAudience =
+      claims?.authMode === 'oauth_authorization_code' && claims?.aud && claims.aud !== 'ihub-apps'
+        ? claims.aud
+        : undefined;
 
-    // If that failed, check if it's an auth code token with client-specific audience
-    if (!decoded) {
-      const peeked = decodeJwt(token);
-      if (
-        peeked?.payload?.authMode === 'oauth_authorization_code' &&
-        peeked?.payload?.aud &&
-        peeked.payload.aud !== 'ihub-apps'
-      ) {
-        decoded = verifyJwt(token, { audience: peeked.payload.aud });
-      }
-    }
+    const decoded =
+      expectedAudience === undefined
+        ? verifyJwt(token)
+        : verifyJwt(token, { audience: expectedAudience });
 
     if (!decoded) {
       logger.warn('Token verification failed', { component: 'OAuthTokenService' });


### PR DESCRIPTION
## Problem

An MCP client (reported with the Claude Code CLI) could complete the whole OAuth authorization-code flow — browser consent, code exchange, refresh token stored — and still fail to connect. The server logs showed the login succeeding, then nothing useful, and `/mcp` answering `400`.

Reproduced against a local server with the real MCP SDK client:

```
GET /mcp (no session id)                    -> 400 {"error":{"code":-32000,
                                                 "message":"Bad Request: Server not initialized"}}
POST /mcp tools/list (unknown session id)   -> 400  (same)
POST /mcp tools/list (no session id)        -> 400  (same)
```

`streamableHttpHandler` treated "no entry in the `sessions` map" as "build a new transport", so any request it could not map to a live session in *this* process was handed to a freshly constructed, uninitialized `StreamableHTTPServerTransport` — which the SDK rejects with `400 Bad Request: Server not initialized`. MCP clients treat that as a fatal protocol error and stop, where the spec expects a status they can recover from. Each of those requests also built an `McpServer` that was never registered and never closed.

## Changes

**Session handling now follows the MCP spec** and never builds a server it cannot use:

| Situation | Before | After |
| --- | --- | --- |
| Unknown / expired `Mcp-Session-Id` | `400 Server not initialized` | `404 Session not found` — client opens a new session |
| Non-`initialize` POST, no session id | `400 Server not initialized` | `400 Mcp-Session-Id header is required` |
| `GET /mcp` outside a session | `400 Server not initialized` | `405 Method Not Allowed` (`Allow: POST, DELETE`) |

**Session registration moved to `onsessioninitialized`.** It previously happened after `handleRequest()` resolved, leaving a window in which the client already held its session id but the gateway did not recognise it yet. The SDK provides the callback for exactly this.

**New `mcpServer.transports.streamableHttp.stateless` option** (admin toggle under MCP gateway → Transports, migration `V081`, default `false`). Session state lives in worker memory; the sticky cluster router covers one instance, but several load-balanced replicas cannot share it, and a client would then have to re-initialize on every request. In stateless mode each request is served by its own short-lived transport, no session id is issued, and no affinity is required. Trade-off: `GET /mcp` answers `405`, i.e. no server-initiated SSE stream — the gateway does not use one today, and clients treat the `405` as "no push channel".

**Diagnosability.** `transport.onerror` is wired to the logger, so transport-level rejections (bad `Accept` header, unsupported protocol version, malformed JSON-RPC) appear under the `McpGateway` component instead of vanishing. This is why the original report had no server-side explanation for the `400`.

**Cleanup and hardening.**
- Idle sessions are swept after an hour instead of being held for the process lifetime.
- An orphaned server (transport rejected the `initialize` it was built for) is released rather than leaked.
- `DELETE /mcp` only terminates sessions owned by the caller.
- `verifyOAuthToken` picks the expected audience up front instead of verifying with the wrong one and retrying. Authorization-code tokens are audience-scoped to their OAuth client by design, and the failed first attempt logged `JWT verification failed — jwt audience invalid. expected: ihub-apps` on every single MCP request. The tokens were always being accepted; the warning was pure noise, and it is what made the reported failure look like an auth problem.

## Verification

End-to-end against a local server (DCR → local admin login → consent → code exchange → MCP handshake), driven by the real `@modelcontextprotocol/sdk` client:

- Stateful (default): client connects, `tools/list` succeeds; unknown session → `404`, `GET` without session → `405`, no audience warnings in the log.
- Stateless: client connects; `initialize` issues no session id; a stale session id from another replica is ignored; `GET` → `405`, which the SDK client tolerates.
- Migration `V081` applies on boot and adds `stateless: false` without touching existing values.

New suite `server/tests/mcp-gateway-sessions.test.js` — 8 tests covering each status above, `onsessioninitialized` registration, stateless behaviour, and session-termination ownership.

Full server suite: `119 failed / 45 failed tests` both before and after this change (pre-existing local breakage, unrelated), with 8 added passing tests (`469 → 477`). `eslint` and `prettier` clean on all touched files.

---
_Generated by [Claude Code](https://claude.ai/code/session_012eUFQBTTjQTGCFTT4uT4PM)_