### PR TITLE
fix(auth): stop the credential rate limiter from taking the platform down; make MCP 405s diagnosable

### DIFF
--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -432,6 +432,24 @@ Troubleshooting:
 - `400 Bad Request: Mcp-Session-Id header is required` → the client sent
   a non-`initialize` request without a session id; it never completed
   (or lost) the handshake.
+- `405 Method Not Allowed` on `GET /mcp` → three different causes, all
+  reported by clients the same way. The `McpGateway` log line for the
+  rejection carries `hadSessionHeader`, `userAgent` and `accept`, which
+  tells them apart:
+  - **Benign.** A Streamable HTTP client probing for the optional
+    server-initiated SSE stream. The MCP SDK reads `405` as "this server
+    has no push channel" and carries on, so tools still list and run.
+    Sign-in works, tools work, and a `405` shows up once per connection —
+    nothing to fix.
+  - **Wrong transport.** A client configured for the *legacy SSE*
+    transport but pointed at `/mcp`. It needs a GET stream and cannot
+    recover from the `405`. Point it at `/mcp/sse`, or reconfigure it as
+    a Streamable HTTP (`http`) client on `/mcp`.
+  - **Header stripped in transit.** A reverse proxy dropping the
+    `Mcp-Session-Id` request header. The give-away is `405` with
+    `hadSessionHeader: false` *after* a successful `initialize`, usually
+    together with `400 … header is required` on the following POSTs.
+    Allow `Mcp-Session-Id` and `MCP-Protocol-Version` through the proxy.
 
 Every rejection the transport makes is logged under the `McpGateway`
 component, so `npm run logs` shows the reason a client was turned away.

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -31,7 +31,10 @@ The system supports six different types of rate limiters, each configurable thro
   - `/api/admin/*` (all admin routes)
 
 ### 3. Auth API Rate Limiter
-- **Default Limit**: 50 requests per 15 minutes per IP address (most restrictive)
+- **Limit**: 30 requests per 15 minutes per IP address in the shipped
+  `platform.json` (`rateLimit.authApi.limit`). The code-level fallback, used only
+  when no `rateLimit.authApi` section is present at all, is 50 per 15 minutes.
+  Either way it is the most restrictive limiter.
 - **Applied to**: Endpoints under `/api/auth` that verify credentials:
   - `POST /api/auth/local/login`
   - `POST /api/auth/ldap/login`

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -32,8 +32,32 @@ The system supports six different types of rate limiters, each configurable thro
 
 ### 3. Auth API Rate Limiter
 - **Default Limit**: 50 requests per 15 minutes per IP address (most restrictive)
-- **Applied to**: Authentication endpoints:
-  - `/auth/*` (all authentication routes)
+- **Applied to**: Endpoints under `/api/auth` that verify credentials:
+  - `POST /api/auth/local/login`
+  - `POST /api/auth/ldap/login`
+  - `GET|POST /api/auth/ntlm/login`
+  - `POST /api/auth/teams/exchange`
+  - `POST /api/auth/teams/config`
+- **Not applied to** read-only endpoints in the same namespace. These are covered
+  by the public API limiter instead:
+  - `GET /api/auth/status` — fetched on every SPA boot and every 401 recovery,
+    and commonly used as the container liveness/readiness probe
+  - `GET /api/auth/user`
+  - `GET /api/auth/oidc/providers`, `GET /api/auth/ldap/providers`,
+    `GET /api/auth/ntlm/status`, `GET /api/auth/teams/client-config`
+  - `GET /api/auth/oidc/:provider` and `GET /api/auth/oidc/:provider/callback` —
+    the SSO redirect targets
+  - `POST /api/auth/logout`
+
+  The brute-force limiter is deliberately tight, so covering the whole namespace
+  with it took the platform down instead of protecting it: a probe polling
+  `/api/auth/status` exhausts a 30-per-15-minute window on its own, and from
+  then on every caller — the probe included — gets `429` until the window
+  resets. Only credential-verifying endpoints belong behind it.
+
+  See also [`trustProxy`](#proxy-hops-and-the-rate-limit-key): if the hop count
+  is too low, all callers share one counter and one busy client can exhaust the
+  window for the whole deployment.
 
 ### 4. Inference API Rate Limiter
 - **Default Limit**: 500 requests per 1 minute per IP address (moderate)
@@ -105,6 +129,35 @@ Each rate limiter supports the following configuration options:
 - `skipSuccessfulRequests`: Don't count successful requests (default: false)
 - `skipFailedRequests`: Don't count failed requests (default: varies by type)
 - `message`: Custom error message when limit exceeded
+
+### Proxy hops and the rate-limit key
+
+Every limiter counts per `req.ip`, and `req.ip` is derived from Express's
+`trust proxy` setting — configured with `trustProxy` in `platform.json`:
+
+```json
+{
+  "trustProxy": 2
+}
+```
+
+The value is the number of proxy hops between the client and iHub. It also
+accepts `true` / `false` or a comma-separated list of trusted addresses and
+subnets (e.g. `"loopback, 10.0.0.0/8"`).
+
+**Set this to the real hop count.** With the default `1` and two hops — an
+ingress plus an internal load balancer, the usual Kubernetes layout —
+`X-Forwarded-For` reads `client, ingress` and `req.ip` resolves to the *ingress*
+address for every request. All users then share a single rate-limit counter, so
+one busy client (or one OAuth/MCP handshake) can exhaust the auth or OAuth window
+for the entire deployment.
+
+Verify the resolved address with any endpoint that logs `ip` (see
+[logging](logging.md)): if every request shows the same address while real
+clients differ, the hop count is too low.
+
+The same setting drives HTTPS detection via `X-Forwarded-Proto` — see
+[SSL/HTTPS setup](ssl-https-setup.md).
 
 ### Inheritance
 

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -765,7 +765,8 @@ step had completed.
 The brute-force limiter that protects login was applied to the whole `/api/auth` namespace,
 including read-only endpoints nothing can avoid calling. Polling `/api/auth/status` — the call the
 web app makes on every page load, and a natural choice for a container health probe — exhausted the
-30-requests-per-15-minutes window on its own, after which every caller including the probe received
+window (30 requests per 15 minutes in the shipped configuration) on its own, after which every
+caller including the probe received
 `429 Too Many Requests` until the window reset. The platform looked completely wedged.
 
 - The strict limiter now covers only endpoints that actually verify credentials

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -759,3 +759,63 @@ step had completed.
 - Authorization-code tokens no longer log a misleading `JWT verification failed — jwt audience
   invalid` warning on every MCP request; those tokens are audience-scoped to their OAuth client by
   design and were always being accepted.
+
+## Health Probes and the Login Screen No Longer Lock Themselves Out With 429s
+
+The brute-force limiter that protects login was applied to the whole `/api/auth` namespace,
+including read-only endpoints nothing can avoid calling. Polling `/api/auth/status` — the call the
+web app makes on every page load, and a natural choice for a container health probe — exhausted the
+30-requests-per-15-minutes window on its own, after which every caller including the probe received
+`429 Too Many Requests` until the window reset. The platform looked completely wedged.
+
+- The strict limiter now covers only endpoints that actually verify credentials
+  (`/api/auth/local/login`, the LDAP/NTLM logins, and the Teams token exchange). Brute-force
+  protection is unchanged for those.
+- Read-only endpoints — `/api/auth/status`, `/api/auth/user`, the provider-discovery endpoints, the
+  OIDC sign-in and callback redirects, and `/api/auth/logout` — are covered by the generous public
+  API limiter instead. A single exhausted window can no longer block SSO sign-ins or logouts for
+  everyone.
+- Health probes are best pointed at `/api/health`, which has never been rate limited.
+
+## New `trustProxy` Setting for Deployments Behind More Than One Proxy
+
+`platform.json` now takes a `trustProxy` value: the number of proxy hops in front of iHub (it also
+accepts `true`/`false` or a list of trusted addresses and subnets). It decides what iHub sees as the
+client address, which is both the rate-limit key and the address recorded in the audit log.
+
+- The default is `1`, matching the previous hard-coded behaviour — nothing changes on upgrade.
+- Raise it if iHub sits behind more than one hop, e.g. an ingress plus an internal load balancer.
+  With a value that is too low, every caller behind the inner proxy is seen as the *same* client, so
+  they all share one rate-limit counter and one busy client can exhaust the auth or OAuth window for
+  the whole deployment. Audit entries also record the proxy rather than the user's address.
+
+```json
+{
+  "trustProxy": 2
+}
+```
+
+## MCP Gateway `405` Responses Are Now Diagnosable
+
+A `GET /mcp` rejected with `405` was returned without a log line, so the three very different causes
+were indistinguishable from the server side. Each rejection is now logged under the `McpGateway`
+component with the request's method, user, user agent, and whether an `Mcp-Session-Id` header
+arrived.
+
+- Most `405`s are harmless: a Streamable HTTP client probing for the optional server-initiated SSE
+  stream. Tools still list and run — nothing to fix.
+- A `405` a client cannot recover from means it is configured for the legacy SSE transport but
+  pointed at `/mcp`; the error message now names `/mcp/sse` explicitly.
+- A `405` with no session header *after* a successful handshake means a reverse proxy is stripping
+  the `Mcp-Session-Id` header — allow it (and `MCP-Protocol-Version`) through.
+
+## Clustering Now Warns When Sticky Routing Collapses Onto One Worker
+
+With `WORKERS` greater than 1, the primary process hands each connection to a worker chosen from the
+TCP peer address. Behind a reverse proxy that address is identical for every request, so all traffic
+lands on a single worker while the others stay idle — and a saturated worker looks like a dead
+server, health probes included.
+
+- The primary now logs this once at startup instead of leaving it to be discovered under load.
+- To actually use several workers, either expose iHub directly, or run `WORKERS=1` with multiple
+  replicas behind proxy-level session stickiness.

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -124,9 +124,29 @@ then exits after a 5-second grace period. Use a process supervisor
 
 ### Uneven load behind NAT / proxies
 
-Routing is hashed on source IP. If many users share one source IP (corporate
-NAT, shared VPN egress, a fronting reverse proxy that does not preserve
-client IPs), they all pile onto the same worker.
+Routing is hashed on the **TCP peer address** — the only client identity
+available before any HTTP byte is parsed. Everyone arriving through the same hop
+therefore lands on the same worker:
+
+- **Behind a reverse proxy or ingress — i.e. most production deployments — that
+  is all traffic.** One worker serves every request while the other `WORKERS - 1`
+  processes stay idle, so the effective capacity is a single process no matter
+  what `WORKERS` says. A saturated worker then looks like a dead server: requests
+  queue, and health probes queue with them.
+- Behind corporate NAT or a shared VPN egress it is every user on that egress IP.
+
+`X-Forwarded-For` does not help here: the sticky router runs at the TCP layer, in
+the primary process, before any HTTP parsing.
+
+The primary logs this once at startup whenever `WORKERS > 1`, so the collapse is
+visible before it has to be discovered under load:
+
+```
+[StickyCluster] Sticky routing hashes the TCP peer address, which a reverse
+proxy makes identical for every request — all traffic will land on one of the 4
+workers. Run WORKERS=1 with several replicas behind proxy-level stickiness, or
+expose iHub directly, to use all workers.
+```
 
 **Mitigations:**
 
@@ -134,10 +154,15 @@ client IPs), they all pile onto the same worker.
   HAProxy `balance uri` / cookie-based stickiness) in front of **multiple
   separate iHub instances**, each with its own port — then iHub's own
   cluster scales per-instance.
-- Ensure upstream proxies forward `X-Forwarded-For` and that iHub sees the
-  real client address. (Current build routes on `connection.remoteAddress`
-  only, not on the `X-Forwarded-For` header — that would require parsing the
-  HTTP request in the primary, which is a larger change.)
+- Or run `WORKERS=1` and scale out with replicas instead — see
+  [multi-server deployment](multi-server-deployment.md). A single process per
+  replica removes the illusion of unused capacity.
+- Ensure upstream proxies forward `X-Forwarded-For` and set `trustProxy` to the
+  real hop count, so `req.ip` (rate-limit key, audit log address) is the client
+  rather than the proxy — see
+  [rate limiting](rate-limiting.md#proxy-hops-and-the-rate-limit-key). This fixes
+  attribution, not worker distribution: the sticky router cannot read
+  `X-Forwarded-For`.
 
 ### Worker-local state
 

--- a/docs/ssl-https-setup.md
+++ b/docs/ssl-https-setup.md
@@ -36,9 +36,8 @@ Browser ──HTTPS:443──▶  nginx / Apache / Traefik  ──HTTP:3000─�
 
 ### How the backend detects HTTPS
 
-iHub Apps trusts the first proxy hop (`app.set('trust proxy', 1)` in
-`server/middleware/setup.js`) and resolves the public protocol from the
-`X-Forwarded-Proto` header (`server/utils/publicBaseUrl.js`). Your proxy must
+iHub Apps trusts one proxy hop by default and resolves the public protocol from
+the `X-Forwarded-Proto` header (`server/utils/publicBaseUrl.js`). Your proxy must
 therefore forward these headers:
 
 ```nginx
@@ -51,6 +50,20 @@ proxy_set_header X-Forwarded-Prefix /ihub;    # only for subpath deployments
 
 Without `X-Forwarded-Proto`, redirect URLs and OAuth/OIDC callbacks may be
 built with the wrong scheme (`http://` instead of `https://`).
+
+If there is more than one proxy in front of iHub, set the hop count in
+`platform.json`:
+
+```json
+{
+  "trustProxy": 2
+}
+```
+
+The default (`1`) assumes a single hop. Too low a value makes `req.ip` resolve to
+the inner proxy rather than the client, which both mis-attributes audit log
+entries and collapses every caller onto one rate-limit counter — see
+[rate limiting](rate-limiting.md#proxy-hops-and-the-rate-limit-key).
 
 ### Minimal nginx example
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -262,6 +262,54 @@ node -e "require('dotenv').config(); console.log('JWT_SECRET exists:', !!process
 
 ## Authentication Troubles
 
+### Everything Returns 429 / Health Probes Fail
+
+**Symptoms:**
+
+- The whole platform looks wedged: the SPA never gets past loading, health
+  probes stop passing, and the container may be restarted by the orchestrator
+- `/api/auth/status` answers `429 Too Many Requests`
+- Often starts right after an SSO or OAuth/MCP sign-in flow
+
+**Cause:**
+
+The auth rate limiter is tight on purpose (30 requests / 15 minutes by default)
+because it guards password guessing. Two things can turn it into a self-inflicted
+outage:
+
+1. Something polls a read-only endpoint in the `/api/auth` namespace —
+   `/api/auth/status` is the usual one, since it is both the SPA's bootstrap call
+   and a natural liveness probe. Read-only auth endpoints are exempt from the
+   credential limiter as of 5.6.0; on older versions they were not.
+2. `trustProxy` is lower than the real number of proxy hops, so `req.ip` resolves
+   to the inner proxy and **every user shares one counter**.
+
+**Debugging Steps:**
+
+```bash
+# Is the limiter the one rejecting? Look at the window and remaining budget.
+curl -si https://your-ihub/api/auth/status | grep -i 'ratelimit\|^HTTP'
+
+# Does req.ip differ per client? If every log line shows the same address
+# while real clients differ, the hop count is too low.
+npm run logs | grep '"ip"' | tail
+```
+
+**Solutions:**
+
+1. Set the hop count to match your topology (`platform.json`):
+
+```json
+{
+  "trustProxy": 2
+}
+```
+
+2. Point liveness/readiness probes at `/api/health`, which is not rate limited.
+
+3. Raise the window if your deployment legitimately needs more credential
+   attempts — see [rate limiting](rate-limiting.md).
+
 ### Login Failures
 
 **Symptoms:**

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -273,14 +273,14 @@ node -e "require('dotenv').config(); console.log('JWT_SECRET exists:', !!process
 
 **Cause:**
 
-The auth rate limiter is tight on purpose (30 requests / 15 minutes by default)
-because it guards password guessing. Two things can turn it into a self-inflicted
-outage:
+The auth rate limiter is tight on purpose — 30 requests / 15 minutes in the
+shipped `platform.json` — because it guards password guessing. Two things can turn
+it into a self-inflicted outage:
 
 1. Something polls a read-only endpoint in the `/api/auth` namespace —
    `/api/auth/status` is the usual one, since it is both the SPA's bootstrap call
    and a natural liveness probe. Read-only auth endpoints are exempt from the
-   credential limiter as of 5.6.0; on older versions they were not.
+   credential limiter as of 5.5.0; on older versions they were not.
 2. `trustProxy` is lower than the real number of proxy hops, so `req.ip` resolves
    to the inner proxy and **every user shares one counter**.
 

--- a/server/clusterSticky.js
+++ b/server/clusterSticky.js
@@ -18,9 +18,20 @@
  * for the lifetime of a chat session, so all per-chat in-memory state remains
  * consistent without any cross-worker coordination.
  *
- * Tradeoff: many users sharing one source IP (NAT, corporate proxy) will pile
- * on the same worker. For that case, deploy behind a reverse proxy that does
- * cookie or chatId-aware stickiness, or migrate to a Redis pub/sub fan-out.
+ * Tradeoff: the routing key is the TCP peer address, which is the only client
+ * identity available before any HTTP byte is parsed — `X-Forwarded-For` is not
+ * visible at this layer. Every caller that reaches iHub through the same hop
+ * therefore hashes to the same worker:
+ *
+ *   - behind a reverse proxy / ingress (i.e. every typical production setup)
+ *     that is ALL traffic, so one worker serves everything and the rest idle;
+ *   - behind NAT or a corporate proxy it is every user on that egress IP.
+ *
+ * `logStickyRoutingCaveat` below reports the collapse once at startup so it is
+ * visible rather than something to discover under load. To actually use several
+ * workers behind a proxy, terminate stickiness at the proxy (cookie- or
+ * chatId-aware upstream hashing) and run iHub as separate replicas, or move the
+ * per-chat state to a shared bus (Redis pub/sub) so affinity stops mattering.
  */
 
 import net from 'node:net';
@@ -45,6 +56,28 @@ function pickWorker(workers, key) {
     if (fallback && !fallback.isDead?.()) return fallback;
   }
   return null;
+}
+
+/**
+ * Warn once that sticky routing keys on the TCP peer address, so a deployment
+ * behind a reverse proxy concentrates all traffic on a single worker.
+ *
+ * Emitted at startup rather than per connection: by the time a worker is
+ * saturated the symptom ("the server stopped responding, even the health
+ * probes") gives no hint that the other workers were idle the whole time.
+ *
+ * @param {number} workerCount - Number of forked workers.
+ */
+export function logStickyRoutingCaveat(workerCount) {
+  if (workerCount <= 1) return;
+  logger.warn({
+    component: 'StickyCluster',
+    message:
+      'Sticky routing hashes the TCP peer address, which a reverse proxy makes identical for every request — all traffic will land on one of the ' +
+      workerCount +
+      ' workers. Run WORKERS=1 with several replicas behind proxy-level stickiness, or expose iHub directly, to use all workers.',
+    workerCount
+  });
 }
 
 /**

--- a/server/defaults/config/platform.json
+++ b/server/defaults/config/platform.json
@@ -92,6 +92,7 @@
     }
   },
   "requestConcurrency": 5,
+  "trustProxy": 1,
   "refreshSalt": {
     "salt": 1,
     "lastUpdated": "2025-07-08T17:00:38.743Z"

--- a/server/middleware/rateLimiting.js
+++ b/server/middleware/rateLimiting.js
@@ -7,16 +7,75 @@ import { recordRateLimitHit } from '../telemetry/metrics.js';
  */
 
 /**
+ * Read-only endpoints below `/api/auth` that must NOT be governed by the strict
+ * credential limiter.
+ *
+ * The auth limiter exists to slow down password guessing, so it is deliberately
+ * tight (30 requests / 15 minutes by default). Applying it to the whole
+ * `/api/auth` namespace also throttles endpoints that carry no credentials and
+ * are polled as a matter of course:
+ *
+ *   - `/api/auth/status` — fetched on every SPA boot and on every 401 recovery,
+ *     and commonly used as the container liveness/readiness probe.
+ *   - `/api/auth/user`, the per-provider discovery endpoints
+ *     (`/api/auth/oidc/providers`, `/api/auth/ldap/providers`,
+ *     `/api/auth/ntlm/status`, `/api/auth/teams/client-config`) — read-only.
+ *   - `/api/auth/oidc/:provider/callback` — the SSO redirect target. One
+ *     exhausted window here locks every user out of logging in.
+ *   - `/api/auth/logout` — must always be able to clear a session.
+ *
+ * Behind two proxy hops `req.ip` resolves to the inner proxy for every caller
+ * (see `trustProxy` in platform.json), so all users share a single counter and
+ * a busy afternoon — or one OAuth/MCP handshake — takes the whole deployment's
+ * status endpoint down for the rest of the window. These paths stay covered by
+ * the public API limiter, which is generous but still bounded.
+ *
+ * Paths are matched mount-relative (the limiter is mounted on `/api/auth`), so
+ * they hold under subpath deployments too.
+ */
+const READ_ONLY_AUTH_PATHS = new Set([
+  '/status',
+  '/user',
+  '/logout',
+  '/oidc/providers',
+  '/ldap/providers',
+  '/ntlm/status',
+  '/teams/client-config'
+]);
+
+/**
+ * True when the request targets a read-only/never-throttle auth endpoint.
+ * Exported for tests.
+ *
+ * @param {import('express').Request} req - Request, as seen by middleware
+ *   mounted on `/api/auth` (so `req.path` is mount-relative, e.g. `/status`).
+ * @returns {boolean}
+ */
+export function isReadOnlyAuthRequest(req) {
+  const path = req.path || '';
+  // Trailing slashes are equivalent for routing; normalise before matching.
+  const normalized = path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+  if (READ_ONLY_AUTH_PATHS.has(normalized)) return true;
+  // OIDC sign-in redirect + callback: /oidc/<provider> and /oidc/<provider>/callback.
+  // GET only — the POST variants (local/ldap/ntlm login) must stay throttled.
+  if (req.method === 'GET' && normalized.startsWith('/oidc/')) return true;
+  return false;
+}
+
+/**
  * Create a rate limiter with given configuration
  * @param {Object} config - Rate limiter configuration
  * @param {Object} defaults - Default configuration to merge with
  * @param {string} type - Type of rate limiter for error messages
+ * @param {(req: import('express').Request) => boolean} [skip] - Predicate that
+ *   exempts a request from this limiter entirely
  * @returns {Function} Express rate limiter middleware
  */
-function createRateLimiter(config = {}, defaults = {}, type = 'API') {
+function createRateLimiter(config = {}, defaults = {}, type = 'API', skip = undefined) {
   const finalConfig = { ...defaults, ...config };
 
   return rateLimit({
+    ...(skip ? { skip } : {}),
     windowMs: finalConfig.windowMs || 1 * 60 * 1000, // 1 minute default
     limit: finalConfig.limit || 500, // 500 requests default
     message: finalConfig.message || {
@@ -105,7 +164,9 @@ export function createRateLimiters(platformConfig = {}) {
   return {
     adminApiLimiter: createRateLimiter(adminApiConfig, {}, 'admin API'),
     publicApiLimiter: createRateLimiter(publicApiConfig, {}, 'public API'),
-    authApiLimiter: createRateLimiter(authApiConfig, {}, 'authentication'),
+    // Read-only auth endpoints skip the strict credential limiter; they are
+    // still bounded by the public API limiter mounted on the same path.
+    authApiLimiter: createRateLimiter(authApiConfig, {}, 'authentication', isReadOnlyAuthRequest),
     inferenceApiLimiter: createRateLimiter(inferenceApiConfig, {}, 'inference API'),
     oauthApiLimiter: createRateLimiter(oauthApiConfig, {}, 'OAuth API')
   };

--- a/server/middleware/rateLimiting.js
+++ b/server/middleware/rateLimiting.js
@@ -11,7 +11,9 @@ import { recordRateLimitHit } from '../telemetry/metrics.js';
  * credential limiter.
  *
  * The auth limiter exists to slow down password guessing, so it is deliberately
- * tight (30 requests / 15 minutes by default). Applying it to the whole
+ * tight: 30 requests / 15 minutes in the shipped `platform.json`, and 50 / 15
+ * minutes from the code fallback below when `rateLimit.authApi` is absent
+ * entirely. Applying it to the whole
  * `/api/auth` namespace also throttles endpoints that carry no credentials and
  * are polled as a matter of course:
  *

--- a/server/middleware/setup.js
+++ b/server/middleware/setup.js
@@ -377,6 +377,35 @@ function setupSessionMiddleware(app, platformConfig) {
 }
 
 /**
+ * Resolve the Express `trust proxy` setting from `platform.trustProxy`.
+ *
+ * Defaults to `1` (one proxy hop) to keep existing deployments unchanged.
+ * Numeric strings are coerced so the value can also come from an
+ * `IHUB_PLATFORM__trustProxy` environment override.
+ *
+ * @param {Object} platformConfig - Platform configuration
+ * @returns {number|boolean|string} Value for `app.set('trust proxy', …)`
+ */
+export function resolveTrustProxy(platformConfig = {}) {
+  const configured = platformConfig.trustProxy;
+  if (configured === undefined || configured === null || configured === '') return 1;
+  if (typeof configured === 'number' || typeof configured === 'boolean') return configured;
+  if (typeof configured === 'string') {
+    const trimmed = configured.trim();
+    if (trimmed === 'true') return true;
+    if (trimmed === 'false') return false;
+    if (/^\d+$/.test(trimmed)) return parseInt(trimmed, 10);
+    // Address / subnet list (e.g. "loopback, 10.0.0.0/8") — hand through verbatim.
+    return trimmed;
+  }
+  logger.warn('Ignoring unsupported trustProxy value; falling back to 1', {
+    component: 'Middleware',
+    trustProxy: typeof configured
+  });
+  return 1;
+}
+
+/**
  * Configure Express middleware.
  * Body parser limits are controlled by the `requestBodyLimitMB` option in
  * `platform.json`.
@@ -398,8 +427,18 @@ export function setupMiddleware(app, platformConfig = {}) {
     });
   }
 
-  // Trust proxy for proper IP and protocol detection
-  app.set('trust proxy', 1);
+  // Trust proxy for proper IP and protocol detection.
+  //
+  // The number is the count of proxy hops in front of iHub, and it decides what
+  // `req.ip` resolves to — which in turn is the rate-limit key and the audit-log
+  // client address. A value that is too low makes every caller behind the inner
+  // proxy share one identity: with `1` and two hops (ingress + internal LB) all
+  // users collapse onto the ingress IP and therefore onto a single rate-limit
+  // counter, so one busy client can exhaust the auth/OAuth window for everyone.
+  //
+  // Accepts anything Express accepts: a hop count, `true`, `false`, or a
+  // comma-separated list of trusted addresses/subnets.
+  app.set('trust proxy', resolveTrustProxy(platformConfig));
 
   // Open the per-request logging context. Subsequent middleware and route
   // handlers run inside an AsyncLocalStorage scope, so every logger call on
@@ -572,7 +611,13 @@ export function setupMiddleware(app, platformConfig = {}) {
   app.use(buildApiPath('/short-links'), rateLimiters.publicApiLimiter);
   app.use(buildApiPath('/integrations'), rateLimiters.publicApiLimiter);
 
-  // Auth API rate limiter for authentication endpoints
+  // Auth API rate limiters. Two layers, deliberately:
+  //   1. the public limiter bounds the whole namespace generously, and
+  //   2. the strict credential limiter covers only the endpoints that verify
+  //      credentials — it skips read-only ones such as /api/auth/status, which
+  //      the SPA fetches on every boot and operators use as a health probe
+  //      (see isReadOnlyAuthRequest in ./rateLimiting.js).
+  app.use(buildApiPath('/auth'), rateLimiters.publicApiLimiter);
   app.use(buildApiPath('/auth'), rateLimiters.authApiLimiter);
 
   // Inference API rate limiter for AI inference endpoints

--- a/server/migrations/V082__add_trust_proxy.js
+++ b/server/migrations/V082__add_trust_proxy.js
@@ -1,0 +1,28 @@
+export const version = '082';
+export const description = 'add_trust_proxy';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/platform.json');
+}
+
+/**
+ * Seed `trustProxy` so the number of proxy hops in front of iHub becomes an
+ * explicit, admin-visible setting instead of a hard-coded `1`.
+ *
+ * `req.ip` is derived from this value, and `req.ip` is the rate-limit key. With
+ * `1` and two hops (e.g. ingress + internal load balancer) `req.ip` resolves to
+ * the inner proxy for every caller, so all users share a single rate-limit
+ * counter — one busy client can then exhaust the auth/OAuth window for the
+ * whole deployment.
+ *
+ * Default stays `1` so behaviour is unchanged; deployments with more hops
+ * should raise it to the real count.
+ */
+export async function up(ctx) {
+  const platform = await ctx.readJson('config/platform.json');
+
+  ctx.setDefault(platform, 'trustProxy', 1);
+
+  await ctx.writeJson('config/platform.json', platform);
+  ctx.log('Added trustProxy default (1 proxy hop)');
+}

--- a/server/routes/mcpServer.js
+++ b/server/routes/mcpServer.js
@@ -105,6 +105,37 @@ function sendRpcError(res, status, code, message, headers = {}) {
 }
 
 /**
+ * Log a gateway-level rejection with everything needed to tell the causes
+ * apart from the server side.
+ *
+ * `405` and `400` here are routinely reported as "the MCP gateway does not
+ * work", and the three causes look identical to the client:
+ *   - a compliant streamable-HTTP client probing for the optional
+ *     server→client SSE stream (harmless — the MCP SDK treats 405 on GET as
+ *     "this server has no push channel" and carries on),
+ *   - a client configured for the legacy SSE transport but pointed at `/mcp`
+ *     instead of `/mcp/sse` (it needs a GET stream and cannot recover), or
+ *   - a reverse proxy dropping the `Mcp-Session-Id` header, so a client that
+ *     did initialize correctly never gets to use its session.
+ *
+ * `hadSessionHeader` is the discriminator: false on a GET right after a
+ * successful initialize means the header is being stripped in transit.
+ */
+function logGatewayRejection(req, { status, reason }) {
+  logger.info('MCP gateway rejected request', {
+    component: 'McpGateway',
+    status,
+    reason,
+    method: req.method,
+    userId: req.user?.id,
+    hadSessionHeader: Boolean(req.headers['mcp-session-id']),
+    accept: req.headers.accept || null,
+    protocolVersion: req.headers['mcp-protocol-version'] || null,
+    userAgent: req.headers['user-agent'] || null
+  });
+}
+
+/**
  * True when the (already parsed) POST body is an MCP `initialize` request —
  * the only message allowed to open a new session.
  */
@@ -221,6 +252,7 @@ export default function registerMcpServerRoutes(app) {
         // to. Declining it with 405 is explicitly allowed by the spec and MCP
         // clients treat it as "this server has no push channel".
         await closeServer(entry.server, null);
+        logGatewayRejection(req, { status: 405, reason: 'stateless_mode_no_sse_stream' });
         return sendRpcError(
           res,
           405,
@@ -286,15 +318,17 @@ export default function registerMcpServerRoutes(app) {
       // gets a targeted error instead of an McpServer that would be built,
       // rejected by the SDK and then leaked.
       if (req.method === 'GET') {
+        logGatewayRejection(req, { status: 405, reason: 'get_stream_without_session' });
         return sendRpcError(
           res,
           405,
           -32000,
-          'Method Not Allowed: open a session with an initialize request before requesting the SSE stream',
+          `Method Not Allowed: open a session with an initialize request before requesting the SSE stream. Legacy SSE clients must connect to ${buildServerPath('/mcp/sse')} instead.`,
           { Allow: 'POST, DELETE' }
         );
       }
       if (!isInitializeRequestBody(req.body)) {
+        logGatewayRejection(req, { status: 400, reason: 'post_without_session' });
         return sendRpcError(res, 400, -32000, 'Bad Request: Mcp-Session-Id header is required');
       }
       try {

--- a/server/server.js
+++ b/server/server.js
@@ -8,7 +8,7 @@ import { loadJson } from './configLoader.js';
 import { getRootDir } from './pathUtils.js';
 import configCache from './configCache.js';
 import logger from './utils/logger.js';
-import { startStickyPrimary, attachStickyWorker } from './clusterSticky.js';
+import { startStickyPrimary, attachStickyWorker, logStickyRoutingCaveat } from './clusterSticky.js';
 
 // Import adapters and utilities
 import registerChatRoutes from './routes/chat/index.js';
@@ -129,6 +129,7 @@ if (cluster.isPrimary && workerCount > 1) {
         port: config.PORT,
         workerCount
       });
+      logStickyRoutingCaveat(workerCount);
       if (config.HOST === '0.0.0.0' || config.HOST === '::') {
         logger.info({
           component: 'Server',

--- a/server/tests/rateLimiting-auth-readonly-exempt.test.js
+++ b/server/tests/rateLimiting-auth-readonly-exempt.test.js
@@ -1,0 +1,214 @@
+/**
+ * The strict auth limiter (30 requests / 15 min by default) is there to slow
+ * password guessing. Mounted on the whole `/api/auth` namespace it also
+ * throttled endpoints that carry no credentials — above all `/api/auth/status`,
+ * which the SPA fetches on every boot and on every 401 recovery, and which
+ * operators use as the container health probe.
+ *
+ * The result was a platform that looked wedged: once the window was spent
+ * (trivially, since behind two proxy hops every caller shares one `req.ip` and
+ * therefore one counter) `/api/auth/status` answered 429 to everyone, including
+ * the probe, for the rest of the window.
+ *
+ * Read-only auth endpoints must therefore skip the credential limiter while the
+ * credential endpoints stay throttled.
+ */
+
+import { jest } from '@jest/globals';
+import request from 'supertest';
+import express from 'express';
+import { setupMiddleware, resolveTrustProxy } from '../middleware/setup.js';
+import { isReadOnlyAuthRequest } from '../middleware/rateLimiting.js';
+
+jest.mock('../configCache.js', () => ({
+  __esModule: true,
+  default: {
+    getPlatform: () => ({})
+  }
+}));
+
+function createTestApp(platformConfig = {}) {
+  const app = express();
+  setupMiddleware(app, platformConfig);
+
+  // Mirrors the real registrations in routes/auth.js.
+  app.get('/api/auth/status', (req, res) => res.status(200).json({ ok: true, ip: req.ip }));
+  app.get('/api/auth/user', (req, res) => res.status(200).json({ ok: true }));
+  app.get('/api/auth/oidc/providers', (req, res) => res.status(200).json({ ok: true }));
+  app.get('/api/auth/oidc/entra/callback', (req, res) => res.status(200).json({ ok: true }));
+  app.post('/api/auth/logout', (req, res) => res.status(200).json({ ok: true }));
+  app.post('/api/auth/local/login', (req, res) => res.status(200).json({ ok: true }));
+
+  return app;
+}
+
+const STRICT = { rateLimit: { authApi: { limit: 3, windowMs: 900_000 } } };
+
+describe('read-only /api/auth endpoints are exempt from the credential limiter', () => {
+  test('/api/auth/status keeps answering well past the auth limit', async () => {
+    const app = createTestApp(STRICT);
+
+    for (let i = 0; i < 25; i++) {
+      const response = await request(app).get('/api/auth/status');
+      expect(response.status).toBe(200);
+    }
+  });
+
+  test('other read-only auth endpoints are exempt too', async () => {
+    const app = createTestApp(STRICT);
+
+    for (const path of ['/api/auth/user', '/api/auth/oidc/providers']) {
+      for (let i = 0; i < 10; i++) {
+        expect((await request(app).get(path)).status).toBe(200);
+      }
+    }
+    // The SSO redirect target: throttling it locks every user out of logging in.
+    for (let i = 0; i < 10; i++) {
+      expect((await request(app).get('/api/auth/oidc/entra/callback')).status).toBe(200);
+    }
+    // Clearing a session must always be possible.
+    for (let i = 0; i < 10; i++) {
+      expect((await request(app).post('/api/auth/logout')).status).toBe(200);
+    }
+  });
+
+  test('credential endpoints are still throttled', async () => {
+    const app = createTestApp(STRICT);
+
+    for (let i = 0; i < 3; i++) {
+      expect((await request(app).post('/api/auth/local/login')).status).toBe(200);
+    }
+    expect((await request(app).post('/api/auth/local/login')).status).toBe(429);
+  });
+
+  test('status traffic does not consume the credential window', async () => {
+    const app = createTestApp(STRICT);
+
+    for (let i = 0; i < 20; i++) {
+      await request(app).get('/api/auth/status');
+    }
+    // The login budget must be untouched by the status polling above.
+    for (let i = 0; i < 3; i++) {
+      expect((await request(app).post('/api/auth/local/login')).status).toBe(200);
+    }
+    expect((await request(app).post('/api/auth/local/login')).status).toBe(429);
+  });
+
+  test('read-only auth endpoints remain bounded by the public limiter', async () => {
+    const app = createTestApp({
+      rateLimit: {
+        authApi: { limit: 3, windowMs: 900_000 },
+        publicApi: { limit: 5, windowMs: 60_000 }
+      }
+    });
+
+    for (let i = 0; i < 5; i++) {
+      expect((await request(app).get('/api/auth/status')).status).toBe(200);
+    }
+    expect((await request(app).get('/api/auth/status')).status).toBe(429);
+  });
+});
+
+describe('isReadOnlyAuthRequest', () => {
+  const check = (method, path) => isReadOnlyAuthRequest({ method, path });
+
+  test('classifies read-only paths', () => {
+    expect(check('GET', '/status')).toBe(true);
+    expect(check('GET', '/status/')).toBe(true);
+    expect(check('GET', '/user')).toBe(true);
+    expect(check('POST', '/logout')).toBe(true);
+    expect(check('GET', '/oidc/providers')).toBe(true);
+    expect(check('GET', '/ldap/providers')).toBe(true);
+    expect(check('GET', '/ntlm/status')).toBe(true);
+    expect(check('GET', '/teams/client-config')).toBe(true);
+    expect(check('GET', '/oidc/entra')).toBe(true);
+    expect(check('GET', '/oidc/entra/callback')).toBe(true);
+  });
+
+  test('leaves credential endpoints throttled', () => {
+    expect(check('POST', '/local/login')).toBe(false);
+    expect(check('POST', '/ldap/login')).toBe(false);
+    expect(check('POST', '/ntlm/login')).toBe(false);
+    expect(check('GET', '/ntlm/login')).toBe(false);
+    expect(check('POST', '/teams/exchange')).toBe(false);
+    // A POST under /oidc/ is not a redirect and stays throttled.
+    expect(check('POST', '/oidc/entra')).toBe(false);
+  });
+});
+
+describe('resolveTrustProxy', () => {
+  test('defaults to a single proxy hop', () => {
+    expect(resolveTrustProxy({})).toBe(1);
+    expect(resolveTrustProxy({ trustProxy: undefined })).toBe(1);
+    expect(resolveTrustProxy({ trustProxy: '' })).toBe(1);
+  });
+
+  test('accepts hop counts, booleans and address lists', () => {
+    expect(resolveTrustProxy({ trustProxy: 2 })).toBe(2);
+    expect(resolveTrustProxy({ trustProxy: '2' })).toBe(2);
+    expect(resolveTrustProxy({ trustProxy: 0 })).toBe(0);
+    expect(resolveTrustProxy({ trustProxy: true })).toBe(true);
+    expect(resolveTrustProxy({ trustProxy: 'false' })).toBe(false);
+    expect(resolveTrustProxy({ trustProxy: 'loopback, 10.0.0.0/8' })).toBe('loopback, 10.0.0.0/8');
+  });
+
+  test('rejects nonsense without throwing', () => {
+    expect(resolveTrustProxy({ trustProxy: { hops: 2 } })).toBe(1);
+  });
+});
+
+describe('trustProxy decides the rate-limit identity', () => {
+  /**
+   * With two proxy hops and trustProxy=1, req.ip is the inner proxy for every
+   * caller, so distinct clients share one counter. Raising it to the real hop
+   * count separates them again.
+   */
+  const xff = '203.0.113.%d, 10.0.0.5';
+
+  test('too-low hop count collapses distinct clients onto one counter', async () => {
+    const app = createTestApp({
+      trustProxy: 1,
+      rateLimit: { authApi: { limit: 2, windowMs: 900_000 } }
+    });
+
+    expect(
+      (
+        await request(app)
+          .post('/api/auth/local/login')
+          .set('X-Forwarded-For', xff.replace('%d', '1'))
+      ).status
+    ).toBe(200);
+    expect(
+      (
+        await request(app)
+          .post('/api/auth/local/login')
+          .set('X-Forwarded-For', xff.replace('%d', '2'))
+      ).status
+    ).toBe(200);
+    // A third, unrelated client is locked out by the first two.
+    expect(
+      (
+        await request(app)
+          .post('/api/auth/local/login')
+          .set('X-Forwarded-For', xff.replace('%d', '3'))
+      ).status
+    ).toBe(429);
+  });
+
+  test('correct hop count gives each client its own counter', async () => {
+    const app = createTestApp({
+      trustProxy: 2,
+      rateLimit: { authApi: { limit: 2, windowMs: 900_000 } }
+    });
+
+    for (const client of ['1', '2', '3', '4']) {
+      expect(
+        (
+          await request(app)
+            .post('/api/auth/local/login')
+            .set('X-Forwarded-For', xff.replace('%d', client))
+        ).status
+      ).toBe(200);
+    }
+  });
+});

--- a/server/tests/rateLimiting-auth-readonly-exempt.test.js
+++ b/server/tests/rateLimiting-auth-readonly-exempt.test.js
@@ -1,6 +1,7 @@
 /**
- * The strict auth limiter (30 requests / 15 min by default) is there to slow
- * password guessing. Mounted on the whole `/api/auth` namespace it also
+ * The strict auth limiter (30 requests / 15 min in the shipped platform.json)
+ * is there to slow password guessing. Mounted on the whole `/api/auth` namespace
+ * it also
  * throttled endpoints that carry no credentials — above all `/api/auth/status`,
  * which the SPA fetches on every boot and on every 401 recovery, and which
  * operators use as the container health probe.

--- a/server/validators/platformConfigSchema.js
+++ b/server/validators/platformConfigSchema.js
@@ -186,6 +186,12 @@ export const platformConfigSchema = z
       })
       .default({}),
     rateLimit: rateLimitSchema.default({}),
+    trustProxy: z
+      .union([z.number().int().min(0), z.boolean(), z.string()])
+      .default(1)
+      .describe(
+        'Express "trust proxy" setting: the number of proxy hops in front of iHub, true/false, or a comma-separated list of trusted addresses/subnets. Decides what req.ip resolves to, which is the rate-limit key and the audited client address. Set it to the real hop count — too low and every caller behind the inner proxy shares one identity (and therefore one rate-limit counter).'
+      ),
     logging: loggingSchema.default({}),
     ssl: z
       .object({


### PR DESCRIPTION
Investigating a report of "Claude Code connects to our iHub MCP, auth works, but we get a 405 — and afterwards the server looked blocked, the `/api/auth/status` probes stopped responding."

Both symptoms were reproduced locally against a real server. They turned out to be unrelated to each other, and the second one is the serious one.

## 1. The dead probes: `/api/auth/*` is rate limited at 30 req / 15 min

`server/middleware/setup.js` mounted the strict brute-force limiter on the whole `/api/auth` namespace. That namespace also contains endpoints that carry no credentials and cannot avoid being called:

- **`/api/auth/status`** — fetched by the SPA on every boot and on every 401 recovery, and a natural choice for a liveness/readiness probe (the reporter uses it as one). A probe polling it exhausts the window on its own.
- **`/api/auth/oidc/:provider/callback`** — the SSO redirect target. One exhausted window locks *every* user out of signing in.
- `/api/auth/logout`, `/api/auth/user`, and the provider-discovery endpoints.

Reproduced on a freshly booted server with the shipped defaults:

```
req  1 -> 200
req 28 -> 429     # RateLimit-Policy: 30;w=900, Retry-After: 637
… every subsequent request 429 for the rest of the window
```

The strict limiter now covers only the endpoints that verify credentials (`local/login`, `ldap/login`, `ntlm/login`, `teams/exchange`, `teams/config`). Read-only endpoints skip it and are bounded by the public API limiter instead. After the change, 120 consecutive probe hits all return 200 while login still throttles at attempt 31.

## 2. Why one client could take down everyone: `trust proxy` was hard-coded to 1

`req.ip` is the rate-limit key, and it is derived from Express's `trust proxy`, which was fixed at `1`. With two hops — ingress plus internal LB, the usual Kubernetes layout — `X-Forwarded-For` reads `client, ingress` and `req.ip` resolves to the **ingress** for every caller, so all users share a single counter. Verified against the running server:

```
distinct single-hop XFF:            Remaining: 29, 29, 29   # separate counters
two-hop XFF, same last hop:         Remaining: 29, 28, 27, 26  # one shared counter
```

That is why the outage followed the MCP/OAuth handshake: a handful of extra `/api/auth/*` calls from one source spent the shared window for the whole deployment. New `platform.trustProxy` setting (hop count, `true`/`false`, or an address/subnet list) makes this fixable; the default stays `1` so nothing changes on upgrade. Migration `V082` seeds it so it shows up in the admin UI.

## 3. The 405 itself

`GET /mcp` is the only place in the codebase that emits 405, and it was returned **without any log line** — which is why it could not be traced. Three causes look identical from the client:

- A compliant Streamable HTTP client probing for the optional server-initiated SSE stream. **Harmless** — the MCP SDK explicitly treats 405 on GET as "no push channel" ([`streamableHttp.js:102`](https://github.com/modelcontextprotocol/typescript-sdk)) and carries on, so tools still list and run. Confirmed against the installed SDK 1.29.0.
- A client configured for the *legacy SSE* transport but pointed at `/mcp` instead of `/mcp/sse`. It needs the GET stream and cannot recover.
- A reverse proxy stripping `Mcp-Session-Id`, so a client that initialized correctly never gets to use its session (405 on GET *plus* 400 on the following POSTs).

Each rejection is now logged with `hadSessionHeader`, `userAgent`, `accept` and a `reason`, which is what tells them apart, and the 405 message names `/mcp/sse` explicitly.

For the record, the full Claude-Code-style handshake works end to end on this build: DCR → authorize → consent → token → `initialize` (200 + session id) → `notifications/initialized` (202) → `tools/list` (200).

## 4. Contributing factor: clustering collapses onto one worker behind a proxy

`clusterSticky.js` hashes the **TCP peer address**, the only client identity available before any HTTP byte is parsed. Behind a reverse proxy that address is identical for every request, so with the default `WORKERS=4` one worker serves 100% of traffic and three idle — and a saturated worker looks like a dead server, health probes included:

```
behind one reverse proxy -> [ 1000, 0, 0, 0 ]
direct client IPs        -> [ 244, 252, 272, 232 ]
```

No behaviour change here (fixing it properly means L7 routing or replicas); the primary now logs the caveat once at startup instead of leaving it to be discovered under load, and `docs/scaling.md` states it plainly.

## Testing

- New `server/tests/rateLimiting-auth-readonly-exempt.test.js` — 14 tests: read-only endpoints survive well past the auth limit, credential endpoints still throttle, status traffic does not consume the login budget, read-only endpoints stay bounded by the public limiter, `resolveTrustProxy` parsing, and the two-hop counter collapse.
- Existing `rateLimiting-auth-inference-mount.test.js`, `mcp-gateway-sessions.test.js`, all `tests/mcp/*` and `migrations-runner.test.js` pass (138 tests total).
- Verified end to end on a booted server: 120 probe hits → all 200; login → 429 at attempt 31; fresh-install boot applies V082 and stays healthy.
- Three auth suites (`authentication-integration`, `authentication-security`, `frontend-auth-flow`) fail to load on this branch **and on `main`** — they import a `setupMiddleware` export that no longer exists in `serverHelpers.js`. Pre-existing, untouched here.

## Operator notes

- Point health probes at `/api/health`, which has never been rate limited.
- If iHub sits behind more than one proxy hop, set `trustProxy` to the real count.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X8wqQH9GpVccidZt8A6nqn)_