### PR TITLE
Jump to cited iFinder passages and highlight them in the document

### DIFF
--- a/client/src/features/apps/pages/AppChat.jsx
+++ b/client/src/features/apps/pages/AppChat.jsx
@@ -1233,7 +1233,9 @@ function AppChat({ preloadedApp = null }) {
     ]
   );
 
-  // Handle citation document actions (openExternal, preview, download, openInApp)
+  // Handle citation document actions (openExternal, download, openInApp).
+  // "preview" is handled inside CitationPanel, which owns the passage texts the
+  // preview highlights.
   const handleDocumentAction = useCallback(
     (action, item, targetAppId) => {
       const getMeta = (doc, key) => {
@@ -1249,19 +1251,6 @@ function AppChat({ preloadedApp = null }) {
       if (action === 'openExternal') {
         if (deepLink) {
           window.open(deepLink, '_blank', 'noopener,noreferrer');
-        }
-      } else if (action === 'preview') {
-        if (accessLink?.documentId) {
-          const params = new URLSearchParams({
-            documentId: accessLink.documentId,
-            ...(accessLink.searchProfile ? { searchProfile: accessLink.searchProfile } : {}),
-            convertToPdf: 'true'
-          });
-          window.open(
-            buildApiUrl(`integrations/ifinder/document?${params}`),
-            '_blank',
-            'noopener,noreferrer'
-          );
         }
       } else if (action === 'download') {
         if (accessLink?.documentId) {

--- a/client/src/features/chat/components/CitationPanel.jsx
+++ b/client/src/features/chat/components/CitationPanel.jsx
@@ -1,9 +1,19 @@
-import { useState, useCallback, useMemo, useRef, useEffect } from 'react';
+import { useState, useCallback, useMemo, useRef, useEffect, lazy, Suspense } from 'react';
 import { useTranslation } from 'react-i18next';
 import { scrollToElement } from '../../../utils/citationTransformer';
 import { buildApiUrl } from '../../../utils/runtimeBasePath';
 import AppSelectionModal from '../../workflows/components/AppSelectionModal';
-import DocumentPreviewModal from '../../documentPreview/components/DocumentPreviewModal';
+import {
+  hasPassageText,
+  selectPreviewPassages
+} from '../../documentPreview/utils/passageSelection';
+
+// Loaded on demand: the preview pulls in pdf.js, which is a deliberately
+// on-demand bundle chunk. Importing it statically here would put pdf.js in
+// every chat page load, whether or not anyone opens a document.
+const DocumentPreviewModal = lazy(
+  () => import('../../documentPreview/components/DocumentPreviewModal')
+);
 
 const PASSAGE_TRUNCATE_LENGTH = 150;
 
@@ -491,17 +501,19 @@ function CitationPanel({ citations, onDocumentAction }) {
    * Handled here rather than through `onDocumentAction` because the passage
    * texts only exist in this component.
    *
+   * Passages with no usable text are dropped, and the passage to focus is
+   * located *after* that filtering. Passing the passage itself rather than its
+   * display index is what keeps the two in step — an index into the unfiltered
+   * list would point at the wrong passage as soon as one is dropped.
+   *
    * @param {Object} item the citation document.
    * @param {Array<{content: string}>} passageList the document's passages, in
    *   the order they are displayed.
-   * @param {number} initialPassageIndex passage to focus, `-1` for all.
+   * @param {{content: string}} [focusPassage] passage to focus; when omitted,
+   *   all passages are highlighted and none is singled out.
    */
-  const openPreview = useCallback((item, passageList, initialPassageIndex = -1) => {
-    setPreviewDoc({
-      item,
-      passages: passageList.map(p => p.content).filter(Boolean),
-      initialPassageIndex
-    });
+  const openPreview = useCallback((item, passageList, focusPassage = null) => {
+    setPreviewDoc({ item, ...selectPreviewPassages(passageList, focusPassage) });
   }, []);
 
   // Merge references and resultItems into unified document list
@@ -699,7 +711,9 @@ function CitationPanel({ citations, onDocumentAction }) {
                         content={passage.content}
                         index={passage.index}
                         onJumpToPassage={
-                          canPreview ? () => openPreview(doc, orderedPassages, pIdx) : null
+                          canPreview && hasPassageText(passage)
+                            ? () => openPreview(doc, orderedPassages, passage)
+                            : null
                         }
                         t={t}
                       />
@@ -726,14 +740,16 @@ function CitationPanel({ citations, onDocumentAction }) {
       )}
 
       {previewDoc && (
-        <DocumentPreviewModal
-          documentId={getDocumentAccess(previewDoc.item)?.documentId}
-          searchProfile={getDocumentAccess(previewDoc.item)?.searchProfile}
-          title={previewDoc.item.title || getMeta(previewDoc.item, 'title')}
-          passages={previewDoc.passages}
-          initialPassageIndex={previewDoc.initialPassageIndex}
-          onClose={() => setPreviewDoc(null)}
-        />
+        <Suspense fallback={null}>
+          <DocumentPreviewModal
+            documentId={getDocumentAccess(previewDoc.item)?.documentId}
+            searchProfile={getDocumentAccess(previewDoc.item)?.searchProfile}
+            title={previewDoc.item.title || getMeta(previewDoc.item, 'title')}
+            passages={previewDoc.passages}
+            initialPassageIndex={previewDoc.initialPassageIndex}
+            onClose={() => setPreviewDoc(null)}
+          />
+        </Suspense>
       )}
     </div>
   );

--- a/client/src/features/chat/components/CitationPanel.jsx
+++ b/client/src/features/chat/components/CitationPanel.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { scrollToElement } from '../../../utils/citationTransformer';
 import { buildApiUrl } from '../../../utils/runtimeBasePath';
 import AppSelectionModal from '../../workflows/components/AppSelectionModal';
+import DocumentPreviewModal from '../../documentPreview/components/DocumentPreviewModal';
 
 const PASSAGE_TRUNCATE_LENGTH = 150;
 
@@ -64,9 +65,10 @@ function DocIcon({ item }) {
 }
 
 /**
- * A single passage with truncate/expand behavior.
+ * A single passage with truncate/expand behavior and, when the document can be
+ * previewed, a button that opens it at this passage.
  */
-function PassageText({ content, index, t }) {
+function PassageText({ content, index, onJumpToPassage, t }) {
   const [expanded, setExpanded] = useState(false);
   const needsTruncation = content && content.length > PASSAGE_TRUNCATE_LENGTH;
 
@@ -80,7 +82,7 @@ function PassageText({ content, index, t }) {
           {index}
         </span>
       )}
-      <p className="whitespace-pre-wrap text-xs leading-relaxed">
+      <p className="whitespace-pre-wrap text-xs leading-relaxed flex-1">
         {displayText}
         {needsTruncation && !expanded && '\u2026 '}
         {needsTruncation && (
@@ -92,6 +94,23 @@ function PassageText({ content, index, t }) {
           </button>
         )}
       </p>
+      {onJumpToPassage && (
+        <button
+          onClick={onJumpToPassage}
+          className="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-400 hover:text-indigo-600 dark:hover:text-indigo-400 flex-shrink-0 self-start"
+          title={t('citations.showInDocument', 'Show this passage in the document')}
+          aria-label={t('citations.showInDocument', 'Show this passage in the document')}
+        >
+          <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+            />
+          </svg>
+        </button>
+      )}
     </div>
   );
 }
@@ -426,6 +445,8 @@ function CitationPanel({ citations, onDocumentAction }) {
   const [expandedDoc, setExpandedDoc] = useState(null);
   const [appPickerDoc, setAppPickerDoc] = useState(null);
   const [detailsDoc, setDetailsDoc] = useState(null);
+  // { item, passages: string[], initialPassageIndex: number }
+  const [previewDoc, setPreviewDoc] = useState(null);
 
   const handleDocAction = useCallback(
     (action, item, appId) => {
@@ -448,19 +469,6 @@ function CitationPanel({ citations, onDocumentAction }) {
         if (deepLink) {
           window.open(deepLink, '_blank', 'noopener,noreferrer');
         }
-      } else if (action === 'preview') {
-        if (access) {
-          const params = new URLSearchParams({
-            documentId: access.documentId,
-            ...(access.searchProfile ? { searchProfile: access.searchProfile } : {}),
-            convertToPdf: 'true'
-          });
-          window.open(
-            buildApiUrl(`integrations/ifinder/document?${params}`),
-            '_blank',
-            'noopener,noreferrer'
-          );
-        }
       } else if (action === 'download') {
         if (access) {
           const params = new URLSearchParams({
@@ -477,6 +485,24 @@ function CitationPanel({ citations, onDocumentAction }) {
     },
     [onDocumentAction]
   );
+
+  /**
+   * Opens the in-app PDF preview with this document's passages highlighted.
+   * Handled here rather than through `onDocumentAction` because the passage
+   * texts only exist in this component.
+   *
+   * @param {Object} item the citation document.
+   * @param {Array<{content: string}>} passageList the document's passages, in
+   *   the order they are displayed.
+   * @param {number} initialPassageIndex passage to focus, `-1` for all.
+   */
+  const openPreview = useCallback((item, passageList, initialPassageIndex = -1) => {
+    setPreviewDoc({
+      item,
+      passages: passageList.map(p => p.content).filter(Boolean),
+      initialPassageIndex
+    });
+  }, []);
 
   // Merge references and resultItems into unified document list
   // Each entry tracks: doc, passages[], resultIndex (1-based position in original resultItems)
@@ -561,6 +587,9 @@ function CitationPanel({ citations, onDocumentAction }) {
           const deepLink = getDeepLink(doc);
           const hasPassages = passages.length > 0;
           const isExpanded = expandedDoc === docId;
+          const canPreview = hasProxyAccess(doc);
+          // Stable display order, also used for the preview's passage indices.
+          const orderedPassages = [...passages].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
 
           // Build subtitle from available metadata
           const subtitleParts = [sourceType, fileName].filter(Boolean);
@@ -647,7 +676,11 @@ function CitationPanel({ citations, onDocumentAction }) {
                   )}
                   <OverflowMenu
                     item={doc}
-                    onAction={handleDocAction}
+                    onAction={(action, actionItem) =>
+                      action === 'preview'
+                        ? openPreview(actionItem, orderedPassages)
+                        : handleDocAction(action, actionItem)
+                    }
                     onOpenInApp={setAppPickerDoc}
                     t={t}
                   />
@@ -657,16 +690,21 @@ function CitationPanel({ citations, onDocumentAction }) {
               {/* Expandable passages */}
               {hasPassages && isExpanded && (
                 <div className="border-t border-gray-100 dark:border-gray-700 px-3 py-2 space-y-1.5">
-                  {passages
-                    .sort((a, b) => (a.index ?? 0) - (b.index ?? 0))
-                    .map((passage, pIdx) => (
-                      <div
-                        key={pIdx}
-                        id={passage.index != null ? `citation-s-${passage.index}` : undefined}
-                      >
-                        <PassageText content={passage.content} index={passage.index} t={t} />
-                      </div>
-                    ))}
+                  {orderedPassages.map((passage, pIdx) => (
+                    <div
+                      key={pIdx}
+                      id={passage.index != null ? `citation-s-${passage.index}` : undefined}
+                    >
+                      <PassageText
+                        content={passage.content}
+                        index={passage.index}
+                        onJumpToPassage={
+                          canPreview ? () => openPreview(doc, orderedPassages, pIdx) : null
+                        }
+                        t={t}
+                      />
+                    </div>
+                  ))}
                 </div>
               )}
             </div>
@@ -685,6 +723,17 @@ function CitationPanel({ citations, onDocumentAction }) {
 
       {detailsDoc && (
         <DocumentDetailsModal item={detailsDoc} onClose={() => setDetailsDoc(null)} t={t} />
+      )}
+
+      {previewDoc && (
+        <DocumentPreviewModal
+          documentId={getDocumentAccess(previewDoc.item)?.documentId}
+          searchProfile={getDocumentAccess(previewDoc.item)?.searchProfile}
+          title={previewDoc.item.title || getMeta(previewDoc.item, 'title')}
+          passages={previewDoc.passages}
+          initialPassageIndex={previewDoc.initialPassageIndex}
+          onClose={() => setPreviewDoc(null)}
+        />
       )}
     </div>
   );

--- a/client/src/features/documentPreview/components/DocumentPreviewModal.jsx
+++ b/client/src/features/documentPreview/components/DocumentPreviewModal.jsx
@@ -20,7 +20,9 @@ const SCALE_STEP = 0.2;
  * @param {string} props.documentId iFinder document id from the ACCESS link.
  * @param {string} [props.searchProfile]
  * @param {string} [props.title] document title for the header.
- * @param {string[]} props.passages passage texts to highlight.
+ * @param {string[]} props.passages passage texts to highlight. Expected to be
+ *   pre-filtered to passages that actually carry text, so `initialPassageIndex`
+ *   indexes the same list that is rendered.
  * @param {number} [props.initialPassageIndex] index into `passages` to focus,
  *   or `-1`/undefined to highlight all of them.
  * @param {Function} props.onClose
@@ -89,28 +91,39 @@ function DocumentPreviewModal({
     const handler = e => {
       if (e.key === 'Escape') {
         onClose();
-      } else if (e.key === 'Enter') {
-        e.preventDefault();
-        if (e.shiftKey) controlRef.current?.previousMatch();
-        else controlRef.current?.nextMatch();
+        return;
       }
+      if (e.key !== 'Enter') return;
+      // Enter must still activate whatever control has focus — the toolbar
+      // buttons, the download link and the passage chips all rely on it. Only
+      // take Enter over when focus is not on something that handles it.
+      const target = e.target;
+      if (
+        target?.isContentEditable ||
+        ['BUTTON', 'A', 'INPUT', 'SELECT', 'TEXTAREA'].includes(target?.tagName)
+      ) {
+        return;
+      }
+      e.preventDefault();
+      if (e.shiftKey) controlRef.current?.previousMatch();
+      else controlRef.current?.nextMatch();
     };
     document.addEventListener('keydown', handler);
     return () => document.removeEventListener('keydown', handler);
   }, [onClose]);
 
-  const activePassages = useMemo(() => {
-    const valid = passages.filter(p => typeof p === 'string' && p.trim().length > 0);
-    if (selectedPassage >= 0 && valid[selectedPassage]) return [valid[selectedPassage]];
-    return valid;
-  }, [passages, selectedPassage]);
+  const activePassages = useMemo(
+    () =>
+      selectedPassage >= 0 && passages[selectedPassage] ? [passages[selectedPassage]] : passages,
+    [passages, selectedPassage]
+  );
 
   const handleStateChange = useCallback(state => setViewerState(state), []);
 
   const downloadUrl = buildApiUrl(`integrations/ifinder/document?${documentParams}`);
 
   const { loading, numPages, totalMatches, currentMatch } = viewerState;
-  const passageCount = passages.filter(p => typeof p === 'string' && p.trim().length > 0).length;
+  const passageCount = passages.length;
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-black/60" onClick={onClose}>
@@ -266,21 +279,19 @@ function DocumentPreviewModal({
             >
               {t('documentPreview.allPassages', 'All')}
             </button>
-            {passages
-              .filter(p => typeof p === 'string' && p.trim().length > 0)
-              .map((_, i) => (
-                <button
-                  key={i}
-                  onClick={() => setSelectedPassage(i)}
-                  className={`text-xs px-2 py-1 rounded flex-shrink-0 ${
-                    selectedPassage === i
-                      ? 'bg-indigo-600 text-white'
-                      : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
-                  }`}
-                >
-                  {i + 1}
-                </button>
-              ))}
+            {passages.map((_, i) => (
+              <button
+                key={i}
+                onClick={() => setSelectedPassage(i)}
+                className={`text-xs px-2 py-1 rounded flex-shrink-0 ${
+                  selectedPassage === i
+                    ? 'bg-indigo-600 text-white'
+                    : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+                }`}
+              >
+                {i + 1}
+              </button>
+            ))}
           </div>
         )}
 

--- a/client/src/features/documentPreview/components/DocumentPreviewModal.jsx
+++ b/client/src/features/documentPreview/components/DocumentPreviewModal.jsx
@@ -1,0 +1,329 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { buildApiUrl } from '../../../utils/runtimeBasePath';
+import PdfPassageViewer from './PdfPassageViewer';
+
+const MIN_SCALE = 0.5;
+const MAX_SCALE = 3;
+const SCALE_STEP = 0.2;
+
+/**
+ * In-app PDF preview for an iFinder document, with the passages that the
+ * search backend returned highlighted in the document text.
+ *
+ * The PDF comes from the existing `integrations/ifinder/document` proxy with
+ * `convertToPdf=true`, i.e. the same generated PDF the "Preview" action used to
+ * open in a browser tab. Fetching it as an ArrayBuffer (instead of handing the
+ * URL to pdf.js) keeps the request on the app's `credentials: 'include'` path.
+ *
+ * @param {Object} props
+ * @param {string} props.documentId iFinder document id from the ACCESS link.
+ * @param {string} [props.searchProfile]
+ * @param {string} [props.title] document title for the header.
+ * @param {string[]} props.passages passage texts to highlight.
+ * @param {number} [props.initialPassageIndex] index into `passages` to focus,
+ *   or `-1`/undefined to highlight all of them.
+ * @param {Function} props.onClose
+ */
+function DocumentPreviewModal({
+  documentId,
+  searchProfile,
+  title,
+  passages = [],
+  initialPassageIndex = -1,
+  onClose
+}) {
+  const { t } = useTranslation();
+  const [data, setData] = useState(null);
+  const [loadError, setLoadError] = useState(null);
+  const [scale, setScale] = useState(1.2);
+  const [selectedPassage, setSelectedPassage] = useState(initialPassageIndex);
+  const [viewerState, setViewerState] = useState({
+    loading: true,
+    numPages: 0,
+    totalMatches: 0,
+    currentMatch: -1
+  });
+  const controlRef = useRef(null);
+
+  const documentParams = useMemo(() => {
+    const params = new URLSearchParams({ documentId });
+    if (searchProfile) params.set('searchProfile', searchProfile);
+    return params;
+  }, [documentId, searchProfile]);
+
+  // Fetch the generated PDF.
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    const params = new URLSearchParams(documentParams);
+    params.set('convertToPdf', 'true');
+
+    setData(null);
+    setLoadError(null);
+
+    fetch(buildApiUrl(`integrations/ifinder/document?${params}`), {
+      credentials: 'include',
+      signal: controller.signal
+    })
+      .then(res => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.arrayBuffer();
+      })
+      .then(buffer => {
+        if (!cancelled) setData(buffer);
+      })
+      .catch(err => {
+        if (!cancelled && err.name !== 'AbortError') setLoadError(err.message);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [documentParams]);
+
+  // Close on Escape, navigate matches with Enter / Shift+Enter.
+  useEffect(() => {
+    const handler = e => {
+      if (e.key === 'Escape') {
+        onClose();
+      } else if (e.key === 'Enter') {
+        e.preventDefault();
+        if (e.shiftKey) controlRef.current?.previousMatch();
+        else controlRef.current?.nextMatch();
+      }
+    };
+    document.addEventListener('keydown', handler);
+    return () => document.removeEventListener('keydown', handler);
+  }, [onClose]);
+
+  const activePassages = useMemo(() => {
+    const valid = passages.filter(p => typeof p === 'string' && p.trim().length > 0);
+    if (selectedPassage >= 0 && valid[selectedPassage]) return [valid[selectedPassage]];
+    return valid;
+  }, [passages, selectedPassage]);
+
+  const handleStateChange = useCallback(state => setViewerState(state), []);
+
+  const downloadUrl = buildApiUrl(`integrations/ifinder/document?${documentParams}`);
+
+  const { loading, numPages, totalMatches, currentMatch } = viewerState;
+  const passageCount = passages.filter(p => typeof p === 'string' && p.trim().length > 0).length;
+
+  return (
+    <div className="fixed inset-0 z-50 flex flex-col bg-black/60" onClick={onClose}>
+      <div
+        className="relative m-2 sm:m-6 flex flex-col flex-1 min-h-0 bg-white dark:bg-gray-800 rounded-xl shadow-2xl overflow-hidden"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+              {title || t('documentPreview.title', 'Document preview')}
+            </p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {loading
+                ? t('documentPreview.loading', 'Loading document…')
+                : t('documentPreview.pageCount', '{{count}} pages', { count: numPages })}
+            </p>
+          </div>
+
+          {/* Match navigation */}
+          {!loading && passageCount > 0 && (
+            <div className="flex items-center gap-1">
+              <span
+                className={`text-xs px-2 py-1 rounded ${
+                  totalMatches > 0
+                    ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-800 dark:text-amber-200'
+                    : 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400'
+                }`}
+              >
+                {totalMatches > 0
+                  ? t('documentPreview.matchPosition', '{{current}} of {{total}}', {
+                      current: currentMatch + 1,
+                      total: totalMatches
+                    })
+                  : t('documentPreview.noMatches', 'Passage not found')}
+              </span>
+              <button
+                onClick={() => controlRef.current?.previousMatch()}
+                disabled={totalMatches === 0}
+                className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300 disabled:opacity-40"
+                title={t('documentPreview.previousMatch', 'Previous highlight')}
+                aria-label={t('documentPreview.previousMatch', 'Previous highlight')}
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 15l7-7 7 7"
+                  />
+                </svg>
+              </button>
+              <button
+                onClick={() => controlRef.current?.nextMatch()}
+                disabled={totalMatches === 0}
+                className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300 disabled:opacity-40"
+                title={t('documentPreview.nextMatch', 'Next highlight')}
+                aria-label={t('documentPreview.nextMatch', 'Next highlight')}
+              >
+                <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M19 9l-7 7-7-7"
+                  />
+                </svg>
+              </button>
+            </div>
+          )}
+
+          {/* Zoom */}
+          <div className="hidden sm:flex items-center gap-1">
+            <button
+              onClick={() => setScale(s => Math.max(MIN_SCALE, +(s - SCALE_STEP).toFixed(2)))}
+              className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
+              title={t('documentPreview.zoomOut', 'Zoom out')}
+              aria-label={t('documentPreview.zoomOut', 'Zoom out')}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
+              </svg>
+            </button>
+            <span className="text-xs text-gray-500 dark:text-gray-400 w-10 text-center">
+              {Math.round(scale * 100)}%
+            </span>
+            <button
+              onClick={() => setScale(s => Math.min(MAX_SCALE, +(s + SCALE_STEP).toFixed(2)))}
+              className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
+              title={t('documentPreview.zoomIn', 'Zoom in')}
+              aria-label={t('documentPreview.zoomIn', 'Zoom in')}
+            >
+              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 4v16m8-8H4"
+                />
+              </svg>
+            </button>
+          </div>
+
+          <a
+            href={downloadUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
+            title={t('citations.download', 'Download')}
+            aria-label={t('citations.download', 'Download')}
+          >
+            <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"
+              />
+            </svg>
+          </a>
+
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-600 dark:text-gray-300"
+            title={t('common.close', 'Close')}
+            aria-label={t('common.close', 'Close')}
+          >
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Passage selector — only meaningful with more than one passage */}
+        {passageCount > 1 && (
+          <div className="flex items-center gap-2 px-4 py-2 border-b border-gray-200 dark:border-gray-700 overflow-x-auto">
+            <span className="text-xs text-gray-500 dark:text-gray-400 flex-shrink-0">
+              {t('documentPreview.highlight', 'Highlight')}
+            </span>
+            <button
+              onClick={() => setSelectedPassage(-1)}
+              className={`text-xs px-2 py-1 rounded flex-shrink-0 ${
+                selectedPassage === -1
+                  ? 'bg-indigo-600 text-white'
+                  : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+              }`}
+            >
+              {t('documentPreview.allPassages', 'All')}
+            </button>
+            {passages
+              .filter(p => typeof p === 'string' && p.trim().length > 0)
+              .map((_, i) => (
+                <button
+                  key={i}
+                  onClick={() => setSelectedPassage(i)}
+                  className={`text-xs px-2 py-1 rounded flex-shrink-0 ${
+                    selectedPassage === i
+                      ? 'bg-indigo-600 text-white'
+                      : 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300'
+                  }`}
+                >
+                  {i + 1}
+                </button>
+              ))}
+          </div>
+        )}
+
+        {/* Body */}
+        {loadError ? (
+          <div className="flex-1 flex items-center justify-center">
+            <p className="text-sm text-red-600 dark:text-red-400">
+              {t('documentPreview.loadFailed', 'Could not load the document: {{error}}', {
+                error: loadError
+              })}
+            </p>
+          </div>
+        ) : !data ? (
+          <div className="flex-1 flex items-center justify-center text-gray-500 dark:text-gray-400">
+            <svg className="animate-spin h-6 w-6 mr-2" fill="none" viewBox="0 0 24 24">
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                strokeWidth="4"
+                stroke="currentColor"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              />
+            </svg>
+            {t('documentPreview.loading', 'Loading document…')}
+          </div>
+        ) : (
+          <PdfPassageViewer
+            data={data}
+            passages={activePassages}
+            scale={scale}
+            controlRef={controlRef}
+            onStateChange={handleStateChange}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default DocumentPreviewModal;

--- a/client/src/features/documentPreview/components/PdfPassageViewer.css
+++ b/client/src/features/documentPreview/components/PdfPassageViewer.css
@@ -1,0 +1,71 @@
+/*
+ * Minimal replacement for pdf.js's `web/pdf_viewer.css`. Only the text-layer
+ * rules the `TextLayer` class actually relies on are reproduced here, plus the
+ * highlight overlay this viewer paints on top of the canvas. Pulling in the
+ * full viewer stylesheet would drag in styling for viewer chrome this app does
+ * not render.
+ */
+
+.ihub-pdf-page {
+  position: relative;
+  margin: 0 auto 1rem;
+  background: #fff;
+  box-shadow:
+    0 1px 3px rgb(0 0 0 / 20%),
+    0 1px 2px rgb(0 0 0 / 12%);
+}
+
+.ihub-pdf-page canvas {
+  display: block;
+}
+
+/* Transparent, selectable text on top of the rendered page. */
+.ihub-pdf-text-layer {
+  position: absolute;
+  text-align: initial;
+  inset: 0;
+  overflow: clip;
+  line-height: 1;
+  text-size-adjust: none;
+  forced-color-adjust: none;
+  transform-origin: 0 0;
+  caret-color: CanvasText;
+  z-index: 2;
+}
+
+.ihub-pdf-text-layer span,
+.ihub-pdf-text-layer br {
+  color: transparent;
+  position: absolute;
+  white-space: pre;
+  cursor: text;
+  transform-origin: 0% 0%;
+}
+
+.ihub-pdf-text-layer span.markedContent {
+  top: 0;
+  height: 0;
+}
+
+.ihub-pdf-text-layer ::selection {
+  background: rgb(59 130 246 / 30%);
+}
+
+/* Highlights sit between canvas and text layer so text stays selectable. */
+.ihub-pdf-highlight-layer {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  pointer-events: none;
+}
+
+.ihub-pdf-highlight {
+  position: absolute;
+  background: rgb(250 204 21 / 45%);
+  border-radius: 2px;
+}
+
+.ihub-pdf-highlight--selected {
+  background: rgb(249 115 22 / 50%);
+  box-shadow: 0 0 0 1px rgb(194 65 12 / 90%);
+}

--- a/client/src/features/documentPreview/components/PdfPassageViewer.jsx
+++ b/client/src/features/documentPreview/components/PdfPassageViewer.jsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { TextLayer } from 'pdfjs-dist';
 import { loadPdfjs } from '../../upload/utils/fileProcessing';
 import {
   buildPageIndex,
@@ -21,7 +20,7 @@ const RENDER_MARGIN_PX = 800;
  * over the text layer spans, so they follow the real glyph geometry instead of
  * approximating it — and the text layer itself stays untouched and selectable.
  */
-function PdfPage({ page, scale, matches, selectedMatchIdx, onHighlightsPainted }) {
+function PdfPage({ page, scale, matches, selectedMatchIdx, onHighlightsPainted, TextLayer }) {
   const wrapperRef = useRef(null);
   const canvasRef = useRef(null);
   const textLayerRef = useRef(null);
@@ -88,7 +87,7 @@ function PdfPage({ page, scale, matches, selectedMatchIdx, onHighlightsPainted }
       renderTask?.cancel();
       textLayer?.cancel();
     };
-  }, [page, viewport]);
+  }, [page, viewport, TextLayer]);
 
   // Derive highlight boxes from the rendered text layer.
   useEffect(() => {
@@ -233,6 +232,10 @@ function PdfPageSlot({ page, scale, scrollRoot, ...pageProps }) {
 function PdfPassageViewer({ data, passages, scale = 1.2, onStateChange, controlRef }) {
   const scrollRef = useRef(null);
   const [pages, setPages] = useState([]);
+  // Taken from the lazily imported pdf.js rather than a static import: the
+  // `pdf` bundle chunk is deliberately on-demand (see vite.config.js), and a
+  // static import would pull it into the chat bundle for every user.
+  const [textLayerCtor, setTextLayerCtor] = useState(null);
   const [matchResult, setMatchResult] = useState(null);
   const [currentMatch, setCurrentMatch] = useState(-1);
   const [error, setError] = useState(null);
@@ -250,6 +253,8 @@ function PdfPassageViewer({ data, passages, scale = 1.2, onStateChange, controlR
       setError(null);
       try {
         const pdfjsLib = await loadPdfjs();
+        if (cancelled) return;
+        setTextLayerCtor(() => pdfjsLib.TextLayer);
         // pdf.js transfers (and thereby neuters) the buffer it is given; hand
         // it a copy so the caller can re-open the same bytes later.
         pdfDocument = await pdfjsLib.getDocument({ data: new Uint8Array(data.slice(0)) }).promise;
@@ -419,6 +424,7 @@ function PdfPassageViewer({ data, passages, scale = 1.2, onStateChange, controlR
     <div ref={scrollRef} className="flex-1 overflow-auto bg-gray-100 dark:bg-gray-900 p-4">
       {error && <p className="text-sm text-red-600 dark:text-red-400 text-center py-8">{error}</p>}
       {!error &&
+        textLayerCtor &&
         pages.map(page => (
           <PdfPageSlot
             key={page.pageIdx}
@@ -428,6 +434,7 @@ function PdfPassageViewer({ data, passages, scale = 1.2, onStateChange, controlR
             matches={matchesByPage[page.pageIdx] || []}
             selectedMatchIdx={currentMatch}
             onHighlightsPainted={handleHighlightsPainted}
+            TextLayer={textLayerCtor}
           />
         ))}
     </div>

--- a/client/src/features/documentPreview/components/PdfPassageViewer.jsx
+++ b/client/src/features/documentPreview/components/PdfPassageViewer.jsx
@@ -1,0 +1,437 @@
+import { useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
+import { TextLayer } from 'pdfjs-dist';
+import { loadPdfjs } from '../../upload/utils/fileProcessing';
+import {
+  buildPageIndex,
+  computePassageMatches,
+  emptyPageIndex,
+  flattenMatches,
+  matchToItemSlices
+} from '../utils/pdfPassageMatching';
+import './PdfPassageViewer.css';
+
+// Pages this far outside the viewport are pre-rendered so scrolling stays
+// smooth without keeping a canvas for every page of a large document alive.
+const RENDER_MARGIN_PX = 800;
+
+/**
+ * Renders a single page: canvas, pdf.js text layer and the highlight overlay.
+ *
+ * Highlights are painted as absolutely positioned boxes derived from DOM ranges
+ * over the text layer spans, so they follow the real glyph geometry instead of
+ * approximating it — and the text layer itself stays untouched and selectable.
+ */
+function PdfPage({ page, scale, matches, selectedMatchIdx, onHighlightsPainted }) {
+  const wrapperRef = useRef(null);
+  const canvasRef = useRef(null);
+  const textLayerRef = useRef(null);
+  // The rendered TextLayer instance. Its `textDivs` are index-aligned with
+  // `textContentItemsStr`, which a DOM query is not: pdf.js appends a `<br>`
+  // instead of a span for items with an empty string, so querying the container
+  // for spans silently shifts every index after the first empty item.
+  const textLayerObjRef = useRef(null);
+  const [highlights, setHighlights] = useState([]);
+  const [textLayerReady, setTextLayerReady] = useState(false);
+
+  const viewport = useMemo(() => page.pdfPage.getViewport({ scale }), [page.pdfPage, scale]);
+
+  // Render canvas + text layer. Both are re-done on scale changes because the
+  // text layer positions its spans in device pixels for a fixed scale.
+  useEffect(() => {
+    let cancelled = false;
+    let renderTask = null;
+    let textLayer = null;
+
+    const canvas = canvasRef.current;
+    const textLayerDiv = textLayerRef.current;
+    if (!canvas || !textLayerDiv) return undefined;
+
+    setTextLayerReady(false);
+
+    const outputScale = window.devicePixelRatio || 1;
+    canvas.width = Math.floor(viewport.width * outputScale);
+    canvas.height = Math.floor(viewport.height * outputScale);
+    canvas.style.width = `${Math.floor(viewport.width)}px`;
+    canvas.style.height = `${Math.floor(viewport.height)}px`;
+
+    const context = canvas.getContext('2d');
+    renderTask = page.pdfPage.render({
+      canvasContext: context,
+      viewport,
+      transform: outputScale !== 1 ? [outputScale, 0, 0, outputScale, 0, 0] : null
+    });
+
+    textLayerDiv.replaceChildren();
+    textLayer = new TextLayer({
+      textContentSource: page.textContent,
+      container: textLayerDiv,
+      viewport
+    });
+    textLayerObjRef.current = textLayer;
+
+    Promise.all([
+      renderTask.promise.catch(err => {
+        // Cancelled renders are expected while scrolling/zooming.
+        if (err?.name !== 'RenderingCancelledException') throw err;
+      }),
+      textLayer.render()
+    ])
+      .then(() => {
+        if (!cancelled) setTextLayerReady(true);
+      })
+      .catch(() => {
+        /* leave the page blank; a failed page must not break the viewer */
+      });
+
+    return () => {
+      cancelled = true;
+      renderTask?.cancel();
+      textLayer?.cancel();
+    };
+  }, [page, viewport]);
+
+  // Derive highlight boxes from the rendered text layer.
+  useEffect(() => {
+    if (!textLayerReady || matches.length === 0) {
+      setHighlights([]);
+      return;
+    }
+    const textLayer = textLayerObjRef.current;
+    const wrapper = wrapperRef.current;
+    if (!textLayer || !wrapper) return;
+
+    // Both come from the text layer itself, so match offsets, item strings and
+    // rendered elements are guaranteed to line up.
+    const textDivs = textLayer.textDivs;
+    const itemStrings = textLayer.textContentItemsStr;
+    const wrapperRect = wrapper.getBoundingClientRect();
+    const boxes = [];
+
+    matches.forEach(match => {
+      for (const slice of matchToItemSlices(itemStrings, match.start, match.length)) {
+        // Empty items render as a `<br>`, so their span has no text node and is
+        // skipped here — they carry no characters and never hold a match.
+        const textNode = textDivs[slice.itemIdx]?.firstChild;
+        if (!textNode || textNode.nodeType !== Node.TEXT_NODE) continue;
+        const range = document.createRange();
+        try {
+          range.setStart(textNode, Math.min(slice.start, textNode.length));
+          range.setEnd(textNode, Math.min(slice.end, textNode.length));
+        } catch {
+          continue;
+        }
+        for (const rect of range.getClientRects()) {
+          if (rect.width <= 0 || rect.height <= 0) continue;
+          boxes.push({
+            key: `${match.matchIdx}-${slice.itemIdx}-${boxes.length}`,
+            matchIdx: match.matchIdx,
+            left: rect.left - wrapperRect.left,
+            top: rect.top - wrapperRect.top,
+            width: rect.width,
+            height: rect.height
+          });
+        }
+        range.detach?.();
+      }
+    });
+
+    setHighlights(boxes);
+    onHighlightsPainted?.(page.pageIdx);
+  }, [textLayerReady, matches, page, onHighlightsPainted]);
+
+  return (
+    <div
+      ref={wrapperRef}
+      className="ihub-pdf-page"
+      data-page-number={page.pageIdx + 1}
+      style={{
+        width: `${Math.floor(viewport.width)}px`,
+        height: `${Math.floor(viewport.height)}px`,
+        // pdf.js's TextLayer sizes its container with calc(var(--scale-factor) * …)
+        '--scale-factor': scale
+      }}
+    >
+      <canvas ref={canvasRef} />
+      <div className="ihub-pdf-highlight-layer">
+        {highlights.map(box => (
+          <div
+            key={box.key}
+            data-match-index={box.matchIdx}
+            className={`ihub-pdf-highlight${
+              box.matchIdx === selectedMatchIdx ? ' ihub-pdf-highlight--selected' : ''
+            }`}
+            style={{
+              left: `${box.left}px`,
+              top: `${box.top}px`,
+              width: `${box.width}px`,
+              height: `${box.height}px`
+            }}
+          />
+        ))}
+      </div>
+      <div ref={textLayerRef} className="ihub-pdf-text-layer" />
+    </div>
+  );
+}
+
+/**
+ * A page slot that only mounts the real {@link PdfPage} while it is near the
+ * viewport. Unrendered slots keep the page's layout height so scroll offsets
+ * (and therefore "jump to page N") stay correct for the whole document.
+ */
+function PdfPageSlot({ page, scale, scrollRoot, ...pageProps }) {
+  const slotRef = useRef(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const node = slotRef.current;
+    if (!node || !scrollRoot) return undefined;
+    const observer = new IntersectionObserver(
+      entries => {
+        for (const entry of entries) setVisible(entry.isIntersecting);
+      },
+      { root: scrollRoot, rootMargin: `${RENDER_MARGIN_PX}px 0px` }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [scrollRoot]);
+
+  const height = Math.floor(page.height * scale);
+  const width = Math.floor(page.width * scale);
+
+  return (
+    <div ref={slotRef} style={{ minHeight: `${height}px` }} data-page-slot={page.pageIdx + 1}>
+      {visible ? (
+        <PdfPage page={page} scale={scale} {...pageProps} />
+      ) : (
+        <div
+          className="ihub-pdf-page"
+          data-page-number={page.pageIdx + 1}
+          style={{ width: `${width}px`, height: `${height}px` }}
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * PDF viewer that highlights backend-supplied passages and can jump between
+ * them.
+ *
+ * Text for *every* page is extracted up front — passages routinely straddle a
+ * page break, so the matcher needs the whole document's shadow text before it
+ * can resolve anything. Canvas rendering stays lazy.
+ *
+ * @param {Object} props
+ * @param {ArrayBuffer} props.data raw PDF bytes.
+ * @param {string[]} props.passages passage texts to highlight.
+ * @param {number} [props.scale] render scale.
+ * @param {Function} [props.onStateChange] called with
+ *   `{ loading, numPages, totalMatches, currentMatch, error }`.
+ * @param {Object} [props.controlRef] receives `{ nextMatch, previousMatch, goToPage }`.
+ */
+function PdfPassageViewer({ data, passages, scale = 1.2, onStateChange, controlRef }) {
+  const scrollRef = useRef(null);
+  const [pages, setPages] = useState([]);
+  const [matchResult, setMatchResult] = useState(null);
+  const [currentMatch, setCurrentMatch] = useState(-1);
+  const [error, setError] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const pendingScrollRef = useRef(null);
+  const pendingInitialJumpRef = useRef(false);
+
+  // Load the document and extract all page text.
+  useEffect(() => {
+    let cancelled = false;
+    let pdfDocument = null;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const pdfjsLib = await loadPdfjs();
+        // pdf.js transfers (and thereby neuters) the buffer it is given; hand
+        // it a copy so the caller can re-open the same bytes later.
+        pdfDocument = await pdfjsLib.getDocument({ data: new Uint8Array(data.slice(0)) }).promise;
+        if (cancelled) return;
+
+        const collected = [];
+        for (let i = 0; i < pdfDocument.numPages; i += 1) {
+          const pdfPage = await pdfDocument.getPage(i + 1);
+          if (cancelled) return;
+          let textContent;
+          try {
+            textContent = await pdfPage.getTextContent();
+          } catch {
+            textContent = { items: [], styles: {} };
+          }
+          if (cancelled) return;
+          const unscaled = pdfPage.getViewport({ scale: 1 });
+          collected.push({
+            pageIdx: i,
+            pdfPage,
+            textContent,
+            index: textContent.items.length ? buildPageIndex(textContent) : emptyPageIndex(),
+            width: unscaled.width,
+            height: unscaled.height
+          });
+        }
+        if (cancelled) return;
+        setPages(collected);
+        setLoading(false);
+      } catch (err) {
+        if (!cancelled) {
+          setError(err?.message || 'Failed to load PDF');
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      pdfDocument?.destroy?.();
+    };
+  }, [data]);
+
+  // Match the passages once the document text is available.
+  useEffect(() => {
+    if (pages.length === 0) {
+      setMatchResult(null);
+      return;
+    }
+    const texts = (passages || []).filter(p => typeof p === 'string' && p.trim().length > 0);
+    if (texts.length === 0) {
+      setMatchResult({
+        pageMatches: pages.map(() => []),
+        total: 0,
+        firstMatchPageIdx: -1,
+        flat: []
+      });
+      setCurrentMatch(-1);
+      pendingInitialJumpRef.current = false;
+      return;
+    }
+    const result = computePassageMatches(
+      texts,
+      pages.map(p => p.index)
+    );
+    setMatchResult({ ...result, flat: flattenMatches(result) });
+    setCurrentMatch(result.total > 0 ? 0 : -1);
+    pendingInitialJumpRef.current = result.total > 0;
+  }, [pages, passages]);
+
+  // Memoized so the identity is stable across renders — the effects and
+  // callbacks below key on it.
+  const flatMatches = useMemo(() => matchResult?.flat || [], [matchResult]);
+
+  // Per-page match lists, tagged with their index in the flat (document-order)
+  // list so a highlight can tell whether it is the selected one.
+  const matchesByPage = useMemo(() => {
+    const byPage = pages.map(() => []);
+    flatMatches.forEach((match, flatIdx) => {
+      byPage[match.pageIdx]?.push({ ...match, matchIdx: flatIdx });
+    });
+    return byPage;
+  }, [pages, flatMatches]);
+
+  const scrollToPage = useCallback(pageIdx => {
+    const root = scrollRef.current;
+    const slot = root?.querySelector(`[data-page-slot="${pageIdx + 1}"]`);
+    if (root && slot) {
+      root.scrollTop = slot.offsetTop - root.offsetTop - 16;
+    }
+  }, []);
+
+  const scrollToMatch = useCallback(
+    flatIdx => {
+      const match = flatMatches[flatIdx];
+      if (!match) return;
+      const root = scrollRef.current;
+      const highlight = root?.querySelector(
+        `[data-page-number="${match.pageIdx + 1}"] [data-match-index="${flatIdx}"]`
+      );
+      if (highlight) {
+        highlight.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        pendingScrollRef.current = null;
+      } else {
+        // The page is not rendered yet — scroll it into view and finish once
+        // its highlights have been painted.
+        pendingScrollRef.current = flatIdx;
+        scrollToPage(match.pageIdx);
+      }
+    },
+    [flatMatches, scrollToPage]
+  );
+
+  const handleHighlightsPainted = useCallback(
+    pageIdx => {
+      const pending = pendingScrollRef.current;
+      if (pending === null || pending === undefined) return;
+      if (flatMatches[pending]?.pageIdx !== pageIdx) return;
+      pendingScrollRef.current = null;
+      requestAnimationFrame(() => scrollToMatch(pending));
+    },
+    [flatMatches, scrollToMatch]
+  );
+
+  // Jump to the first match once a freshly computed match set has been
+  // committed. The ref keeps this to the initial jump — later navigation
+  // scrolls explicitly via goToMatch.
+  useEffect(() => {
+    if (!pendingInitialJumpRef.current || flatMatches.length === 0) return;
+    pendingInitialJumpRef.current = false;
+    scrollToMatch(0);
+  }, [flatMatches, scrollToMatch]);
+
+  const goToMatch = useCallback(
+    next => {
+      if (flatMatches.length === 0) return;
+      setCurrentMatch(prev => {
+        const target = (prev + (next ? 1 : -1) + flatMatches.length) % flatMatches.length;
+        scrollToMatch(target);
+        return target;
+      });
+    },
+    [flatMatches, scrollToMatch]
+  );
+
+  useImperativeHandle(
+    controlRef,
+    () => ({
+      nextMatch: () => goToMatch(true),
+      previousMatch: () => goToMatch(false),
+      goToPage: scrollToPage
+    }),
+    [goToMatch, scrollToPage]
+  );
+
+  useEffect(() => {
+    onStateChange?.({
+      loading,
+      error,
+      numPages: pages.length,
+      totalMatches: flatMatches.length,
+      currentMatch
+    });
+  }, [loading, error, pages.length, flatMatches.length, currentMatch, onStateChange]);
+
+  return (
+    <div ref={scrollRef} className="flex-1 overflow-auto bg-gray-100 dark:bg-gray-900 p-4">
+      {error && <p className="text-sm text-red-600 dark:text-red-400 text-center py-8">{error}</p>}
+      {!error &&
+        pages.map(page => (
+          <PdfPageSlot
+            key={page.pageIdx}
+            page={page}
+            scale={scale}
+            scrollRoot={scrollRef.current}
+            matches={matchesByPage[page.pageIdx] || []}
+            selectedMatchIdx={currentMatch}
+            onHighlightsPainted={handleHighlightsPainted}
+          />
+        ))}
+    </div>
+  );
+}
+
+export default PdfPassageViewer;

--- a/client/src/features/documentPreview/utils/passageMatcher.js
+++ b/client/src/features/documentPreview/utils/passageMatcher.js
@@ -1,0 +1,469 @@
+/**
+ * Text matching for passage highlighting in the PDF document preview.
+ *
+ * Ported unchanged in behaviour from the iFinder searchbar
+ * (`app/features/PdfJs/passageMatcher.js`, intrafind/ifinder#2655) so both
+ * products highlight passages identically. Only formatting was adapted to this
+ * repository's Prettier config — keep the algorithm in sync with iFinder.
+ *
+ * Passages are substrings of the fulltext the converter extracted into the
+ * search index, while the preview is a *generated* PDF whose text layer can
+ * differ from that fulltext in whitespace, punctuation, ligatures, page
+ * furniture (headers/footers) and even spurious spaces inside words. Matching
+ * therefore happens on a "shadow text": both sides are reduced to their
+ * Unicode letters and digits only (NFKC-folded, lowercased), with an offset
+ * map back to the original text-layer coordinates. Searching the shadow with
+ * `indexOf` is linear in the document size — unlike a regex approach, it
+ * cannot backtrack catastrophically on large documents.
+ *
+ * When a passage cannot be found as a whole (e.g. it crosses a page break
+ * and the generated PDF inserts a footer there), it is split into
+ * sentence-like fragments that are matched individually, so the passage is
+ * still highlighted partially instead of not at all.
+ */
+
+const CHARACTERS_TO_NORMALIZE = {
+  '‐': '-',
+  '‘': "'",
+  '’': "'",
+  '‚': "'",
+  '‛': "'",
+  '“': '"',
+  '”': '"',
+  '„': '"',
+  '‟': '"',
+  '¼': '1/4',
+  '½': '1/2',
+  '¾': '3/4'
+};
+const DIACRITICS_REG_EXP = /\p{M}+/gu;
+// Hangul syllables plus the CJK compatibility ideographs that decompose to
+// astral-plane characters. Written with \u escapes on purpose: as literal
+// characters the compatibility ideographs decompose under NFD into surrogate
+// pairs, which turns this character class into a syntax error ("range out of
+// order"). Keep the escapes when syncing this file.
+const SYLLABLES_REG_EXP = /[\uAC00-\uD7AF\uFA6C\uFACF-\uFAD1\uFAD5-\uFAD7]+/g;
+const SYLLABLES_LENGTHS = new Map();
+const FIRST_CHAR_SYLLABLES_REG_EXP =
+  '[\\u1100-\\u1112\\ud7a4-\\ud7af\\ud84a\\ud84c\\ud850\\ud854\\ud857\\ud85f]';
+const NFKC_CHARS_TO_NORMALIZE = new Map();
+let noSyllablesRegExp = null;
+let withSyllablesRegExp = null;
+
+/**
+ * Normalizes text the same way pdf.js prepares page text for matching (NFD,
+ * quote/hyphen folding, hyphenation-at-line-break removal, newline handling)
+ * and returns a position diff array that maps normalized offsets back to the
+ * original string.
+ *
+ * @param {string} text
+ * @returns {[string, Array<[number, number]>, boolean]} normalized text,
+ *   position diffs and whether the text contains diacritics.
+ */
+function normalize(text) {
+  const syllablePositions = [];
+  let m;
+  while ((m = SYLLABLES_REG_EXP.exec(text)) !== null) {
+    let { index } = m;
+    for (const char of m[0]) {
+      let len = SYLLABLES_LENGTHS.get(char);
+      if (!len) {
+        len = char.normalize('NFD').length;
+        SYLLABLES_LENGTHS.set(char, len);
+      }
+      syllablePositions.push([len, index++]);
+    }
+  }
+  let normalizationRegex;
+  if (syllablePositions.length === 0 && noSyllablesRegExp) {
+    normalizationRegex = noSyllablesRegExp;
+  } else if (syllablePositions.length > 0 && withSyllablesRegExp) {
+    normalizationRegex = withSyllablesRegExp;
+  } else {
+    const replace = Object.keys(CHARACTERS_TO_NORMALIZE).join('');
+    const toNormalizeWithNFKC = '①-⑳' + 'Ⓐ-⓿' + '㉄-㊿' + '㋐-㋾' + '＀-￯';
+    const CJK = '(?:\\p{Ideographic}|[぀-ヿ])';
+    const regexp = `([${replace}])|([${toNormalizeWithNFKC}])|(\\p{M}+(?:-\\n)?)|(\\S-\\n)|(${CJK}\\n)|(\\n)`;
+    if (syllablePositions.length === 0) {
+      normalizationRegex = noSyllablesRegExp = new RegExp(`${regexp}|(\\u0000)`, 'gum');
+    } else {
+      normalizationRegex = withSyllablesRegExp = new RegExp(
+        `${regexp}|(${FIRST_CHAR_SYLLABLES_REG_EXP})`,
+        'gum'
+      );
+    }
+  }
+  const rawDiacriticsPositions = [];
+  while ((m = DIACRITICS_REG_EXP.exec(text)) !== null) {
+    rawDiacriticsPositions.push([m[0].length, m.index]);
+  }
+  let normalized = text.normalize('NFD');
+  const positions = [[0, 0]];
+  let rawDiacriticsIndex = 0;
+  let syllableIndex = 0;
+  let shift = 0;
+  let shiftOrigin = 0;
+  let eol = 0;
+  let hasDiacritics = false;
+  normalized = normalized.replace(normalizationRegex, (match, p1, p2, p3, p4, p5, p6, p7, i) => {
+    i -= shiftOrigin;
+    if (p1) {
+      const replacement = CHARACTERS_TO_NORMALIZE[p1];
+      const jj = replacement.length;
+      for (let j = 1; j < jj; j++) {
+        positions.push([i - shift + j, shift - j]);
+      }
+      shift -= jj - 1;
+      return replacement;
+    }
+    if (p2) {
+      let replacement = NFKC_CHARS_TO_NORMALIZE.get(p2);
+      if (!replacement) {
+        replacement = p2.normalize('NFKC');
+        NFKC_CHARS_TO_NORMALIZE.set(p2, replacement);
+      }
+      const jj = replacement.length;
+      for (let j = 1; j < jj; j++) {
+        positions.push([i - shift + j, shift - j]);
+      }
+      shift -= jj - 1;
+      return replacement;
+    }
+    if (p3) {
+      const hasTrailingDashEOL = p3.endsWith('\n');
+      const len = hasTrailingDashEOL ? p3.length - 2 : p3.length;
+      hasDiacritics = true;
+      let jj = len;
+      if (i + eol === rawDiacriticsPositions[rawDiacriticsIndex]?.[1]) {
+        jj -= rawDiacriticsPositions[rawDiacriticsIndex][0];
+        ++rawDiacriticsIndex;
+      }
+      for (let j = 1; j <= jj; j++) {
+        positions.push([i - 1 - shift + j, shift - j]);
+      }
+      shift -= jj;
+      shiftOrigin += jj;
+      if (hasTrailingDashEOL) {
+        i += len - 1;
+        positions.push([i - shift + 1, 1 + shift]);
+        shift += 1;
+        shiftOrigin += 1;
+        eol += 1;
+        return p3.slice(0, len);
+      }
+      return p3;
+    }
+    if (p4) {
+      positions.push([i - shift + 1, 1 + shift]);
+      shift += 1;
+      shiftOrigin += 1;
+      eol += 1;
+      return p4.charAt(0);
+    }
+    if (p5) {
+      positions.push([i - shift + 1, shift]);
+      shiftOrigin += 1;
+      eol += 1;
+      return p5.charAt(0);
+    }
+    if (p6) {
+      positions.push([i - shift + 1, shift - 1]);
+      shift -= 1;
+      shiftOrigin += 1;
+      eol += 1;
+      return ' ';
+    }
+    if (i + eol === syllablePositions[syllableIndex]?.[1]) {
+      const newCharLen = syllablePositions[syllableIndex][0] - 1;
+      ++syllableIndex;
+      for (let j = 1; j <= newCharLen; j++) {
+        positions.push([i - (shift - j), shift - j]);
+      }
+      shift -= newCharLen;
+      shiftOrigin += newCharLen;
+    }
+    return p7;
+  });
+  positions.push([normalized.length, shift]);
+  return [normalized, positions, hasDiacritics];
+}
+
+function binarySearchFirstItem(items, condition, start = 0) {
+  let minIndex = start;
+  let maxIndex = items.length - 1;
+  if (maxIndex < 0 || !condition(items[maxIndex])) {
+    return items.length;
+  }
+  if (condition(items[minIndex])) {
+    return minIndex;
+  }
+  while (minIndex < maxIndex) {
+    const currentIndex = (minIndex + maxIndex) >> 1;
+    const currentItem = items[currentIndex];
+    if (condition(currentItem)) {
+      maxIndex = currentIndex;
+    } else {
+      minIndex = currentIndex + 1;
+    }
+  }
+  return minIndex;
+}
+
+/**
+ * Maps a position/length in normalized text back to the original text via
+ * the diffs produced by {@link normalize}.
+ *
+ * @param {Array<[number, number]>|null} diffs
+ * @param {number} pos
+ * @param {number} len
+ * @returns {[number, number]} position and length in the original text.
+ */
+function getOriginalIndex(diffs, pos, len) {
+  if (!diffs) {
+    return [pos, len];
+  }
+  const start = pos;
+  const end = pos + len;
+  let i = binarySearchFirstItem(diffs, x => x[0] >= start);
+  if (diffs[i][0] > start) {
+    --i;
+  }
+  let j = binarySearchFirstItem(diffs, x => x[0] >= end, i);
+  if (diffs[j][0] > end) {
+    --j;
+  }
+  return [start + diffs[i][1], len + diffs[j][1] - diffs[i][1]];
+}
+
+const SHADOW_CHAR_REG_EXP = /[\p{L}\p{N}]/u;
+const NON_ALPHANUMERIC_REG_EXP = /[^\p{L}\p{N}]/gu;
+const SENTENCE_REG_EXP = /[^.!?…]+[.!?…]*\s*/g;
+
+// Cap on how many occurrences of the same passage text get highlighted, so a
+// passage consisting of boilerplate repeated hundreds of times stays cheap.
+const MAX_PASSAGE_OCCURRENCES = 50;
+// Fragments shorter than this (in shadow characters) are too ambiguous to
+// match on their own and get merged with their neighbors.
+const MIN_FRAGMENT_SHADOW_LENGTH = 15;
+
+/**
+ * Reduces text to its letters and digits only (NFKC-folded, lowercased) and
+ * keeps a per-character map back to the input coordinates. NFKC folding makes
+ * ligatures ("ﬁ" vs. "fi"), full-width forms and similar compatibility
+ * characters comparable across the converter fulltext and the PDF text layer.
+ *
+ * @param {string} text
+ * @returns {{text: string, mapStart: number[], mapEnd: number[]}} the shadow
+ *   text plus, per shadow character, the start (inclusive) and end
+ *   (exclusive) offsets of the source character in `text`.
+ */
+export function buildShadow(text) {
+  const parts = [];
+  const mapStart = [];
+  const mapEnd = [];
+  let index = 0;
+  for (const char of text) {
+    const charLength = char.length;
+    if (SHADOW_CHAR_REG_EXP.test(char)) {
+      const folded = char.normalize('NFKC').toLowerCase().replace(NON_ALPHANUMERIC_REG_EXP, '');
+      for (let j = 0; j < folded.length; j += 1) {
+        mapStart.push(index);
+        mapEnd.push(index + charLength);
+      }
+      parts.push(folded);
+    }
+    index += charLength;
+  }
+  return { text: parts.join(''), mapStart, mapEnd };
+}
+
+function shadowLength(text) {
+  return buildShadow(text).text.length;
+}
+
+function findAllOccurrences(haystack, needle) {
+  const positions = [];
+  let pos = haystack.indexOf(needle);
+  while (pos !== -1 && positions.length < MAX_PASSAGE_OCCURRENCES) {
+    positions.push(pos);
+    pos = haystack.indexOf(needle, pos + needle.length);
+  }
+  return positions;
+}
+
+/**
+ * Splits a normalized passage into sentence-like fragments suitable for
+ * partial matching. Sentences too short to be unambiguous are merged with the
+ * following sentence; fragments that still fail to match are subdivided
+ * further by {@link computePassageMatches}.
+ *
+ * @param {string} normalizedText
+ * @returns {string[]}
+ */
+export function splitIntoFragments(normalizedText) {
+  const sentences = normalizedText.match(SENTENCE_REG_EXP) || [normalizedText];
+
+  const fragments = [];
+  let pending = '';
+  for (const sentence of sentences) {
+    pending = pending ? `${pending} ${sentence}` : sentence;
+    if (shadowLength(pending) >= MIN_FRAGMENT_SHADOW_LENGTH) {
+      fragments.push(pending);
+      pending = '';
+    }
+  }
+  if (pending) {
+    if (fragments.length) {
+      fragments[fragments.length - 1] += ` ${pending}`;
+    } else {
+      fragments.push(pending);
+    }
+  }
+  return fragments;
+}
+
+function shadowRangeToPageRanges(start, end, pages, pageShadowOffsets) {
+  const result = [];
+  let pageIdx = binarySearchFirstItem(pageShadowOffsets, x => x > start) - 1;
+  if (pageIdx < 0) {
+    pageIdx = 0;
+  }
+  for (let p = pageIdx; p < pages.length; p += 1) {
+    const base = pageShadowOffsets[p];
+    if (base >= end) {
+      break;
+    }
+    const { text, mapStart, mapEnd } = pages[p].shadow;
+    const localStart = Math.max(0, start - base);
+    const localEnd = Math.min(end - base, text.length);
+    if (localEnd <= localStart) {
+      continue;
+    }
+    const normalizedStart = mapStart[localStart];
+    const normalizedLength = mapEnd[localEnd - 1] - normalizedStart;
+    const [rawStart, rawLength] = getOriginalIndex(
+      pages[p].diffs,
+      normalizedStart,
+      normalizedLength
+    );
+    if (rawLength > 0) {
+      result.push({ pageIdx: p, start: rawStart, length: rawLength });
+    }
+  }
+  return result;
+}
+
+/**
+ * Finds one or more passages in the extracted page texts.
+ *
+ * Each passage is first searched as a whole in the concatenated shadow text
+ * (cross-page matches included). If it cannot be found — typically because
+ * headers/footers of the generated PDF interrupt it at a page break, or
+ * because converter fulltext and PDF text layer genuinely diverge — it falls
+ * back to matching sentence-like fragments individually, preferring
+ * occurrences in reading order.
+ *
+ * @param {string[]} passages passage texts as delivered by the backend.
+ * @param {Array<{shadow: {text: string, mapStart: number[], mapEnd: number[]},
+ *   diffs: Array<[number, number]>|null}>} pages per-page shadow (built from
+ *   the normalized page content via {@link buildShadow}) and normalization
+ *   diffs of the page.
+ * @returns {{pageMatches: number[][], pageMatchesLength: number[][],
+ *   total: number, firstMatchPageIdx: number}} match positions/lengths per
+ *   page in original text-layer coordinates.
+ */
+export function computePassageMatches(passages, pages) {
+  const pageShadowOffsets = [];
+  let offset = 0;
+  for (const page of pages) {
+    pageShadowOffsets.push(offset);
+    offset += page.shadow.text.length;
+  }
+  const documentShadow = pages.map(page => page.shadow.text).join('');
+
+  const rawRanges = [];
+  for (const passage of passages) {
+    const [normalized] = normalize(passage);
+    const needle = buildShadow(normalized).text;
+    if (!needle) {
+      continue;
+    }
+    const occurrences = findAllOccurrences(documentShadow, needle);
+    if (occurrences.length > 0) {
+      for (const pos of occurrences) {
+        rawRanges.push(
+          ...shadowRangeToPageRanges(pos, pos + needle.length, pages, pageShadowOffsets)
+        );
+      }
+      continue;
+    }
+    // Fallback: match sentence-like fragments individually. Fragments that
+    // fail (e.g. because they cross a page break interrupted by a footer)
+    // are halved at word boundaries and retried. The cursor prefers
+    // occurrences in reading order so repeated phrases resolve to the
+    // occurrence closest to the previously matched fragment.
+    const matchFragment = (fragment, cursor) => {
+      const fragmentNeedle = buildShadow(fragment).text;
+      if (fragmentNeedle.length < MIN_FRAGMENT_SHADOW_LENGTH) {
+        return cursor;
+      }
+      let pos = documentShadow.indexOf(fragmentNeedle, cursor);
+      if (pos === -1) {
+        pos = documentShadow.lastIndexOf(fragmentNeedle, cursor);
+      }
+      if (pos !== -1) {
+        rawRanges.push(
+          ...shadowRangeToPageRanges(pos, pos + fragmentNeedle.length, pages, pageShadowOffsets)
+        );
+        return pos + fragmentNeedle.length;
+      }
+      if (fragmentNeedle.length >= 2 * MIN_FRAGMENT_SHADOW_LENGTH) {
+        const words = fragment.split(/\s+/).filter(Boolean);
+        if (words.length >= 2) {
+          const mid = words.length >> 1;
+          const nextCursor = matchFragment(words.slice(0, mid).join(' '), cursor);
+          return matchFragment(words.slice(mid).join(' '), nextCursor);
+        }
+      }
+      return cursor;
+    };
+    let cursor = 0;
+    for (const fragment of splitIntoFragments(normalized)) {
+      cursor = matchFragment(fragment, cursor);
+    }
+  }
+
+  const perPage = pages.map(() => []);
+  for (const range of rawRanges) {
+    perPage[range.pageIdx].push(range);
+  }
+
+  const pageMatches = pages.map(() => []);
+  const pageMatchesLength = pages.map(() => []);
+  let total = 0;
+  let firstMatchPageIdx = -1;
+  perPage.forEach((ranges, pageIdx) => {
+    ranges.sort((a, b) => a.start - b.start);
+    const merged = [];
+    for (const range of ranges) {
+      const last = merged[merged.length - 1];
+      if (last && range.start <= last.start + last.length) {
+        last.length = Math.max(last.length, range.start + range.length - last.start);
+      } else {
+        merged.push({ start: range.start, length: range.length });
+      }
+    }
+    for (const match of merged) {
+      pageMatches[pageIdx].push(match.start);
+      pageMatchesLength[pageIdx].push(match.length);
+    }
+    total += merged.length;
+    if (merged.length && firstMatchPageIdx === -1) {
+      firstMatchPageIdx = pageIdx;
+    }
+  });
+
+  return { pageMatches, pageMatchesLength, total, firstMatchPageIdx };
+}
+
+export { normalize, getOriginalIndex, binarySearchFirstItem };

--- a/client/src/features/documentPreview/utils/passageSelection.js
+++ b/client/src/features/documentPreview/utils/passageSelection.js
@@ -1,0 +1,36 @@
+/**
+ * Turns a citation document's passage list into the props the document preview
+ * expects.
+ *
+ * The preview highlights a list of passage texts and may single one of them out.
+ * Those two must be derived together: the list drops passages with no usable
+ * text, so an index taken from the *displayed* list would point at the wrong
+ * passage as soon as one is dropped. Callers therefore name the passage they
+ * want focused and let this resolve its position.
+ */
+
+/**
+ * Whether a passage carries text that could be matched in a document. Blank and
+ * whitespace-only content is useless to the matcher and is not counted.
+ *
+ * @param {{content: string}} passage
+ * @returns {boolean}
+ */
+export const hasPassageText = passage =>
+  typeof passage?.content === 'string' && passage.content.trim().length > 0;
+
+/**
+ * @param {Array<{content: string}>} passageList the document's passages, in
+ *   display order.
+ * @param {{content: string}} [focusPassage] the passage to single out; must be
+ *   an element of `passageList` (identity comparison).
+ * @returns {{passages: string[], initialPassageIndex: number}} passage texts and
+ *   the index of the focused one within them, or `-1` for none.
+ */
+export function selectPreviewPassages(passageList, focusPassage = null) {
+  const usable = (passageList || []).filter(hasPassageText);
+  return {
+    passages: usable.map(p => p.content),
+    initialPassageIndex: focusPassage ? usable.indexOf(focusPassage) : -1
+  };
+}

--- a/client/src/features/documentPreview/utils/pdfPassageMatching.js
+++ b/client/src/features/documentPreview/utils/pdfPassageMatching.js
@@ -1,0 +1,108 @@
+/**
+ * Glue between pdf.js text extraction and the shadow-text passage matcher.
+ *
+ * The matcher works on "page indexes" (a shadow text plus normalization
+ * diffs). It returns match positions in *text-layer coordinates*: offsets into
+ * the concatenation of the page's `textContent.items[].str`, with the synthetic
+ * end-of-line markers removed again. Those offsets are what
+ * {@link matchToItemSlices} turns back into per-text-item slices so the DOM
+ * ranges of the rendered text layer can be highlighted.
+ */
+
+import { normalize, buildShadow, computePassageMatches } from './passageMatcher.js';
+
+/**
+ * Builds the page index the matcher expects from a pdf.js text content object.
+ *
+ * The extraction buffer mirrors what pdf.js's own find controller builds: the
+ * item strings concatenated, with a newline pushed wherever an item ends a
+ * line. `normalize()` folds those newlines away again, so the resulting diffs
+ * map normalized offsets back to the item strings without them.
+ *
+ * @param {{items: Array<{str: string, hasEOL: boolean}>}} textContent
+ * @returns {{shadow: object, diffs: Array<[number, number]>|null}}
+ */
+export function buildPageIndex(textContent) {
+  const strBuf = [];
+  for (const item of textContent.items) {
+    if (item.str === undefined) continue;
+    strBuf.push(item.str);
+    if (item.hasEOL) {
+      strBuf.push('\n');
+    }
+  }
+  const [content, diffs] = normalize(strBuf.join(''));
+  return { shadow: buildShadow(content), diffs };
+}
+
+/**
+ * The item strings a match's offsets are relative to.
+ *
+ * Uses the same rule as pdf.js's `TextLayer` (`item.str === undefined` marks a
+ * marked-content boundary rather than text), so this list is index-aligned with
+ * the layer's `textContentItemsStr` / `textDivs` — which is what lets a match
+ * offset be resolved to a rendered element.
+ *
+ * @param {{items: Array<{str: string}>}} textContent
+ * @returns {string[]}
+ */
+export function itemStringsOf(textContent) {
+  return textContent.items.filter(item => item.str !== undefined).map(item => item.str);
+}
+
+/** Page index for a page whose text could not be extracted. */
+export function emptyPageIndex() {
+  return { shadow: buildShadow(''), diffs: null };
+}
+
+/**
+ * Splits a match into the text items it covers.
+ *
+ * @param {string[]} itemStrings the page's `textContent.items[].str`, in order.
+ * @param {number} matchStart offset into the concatenated item strings.
+ * @param {number} matchLength length of the match in the same coordinates.
+ * @returns {Array<{itemIdx: number, start: number, end: number}>} per-item
+ *   slices, `start`/`end` being offsets within that item's string.
+ */
+export function matchToItemSlices(itemStrings, matchStart, matchLength) {
+  const slices = [];
+  const matchEnd = matchStart + matchLength;
+  let offset = 0;
+  for (let i = 0; i < itemStrings.length; i += 1) {
+    const itemStart = offset;
+    const itemEnd = offset + itemStrings[i].length;
+    offset = itemEnd;
+    if (itemEnd <= matchStart) continue;
+    if (itemStart >= matchEnd) break;
+    const start = Math.max(0, matchStart - itemStart);
+    const end = Math.min(itemStrings[i].length, matchEnd - itemStart);
+    if (end > start) {
+      slices.push({ itemIdx: i, start, end });
+    }
+  }
+  return slices;
+}
+
+/**
+ * Flattens the matcher's per-page result into a document-ordered list, which
+ * is what the viewer's "next/previous match" navigation walks.
+ *
+ * @param {{pageMatches: number[][], pageMatchesLength: number[][]}} result
+ * @returns {Array<{pageIdx: number, matchIdx: number, start: number, length: number}>}
+ */
+export function flattenMatches(result) {
+  const flat = [];
+  result.pageMatches.forEach((positions, pageIdx) => {
+    positions.forEach((start, matchIdx) => {
+      flat.push({
+        pageIdx,
+        matchIdx,
+        start,
+        length: result.pageMatchesLength[pageIdx][matchIdx]
+      });
+    });
+  });
+  return flat;
+}
+
+export { computePassageMatches };

--- a/docs/iFinder-Integration.md
+++ b/docs/iFinder-Integration.md
@@ -14,6 +14,8 @@ The iFinder integration allows iHub Apps to search, retrieve, and analyze docume
 - **📄 Content Retrieval**: Fetch full document content for analysis and summarization
 - **ℹ️ Metadata Access**: Get detailed document metadata (author, creation date, file type, etc.)
 - **💾 Document Download**: Save documents locally or get download information
+- **🖍️ Passage Highlighting**: Jump from a cited passage to its position in the source document and
+  highlight it in the in-app PDF preview
 - **🔐 Secure Authentication**: User-based JWT authentication for all operations
 - **👤 User Context**: All operations respect the authenticated user's permissions
 
@@ -362,6 +364,48 @@ The system includes a pre-configured app called "iFinder Document Explorer" that
 4. **"Download the latest contract for review"**
    - AI searches for recent contracts
    - Provides download information or saves locally
+
+### Passage Highlighting in the Document Preview
+
+When an answer cites iFinder documents, the **Documents** section below the answer lists each
+document with the passages the search backend returned. Those passages can be located and
+highlighted in the source document:
+
+- Expanding a document shows its passages; each has a magnifier button that opens the document at
+  that passage.
+- The document's overflow menu offers **Preview (PDF)**, which opens the same viewer with all of
+  that document's cited passages highlighted.
+- The viewer navigates highlight to highlight (buttons, or `Enter` / `Shift+Enter`), supports zoom
+  and download, and — when a document is cited more than once — can filter down to a single
+  passage.
+
+Both entries appear only for documents that expose an `ACCESS` link, which is what the
+`/api/integrations/ifinder/document` proxy needs to resolve the binary. The preview requests that
+proxy with `convertToPdf=true`, i.e. the PDF rendition iFinder generates for the document.
+
+**How passages are located.** A passage is a substring of the fulltext that the converter put into
+the search index, but the preview is a *generated* PDF whose text layer differs from that fulltext:
+whitespace and line breaks fall differently, ligatures may be expanded or not, words can be
+hyphenated across lines, and page headers or footers appear in the middle of the text stream.
+Matching therefore does not compare the strings directly. Both the passage and the page text are
+reduced to their Unicode letters and digits (NFKC-folded, lowercased), and the passage is searched
+in that reduced form, with an offset map back to the real text-layer positions. Consequences worth
+knowing:
+
+- Punctuation, spacing, casing and ligature differences never prevent a match, and matches are not
+  script-specific — Cyrillic, Greek and CJK passages work the same as Latin ones.
+- Passages that straddle a page break are highlighted on both pages.
+- If a header or footer interrupts a passage at a page break, the passage is split into
+  sentence-like fragments and matched individually, so it is highlighted partially rather than not
+  at all.
+- Highlights begin and end on a letter or digit, so trailing punctuation of a passage is not
+  included in the highlight.
+- If a passage genuinely does not occur in the generated PDF, the preview still opens and reports
+  "Passage not found".
+
+The matcher (`client/src/features/documentPreview/utils/passageMatcher.js`) is a port of the same
+module used by the iFinder searchbar preview, so both products resolve passages identically. Keep
+the two in sync when changing either.
 
 ## Security Considerations
 

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -846,3 +846,26 @@ at your ingress.
 Running more than one **replica** still requires cookie-based session affinity at the ingress — the
 relay works between workers in a pod, not between pods. See
 [Scaling with Multiple Workers](../../scaling.md) for Kubernetes examples.
+
+## Cited Passages Can Now Be Located and Highlighted Inside the Source Document
+
+When an app uses iFinder as its search backend, the passages listed under a chat answer's
+**Documents** section can now be opened directly in the document they came from. The document opens
+in an in-app PDF preview with every cited passage highlighted, scrolled to the first one.
+
+- Each passage in an expanded document gets a magnifier button that opens the preview at that
+  passage. The overflow menu's **Preview (PDF)** entry opens the same viewer with all of the
+  document's cited passages highlighted.
+- The preview replaces the previous behaviour of opening the converted PDF in a new browser tab,
+  which could not highlight anything. It adds highlight-to-highlight navigation (also `Enter` /
+  `Shift+Enter`), a page count, zoom, download, and a per-passage filter when a document is cited
+  more than once.
+- Passage text and the generated preview PDF do not match character-for-character — the PDF's text
+  layer differs in whitespace, ligatures, hyphenation and page furniture such as headers and
+  footers. Matching therefore compares only letters and digits, so passages are still found across
+  those differences, in any script (including Cyrillic and CJK), and across page breaks.
+- A passage that a header or footer interrupts at a page break is highlighted sentence by sentence
+  rather than not at all. If a passage genuinely cannot be located, the preview still opens and
+  reports "Passage not found" instead of failing.
+- Documents without a downloadable version are unaffected: the passage button and preview entry
+  only appear where iFinder exposes document access.

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -454,7 +454,8 @@
     "mentioned": "Erwähnt",
     "passages": "{{count}} Passage",
     "passages_plural": "{{count}} Passagen",
-    "openExternal": "Im Browser öffnen"
+    "openExternal": "Im Browser öffnen",
+    "showInDocument": "Diese Textstelle im Dokument anzeigen"
   },
   "chatMessage": {
     "user": "Du",
@@ -2566,5 +2567,20 @@
     },
     "toggleLabel": "Transkription",
     "toggleDescription": "Hochgeladene Audio-/Videodateien mit dem Transkriptionsmodell statt dem Chat-Modell transkribieren"
+  },
+  "documentPreview": {
+    "title": "Dokumentvorschau",
+    "loading": "Dokument wird geladen…",
+    "pageCount": "{{count}} Seite",
+    "pageCount_plural": "{{count}} Seiten",
+    "matchPosition": "{{current}} von {{total}}",
+    "noMatches": "Textstelle nicht gefunden",
+    "previousMatch": "Vorherige Markierung",
+    "nextMatch": "Nächste Markierung",
+    "zoomIn": "Vergrößern",
+    "zoomOut": "Verkleinern",
+    "highlight": "Markieren",
+    "allPassages": "Alle",
+    "loadFailed": "Dokument konnte nicht geladen werden: {{error}}"
   }
 }

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1928,7 +1928,8 @@
     "mentioned": "Mentioned",
     "passages": "{{count}} passage",
     "passages_plural": "{{count}} passages",
-    "openExternal": "Open in browser"
+    "openExternal": "Open in browser",
+    "showInDocument": "Show this passage in the document"
   },
   "chatMessage": {
     "user": "You",
@@ -2601,5 +2602,20 @@
     },
     "toggleLabel": "Transcription",
     "toggleDescription": "Transcribe uploaded audio/video with the transcription model instead of the chat model"
+  },
+  "documentPreview": {
+    "title": "Document preview",
+    "loading": "Loading document…",
+    "pageCount": "{{count}} page",
+    "pageCount_plural": "{{count}} pages",
+    "matchPosition": "{{current}} of {{total}}",
+    "noMatches": "Passage not found",
+    "previousMatch": "Previous highlight",
+    "nextMatch": "Next highlight",
+    "zoomIn": "Zoom in",
+    "zoomOut": "Zoom out",
+    "highlight": "Highlight",
+    "allPassages": "All",
+    "loadFailed": "Could not load the document: {{error}}"
   }
 }

--- a/tests/unit/client/passageMatcher.test.jsx
+++ b/tests/unit/client/passageMatcher.test.jsx
@@ -1,0 +1,282 @@
+import {
+  normalize,
+  buildShadow,
+  splitIntoFragments,
+  computePassageMatches
+} from '../../../client/src/features/documentPreview/utils/passageMatcher.js';
+
+/**
+ * Builds the page structures the matcher expects from raw text-layer
+ * strings, the same way the viewer does after text extraction.
+ */
+function makePages(rawPageTexts) {
+  return rawPageTexts.map(raw => {
+    const [content, diffs] = normalize(raw);
+    return { shadow: buildShadow(content), diffs };
+  });
+}
+
+/**
+ * Resolves the matches back to substrings of the text-layer content, which
+ * is exactly what gets highlighted. Newlines in the extraction buffer are
+ * synthetic EOL markers (pushed for `hasEOL`) that do not exist in the text
+ * layer DOM, so the diff coordinates produced by normalize() are relative to
+ * the page text without them.
+ */
+function highlightedSnippets(rawPageTexts, result) {
+  const domTexts = rawPageTexts.map(raw => raw.replace(/\n/g, ''));
+  const snippets = [];
+  result.pageMatches.forEach((positions, pageIdx) => {
+    positions.forEach((start, i) => {
+      const length = result.pageMatchesLength[pageIdx][i];
+      snippets.push(domTexts[pageIdx].slice(start, start + length));
+    });
+  });
+  return snippets;
+}
+
+describe('passageMatcher', () => {
+  describe('buildShadow', () => {
+    it('should keep only letters and digits, lowercased', () => {
+      const { text } = buildShadow('Ab, c – 12!');
+      expect(text).toBe('abc12');
+    });
+
+    it('should map shadow characters back to source offsets', () => {
+      const { text, mapStart, mapEnd } = buildShadow('Ab, c');
+      expect(text).toBe('abc');
+      expect(mapStart).toEqual([0, 1, 4]);
+      expect(mapEnd).toEqual([1, 2, 5]);
+    });
+
+    it('should expand ligatures via NFKC folding', () => {
+      const { text, mapStart, mapEnd } = buildShadow('ﬁle');
+      expect(text).toBe('file');
+      // both expanded characters point at the single source ligature
+      expect(mapStart).toEqual([0, 0, 1, 2]);
+      expect(mapEnd).toEqual([1, 1, 2, 3]);
+    });
+
+    it('should drop combining marks of decomposed umlauts', () => {
+      const [normalized] = normalize('Müller');
+      expect(buildShadow(normalized).text).toBe('muller');
+    });
+
+    it('should keep non-Latin scripts', () => {
+      expect(buildShadow('Договор 2027').text).toBe('договор2027');
+      expect(buildShadow('契約期間は二年間').text).toBe('契約期間は二年間');
+    });
+  });
+
+  describe('splitIntoFragments', () => {
+    it('should split on sentence boundaries', () => {
+      const fragments = splitIntoFragments(
+        'The first sentence is here. The second sentence follows. '
+      );
+      expect(fragments).toHaveLength(2);
+      expect(fragments[0]).toContain('first sentence');
+      expect(fragments[1]).toContain('second sentence');
+    });
+
+    it('should merge fragments that are too short to be unambiguous', () => {
+      const fragments = splitIntoFragments(
+        'Yes. No. This second part makes the fragment long enough to match.'
+      );
+      expect(fragments).toHaveLength(1);
+    });
+  });
+
+  describe('computePassageMatches', () => {
+    it('should match despite whitespace, quote and newline differences', () => {
+      const raw = 'The quick\nbrown fox jumps over the “lazy” dog. More text.';
+      const pages = makePages([raw]);
+      const passage = 'The quick brown fox — jumps, over the "lazy" dog.';
+
+      const result = computePassageMatches([passage], pages);
+
+      expect(result.total).toBe(1);
+      expect(result.firstMatchPageIdx).toBe(0);
+      const [snippet] = highlightedSnippets([raw], result);
+      // 'quick\nbrown' collapses to 'quickbrown' in text-layer coordinates
+      expect(snippet).toContain('quickbrown fox');
+      expect(snippet).toContain('“lazy” dog');
+    });
+
+    it('should map matches back through hyphenation-at-line-break removal', () => {
+      const raw = 'Ver-\ntrag gilt ab sofort und bleibt bestehen.';
+      const pages = makePages([raw]);
+
+      const result = computePassageMatches(['Vertrag gilt ab sofort'], pages);
+
+      expect(result.total).toBe(1);
+      expect(highlightedSnippets([raw], result)).toEqual(['Ver-trag gilt ab sofort']);
+    });
+
+    it('should match a passage that contains ligatures against expanded page text', () => {
+      const raw = 'The final configuration file was modified yesterday.';
+      const pages = makePages([raw]);
+
+      const result = computePassageMatches(['The ﬁnal conﬁguration ﬁle was modiﬁed'], pages);
+
+      expect(result.total).toBe(1);
+      expect(highlightedSnippets([raw], result)).toEqual([
+        'The final configuration file was modified'
+      ]);
+    });
+
+    it('should match despite a spurious space inside a word in the text layer', () => {
+      const raw = 'Die Kündigungs frist beträgt drei Monate ab Zugang.';
+      const pages = makePages([raw]);
+
+      const result = computePassageMatches(['Die Kündigungsfrist beträgt drei Monate'], pages);
+
+      expect(result.total).toBe(1);
+    });
+
+    it('should match Cyrillic passages at the correct position only', () => {
+      const raw =
+        'Преамбула документа описывает стороны. Договор действует до декабря 2027 года. Прочее.';
+      const pages = makePages([raw]);
+
+      const result = computePassageMatches(['Договор действует до декабря 2027 года.'], pages);
+
+      expect(result.total).toBe(1);
+      expect(highlightedSnippets([raw], result)).toEqual([
+        'Договор действует до декабря 2027 года'
+      ]);
+    });
+
+    it('should match CJK passages', () => {
+      const raw = '会社概要の説明。第三条 契約期間は二年間とする。以上。';
+      const pages = makePages([raw]);
+
+      const result = computePassageMatches(['第三条 契約期間は二年間とする。'], pages);
+
+      expect(result.total).toBe(1);
+      expect(highlightedSnippets([raw], result)).toEqual(['第三条 契約期間は二年間とする']);
+    });
+
+    it('should match a passage crossing a clean page break', () => {
+      const rawPages = [
+        'Intro text on page one. This contract shall remain valid until ',
+        'December 2027 and renews automatically. Other text.'
+      ];
+      const pages = makePages(rawPages);
+
+      const result = computePassageMatches(
+        ['This contract shall remain valid until December 2027 and renews automatically.'],
+        pages
+      );
+
+      expect(result.total).toBe(2);
+      expect(result.firstMatchPageIdx).toBe(0);
+      expect(result.pageMatches[0]).toHaveLength(1);
+      expect(result.pageMatches[1]).toHaveLength(1);
+      const snippets = highlightedSnippets(rawPages, result);
+      expect(snippets[0]).toContain('shall remain valid until');
+      expect(snippets[1]).toContain('December 2027 and renews automatically');
+    });
+
+    it('should partially highlight a passage interrupted by a page footer', () => {
+      const rawPages = [
+        'Intro. The first sentence about the contract terms is complete here. The second sentence begins with details ',
+        'Page 2 of 15\nabout the renewal and ends here. The third sentence is also fully on page two.'
+      ];
+      const pages = makePages(rawPages);
+
+      const result = computePassageMatches(
+        [
+          'The first sentence about the contract terms is complete here. ' +
+            'The second sentence begins with details about the renewal and ends here. ' +
+            'The third sentence is also fully on page two.'
+        ],
+        pages
+      );
+
+      // full match is impossible (footer interrupts sentence two), but the
+      // surrounding sentences and both halves of the broken one are found
+      expect(result.total).toBeGreaterThanOrEqual(2);
+      const snippets = highlightedSnippets(rawPages, result).join(' | ');
+      expect(snippets).toContain('first sentence about the contract terms is complete here');
+      expect(snippets).toContain('third sentence is also fully on page two');
+      expect(snippets).not.toContain('Page 2 of 15');
+    });
+
+    it('should span an empty middle page without failing or looping', () => {
+      const rawPages = [
+        'Text before the image page ends with the first part of the passage ',
+        '',
+        'and the second part of the passage continues on page three.'
+      ];
+      const pages = makePages(rawPages);
+
+      const result = computePassageMatches(
+        ['ends with the first part of the passage and the second part of the passage continues'],
+        pages
+      );
+
+      expect(result.total).toBe(2);
+      expect(result.pageMatches[1]).toHaveLength(0);
+    });
+
+    it('should highlight every occurrence of a repeated passage', () => {
+      const raw =
+        'The same disclaimer text appears twice. Some middle part. The same disclaimer text appears twice.';
+      const pages = makePages([raw]);
+
+      const result = computePassageMatches(['The same disclaimer text appears twice.'], pages);
+
+      expect(result.total).toBe(2);
+    });
+
+    it('should support multiple passages', () => {
+      const raw =
+        'First interesting statement here. Unrelated filler text. Second interesting statement there.';
+      const pages = makePages([raw]);
+
+      const result = computePassageMatches(
+        ['First interesting statement here.', 'Second interesting statement there.'],
+        pages
+      );
+
+      expect(result.total).toBe(2);
+    });
+
+    it('should return no matches for empty or blank passages', () => {
+      const pages = makePages(['Some page content that could match.']);
+
+      const result = computePassageMatches(['', '   ', '\n'], pages);
+
+      expect(result.total).toBe(0);
+      expect(result.firstMatchPageIdx).toBe(-1);
+    });
+
+    it('should return no matches when the passage text does not occur', () => {
+      const pages = makePages(['Completely different page content.']);
+
+      const result = computePassageMatches(
+        ['This text is definitely not part of the document.'],
+        pages
+      );
+
+      expect(result.total).toBe(0);
+      expect(result.firstMatchPageIdx).toBe(-1);
+    });
+
+    it('should merge overlapping ranges from multiple passages', () => {
+      const raw = 'A shared region of text that two passages both cover fully.';
+      const pages = makePages([raw]);
+
+      const result = computePassageMatches(
+        [
+          'A shared region of text that two passages',
+          'region of text that two passages both cover fully.'
+        ],
+        pages
+      );
+
+      expect(result.total).toBe(1);
+      expect(result.pageMatches[0]).toHaveLength(1);
+    });
+  });
+});

--- a/tests/unit/client/passageSelection.test.jsx
+++ b/tests/unit/client/passageSelection.test.jsx
@@ -1,0 +1,73 @@
+import {
+  hasPassageText,
+  selectPreviewPassages
+} from '../../../client/src/features/documentPreview/utils/passageSelection.js';
+
+describe('passageSelection', () => {
+  describe('hasPassageText', () => {
+    it.each([
+      ['a real passage', true],
+      ['', false],
+      ['   ', false],
+      ['\n\t ', false]
+    ])('should treat %j as usable=%s', (content, expected) => {
+      expect(hasPassageText({ content })).toBe(expected);
+    });
+
+    it('should reject passages with no or non-string content', () => {
+      expect(hasPassageText({})).toBe(false);
+      expect(hasPassageText({ content: null })).toBe(false);
+      expect(hasPassageText({ content: 42 })).toBe(false);
+      expect(hasPassageText(undefined)).toBe(false);
+    });
+  });
+
+  describe('selectPreviewPassages', () => {
+    it('should return every usable passage and focus none by default', () => {
+      const list = [{ content: 'first passage' }, { content: 'second passage' }];
+      expect(selectPreviewPassages(list)).toEqual({
+        passages: ['first passage', 'second passage'],
+        initialPassageIndex: -1
+      });
+    });
+
+    it('should index the focused passage against the filtered list', () => {
+      // The blank passage is dropped, so the third displayed passage is the
+      // second one the preview renders. An index taken from the displayed list
+      // would have focused the wrong passage here.
+      const blank = { content: '   ' };
+      const target = { content: 'the passage the user clicked' };
+      const list = [{ content: 'first passage' }, blank, target];
+
+      expect(selectPreviewPassages(list, target)).toEqual({
+        passages: ['first passage', 'the passage the user clicked'],
+        initialPassageIndex: 1
+      });
+    });
+
+    it('should drop leading unusable passages without shifting the focus', () => {
+      const target = { content: 'only real passage' };
+      const list = [{ content: '' }, { content: '  ' }, target];
+
+      expect(selectPreviewPassages(list, target)).toEqual({
+        passages: ['only real passage'],
+        initialPassageIndex: 0
+      });
+    });
+
+    it('should report no focus when the focused passage is itself unusable', () => {
+      const blank = { content: '   ' };
+      const list = [{ content: 'real passage' }, blank];
+
+      expect(selectPreviewPassages(list, blank)).toEqual({
+        passages: ['real passage'],
+        initialPassageIndex: -1
+      });
+    });
+
+    it('should handle an empty or missing list', () => {
+      expect(selectPreviewPassages([])).toEqual({ passages: [], initialPassageIndex: -1 });
+      expect(selectPreviewPassages(undefined)).toEqual({ passages: [], initialPassageIndex: -1 });
+    });
+  });
+});

--- a/tests/unit/client/pdfPassageMatching.test.jsx
+++ b/tests/unit/client/pdfPassageMatching.test.jsx
@@ -1,0 +1,229 @@
+import {
+  buildPageIndex,
+  computePassageMatches,
+  emptyPageIndex,
+  flattenMatches,
+  itemStringsOf,
+  matchToItemSlices
+} from '../../../client/src/features/documentPreview/utils/pdfPassageMatching.js';
+
+/** Fake pdf.js text content: one entry per text item. */
+function textContent(items) {
+  return { items: items.map(([str, hasEOL = false]) => ({ str, hasEOL })) };
+}
+
+/**
+ * Reconstructs what would be highlighted: the matched slices resolved back to
+ * substrings of the text items the viewer draws boxes over.
+ */
+function highlighted(pageContents, result) {
+  const out = [];
+  result.pageMatches.forEach((positions, pageIdx) => {
+    const itemStrings = itemStringsOf(pageContents[pageIdx]);
+    positions.forEach((start, i) => {
+      const length = result.pageMatchesLength[pageIdx][i];
+      const text = matchToItemSlices(itemStrings, start, length)
+        .map(slice => itemStrings[slice.itemIdx].slice(slice.start, slice.end))
+        .join('');
+      out.push({ pageIdx, text });
+    });
+  });
+  return out;
+}
+
+describe('pdfPassageMatching', () => {
+  describe('matchToItemSlices', () => {
+    const itemStrings = ['Hello ', 'brave ', 'new ', 'world'];
+
+    it('should return a single slice for a match inside one item', () => {
+      expect(matchToItemSlices(itemStrings, 6, 5)).toEqual([{ itemIdx: 1, start: 0, end: 5 }]);
+    });
+
+    it('should split a match spanning several items', () => {
+      // "brave new wo" starts at offset 6 and is 12 characters long
+      expect(matchToItemSlices(itemStrings, 6, 12)).toEqual([
+        { itemIdx: 1, start: 0, end: 6 },
+        { itemIdx: 2, start: 0, end: 4 },
+        { itemIdx: 3, start: 0, end: 2 }
+      ]);
+    });
+
+    it('should clip partial slices at both ends', () => {
+      // "llo brave ne"
+      expect(matchToItemSlices(itemStrings, 2, 12)).toEqual([
+        { itemIdx: 0, start: 2, end: 6 },
+        { itemIdx: 1, start: 0, end: 6 },
+        { itemIdx: 2, start: 0, end: 2 }
+      ]);
+    });
+
+    it('should skip empty items instead of emitting zero-width slices', () => {
+      expect(matchToItemSlices(['ab', '', 'cd'], 0, 4)).toEqual([
+        { itemIdx: 0, start: 0, end: 2 },
+        { itemIdx: 2, start: 0, end: 2 }
+      ]);
+    });
+
+    it('should return nothing for a match beyond the page text', () => {
+      expect(matchToItemSlices(itemStrings, 500, 10)).toEqual([]);
+    });
+  });
+
+  describe('buildPageIndex', () => {
+    it('should produce a shadow of the page text', () => {
+      const index = buildPageIndex(
+        textContent([
+          ['Hello, ', false],
+          ['World!', false]
+        ])
+      );
+      expect(index.shadow.text).toBe('helloworld');
+    });
+
+    it('should tolerate items without a string', () => {
+      const index = buildPageIndex({
+        items: [{ str: 'ok' }, { type: 'beginMarkedContent' }, { str: 'ay' }]
+      });
+      expect(index.shadow.text).toBe('okay');
+    });
+
+    it('should produce an empty index for a page with no text', () => {
+      expect(emptyPageIndex().shadow.text).toBe('');
+    });
+  });
+
+  describe('itemStringsOf', () => {
+    it('should keep empty items so indices stay aligned with the text layer', () => {
+      // pdf.js's TextLayer pushes a textDiv for every item whose `str` is
+      // defined — empty strings included. Dropping them here would shift every
+      // slice index after the first empty item and highlight the wrong text.
+      const page = textContent([
+        ['First item. ', true],
+        ['', true],
+        ['Second item.', false]
+      ]);
+      expect(itemStringsOf(page)).toEqual(['First item. ', '', 'Second item.']);
+    });
+
+    it('should drop marked-content boundaries, which produce no textDiv', () => {
+      expect(
+        itemStringsOf({ items: [{ str: 'a' }, { type: 'beginMarkedContent' }, { str: 'b' }] })
+      ).toEqual(['a', 'b']);
+    });
+
+    it('should resolve a match to the right item when an empty item precedes it', () => {
+      const page = textContent([
+        ['Preamble sentence here. ', true],
+        ['', true],
+        ['The clause that must be highlighted.', false]
+      ]);
+      const itemStrings = itemStringsOf(page);
+      const result = computePassageMatches(
+        ['The clause that must be highlighted.'],
+        [buildPageIndex(page)]
+      );
+
+      const slices = matchToItemSlices(
+        itemStrings,
+        result.pageMatches[0][0],
+        result.pageMatchesLength[0][0]
+      );
+      expect(slices).toEqual([{ itemIdx: 2, start: 0, end: 35 }]);
+      expect(itemStrings[2].slice(0, 35)).toBe('The clause that must be highlighted');
+    });
+  });
+
+  describe('end-to-end offset mapping', () => {
+    it('should resolve a passage back to the exact text items', () => {
+      const page = textContent([
+        ['The contract ', false],
+        ['shall remain ', false],
+        ['valid until December 2027.', true],
+        [' Unrelated trailing text.', false]
+      ]);
+      const result = computePassageMatches(
+        ['shall remain valid until December 2027'],
+        [buildPageIndex(page)]
+      );
+
+      expect(result.total).toBe(1);
+      expect(highlighted([page], result)).toEqual([
+        { pageIdx: 0, text: 'shall remain valid until December 2027' }
+      ]);
+    });
+
+    it('should resolve a match that starts and ends mid-item', () => {
+      const page = textContent([['Preamble text. The important clause is here. Epilogue.', false]]);
+      const result = computePassageMatches(
+        ['The important clause is here.'],
+        [buildPageIndex(page)]
+      );
+
+      expect(highlighted([page], result)).toEqual([
+        { pageIdx: 0, text: 'The important clause is here' }
+      ]);
+    });
+
+    it('should resolve a cross-page passage to slices on both pages', () => {
+      const pages = [
+        textContent([['Page one ends with the beginning of the ', false]]),
+        textContent([['passage and page two carries it on. Rest.', false]])
+      ];
+      const result = computePassageMatches(
+        ['ends with the beginning of the passage and page two carries it on'],
+        pages.map(buildPageIndex)
+      );
+
+      expect(result.total).toBe(2);
+      expect(highlighted(pages, result)).toEqual([
+        { pageIdx: 0, text: 'ends with the beginning of the' },
+        { pageIdx: 1, text: 'passage and page two carries it on' }
+      ]);
+    });
+
+    it('should resolve through end-of-line markers between items', () => {
+      const page = textContent([
+        ['Die Kündigungsfrist', true],
+        ['beträgt drei Monate.', false]
+      ]);
+      const result = computePassageMatches(
+        ['Die Kündigungsfrist beträgt drei Monate'],
+        [buildPageIndex(page)]
+      );
+
+      expect(result.total).toBe(1);
+      // The synthetic newline is not part of the text layer, so the two items
+      // are highlighted back-to-back with nothing in between.
+      expect(highlighted([page], result)).toEqual([
+        { pageIdx: 0, text: 'Die Kündigungsfristbeträgt drei Monate' }
+      ]);
+    });
+
+    it('should resolve a hyphenated line break to the full source span', () => {
+      const page = textContent([
+        ['Ver-', true],
+        ['trag gilt ab sofort.', false]
+      ]);
+      const result = computePassageMatches(['Vertrag gilt ab sofort'], [buildPageIndex(page)]);
+
+      expect(result.total).toBe(1);
+      expect(highlighted([page], result)).toEqual([
+        { pageIdx: 0, text: 'Ver-trag gilt ab sofort' }
+      ]);
+    });
+  });
+
+  describe('flattenMatches', () => {
+    it('should flatten per-page matches into document order', () => {
+      const flat = flattenMatches({
+        pageMatches: [[10], [], [3, 40]],
+        pageMatchesLength: [[5], [], [7, 2]]
+      });
+      expect(flat).toEqual([
+        { pageIdx: 0, matchIdx: 0, start: 10, length: 5 },
+        { pageIdx: 2, matchIdx: 0, start: 3, length: 7 },
+        { pageIdx: 2, matchIdx: 1, start: 40, length: 2 }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## Why

Question asked: can the passage highlighting built in [intrafind/ifinder#2655](https://github.com/intrafind/ifinder/pull/2655) be reused here? iHub receives the same passages from iFinder (`citations.references[].content`) and can already fetch the document (`/api/integrations/ifinder/document?convertToPdf=true`), but "Preview (PDF)" just did `window.open()` into a browser tab — where nothing can be highlighted. So the data was there and the capability wasn't.

**Answer: the valuable half ports verbatim, the other half does not.**

| iFinder PR file | Reusable here? |
|---|---|
| `passageMatcher.js` | **Yes, verbatim.** Pure ESM, zero dependencies, no DOM. |
| `passageMatcher.test.js` (21 tests) | **Yes, verbatim.** Passes unmodified against the port. |
| `custom_pdf_viewer.js` (`PDFFindController`) | **No.** Bound to the pdf.js *viewer* layer (`EventBus`, `PDFLinkService`, `PDFViewer`, `TextHighlighter`) plus iFinder's `eventbusjs` and Handlebars templates. iHub uses only the pdf.js *core*, and has no PDF viewer component at all. |
| `PdfJs.js`, `ifs-preview.js`, `PdfViewer.js` | **No.** iFinder viewer chrome. |

`pdfjs-dist` (4.10.38) was already a client dependency, and `TextLayer` ships in its core export — so no new dependency and no viewer bundle was needed. iFinder is on pdf.js v5; the ported matcher is version-independent, and the new viewer is written against the installed v4.

## What

**Ported** — `client/src/features/documentPreview/utils/passageMatcher.js`: behaviour-identical, only Prettier formatting changed. One deliberate deviation: `SYLLABLES_REG_EXP` is written with `\u` escapes. As literal characters, the CJK compatibility ideographs (`U+FA6C`, `U+FACF-FAD1`, `U+FAD5-FAD7`) decompose under NFD into surrogate pairs, which makes the character class a `Range out of order` syntax error. Escapes are normalization-proof.

**New** — `utils/pdfPassageMatching.js` maps matcher output (offsets into the concatenated text-layer item strings) onto pdf.js text items.

**New** — `components/PdfPassageViewer.jsx` renders pages with pdfjs-dist's `TextLayer` and paints highlights from DOM ranges over the text divs, so highlight geometry follows real glyph positions and the text layer stays selectable. Text for every page is extracted up front (passages routinely straddle page breaks, so the matcher needs the whole document's shadow text); canvas rendering is lazy via `IntersectionObserver`, with unrendered slots holding page height so scroll offsets stay correct.

**New** — `components/DocumentPreviewModal.jsx`: fetches the PDF through the existing proxy as an `ArrayBuffer` (keeps `credentials: 'include'`), with highlight-to-highlight navigation (also `Enter` / `Shift+Enter`), page count, zoom, download, and a per-passage filter when a document is cited more than once.

**Wiring** — `CitationPanel` handles `preview` itself, since it owns the passage texts, and each passage gets a magnifier button that opens the document at that passage. The resulting unreachable `preview` branch in `AppChat`'s handler is removed, so there is one preview path rather than two divergent ones.

### A bug worth calling out

Highlight indices come from `textLayer.textDivs` / `textLayer.textContentItemsStr`, **not** from a DOM query. My first implementation used `querySelectorAll('span')`; pdf.js emits a `<br>` instead of a span for items with an empty string, so every index after the first empty item shifted by one and the wrong text was highlighted. Only the browser check surfaced this — unit tests over item-string arrays cannot. There is now a regression test for it.

## Verification

- **Ported matcher suite** — 21/21 pass unmodified (`tests/unit/client/passageMatcher.test.jsx`): page-break-with-footer partial highlighting, ligatures, Cyrillic/CJK, umlauts, spurious in-word spaces, hyphenation-at-EOL offset mapping, empty middle pages, repeated passages, passage arrays, overlap merging.
- **New offset-pipeline suite** — 14 tests (`tests/unit/client/pdfPassageMatching.test.jsx`) covering multi-item and mid-item slicing, cross-page resolution, EOL markers, hyphenated breaks, and the empty-item alignment invariant.
- `npx jest tests/unit/client/` → **178 passed, 18 suites**. `eslint` 0 errors. `vite build` clean.
- **Browser check** (Chromium + Playwright, throwaway harness): a two-page generated PDF with a footer, matched against four passages. `textDivs`/`textContentItemsStr`/item-strings counts agree exactly (7/7 and 5/5) with zero mismatches; all four passages resolved; screenshot confirms highlights land pixel-accurately on the correct glyphs across wrapped lines, both pages, German umlauts and Cyrillic, with the selected match visually distinct.

Highlights end on the last letter or digit, so a passage's trailing period is not covered — that is the ported matcher's intended behaviour (no greedy over-extension into punctuation), not a mapping error.

## Notes for review

- **Not ported deliberately**, same as the upstream PR: per-page location data at indexing time, which isn't available for all document types. Matching stays client-side against the generated PDF.
- Passage/preview affordances only appear for documents exposing an `ACCESS` link, which the proxy needs to resolve the binary — unchanged from the previous `hasProxyAccess` gate.
- `passageMatcher.js` is now duplicated across two products. Both copies carry a header saying so; if the algorithm changes in either, sync the other.
- Not covered here: an end-to-end run against a live iFinder backend, which this environment has no access to. Everything above is verified against generated PDFs and unit fixtures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012dmZfb4gzH1AhGDgD49hnn

---
_Generated by [Claude Code](https://claude.ai/code/session_012dmZfb4gzH1AhGDgD49hnn)_