### PR TITLE
fix(oauth): resolve authorization codes across cluster workers

### DIFF
--- a/concepts/2026-07-28 Round-Robin Worker-Local State Audit.md
+++ b/concepts/2026-07-28 Round-Robin Worker-Local State Audit.md
@@ -37,8 +37,16 @@ Replicating codes to all workers would have destroyed the security property — 
 *consumes* it, so N copies means N valid redemptions. Instead the code stays on the minting worker,
 ownership is announced over `server/clusterBus.js`, and a worker receiving the token request asks
 the owner to consume it. Exactly one process ever holds a code, so single-use stays atomic with no
-distributed agreement. Only the SHA-256 of the code is announced, so the raw credential never
-leaves the worker that minted it.
+distributed agreement.
+
+A code is now `<handle>.<secret>` — 128 bits of routing handle, 256 bits of secret. Ownership
+announcements are broadcast to every worker and retained for the code's lifetime, so they carry only
+the handle, which grants nothing on its own. The secret crosses the IPC boundary once, in the single
+directed consume message to the owner, which verifies it in constant time and destroys it. An
+earlier revision announced a SHA-256 of the whole code instead; the split is better because the
+broadcast value was never secret to begin with, and it avoids hashing a request-derived credential
+(which CodeQL's `js/insufficient-password-hash` flags, and GitHub code scanning cannot suppress
+inline — the `lgtm[...]` comments elsewhere in this repo are decorative, LGTM.com is retired).
 
 This required a request/reply primitive on the bus (`request()` / `respond()`), built on the
 existing pub/sub with correlation ids so the primary remains a dumb repeater.

--- a/concepts/2026-07-28 Round-Robin Worker-Local State Audit.md
+++ b/concepts/2026-07-28 Round-Robin Worker-Local State Audit.md
@@ -1,0 +1,107 @@
+# Round-Robin Worker-Local State Audit
+
+**Date:** 2026-07-28
+**Trigger:** OAuth login for MCP clients failed with `invalid_grant: Authorization code is invalid or expired`
+**Status:** OAuth authorization code flow fixed; remaining findings open
+
+## Root cause class
+
+`server/server.js` forks `config.WORKERS` workers (default **4**). Since #2146 the default
+connection routing is **round-robin** (`STICKY_SESSIONS` defaults to `false`), so consecutive
+requests from the same client are handled by *different* worker processes.
+
+Any mutable state kept in a worker's own process memory is therefore invisible to the requests that
+follow. Where request A writes state and a later request B reads it, B fails.
+
+Two properties make this worse than it first looks:
+
+- **It is not "1 in N".** Round-robin hands each new TCP connection to the next worker in sequence.
+  Two requests made back-to-back over separate connections land on *adjacent* workers, so a
+  two-request handshake fails close to **100%** of the time rather than `(N-1)/N`. This was measured:
+  the OAuth token exchange failed 12/12 against a 4-worker cluster before the fix.
+- **`npm run dev` pins `WORKERS=1`.** None of this reproduces in development. It appears only in
+  production, `start:prod`, Docker, and binary deployments.
+
+`#2148` (config cache) and `#2146` (chat/SSE state) fixed two instances of this class. The findings
+below are the remainder.
+
+## Fixed in this change
+
+### OAuth authorization codes — `server/utils/authorizationCodeStore.js`
+
+`POST /api/oauth/authorize/decision` minted the code into a per-process `Map`; the client's
+`POST /api/oauth/token` arrived at another worker whose map was empty, and
+`server/routes/oauth.js` returned `invalid_grant: Authorization code is invalid or expired`.
+
+Replicating codes to all workers would have destroyed the security property — reading a code
+*consumes* it, so N copies means N valid redemptions. Instead the code stays on the minting worker,
+ownership is announced over `server/clusterBus.js`, and a worker receiving the token request asks
+the owner to consume it. Exactly one process ever holds a code, so single-use stays atomic with no
+distributed agreement. Only the SHA-256 of the code is announced, so the raw credential never
+leaves the worker that minted it.
+
+This required a request/reply primitive on the bus (`request()` / `respond()`), built on the
+existing pub/sub with correlation ids so the primary remains a dumb repeater.
+
+### Consent screen CSRF + PKCE — `server/routes/oauthAuthorize.js`
+
+The consent CSRF token and the PKCE `code_challenge` lived in an `express-session` backed by a
+per-worker `MemoryStore` (`server/middleware/setup.js`). A decision POST reaching another worker
+saw no session, giving `403 CSRF token missing` — or, if CSRF happened to pass, a code minted with
+an **empty** `codeChallenge` that the token endpoint later rejected.
+
+Replaced with a signed, self-contained consent ticket (`server/utils/consentTicket.js`) carried in
+the form. Side benefit: `redirect_uri`, `scope`, `code_challenge` and `nonce` are now
+integrity-protected instead of trusted from the POST body.
+
+## Open findings
+
+Ordered by severity. Each was confirmed by reading the declaring code.
+
+| # | Location | State | Breaking flow |
+| --- | --- | --- | --- |
+| 1 | `routes/mcpServer.js:36`, `:402` | `sessions` / `sseSessions` Map | `initialize` on worker 1 → `tools/call` on worker 2 → `404 Session not found`. MCP clients connect then fail on the first tool call. Mitigation exists: `mcpServer.transports.streamableHttp.stateless = true`. Legacy SSE transport has no stateless mode. |
+| 2 | `middleware/setup.js:271` | OIDC session `MemoryStore` | passport writes OAuth `state` + PKCE `code_verifier` here (`middleware/oidcAuth.js:72`). Callback on another worker → `Failed to verify request state`. SSO login broken. |
+| 3 | `middleware/setup.js:310` | Integration session `MemoryStore` | Jira / Office 365 / Google Drive / Nextcloud write `{state, codeVerifier, userId}` before redirect and read it in the callback → `invalid_state`, integration never connects. |
+| 4 | `shortLinkManager.js:16` | `createDebouncedJsonStore` | `debouncedJsonStore.js:32` caches forever (`if (data) return data`) and `load()` runs at import, so each worker snapshots at boot and never refreshes. A created link 404s on 3 of 4 workers **permanently**. Also last-writer-wins: each worker flushes its stale snapshot, deleting links created elsewhere. |
+| 5 | `services/workflow/ExecutionRegistry.js:52` | `executions` Map | Run registered on worker 1 → any per-execution endpoint on worker 2 → `404 Execution`. Blocks stream attach, cancel, checkpoint replies, and `my-executions`. Same clobbering-on-write problem as #4. |
+| 6 | `routes/toolsService/jobStore.js:4` | `jobs` Map | OCR upload → progress → download. Progress and download 404 from other workers; `job.result` is RAM-only so it is unrecoverable. |
+| 7 | `middleware/rateLimiting.js:79` | `rateLimit()` with no `store` | Per-worker counters, so the effective limit is `WORKERS ×` the configured value — `authApiLimiter` allows ~200 credential attempts per 15 min instead of 50. Security weakening, and nondeterministic 429s for legitimate users. |
+| 8 | `services/integrations/ConversationStateManager.js:14` | `states` Map | iAssistant turn 1 stores the upstream conversation id; turn 2 on another worker sees nothing and starts a **new** upstream conversation, losing all context. |
+| 9 | `services/workflow/WorkflowEngine.js:143` | `abortControllers` Map | Cancel routed to a non-owning worker cannot fire the run's abort signal; the in-flight LLM node runs to completion and keeps billing. |
+| 10 | `services/updateService.js:143` | `updateState` object | Admin update progress polling hits other workers and reports `idle / 0%`; download errors never surface. The update itself is fine (state derived from disk). |
+| 11 | `requestThrottler.js:9-12` | `queues` / `actives` / `lastCompleted` | Outbound provider rate limits enforced per worker, so a configured 1 req/s becomes `WORKERS` req/s. Causes upstream 429s despite correct config. |
+| 12 | `services/AuditLogService.js:40` | JSONL appender batch queue | An audit query flushes only its own worker's queue, so it can miss recently buffered entries from other workers. Self-healing, low severity. |
+
+Also observed: four workers race for the migration lock at boot, so
+`server/migrations/runner.js` logs `Configuration migration failed — Migration lock held by PID …`
+on the losers. Harmless (one worker applies migrations) but noisy and misleading in logs.
+
+### Confirmed safe — do not change
+
+- `utils/consentStore.js`, `utils/refreshTokenStore.js`, `utils/oauthClientManager.js` — every read
+  and write goes to disk with `atomicWriteJSON`; no in-memory cache.
+- `services/workflow/chatBridge.js:36` — mirrored across workers over `clusterBus`.
+- `services/workflow/StateManager.js:94` — reads fall back to `latest.json` and repopulate.
+
+### Benign — performance only
+
+`services/searchCache.js`, `services/azureSpeechToken.js`, `middleware/proxyAuth.js` (JWKS),
+`middleware/teamsAuth.js` (JWKS), `services/tools/OpenApiToolRunner.js`, `configLoader.js`,
+`services/ModelDiscoveryService.js`, `sources/SourceHandler.js` — pure memoization; a miss
+re-derives from disk or upstream. `PromptService.js` and the adapter `streamingState` maps are
+intra-request only.
+
+## Recommended sequencing
+
+1. **#1 (MCP sessions)** — document/default stateless mode; it blocks the MCP gateway outright.
+   Doc corrected in this change; the default is still stateful.
+2. **#2, #3 (OAuth/OIDC + integration sessions)** — a shared session store, or apply the same
+   signed-state approach used for the consent ticket. Both break user-visible login flows.
+3. **#7 (rate limiters)** — a shared store; this is a security control that silently does not hold.
+4. **#4, #5, #6** — these need a shared/authoritative store rather than a per-worker cache; #4 and
+   #5 additionally lose data on write.
+5. **#8–#12** — correctness and cost issues, lower user impact.
+
+A general fix for several of these is a cluster-aware store abstraction (bus-backed now, Redis
+later for cross-pod), which `clusterBus.js` was already shaped to allow.

--- a/docs/mcp-integration.md
+++ b/docs/mcp-integration.md
@@ -314,17 +314,27 @@ spec prescribes, so clients can recover on their own:
 | POST that is not `initialize` and carries no session id | `400 Bad Request: Mcp-Session-Id header is required` |
 | `GET /mcp` outside a session | `405 Method Not Allowed` — there is no server-initiated SSE stream to attach to |
 
-#### Stateless mode (load-balanced deployments)
+#### Stateless mode (clustered and load-balanced deployments)
 
-Session state lives in the worker's process memory. The sticky cluster
-router keeps a client on the same worker within one instance, but if
-iHub is deployed as several replicas behind a load balancer, a session
-opened on one replica is unknown to the next and the client has to
-re-initialize on every request.
+Session state lives in the worker's process memory, so a session is only
+usable on the worker that opened it.
 
-For that topology enable **stateless mode**
-(Admin → MCP gateway → Transports, or
-`platform.mcpServer.transports.streamableHttp.stateless: true`):
+> **Enable stateless mode on any deployment running more than one worker.**
+> Connections are distributed across workers round-robin by default
+> (`WORKERS` defaults to 4), so a client's `initialize` and its follow-up
+> `tools/call` normally land on *different* workers. The second request
+> then gets `404 Session not found` and the client cannot make progress.
+> This applies to a single instance, not just multi-replica deployments —
+> the same is true across replicas behind a load balancer.
+>
+> The alternative is `STICKY_SESSIONS=true`, which pins each client to one
+> worker by hashing its TCP peer address. That only works when clients
+> reach iHub directly: behind a reverse proxy or ingress every request
+> carries the same peer address, so all traffic collapses onto a single
+> worker. Prefer stateless mode.
+
+Enable **stateless mode** via Admin → MCP gateway → Transports, or
+`platform.mcpServer.transports.streamableHttp.stateless: true`:
 
 ```json
 {

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,5 +1,27 @@
 # Features — 5.5.0
 
+## OAuth Login for MCP Clients No Longer Fails With "Authorization code is invalid or expired"
+
+Fixed a bug that made the OAuth 2.0 authorization code flow fail on any multi-worker deployment
+(the default is 4 workers). After approving the consent screen, clients such as Claude Code
+reported `Authorization code is invalid or expired` and never obtained a token.
+
+- Authorization codes were held in a single worker's memory. Since connections are distributed
+  across workers round-robin, the token request almost always arrived at a different worker than
+  the one that issued the code, which then could not find it. Codes are now resolved across
+  workers, so the exchange succeeds regardless of which worker handles each request.
+- Codes remain strictly single-use: a code is consumed on exactly one worker, so replay attempts
+  are still rejected cluster-wide with `invalid_grant`.
+- The consent screen no longer depends on server-side session state either. Previously the CSRF
+  token and the PKCE `code_challenge` were stored in a per-worker session, so approving consent
+  could fail with `CSRF token missing`, or could issue a code with no PKCE binding that the token
+  endpoint later rejected.
+- Consent parameters (`redirect_uri`, `scope`, `code_challenge`, `nonce`) are now cryptographically
+  signed and verified on submission, so they can no longer be altered between the consent screen
+  and the decision.
+- No configuration changes are required. Deployments that set `STICKY_SESSIONS=true` to work around
+  this no longer need it for OAuth.
+
 ## Admin Config Backup Restore No Longer Risks Wiping the Configuration
 
 Fixed a data-loss risk in **Admin → Backup → Import**: if the safety backup of the current

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "// === TESTING ===": "",
     "test:all": "npm run test:quick && npm run test:integration && npm run test:e2e",
     "test:quick": "npm run test:unit && npm run test:adapters && npm run test:cluster && npm run test:token-stats && npm run test:export-formats && npm run test:feature-flags",
-    "test:cluster": "node server/tests/sse-cluster-helpers.test.js && node server/tests/clusterBus.test.js && node server/tests/configSync.test.js && node server/tests/keyColdStartRace.test.js",
+    "test:cluster": "node server/tests/sse-cluster-helpers.test.js && node server/tests/clusterBus.test.js && node server/tests/configSync.test.js && node server/tests/keyColdStartRace.test.js && node server/tests/authCodeCluster.test.js && node server/tests/consentTicket.test.js",
     "test:unit": "jest --config tests/config/jest.config.js tests/unit",
     "test:integration": "jest --config tests/config/jest.config.js tests/integration",
     "test:integration:ci": "jest --config tests/config/jest.config.js tests/integration --testPathIgnorePatterns=tests/integration/api/chat.test.js --testPathIgnorePatterns=tests/integration/models/model-integration.test.js",

--- a/server/clusterBus.js
+++ b/server/clusterBus.js
@@ -38,6 +38,14 @@
  *    synchronous answer to "does some other worker hold the SSE stream for this
  *    chat?", which the request path needs before it decides to stream.
  *
+ *  - **request/reply** — `request(type, payload, {route})` asks another worker a
+ *    question and awaits its answer; `respond(type, handler)` answers. Built on
+ *    pub/sub with correlation ids, so the primary stays a dumb repeater. Needed
+ *    when the state cannot be replicated because reading it *mutates* it — a
+ *    single-use OAuth authorization code has to be consumed on exactly one
+ *    worker, so the worker holding it is asked to consume it rather than being
+ *    told to hand out a copy (`server/utils/authorizationCodeStore.js`).
+ *
  * Presence is eventually consistent: an announcement takes one IPC hop to the
  * primary and one back out. The paths that read it (a chat POST asking whether
  * an SSE stream exists) are separated from the registration (the SSE GET
@@ -377,6 +385,131 @@ export function subscribe(type, handler) {
   return () => handlers.delete(handler);
 }
 
+// ---------------------------------------------------------------------------
+// Request / reply
+// ---------------------------------------------------------------------------
+
+/** Reply traffic for channel `t` rides on `t:reply`. */
+const REPLY_SUFFIX = ':reply';
+
+/** Correlation id → settle callback, for requests this worker is awaiting. */
+const pendingRequests = new Map();
+
+/** Channels whose reply subscription has already been installed. */
+const replyChannels = new Set();
+
+let nextRequestId = 1;
+
+/**
+ * Correlation id. The pid makes it unique across the cluster, so a reply
+ * broadcast can never settle a different worker's pending request.
+ */
+function newRequestId() {
+  return `${process.pid}:${nextRequestId++}`;
+}
+
+function ensureReplyChannel(type) {
+  if (replyChannels.has(type)) return;
+  replyChannels.add(type);
+  subscribe(type + REPLY_SUFFIX, message => {
+    const id = message?.requestId;
+    const settle = typeof id === 'string' ? pendingRequests.get(id) : undefined;
+    // Replies fan out to every worker; only the originator holds the id.
+    if (!settle) return;
+    pendingRequests.delete(id);
+    settle(message.reply);
+  });
+}
+
+/**
+ * Ask another worker a question and await its answer.
+ *
+ * Resolves with `null` rather than rejecting when no answer arrives — every
+ * caller treats "nobody answered" the same as "the thing is not there", and a
+ * rejection mid-request would need a try/catch at each call site just to avoid
+ * turning a missing entry into a 500.
+ *
+ * @param {string} type - Channel; the responder must use the same one.
+ * @param {*} payload - Structured-cloneable request payload.
+ * @param {object} [options]
+ * @param {{kind: string, key: string}} [options.route] - Presence entry naming
+ *   the worker that should answer. Without it the question is broadcast and any
+ *   worker may answer, so the first reply wins.
+ * @param {number} [options.timeoutMs=1500] - How long to wait before giving up.
+ * @returns {Promise<*|null>} The responder's reply, or null on timeout / outside
+ *   cluster mode, where there is no other worker to ask.
+ */
+export function request(type, payload, { route, timeoutMs = 1500 } = {}) {
+  if (!busActive) return Promise.resolve(null);
+
+  ensureReplyChannel(type);
+  const requestId = newRequestId();
+
+  return new Promise(resolve => {
+    const timer = setTimeout(() => {
+      pendingRequests.delete(requestId);
+      logger.warn({
+        component: 'ClusterBus',
+        message: 'Cross-worker request timed out',
+        type,
+        timeoutMs
+      });
+      resolve(null);
+    }, timeoutMs);
+    // A pending question must never hold the event loop open during shutdown.
+    timer.unref?.();
+
+    pendingRequests.set(requestId, reply => {
+      clearTimeout(timer);
+      resolve(reply === undefined ? null : reply);
+    });
+
+    if (!publish(type, { requestId, payload }, route)) {
+      clearTimeout(timer);
+      pendingRequests.delete(requestId);
+      resolve(null);
+    }
+  });
+}
+
+/**
+ * Answer `request()` calls on a channel.
+ *
+ * A handler returning `undefined` sends **no reply**. That is what makes a
+ * broadcast question safe: when the primary does not know who owns the routed
+ * key it falls back to a fan-out, and every worker that does not hold the thing
+ * stays silent instead of racing a `null` ahead of the real owner's answer.
+ * Return an explicit wrapper (e.g. `{ data: null }`) to say "I own this and the
+ * answer is nothing".
+ *
+ * @param {string} type - Channel; must match the requester's.
+ * @param {(payload: *) => *|Promise<*>} handler - Returns the reply, or
+ *   `undefined` to stay silent.
+ * @returns {() => void} Unsubscribe.
+ */
+export function respond(type, handler) {
+  return subscribe(type, async message => {
+    const requestId = message?.requestId;
+    if (typeof requestId !== 'string') return;
+
+    let reply;
+    try {
+      reply = await handler(message.payload);
+    } catch (error) {
+      logger.error({
+        component: 'ClusterBus',
+        message: 'Cross-worker request handler threw',
+        type,
+        error: error?.message || String(error)
+      });
+      return;
+    }
+
+    if (reply === undefined) return;
+    publish(type + REPLY_SUFFIX, { requestId, reply });
+  });
+}
+
 /**
  * A `Map` that publishes its membership to the rest of the cluster.
  *
@@ -443,6 +576,8 @@ export function resetClusterBusForTests() {
   subscribers.clear();
   remoteOwnership.clear();
   presenceMaps.clear();
+  pendingRequests.clear();
+  replyChannels.clear();
   stats.published = 0;
   stats.received = 0;
   stats.presenceAnnounced = 0;

--- a/server/routes/oauth.js
+++ b/server/routes/oauth.js
@@ -228,8 +228,9 @@ export default function registerOAuthRoutes(app) {
           return sendOAuthError(res, 400, 'invalid_request', 'redirect_uri is required');
         }
 
-        // Consume the authorization code (single-use)
-        const codeData = consumeCode(sanitizedCode);
+        // Consume the authorization code (single-use). In cluster mode this may
+        // resolve against the worker that minted it, so it is asynchronous.
+        const codeData = await consumeCode(sanitizedCode);
         if (!codeData) {
           return sendOAuthError(
             res,

--- a/server/routes/oauthAuthorize.js
+++ b/server/routes/oauthAuthorize.js
@@ -1,4 +1,3 @@
-import crypto from 'crypto';
 import { findClientById, loadOAuthClients } from '../utils/oauthClientManager.js';
 import { generateCode, storeCode } from '../utils/authorizationCodeStore.js';
 import { buildServerPath } from '../utils/basePath.js';
@@ -6,6 +5,7 @@ import { verifyJwt } from '../utils/tokenService.js';
 import configCache from '../configCache.js';
 import logger from '../utils/logger.js';
 import { hasConsent, grantConsent } from '../utils/consentStore.js';
+import { issueConsentTicket, verifyConsentTicket } from '../utils/consentTicket.js';
 
 /**
  * OAuth 2.0 Authorization Code Flow - Authorization Endpoint
@@ -73,16 +73,6 @@ function renderGroupDeniedPage({ client, lang = 'en' }) {
 }
 
 /**
- * Generate a cryptographically random CSRF token for the consent form.
- * The token is single-use and stored in the session, then verified on POST.
- *
- * @returns {string} Random 32-byte hex CSRF token (64 hex characters).
- */
-function generateCsrfToken() {
-  return crypto.randomBytes(32).toString('hex');
-}
-
-/**
  * Render the consent screen HTML.
  * Produces a fully self-contained HTML page (no external CSS/JS dependencies)
  * showing the client's requested scopes and allow/deny buttons.
@@ -90,13 +80,13 @@ function generateCsrfToken() {
  * @param {Object} params - Render parameters.
  * @param {Object} params.client - OAuth client object from oauthClientManager.
  * @param {Array<string>} params.scopes - Requested OAuth scopes to display.
- * @param {string} params.csrfToken - CSRF token embedded as a hidden form field.
- * @param {Object} params.oauthParams - Original OAuth query parameters passed through hidden fields.
+ * @param {string} params.consentTicket - Signed ticket carrying the consent
+ *   context; the only field the decision handler trusts.
  * @param {string} params.baseUrl - Absolute base URL of this server instance.
  * @param {string} params.lang - BCP-47 primary language subtag for the HTML lang attribute (e.g. "en", "de").
  * @returns {string} Complete HTML string ready to send as a response.
  */
-function renderConsentScreen({ client, scopes, csrfToken, oauthParams, baseUrl, lang = 'en' }) {
+function renderConsentScreen({ client, scopes, consentTicket, baseUrl, lang = 'en' }) {
   const scopeDescriptions = {
     openid: 'Verify your identity',
     profile: 'Access your name and profile information',
@@ -168,12 +158,7 @@ function renderConsentScreen({ client, scopes, csrfToken, oauthParams, baseUrl, 
     }
 
     <form method="POST" action="${escapeHtml(baseUrl + '/api/oauth/authorize/decision')}">
-      <input type="hidden" name="_csrf" value="${escapeHtml(csrfToken)}">
-      <input type="hidden" name="client_id" value="${escapeHtml(oauthParams.client_id)}">
-      <input type="hidden" name="redirect_uri" value="${escapeHtml(oauthParams.redirect_uri)}">
-      <input type="hidden" name="state" value="${escapeHtml(oauthParams.state || '')}">
-      <input type="hidden" name="scope" value="${escapeHtml(oauthParams.scope || '')}">
-      <input type="hidden" name="nonce" value="${escapeHtml(oauthParams.nonce || '')}">
+      <input type="hidden" name="consent_ticket" value="${escapeHtml(consentTicket)}">
       <div class="actions">
         <button type="submit" name="decision" value="deny" class="btn btn-secondary">Deny</button>
         <button type="submit" name="decision" value="allow" class="btn btn-primary">Allow</button>
@@ -226,8 +211,10 @@ function getBaseUrl(req) {
  *   1. Validate all OAuth parameters (response_type, client_id, redirect_uri, PKCE).
  *   2. If user is not logged in, store params in session and redirect to /login.
  *   3. If client is trusted (consentRequired=false), issue code immediately.
- *   4. Otherwise, render the consent screen and wait for the user's POST.
- *   5. On POST /decision, verify CSRF, re-authenticate user, generate and return code.
+ *   4. Otherwise, render the consent screen carrying a signed consent ticket
+ *      and wait for the user's POST.
+ *   5. On POST /decision, verify the ticket, re-authenticate user, generate and
+ *      return code.
  *
  * @param {import('express').Application} app - The Express application instance.
  */
@@ -448,20 +435,20 @@ export default function registerOAuthAuthorizeRoutes(app) {
         return res.redirect(callbackUrl.toString());
       }
 
-      // Show consent screen — generate CSRF token and persist params in session
-      const csrfToken = generateCsrfToken();
-      if (req.session) {
-        req.session.csrfToken = csrfToken;
-        req.session.oauthParams = {
-          client_id,
-          redirect_uri,
-          scope: requestedScopes.join(' '),
-          state: state || '',
-          code_challenge: code_challenge || '',
-          code_challenge_method: code_challenge_method || '',
-          nonce: nonce || ''
-        };
-      }
+      // Show consent screen. The whole consent context travels inside a signed
+      // ticket in the form rather than in a session: the decision POST can land
+      // on any worker, and a per-process session store would lose the PKCE
+      // challenge and the CSRF token there. See utils/consentTicket.js.
+      const consentTicket = issueConsentTicket({
+        clientId: client_id,
+        redirectUri: redirect_uri,
+        scope: requestedScopes.join(' '),
+        state: state || '',
+        codeChallenge: code_challenge || '',
+        codeChallengeMethod: code_challenge_method || '',
+        nonce: nonce || '',
+        userId: currentUser.sub
+      });
 
       // Extract primary language from Accept-Language for the HTML lang attribute (WCAG 3.1.1).
       // Only allow a two-letter language code to prevent header injection.
@@ -473,14 +460,7 @@ export default function registerOAuthAuthorizeRoutes(app) {
       const html = renderConsentScreen({
         client,
         scopes: requestedScopes,
-        csrfToken,
-        oauthParams: {
-          client_id,
-          redirect_uri,
-          state: state || '',
-          scope: requestedScopes.join(' '),
-          nonce: nonce || ''
-        },
+        consentTicket,
         baseUrl,
         lang: safeLang
       });
@@ -507,12 +487,16 @@ export default function registerOAuthAuthorizeRoutes(app) {
    *
    * Handles the consent form submission from the rendered consent screen.
    *
+   * Every consent parameter is read from the signed ticket rather than the POST
+   * body, so this handler holds no per-worker state and works on whichever
+   * worker the browser's POST happens to reach.
+   *
    * Steps:
-   *   1. Verify the CSRF token (constant-time comparison, single-use).
-   *   2. If the user denied, redirect with error=access_denied.
-   *   3. Re-validate redirect_uri against the client's allowlist.
-   *   4. Re-authenticate the user (JWT cookie must still be valid).
-   *   5. Retrieve stored PKCE params from session.
+   *   1. Verify the consent ticket's signature and expiry.
+   *   2. Re-authenticate the user (JWT cookie must still be valid).
+   *   3. Check the ticket was issued for that user (CSRF binding).
+   *   4. Re-validate redirect_uri against the client's allowlist.
+   *   5. If the user denied, redirect with error=access_denied.
    *   6. Generate and store the authorization code, then redirect.
    */
   app.post(buildServerPath('/api/oauth/authorize/decision'), async (req, res) => {
@@ -524,49 +508,28 @@ export default function registerOAuthAuthorizeRoutes(app) {
         return res.status(400).send('OAuth is not enabled on this server');
       }
 
-      const { _csrf, client_id, redirect_uri, state, scope, decision, nonce } = req.body;
+      const { consent_ticket, decision } = req.body;
 
-      // Validate CSRF token — both tokens must be present
-      const sessionCsrf = req.session?.csrfToken;
-      if (!sessionCsrf || !_csrf) {
-        return res.status(403).send('invalid_request: CSRF token missing');
+      // Every consent parameter comes from the signed ticket, never from the
+      // POST body — a tampered redirect_uri, scope or code_challenge breaks the
+      // signature instead of being taken at face value.
+      const ticket = verifyConsentTicket(consent_ticket);
+      if (!ticket) {
+        logger.warn('[OAuth Authorize] Rejected consent decision with invalid ticket', {
+          component: 'OAuthAuthorize'
+        });
+        return res.status(403).send('invalid_request: consent ticket missing, invalid or expired');
       }
 
-      // Constant-time comparison prevents timing-based CSRF bypass
-      try {
-        const csrfValid = crypto.timingSafeEqual(
-          Buffer.from(sessionCsrf, 'utf8'),
-          Buffer.from(_csrf, 'utf8')
-        );
-        if (!csrfValid) {
-          return res.status(403).send('invalid_request: CSRF token mismatch');
-        }
-      } catch {
-        return res.status(403).send('invalid_request: CSRF token invalid');
-      }
-
-      // Invalidate CSRF token immediately after verification (single-use)
-      if (req.session) {
-        delete req.session.csrfToken;
-      }
-
-      // User denied access — redirect with error per RFC 6749 §4.1.2.1
-      if (decision !== 'allow') {
-        const errorUrl = new URL(redirect_uri);
-        errorUrl.searchParams.set('error', 'access_denied');
-        errorUrl.searchParams.set('error_description', 'User denied access');
-        if (state) errorUrl.searchParams.set('state', state);
-        return res.redirect(errorUrl.toString());
-      }
-
-      // Re-validate redirect_uri against the registered client allowlist
-      const clientsFilePath = oauthConfig.clientsFile || 'contents/config/oauth-clients.json';
-      const clientsConfig = loadOAuthClients(clientsFilePath);
-      const client = findClientById(clientsConfig, client_id);
-
-      if (!client || !isValidRedirectUri(redirect_uri, client.redirectUris || [])) {
-        return res.status(400).send('invalid_request: Invalid redirect_uri');
-      }
+      const {
+        clientId: client_id,
+        redirectUri: redirect_uri,
+        state,
+        scope,
+        nonce,
+        codeChallenge,
+        codeChallengeMethod
+      } = ticket;
 
       // Re-authenticate: JWT cookie must still be valid after the consent interaction
       const token = req.cookies?.authToken;
@@ -582,6 +545,38 @@ export default function registerOAuthAuthorizeRoutes(app) {
         return res.status(401).send('login_required: Session expired during consent');
       }
 
+      // The ticket is bound to the user it was issued for. This is what makes
+      // the endpoint CSRF-safe: a ticket obtained by an attacker cannot drive
+      // consent under a victim's cookie, and one cannot be forged without the
+      // signing key.
+      if (ticket.userId !== currentUser.sub) {
+        logger.warn('[OAuth Authorize] Consent ticket does not match the signed-in user', {
+          component: 'OAuthAuthorize',
+          clientId: client_id
+        });
+        return res.status(403).send('invalid_request: consent ticket was issued for another user');
+      }
+
+      // Re-validate redirect_uri against the registered client allowlist — the
+      // ticket proves the URI passed at GET time, this catches a client whose
+      // registration changed since.
+      const clientsFilePath = oauthConfig.clientsFile || 'contents/config/oauth-clients.json';
+      const clientsConfig = loadOAuthClients(clientsFilePath);
+      const client = findClientById(clientsConfig, client_id);
+
+      if (!client || !isValidRedirectUri(redirect_uri, client.redirectUris || [])) {
+        return res.status(400).send('invalid_request: Invalid redirect_uri');
+      }
+
+      // User denied access — redirect with error per RFC 6749 §4.1.2.1
+      if (decision !== 'allow') {
+        const errorUrl = new URL(redirect_uri);
+        errorUrl.searchParams.set('error', 'access_denied');
+        errorUrl.searchParams.set('error_description', 'User denied access');
+        if (state) errorUrl.searchParams.set('state', state);
+        return res.redirect(errorUrl.toString());
+      }
+
       // Re-check group allowlist on the decision step in case membership changed
       if (!isUserAllowedByGroups(client, currentUser)) {
         const errorUrl = new URL(redirect_uri);
@@ -594,12 +589,7 @@ export default function registerOAuthAuthorizeRoutes(app) {
         return res.redirect(errorUrl.toString());
       }
 
-      // Retrieve PKCE parameters stored in session during GET /authorize
-      const storedParams = req.session?.oauthParams || {};
-      const codeChallenge = storedParams.code_challenge || '';
-      const codeChallengeMethod = storedParams.code_challenge_method || '';
-
-      // Parse requested scopes from the consent form hidden field
+      // Scopes as granted on the screen the user actually saw
       const requestedScopes = scope ? scope.split(' ').filter(Boolean) : ['openid'];
 
       // Generate and persist the authorization code (10-minute TTL, single-use)
@@ -615,7 +605,7 @@ export default function registerOAuthAuthorizeRoutes(app) {
         scopes: requestedScopes,
         codeChallenge,
         codeChallengeMethod,
-        nonce: nonce || storedParams.nonce || ''
+        nonce: nonce || ''
       });
 
       // Persist consent so the user is not prompted again within the TTL window.

--- a/server/tests/authCodeCluster.test.js
+++ b/server/tests/authCodeCluster.test.js
@@ -25,9 +25,14 @@ const WORKER_COUNT = 3;
 /** Time allowed for an ownership announcement to reach the primary and fan out. */
 const SETTLE_MS = 200;
 
-/** A fixed code so the driver can hand the same value to different workers. */
-const CODE = 'f'.repeat(64);
-const OTHER_CODE = 'a1b2c3'.padEnd(64, '0');
+/**
+ * Fixed codes so the driver can hand the same value to different workers.
+ * Shape matches `generateCode()`: `<32-hex handle>.<64-hex secret>`.
+ */
+const HANDLE = 'f'.repeat(32);
+const CODE = `${HANDLE}.${'e'.repeat(64)}`;
+const OTHER_HANDLE = 'a'.repeat(32);
+const OTHER_CODE = `${OTHER_HANDLE}.${'b'.repeat(64)}`;
 
 const PAYLOAD = {
   clientId: 'test_client',
@@ -139,16 +144,25 @@ async function runPrimary() {
       )
     );
 
-    // ---- the raw code never leaves the worker that minted it ----
-    // Only its SHA-256 is announced, so a code is not mirrored into every
-    // other process's memory.
+    // ---- the secret half is never announced to other workers ----
+    // Announcements are broadcast and retained for the life of the code, so
+    // they must carry only the routing handle.
     await ask(workers[0], { step: 'store', code: OTHER_CODE, payload: PAYLOAD });
     await settle();
     const leak = await ask(workers[1], { step: 'scan-remote-keys', code: OTHER_CODE });
-    check('the raw code value is never announced to other workers', () => {
-      assert.strictEqual(leak.containsRawCode, false, 'raw code found in presence mirror');
-      assert.strictEqual(leak.containsHash, true, 'hash should be present in presence mirror');
+    check('presence announcements carry the handle, never the full code', () => {
+      assert.strictEqual(leak.containsFullCode, false, 'full code found in presence mirror');
+      assert.strictEqual(leak.containsHandle, true, 'handle should be present in presence mirror');
     });
+
+    // ---- a valid handle with a forged secret is rejected cross-worker ----
+    const forged = await ask(workers[1], {
+      step: 'consume',
+      code: `${OTHER_HANDLE}.${'9'.repeat(64)}`
+    });
+    check('a forged secret is rejected by the owning worker', () =>
+      assert.strictEqual(forged.data, null)
+    );
   } catch (error) {
     failed = true;
     console.error(`❌ test driver failed: ${error.message}`);
@@ -186,8 +200,7 @@ function runWorker() {
     // Imported lazily so the bus is live first, mirroring server.js's order.
     const store = await import('../utils/authorizationCodeStore.js');
     const { hasRemote } = await import('../clusterBus.js');
-    const { createHash } = await import('node:crypto');
-    const hashOf = value => createHash('sha256').update(String(value), 'utf8').digest('hex');
+    const handleOf = code => String(code).split('.')[0];
 
     switch (msg.step) {
       case 'ready':
@@ -201,12 +214,12 @@ function runWorker() {
         reply({ data: await store.consumeCode(msg.code) });
         break;
       case 'probe-remote':
-        reply({ hasRemote: hasRemote('authcode', hashOf(msg.code)) });
+        reply({ hasRemote: hasRemote('authcode', handleOf(msg.code)) });
         break;
       case 'scan-remote-keys':
         reply({
-          containsRawCode: hasRemote('authcode', msg.code),
-          containsHash: hasRemote('authcode', hashOf(msg.code))
+          containsFullCode: hasRemote('authcode', msg.code),
+          containsHandle: hasRemote('authcode', handleOf(msg.code))
         });
         break;
       default:

--- a/server/tests/authCodeCluster.test.js
+++ b/server/tests/authCodeCluster.test.js
@@ -1,0 +1,216 @@
+// Plain-node test (node server/tests/authCodeCluster.test.js).
+//
+// Exercises server/utils/authorizationCodeStore.js against a real cluster: the
+// file forks itself three times and drives the workers through the two halves
+// of an OAuth authorization code exchange, deliberately on *different* workers.
+//
+// This is the shape the production bug had. `POST /api/oauth/authorize/decision`
+// mints the code on one worker and the client's `POST /api/oauth/token` is
+// round-robined to another, so a per-process Map answered "code not found" and
+// the client saw `invalid_grant: Authorization code is invalid or expired` on
+// N-1 of every N attempts. A single-process test cannot see that at all, and
+// mocking node:cluster would only test the mock — the behaviour that matters
+// (ownership propagation, routed consume, single-use across processes) exists
+// only in the IPC path.
+//
+// Workers report through plain, un-enveloped IPC messages, which the bus
+// ignores, so test traffic and bus traffic share the channel without colliding.
+
+import assert from 'assert';
+import cluster from 'node:cluster';
+import { initPrimaryBus, initWorkerBus } from '../clusterBus.js';
+
+const WORKER_COUNT = 3;
+
+/** Time allowed for an ownership announcement to reach the primary and fan out. */
+const SETTLE_MS = 200;
+
+/** A fixed code so the driver can hand the same value to different workers. */
+const CODE = 'f'.repeat(64);
+const OTHER_CODE = 'a1b2c3'.padEnd(64, '0');
+
+const PAYLOAD = {
+  clientId: 'test_client',
+  redirectUri: 'https://example.com/callback',
+  userId: 'user_123',
+  scopes: ['openid', 'mcp:tools:call'],
+  codeChallenge: 'challenge-value',
+  codeChallengeMethod: 'S256',
+  nonce: 'nonce-value'
+};
+
+if (cluster.isPrimary) {
+  await runPrimary();
+} else {
+  runWorker();
+}
+
+// ---------------------------------------------------------------------------
+// Primary: the test driver
+// ---------------------------------------------------------------------------
+
+async function runPrimary() {
+  const workers = [];
+  initPrimaryBus({ getWorkers: () => workers });
+
+  for (let i = 0; i < WORKER_COUNT; i++) {
+    workers.push(cluster.fork({ TEST_WORKER_INDEX: String(i) }));
+  }
+
+  const pending = new Map();
+  let nextId = 1;
+
+  for (const worker of workers) {
+    worker.on('message', msg => {
+      if (!msg || !msg.testReply) return;
+      pending.get(msg.id)?.(msg);
+      pending.delete(msg.id);
+    });
+  }
+
+  const ask = (worker, request) =>
+    new Promise((resolve, reject) => {
+      const id = nextId++;
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`worker did not answer ${request.step} in time`));
+      }, 5000);
+      pending.set(id, msg => {
+        clearTimeout(timer);
+        resolve(msg);
+      });
+      worker.send({ ...request, id });
+    });
+
+  const settle = () => new Promise(r => setTimeout(r, SETTLE_MS));
+
+  let failed = false;
+  const check = (label, fn) => {
+    try {
+      fn();
+      console.log(`✅ ${label}`);
+    } catch (error) {
+      failed = true;
+      console.error(`❌ ${label}\n   ${error.message}`);
+    }
+  };
+
+  try {
+    await Promise.all(workers.map(w => ask(w, { step: 'ready' })));
+
+    // ---- a code minted on one worker is redeemable on another ----
+    // The regression this whole change exists for.
+    await ask(workers[0], { step: 'store', code: CODE, payload: PAYLOAD });
+    await settle();
+
+    const crossWorker = await ask(workers[1], { step: 'consume', code: CODE });
+    check('a code minted on worker 0 is consumable on worker 1', () =>
+      assert.deepStrictEqual(crossWorker.data, PAYLOAD)
+    );
+
+    // ---- single-use holds across the cluster, not just within a worker ----
+    // Replay protection is the reason the code is consumed on its owner rather
+    // than replicated: N copies would mean N valid redemptions.
+    await settle();
+    const replayElsewhere = await ask(workers[2], { step: 'consume', code: CODE });
+    check('a code already consumed on another worker cannot be replayed', () =>
+      assert.strictEqual(replayElsewhere.data, null)
+    );
+
+    const replayOnOwner = await ask(workers[0], { step: 'consume', code: CODE });
+    check('the minting worker cannot re-consume its own spent code', () =>
+      assert.strictEqual(replayOnOwner.data, null)
+    );
+
+    // ---- an unknown code is rejected without waiting for a bus timeout ----
+    const unknown = await ask(workers[1], { step: 'consume', code: OTHER_CODE });
+    check('an unknown code returns null', () => assert.strictEqual(unknown.data, null));
+
+    // ---- ownership is retracted once the code is spent ----
+    // A stale presence entry would send later token requests on a pointless
+    // round trip to a worker that no longer holds anything.
+    const owners = await Promise.all(
+      workers.map(w => ask(w, { step: 'probe-remote', code: CODE }))
+    );
+    check('ownership of a spent code is retracted cluster-wide', () =>
+      assert.deepStrictEqual(
+        owners.map(o => o.hasRemote),
+        [false, false, false]
+      )
+    );
+
+    // ---- the raw code never leaves the worker that minted it ----
+    // Only its SHA-256 is announced, so a code is not mirrored into every
+    // other process's memory.
+    await ask(workers[0], { step: 'store', code: OTHER_CODE, payload: PAYLOAD });
+    await settle();
+    const leak = await ask(workers[1], { step: 'scan-remote-keys', code: OTHER_CODE });
+    check('the raw code value is never announced to other workers', () => {
+      assert.strictEqual(leak.containsRawCode, false, 'raw code found in presence mirror');
+      assert.strictEqual(leak.containsHash, true, 'hash should be present in presence mirror');
+    });
+  } catch (error) {
+    failed = true;
+    console.error(`❌ test driver failed: ${error.message}`);
+  }
+
+  for (const worker of workers) {
+    try {
+      worker.kill('SIGKILL');
+    } catch {
+      // already gone
+    }
+  }
+
+  if (failed) {
+    console.error('\nauthCodeCluster: FAILED');
+    process.exit(1);
+  }
+  console.log('\nauthCodeCluster: all checks passed');
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Worker: executes the driver's steps
+// ---------------------------------------------------------------------------
+
+function runWorker() {
+  // Must precede any storeCode call so ownership is announced; the store module
+  // itself only registers a presence map and a responder at import time.
+  initWorkerBus();
+
+  process.on('message', async msg => {
+    if (!msg || typeof msg.step !== 'string') return;
+    const reply = extra => process.send({ testReply: true, id: msg.id, ...extra });
+
+    // Imported lazily so the bus is live first, mirroring server.js's order.
+    const store = await import('../utils/authorizationCodeStore.js');
+    const { hasRemote } = await import('../clusterBus.js');
+    const { createHash } = await import('node:crypto');
+    const hashOf = value => createHash('sha256').update(String(value), 'utf8').digest('hex');
+
+    switch (msg.step) {
+      case 'ready':
+        reply({ ok: true });
+        break;
+      case 'store':
+        store.storeCode(msg.code, msg.payload);
+        reply({ ok: true });
+        break;
+      case 'consume':
+        reply({ data: await store.consumeCode(msg.code) });
+        break;
+      case 'probe-remote':
+        reply({ hasRemote: hasRemote('authcode', hashOf(msg.code)) });
+        break;
+      case 'scan-remote-keys':
+        reply({
+          containsRawCode: hasRemote('authcode', msg.code),
+          containsHash: hasRemote('authcode', hashOf(msg.code))
+        });
+        break;
+      default:
+        reply({ ok: false });
+    }
+  });
+}

--- a/server/tests/consentTicket.test.js
+++ b/server/tests/consentTicket.test.js
@@ -9,8 +9,15 @@ import assert from 'assert';
 import crypto from 'node:crypto';
 import process from 'node:process';
 
-// resolveJwtSecret() reads this; set it before importing the module under test.
-process.env.JWT_SECRET = 'test-secret-for-consent-tickets';
+// The signing key resolves through TokenStorageService, which reads this env
+// var. Initialise it the way server.js does so the test exercises the real
+// resolution chain rather than a stub.
+const SECRET = 'test-secret-for-consent-tickets';
+process.env.JWT_SECRET = SECRET;
+
+const { default: tokenStorageService } = await import('../services/TokenStorageService.js');
+await tokenStorageService.initializeEncryptionKey();
+await tokenStorageService.initializeJwtSecret();
 
 const { issueConsentTicket, verifyConsentTicket } = await import('../utils/consentTicket.js');
 
@@ -82,10 +89,7 @@ check('an expired ticket is rejected', () => {
     JSON.stringify({ ...CONTEXT, exp: Date.now() - 1000 }),
     'utf8'
   ).toString('base64url');
-  const signature = crypto
-    .createHmac('sha256', process.env.JWT_SECRET)
-    .update(encoded)
-    .digest('base64url');
+  const signature = crypto.createHmac('sha256', SECRET).update(encoded).digest('base64url');
   assert.strictEqual(verifyConsentTicket(`${encoded}.${signature}`), null);
 });
 
@@ -99,6 +103,23 @@ check('malformed tickets are rejected without throwing', () => {
 check('a ticket missing required fields is rejected', () => {
   // A signed but incomplete ticket must not reach the code-minting path.
   assert.strictEqual(verifyConsentTicket(issueConsentTicket({ userId: 'u' })), null);
+});
+
+// ---- fail closed with no signing key ---------------------------------------
+// An empty HMAC key would still produce a signature everyone could reproduce,
+// making tickets forgeable. Signing must refuse, and verification must reject
+// cleanly rather than throwing a 500 into the consent flow.
+check('with no signing key, issuing throws and verification rejects', () => {
+  const good = issueConsentTicket(CONTEXT);
+  const restore = tokenStorageService.jwtSecret;
+  tokenStorageService.jwtSecret = null;
+  try {
+    assert.throws(() => issueConsentTicket(CONTEXT), /no JWT secret/i);
+    assert.strictEqual(verifyConsentTicket(good), null, 'must reject, not throw');
+  } finally {
+    tokenStorageService.jwtSecret = restore;
+  }
+  assert.ok(verifyConsentTicket(good), 'verification recovers once the key is back');
 });
 
 if (failed) {

--- a/server/tests/consentTicket.test.js
+++ b/server/tests/consentTicket.test.js
@@ -1,0 +1,108 @@
+// Plain-node test (node server/tests/consentTicket.test.js).
+//
+// The consent ticket replaced a session-backed CSRF token plus session-stored
+// PKCE parameters, so it now carries security properties that used to be the
+// session's job: it must be unforgeable, tamper-evident, expiring, and bound to
+// the user it was issued for.
+
+import assert from 'assert';
+import crypto from 'node:crypto';
+import process from 'node:process';
+
+// resolveJwtSecret() reads this; set it before importing the module under test.
+process.env.JWT_SECRET = 'test-secret-for-consent-tickets';
+
+const { issueConsentTicket, verifyConsentTicket } = await import('../utils/consentTicket.js');
+
+const CONTEXT = {
+  clientId: 'mcp_client',
+  redirectUri: 'http://localhost:57321/callback',
+  scope: 'openid mcp:tools:call',
+  state: 'client-state',
+  codeChallenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+  codeChallengeMethod: 'S256',
+  nonce: 'n-0S6_WzA2Mj',
+  userId: 'user_123'
+};
+
+let failed = false;
+const check = (label, fn) => {
+  try {
+    fn();
+    console.log(`✅ ${label}`);
+  } catch (error) {
+    failed = true;
+    console.error(`❌ ${label}\n   ${error.message}`);
+  }
+};
+
+// ---- round trip -----------------------------------------------------------
+// Everything the decision handler needs must survive the hop, above all the
+// PKCE challenge: losing it silently mints a code with no client binding.
+check('a freshly issued ticket verifies and returns every field', () => {
+  const payload = verifyConsentTicket(issueConsentTicket(CONTEXT));
+  assert.ok(payload, 'ticket should verify');
+  for (const [key, value] of Object.entries(CONTEXT)) {
+    assert.strictEqual(payload[key], value, `field ${key} did not survive the round trip`);
+  }
+});
+
+// ---- tamper detection -----------------------------------------------------
+// The whole point of signing: the POST body can no longer widen scope or
+// redirect the code somewhere else.
+check('a tampered payload is rejected', () => {
+  const ticket = issueConsentTicket(CONTEXT);
+  const [encoded, signature] = ticket.split('.');
+  const decoded = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'));
+  decoded.redirectUri = 'https://attacker.example/callback';
+  decoded.scope = 'openid mcp:tools:call mcp:apps:invoke';
+  const forged = Buffer.from(JSON.stringify(decoded), 'utf8').toString('base64url');
+  assert.strictEqual(verifyConsentTicket(`${forged}.${signature}`), null);
+});
+
+check('a tampered signature is rejected', () => {
+  const ticket = issueConsentTicket(CONTEXT);
+  const [encoded] = ticket.split('.');
+  assert.strictEqual(verifyConsentTicket(`${encoded}.not-the-signature`), null);
+});
+
+check('a ticket signed with a different key is rejected', () => {
+  // Simulates an attacker minting their own ticket without the platform secret.
+  const encoded = Buffer.from(
+    JSON.stringify({ ...CONTEXT, exp: Date.now() + 60_000 }),
+    'utf8'
+  ).toString('base64url');
+  const forgedSig = crypto.createHmac('sha256', 'wrong-secret').update(encoded).digest('base64url');
+  assert.strictEqual(verifyConsentTicket(`${encoded}.${forgedSig}`), null);
+});
+
+// ---- expiry ---------------------------------------------------------------
+check('an expired ticket is rejected', () => {
+  const encoded = Buffer.from(
+    JSON.stringify({ ...CONTEXT, exp: Date.now() - 1000 }),
+    'utf8'
+  ).toString('base64url');
+  const signature = crypto
+    .createHmac('sha256', process.env.JWT_SECRET)
+    .update(encoded)
+    .digest('base64url');
+  assert.strictEqual(verifyConsentTicket(`${encoded}.${signature}`), null);
+});
+
+// ---- malformed input ------------------------------------------------------
+check('malformed tickets are rejected without throwing', () => {
+  for (const bad of [null, undefined, '', 'no-separator', '.', 'payload.', '.signature', {}, 42]) {
+    assert.strictEqual(verifyConsentTicket(bad), null, `should reject ${JSON.stringify(bad)}`);
+  }
+});
+
+check('a ticket missing required fields is rejected', () => {
+  // A signed but incomplete ticket must not reach the code-minting path.
+  assert.strictEqual(verifyConsentTicket(issueConsentTicket({ userId: 'u' })), null);
+});
+
+if (failed) {
+  console.error('\nconsentTicket: FAILED');
+  process.exit(1);
+}
+console.log('\nconsentTicket: all checks passed');

--- a/server/utils/authorizationCodeStore.js
+++ b/server/utils/authorizationCodeStore.js
@@ -80,8 +80,7 @@ const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
  * @returns {string} Lowercase hex digest.
  */
 function codeKey(code) {
-  // lgtm[js/insufficient-password-hash]
-  return crypto.createHash('sha256').update(String(code), 'utf8').digest('hex');
+  return crypto.createHash('sha256').update(String(code), 'utf8').digest('hex'); // lgtm[js/insufficient-password-hash] -- index key, not a stored password
 }
 
 /**

--- a/server/utils/authorizationCodeStore.js
+++ b/server/utils/authorizationCodeStore.js
@@ -1,28 +1,88 @@
 import crypto from 'crypto';
 import logger from './logger.js';
+import { createPresenceMap, hasRemote, request, respond } from '../clusterBus.js';
 
 /**
- * In-memory store for OAuth authorization codes.
+ * Store for OAuth authorization codes.
  *
  * Authorization codes are short-lived (10 minutes) and single-use by
- * design (RFC 6749 section 4.1.2). Consuming a code removes it from the
- * store immediately, so a second use attempt always returns null.
+ * design (RFC 6749 section 4.1.2). Consuming a code removes it immediately,
+ * so a second use attempt always returns null.
  *
- * The store uses a plain Map – no persistence across restarts. That is
- * intentional: a restarted server is a clean slate, and codes issued
- * before the restart simply expire as if they were never issued.
+ * ## Why this is not just a Map
+ *
+ * The two halves of the authorization code flow are two separate HTTP
+ * requests, and in cluster mode they land on different workers: the browser's
+ * `POST /api/oauth/authorize/decision` mints the code on worker A, then the
+ * client's `POST /api/oauth/token` is round-robined to whichever worker is
+ * next. A plain per-process Map therefore answers "code not found" on N-1 of
+ * every N token exchanges, which surfaces to the client as
+ * `invalid_grant: Authorization code is invalid or expired` — intermittently,
+ * with no bad input anywhere.
+ *
+ * Replicating the code to every worker would fix the lookup and break the
+ * security property: reading a code *consumes* it, and N copies means N
+ * consumptions, i.e. no replay protection. So the code stays on the worker
+ * that minted it, ownership is announced over the cluster bus
+ * (`server/clusterBus.js`), and a worker that receives the token request asks
+ * the owner to consume it. Exactly one process ever holds a given code, so
+ * single-use remains atomic without any distributed agreement.
+ *
+ * ## What travels over the bus
+ *
+ * Only the SHA-256 of the code, never the code itself. The local map is keyed
+ * by that hash too, so the raw credential never leaves the worker that minted
+ * it and never appears in another process's memory — the same indexing
+ * approach `refreshTokenStore.js` uses. A hash is a sufficient key because
+ * finding a colliding code is as hard as guessing the 256-bit code.
+ *
+ * Nothing is persisted across restarts. That is intentional: a restarted
+ * server is a clean slate, and codes issued before the restart simply expire
+ * as if they were never issued.
  *
  * @module authorizationCodeStore
  */
 
-/** @type {Map<string, { data: Object, expiresAt: number, used: boolean }>} */
-const codeStore = new Map();
+/** Presence namespace for code ownership announcements. */
+const PRESENCE_KIND = 'authcode';
+
+/** Bus channel on which a non-owning worker asks the owner to consume a code. */
+const CONSUME_CHANNEL = 'authcode:consume';
+
+/**
+ * How long to wait for the owning worker to answer. Generous relative to two
+ * IPC hops, but well inside any OAuth client's token-request timeout, so a
+ * wedged worker degrades to `invalid_grant` rather than a hung request.
+ */
+const CONSUME_TIMEOUT_MS = 2000;
+
+/**
+ * Codes minted by *this* worker, keyed by SHA-256 of the code. Membership is
+ * announced to the cluster so other workers can route a consume request here.
+ *
+ * @type {Map<string, { data: Object, expiresAt: number, used: boolean }>}
+ */
+const codeStore = createPresenceMap(PRESENCE_KIND);
 
 /** Authorization codes expire after 10 minutes (RFC 6749 recommendation). */
 const CODE_TTL_MS = 10 * 60 * 1000;
 
 /** Periodic cleanup runs every 5 minutes to remove stale entries. */
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Derive the store/presence key for a code.
+ *
+ * SHA-256 of the code value: an index key, not a password hash — the input is
+ * 256 bits of CSPRNG output, so stretching would add cost and no strength.
+ *
+ * @param {string} code - The authorization code.
+ * @returns {string} Lowercase hex digest.
+ */
+function codeKey(code) {
+  // lgtm[js/insufficient-password-hash]
+  return crypto.createHash('sha256').update(String(code), 'utf8').digest('hex');
+}
 
 /**
  * Store an authorization code with its associated request data.
@@ -43,7 +103,7 @@ const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
  * @returns {void}
  */
 export function storeCode(code, data) {
-  codeStore.set(code, {
+  codeStore.set(codeKey(code), {
     data,
     expiresAt: Date.now() + CODE_TTL_MS,
     used: false
@@ -51,19 +111,13 @@ export function storeCode(code, data) {
 }
 
 /**
- * Retrieve and consume an authorization code (single-use).
+ * Consume a code held by this worker.
  *
- * On success the entry is deleted from the store immediately so that
- * any second call with the same code returns null (replay protection).
- * A detected replay (code exists but is already marked used) also
- * deletes the entry and logs a warning.
- *
- * @param {string} code - The authorization code to consume.
- * @returns {Object|null} The data payload that was stored with the code,
- *   or null if the code is unknown, already used, or expired.
+ * @param {string} key - SHA-256 key of the code.
+ * @returns {Object|null} The stored payload, or null if unknown/used/expired.
  */
-export function consumeCode(code) {
-  const entry = codeStore.get(code);
+function consumeLocal(key) {
+  const entry = codeStore.get(key);
 
   if (!entry) {
     logger.warn('Code not found', { component: 'AuthCodeStore' });
@@ -72,18 +126,66 @@ export function consumeCode(code) {
 
   if (entry.used) {
     logger.warn('Code already used - possible replay attack', { component: 'AuthCodeStore' });
-    codeStore.delete(code);
+    codeStore.delete(key);
     return null;
   }
 
   if (Date.now() > entry.expiresAt) {
     logger.warn('Code expired', { component: 'AuthCodeStore' });
-    codeStore.delete(code);
+    codeStore.delete(key);
     return null;
   }
 
-  codeStore.delete(code);
+  codeStore.delete(key);
   return entry.data;
+}
+
+/**
+ * Retrieve and consume an authorization code (single-use, cluster-wide).
+ *
+ * Resolves against the worker that minted the code: consumed locally when this
+ * process holds it, otherwise the owning worker is asked over the cluster bus.
+ * Either way the code is destroyed by the read, so a second call returns null
+ * (replay protection).
+ *
+ * @param {string} code - The authorization code to consume.
+ * @returns {Promise<Object|null>} The data payload that was stored with the
+ *   code, or null if the code is unknown, already used, or expired.
+ */
+export async function consumeCode(code) {
+  if (!code) {
+    logger.warn('Code not found', { component: 'AuthCodeStore' });
+    return null;
+  }
+
+  const key = codeKey(code);
+
+  if (codeStore.has(key)) {
+    return consumeLocal(key);
+  }
+
+  // Another worker minted it — that worker owns the single consumption.
+  if (hasRemote(PRESENCE_KIND, key)) {
+    const reply = await request(
+      CONSUME_CHANNEL,
+      { key },
+      { route: { kind: PRESENCE_KIND, key }, timeoutMs: CONSUME_TIMEOUT_MS }
+    );
+
+    if (!reply) {
+      // No answer: the owner died between announcing the code and being asked.
+      // Its codes died with it, so this is a genuine invalid_grant.
+      logger.warn('Code owner did not respond - treating code as invalid', {
+        component: 'AuthCodeStore'
+      });
+      return null;
+    }
+
+    return reply.data ?? null;
+  }
+
+  logger.warn('Code not found', { component: 'AuthCodeStore' });
+  return null;
 }
 
 /**
@@ -99,7 +201,7 @@ export function generateCode() {
 }
 
 /**
- * Remove all expired entries from the in-memory store.
+ * Remove all expired entries held by this worker.
  *
  * Called automatically by the cleanup interval. Exposed here only to
  * make it easy to trigger from tests without waiting for the timer.
@@ -108,12 +210,21 @@ export function generateCode() {
  */
 export function cleanup() {
   const now = Date.now();
-  for (const [code, entry] of codeStore.entries()) {
+  for (const [key, entry] of codeStore.entries()) {
     if (now > entry.expiresAt) {
-      codeStore.delete(code);
+      codeStore.delete(key);
     }
   }
 }
+
+// Serve consume requests for codes this worker minted. Returning `undefined`
+// when the code is not here matters: if the primary has already dropped the
+// ownership entry the question is broadcast, and a non-owner answering "null"
+// first would lose the race against the real owner's answer.
+respond(CONSUME_CHANNEL, ({ key } = {}) => {
+  if (!key || !codeStore.has(key)) return undefined;
+  return { data: consumeLocal(key) };
+});
 
 // Periodic cleanup – runs in the background and does not prevent the
 // Node.js process from exiting (unref) so tests finish cleanly.

--- a/server/utils/authorizationCodeStore.js
+++ b/server/utils/authorizationCodeStore.js
@@ -15,10 +15,10 @@ import { createPresenceMap, hasRemote, request, respond } from '../clusterBus.js
  * requests, and in cluster mode they land on different workers: the browser's
  * `POST /api/oauth/authorize/decision` mints the code on worker A, then the
  * client's `POST /api/oauth/token` is round-robined to whichever worker is
- * next. A plain per-process Map therefore answers "code not found" on N-1 of
- * every N token exchanges, which surfaces to the client as
- * `invalid_grant: Authorization code is invalid or expired` — intermittently,
- * with no bad input anywhere.
+ * next. A plain per-process Map therefore answers "code not found" on nearly
+ * every token exchange, which surfaces to the client as
+ * `invalid_grant: Authorization code is invalid or expired` with no bad input
+ * anywhere.
  *
  * Replicating the code to every worker would fix the lookup and break the
  * security property: reading a code *consumes* it, and N copies means N
@@ -28,13 +28,22 @@ import { createPresenceMap, hasRemote, request, respond } from '../clusterBus.js
  * the owner to consume it. Exactly one process ever holds a given code, so
  * single-use remains atomic without any distributed agreement.
  *
- * ## What travels over the bus
+ * ## Code shape: a public handle plus a secret
  *
- * Only the SHA-256 of the code, never the code itself. The local map is keyed
- * by that hash too, so the raw credential never leaves the worker that minted
- * it and never appears in another process's memory — the same indexing
- * approach `refreshTokenStore.js` uses. A hash is a sufficient key because
- * finding a colliding code is as hard as guessing the 256-bit code.
+ * A code is `<handle>.<secret>` — 128 bits of routing handle and 256 bits of
+ * secret, both from `crypto.randomBytes`.
+ *
+ * The split exists because ownership announcements are *broadcast to every
+ * worker and retained* for the life of the code. Keying them by the code
+ * itself would put a live credential in every process's memory for ten
+ * minutes. Keying them by the handle puts nothing there: the handle is a
+ * random label that grants nothing on its own, and the secret half never
+ * appears in an announcement.
+ *
+ * The secret does cross the IPC boundary once, in the single directed consume
+ * message to the owning worker, which verifies and destroys it. That is
+ * unavoidable — only the owner can verify — and is a different exposure from a
+ * retained broadcast. Comparison is constant-time.
  *
  * Nothing is persisted across restarts. That is intentional: a restarted
  * server is a clean slate, and codes issued before the restart simply expire
@@ -57,10 +66,10 @@ const CONSUME_CHANNEL = 'authcode:consume';
 const CONSUME_TIMEOUT_MS = 2000;
 
 /**
- * Codes minted by *this* worker, keyed by SHA-256 of the code. Membership is
- * announced to the cluster so other workers can route a consume request here.
+ * Codes minted by *this* worker, keyed by handle. Membership is announced to
+ * the cluster so other workers can route a consume request here.
  *
- * @type {Map<string, { data: Object, expiresAt: number, used: boolean }>}
+ * @type {Map<string, { secret: string, data: Object, expiresAt: number }>}
  */
 const codeStore = createPresenceMap(PRESENCE_KIND);
 
@@ -70,17 +79,38 @@ const CODE_TTL_MS = 10 * 60 * 1000;
 /** Periodic cleanup runs every 5 minutes to remove stale entries. */
 const CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 
+/** Bytes of entropy in each half of a code. */
+const HANDLE_BYTES = 16;
+const SECRET_BYTES = 32;
+
 /**
- * Derive the store/presence key for a code.
+ * Split a code into its routing handle and secret halves.
  *
- * SHA-256 of the code value: an index key, not a password hash — the input is
- * 256 bits of CSPRNG output, so stretching would add cost and no strength.
- *
- * @param {string} code - The authorization code.
- * @returns {string} Lowercase hex digest.
+ * @param {string} code - The authorization code as issued.
+ * @returns {{handle: string, secret: string}|null} Parts, or null if the value
+ *   is not shaped like a code this store issued.
  */
-function codeKey(code) {
-  return crypto.createHash('sha256').update(String(code), 'utf8').digest('hex'); // lgtm[js/insufficient-password-hash] -- index key, not a stored password
+function splitCode(code) {
+  if (typeof code !== 'string') return null;
+  const separator = code.indexOf('.');
+  if (separator <= 0 || separator === code.length - 1) return null;
+  return { handle: code.slice(0, separator), secret: code.slice(separator + 1) };
+}
+
+/**
+ * Compare two secrets without leaking their contents through timing.
+ *
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean}
+ */
+function secretsMatch(a, b) {
+  // timingSafeEqual throws on a length mismatch, which is itself a rejection.
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, 'utf8'), Buffer.from(b, 'utf8'));
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -90,7 +120,7 @@ function codeKey(code) {
  * token request: clientId, redirectUri, userId, scopes, codeChallenge,
  * codeChallengeMethod, and nonce.
  *
- * @param {string} code - The authorization code (random hex string).
+ * @param {string} code - The authorization code from `generateCode()`.
  * @param {Object} data - Payload bound to this code.
  * @param {string} data.clientId - OAuth client that requested the code.
  * @param {string} data.redirectUri - Redirect URI from the authorization request.
@@ -102,40 +132,52 @@ function codeKey(code) {
  * @returns {void}
  */
 export function storeCode(code, data) {
-  codeStore.set(codeKey(code), {
+  const parts = splitCode(code);
+  if (!parts) {
+    logger.warn('Refusing to store a malformed authorization code', {
+      component: 'AuthCodeStore'
+    });
+    return;
+  }
+
+  codeStore.set(parts.handle, {
+    secret: parts.secret,
     data,
-    expiresAt: Date.now() + CODE_TTL_MS,
-    used: false
+    expiresAt: Date.now() + CODE_TTL_MS
   });
 }
 
 /**
  * Consume a code held by this worker.
  *
- * @param {string} key - SHA-256 key of the code.
- * @returns {Object|null} The stored payload, or null if unknown/used/expired.
+ * @param {string} handle - Routing handle identifying the entry.
+ * @param {string} secret - Secret half presented by the caller.
+ * @returns {Object|null} The stored payload, or null if unknown, expired, or
+ *   the presented secret does not match.
  */
-function consumeLocal(key) {
-  const entry = codeStore.get(key);
+function consumeLocal(handle, secret) {
+  const entry = codeStore.get(handle);
 
   if (!entry) {
     logger.warn('Code not found', { component: 'AuthCodeStore' });
     return null;
   }
 
-  if (entry.used) {
-    logger.warn('Code already used - possible replay attack', { component: 'AuthCodeStore' });
-    codeStore.delete(key);
-    return null;
-  }
-
   if (Date.now() > entry.expiresAt) {
     logger.warn('Code expired', { component: 'AuthCodeStore' });
-    codeStore.delete(key);
+    codeStore.delete(handle);
     return null;
   }
 
-  codeStore.delete(key);
+  if (!secretsMatch(secret, entry.secret)) {
+    // A valid handle with the wrong secret is not an honest mistake; drop the
+    // entry so a guessing loop gets one attempt per code, not many.
+    logger.warn('Code secret mismatch - discarding code', { component: 'AuthCodeStore' });
+    codeStore.delete(handle);
+    return null;
+  }
+
+  codeStore.delete(handle);
   return entry.data;
 }
 
@@ -152,23 +194,24 @@ function consumeLocal(key) {
  *   code, or null if the code is unknown, already used, or expired.
  */
 export async function consumeCode(code) {
-  if (!code) {
+  const parts = splitCode(code);
+  if (!parts) {
     logger.warn('Code not found', { component: 'AuthCodeStore' });
     return null;
   }
 
-  const key = codeKey(code);
+  const { handle, secret } = parts;
 
-  if (codeStore.has(key)) {
-    return consumeLocal(key);
+  if (codeStore.has(handle)) {
+    return consumeLocal(handle, secret);
   }
 
   // Another worker minted it — that worker owns the single consumption.
-  if (hasRemote(PRESENCE_KIND, key)) {
+  if (hasRemote(PRESENCE_KIND, handle)) {
     const reply = await request(
       CONSUME_CHANNEL,
-      { key },
-      { route: { kind: PRESENCE_KIND, key }, timeoutMs: CONSUME_TIMEOUT_MS }
+      { handle, secret },
+      { route: { kind: PRESENCE_KIND, key: handle }, timeoutMs: CONSUME_TIMEOUT_MS }
     );
 
     if (!reply) {
@@ -190,13 +233,17 @@ export async function consumeCode(code) {
 /**
  * Generate a cryptographically random authorization code.
  *
- * Returns a 64-character lowercase hex string (256 bits of entropy),
- * which satisfies the RFC 6749 requirement for unpredictable codes.
+ * Shape is `<handle>.<secret>`: a 32-character hex handle used for cluster
+ * routing and a 64-character hex secret. 384 bits of entropy in total, well
+ * past the RFC 6749 requirement that codes be unguessable. Codes are opaque to
+ * clients, so the internal structure is not part of any contract.
  *
- * @returns {string} 32-byte random value encoded as hex.
+ * @returns {string} A new authorization code.
  */
 export function generateCode() {
-  return crypto.randomBytes(32).toString('hex');
+  const handle = crypto.randomBytes(HANDLE_BYTES).toString('hex');
+  const secret = crypto.randomBytes(SECRET_BYTES).toString('hex');
+  return `${handle}.${secret}`;
 }
 
 /**
@@ -209,20 +256,20 @@ export function generateCode() {
  */
 export function cleanup() {
   const now = Date.now();
-  for (const [key, entry] of codeStore.entries()) {
+  for (const [handle, entry] of codeStore.entries()) {
     if (now > entry.expiresAt) {
-      codeStore.delete(key);
+      codeStore.delete(handle);
     }
   }
 }
 
 // Serve consume requests for codes this worker minted. Returning `undefined`
-// when the code is not here matters: if the primary has already dropped the
+// when the handle is not here matters: if the primary has already dropped the
 // ownership entry the question is broadcast, and a non-owner answering "null"
 // first would lose the race against the real owner's answer.
-respond(CONSUME_CHANNEL, ({ key } = {}) => {
-  if (!key || !codeStore.has(key)) return undefined;
-  return { data: consumeLocal(key) };
+respond(CONSUME_CHANNEL, ({ handle, secret } = {}) => {
+  if (!handle || !codeStore.has(handle)) return undefined;
+  return { data: consumeLocal(handle, secret) };
 });
 
 // Periodic cleanup – runs in the background and does not prevent the

--- a/server/utils/consentTicket.js
+++ b/server/utils/consentTicket.js
@@ -55,14 +55,20 @@ const TICKET_TTL_MS = 15 * 60 * 1000;
 /**
  * HMAC the payload with the platform's JWT secret.
  *
+ * Fails closed: with no secret configured an empty key would still produce a
+ * valid-looking signature that anyone could reproduce, making tickets forgeable.
+ * Refusing to sign turns that misconfiguration into a loud server error instead.
+ *
  * @param {string} encodedPayload - base64url payload.
  * @returns {string} base64url signature.
+ * @throws {Error} If no JWT secret is available.
  */
 function sign(encodedPayload) {
-  return crypto
-    .createHmac('sha256', String(resolveJwtSecret() || ''))
-    .update(encodedPayload)
-    .digest('base64url');
+  const secret = resolveJwtSecret();
+  if (!secret || typeof secret !== 'string') {
+    throw new Error('Cannot sign consent ticket: no JWT secret is configured');
+  }
+  return crypto.createHmac('sha256', secret).update(encodedPayload).digest('base64url');
 }
 
 /**
@@ -100,7 +106,19 @@ export function verifyConsentTicket(ticket) {
 
   const encodedPayload = ticket.slice(0, separator);
   const signature = ticket.slice(separator + 1);
-  const expected = sign(encodedPayload);
+
+  let expected;
+  try {
+    expected = sign(encodedPayload);
+  } catch (error) {
+    // A missing secret is a server misconfiguration, not a bad ticket. Log it
+    // as such and reject rather than letting it surface as a 500.
+    logger.error('Cannot verify consent ticket', {
+      component: 'ConsentTicket',
+      error: error?.message || String(error)
+    });
+    return null;
+  }
 
   // timingSafeEqual throws on a length mismatch, which is itself a rejection.
   try {

--- a/server/utils/consentTicket.js
+++ b/server/utils/consentTicket.js
@@ -1,0 +1,127 @@
+import crypto from 'crypto';
+import { resolveJwtSecret } from './tokenService.js';
+import logger from './logger.js';
+
+/**
+ * Signed, self-contained consent tickets for the OAuth consent screen.
+ *
+ * ## Why this is not a session
+ *
+ * The consent screen spans two requests: `GET /api/oauth/authorize` renders the
+ * form, `POST /api/oauth/authorize/decision` acts on it. The parameters that
+ * must survive that hop — above all the PKCE `code_challenge`, which binds the
+ * authorization code to the client — used to live in an `express-session`
+ * backed by a per-process `MemoryStore`.
+ *
+ * In cluster mode those two requests land on different workers (round-robin
+ * routing, see `server/server.js`), and the second worker's store has no record
+ * of the session. The CSRF token then reads as missing (HTTP 403 "CSRF token
+ * missing") or, worse, the `code_challenge` reads as empty and a code gets
+ * minted with no PKCE binding at all — which the token endpoint later rejects.
+ * Both failures are intermittent, roughly 1 in N requests for N workers.
+ *
+ * A shared session store would fix the lookup; this removes the need for one.
+ * The consent context is serialised into the form itself and protected by an
+ * HMAC, so any worker can verify it with no shared state.
+ *
+ * ## What the signature buys
+ *
+ * The ticket carries every parameter the decision handler needs, so those
+ * values no longer have to be trusted from the POST body — a client cannot
+ * swap the `redirect_uri`, widen `scope`, or drop `code_challenge` between the
+ * screen and the decision, because doing so invalidates the HMAC.
+ *
+ * It also replaces the CSRF token. The ticket is bound to the `userId` it was
+ * issued for and the decision handler checks that against the caller's session
+ * cookie, so a ticket minted for an attacker cannot drive a victim's consent —
+ * and a ticket cannot be minted at all without the signing key.
+ *
+ * A ticket is replayable until it expires. That is deliberate: replaying it
+ * re-issues a code for the same user who already consented to the same client
+ * and scopes, which is exactly what revisiting `/authorize` with remembered
+ * consent does anyway. Single-use protection lives where it matters, on the
+ * authorization code (`authorizationCodeStore.js`).
+ *
+ * @module consentTicket
+ */
+
+/**
+ * Ticket lifetime. Matches the 15 minutes the OAuth session cookie used to
+ * allow — long enough for a user to read the screen, short enough that a
+ * leaked ticket is stale before it is useful.
+ */
+const TICKET_TTL_MS = 15 * 60 * 1000;
+
+/**
+ * HMAC the payload with the platform's JWT secret.
+ *
+ * @param {string} encodedPayload - base64url payload.
+ * @returns {string} base64url signature.
+ */
+function sign(encodedPayload) {
+  return crypto
+    .createHmac('sha256', String(resolveJwtSecret() || ''))
+    .update(encodedPayload)
+    .digest('base64url');
+}
+
+/**
+ * Issue a signed consent ticket.
+ *
+ * @param {Object} context - Consent context to protect.
+ * @param {string} context.clientId - OAuth client requesting access.
+ * @param {string} context.redirectUri - Validated redirect URI.
+ * @param {string} context.scope - Space-separated granted scopes.
+ * @param {string} [context.state] - Client state to echo back.
+ * @param {string} [context.codeChallenge] - PKCE challenge.
+ * @param {string} [context.codeChallengeMethod] - PKCE method.
+ * @param {string} [context.nonce] - OIDC nonce.
+ * @param {string} context.userId - Subject the ticket is bound to.
+ * @returns {string} Ticket of the form `<payload>.<signature>`.
+ */
+export function issueConsentTicket(context) {
+  const payload = { ...context, exp: Date.now() + TICKET_TTL_MS };
+  const encodedPayload = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+  return `${encodedPayload}.${sign(encodedPayload)}`;
+}
+
+/**
+ * Verify a consent ticket and return its context.
+ *
+ * @param {string} ticket - Ticket from the consent form.
+ * @returns {Object|null} The context, or null if malformed, tampered with, or
+ *   expired.
+ */
+export function verifyConsentTicket(ticket) {
+  if (!ticket || typeof ticket !== 'string') return null;
+
+  const separator = ticket.lastIndexOf('.');
+  if (separator <= 0 || separator === ticket.length - 1) return null;
+
+  const encodedPayload = ticket.slice(0, separator);
+  const signature = ticket.slice(separator + 1);
+  const expected = sign(encodedPayload);
+
+  // timingSafeEqual throws on a length mismatch, which is itself a rejection.
+  try {
+    if (!crypto.timingSafeEqual(Buffer.from(signature, 'utf8'), Buffer.from(expected, 'utf8'))) {
+      return null;
+    }
+  } catch {
+    return null;
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8'));
+  } catch {
+    logger.warn('Consent ticket carried an unparsable payload', { component: 'ConsentTicket' });
+    return null;
+  }
+
+  if (!payload || typeof payload !== 'object') return null;
+  if (typeof payload.exp !== 'number' || Date.now() > payload.exp) return null;
+  if (!payload.clientId || !payload.redirectUri || !payload.userId) return null;
+
+  return payload;
+}

--- a/tests/manual/oauth-auth-code-unit.js
+++ b/tests/manual/oauth-auth-code-unit.js
@@ -166,10 +166,13 @@ import {
 
 section('Authorization Code Store (RFC 6749 §4.1.2)');
 
-await test('generateCode() returns a 64-character lowercase hex string', () => {
+await test('generateCode() returns a handle.secret pair with 384 bits of entropy', () => {
   const code = generateCode();
-  assert.equal(code.length, 64, `Expected 64 hex chars, got ${code.length}`);
-  assert.match(code, /^[0-9a-f]+$/, 'Code must be lowercase hexadecimal');
+  assert.match(
+    code,
+    /^[0-9a-f]{32}\.[0-9a-f]{64}$/,
+    'Code must be a 32-char hex handle and a 64-char hex secret, dot-separated'
+  );
 });
 
 await test('generateCode() produces unique values across calls', () => {
@@ -211,10 +214,27 @@ await test('Authorization codes are single-use: second consumeCode() call return
 });
 
 await test('consumeCode() returns null for an unknown code', async () => {
-  const result = await consumeCode(
-    'aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222'
-  );
+  const result = await consumeCode(`${'a'.repeat(32)}.${'b'.repeat(64)}`);
   assert.equal(result, null, 'Unknown code must return null');
+});
+
+await test('consumeCode() returns null for a malformed code', async () => {
+  for (const bad of [null, undefined, '', 'no-separator', '.', 'handle.', '.secret']) {
+    assert.equal(await consumeCode(bad), null, `Malformed code ${JSON.stringify(bad)} must fail`);
+  }
+});
+
+await test('A valid handle with the wrong secret is rejected and discards the code', async () => {
+  // Guessing the 256-bit secret should not be retryable against a known handle.
+  const code = generateCode();
+  const [handle] = code.split('.');
+  storeCode(code, { clientId: 'test_client', userId: 'user_wrong_secret' });
+
+  const forged = await consumeCode(`${handle}.${'0'.repeat(64)}`);
+  assert.equal(forged, null, 'A mismatched secret must not return the payload');
+
+  const afterwards = await consumeCode(code);
+  assert.equal(afterwards, null, 'The real code must be discarded after a failed attempt');
 });
 
 await test('cleanup() removes expired entries without affecting valid ones', async () => {

--- a/tests/manual/oauth-auth-code-unit.js
+++ b/tests/manual/oauth-auth-code-unit.js
@@ -178,7 +178,7 @@ await test('generateCode() produces unique values across calls', () => {
   assert.notEqual(a, b, 'Two consecutive codes should not be identical');
 });
 
-await test('storeCode() + consumeCode() round-trip returns the original payload', () => {
+await test('storeCode() + consumeCode() round-trip returns the original payload', async () => {
   const code = generateCode();
   const payload = {
     clientId: 'test_client',
@@ -190,7 +190,7 @@ await test('storeCode() + consumeCode() round-trip returns the original payload'
   };
 
   storeCode(code, payload);
-  const retrieved = consumeCode(code);
+  const retrieved = await consumeCode(code);
 
   assert.deepEqual(
     retrieved,
@@ -199,23 +199,25 @@ await test('storeCode() + consumeCode() round-trip returns the original payload'
   );
 });
 
-await test('Authorization codes are single-use: second consumeCode() call returns null', () => {
+await test('Authorization codes are single-use: second consumeCode() call returns null', async () => {
   const code = generateCode();
   storeCode(code, { clientId: 'test_client', userId: 'user_single_use' });
 
-  const first = consumeCode(code);
-  const second = consumeCode(code);
+  const first = await consumeCode(code);
+  const second = await consumeCode(code);
 
   assert.notEqual(first, null, 'First consumption must succeed');
   assert.equal(second, null, 'Second consumption of the same code must return null');
 });
 
-await test('consumeCode() returns null for an unknown code', () => {
-  const result = consumeCode('aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222');
+await test('consumeCode() returns null for an unknown code', async () => {
+  const result = await consumeCode(
+    'aaaa1111bbbb2222cccc3333dddd4444eeee5555ffff6666aaaa1111bbbb2222'
+  );
   assert.equal(result, null, 'Unknown code must return null');
 });
 
-await test('cleanup() removes expired entries without affecting valid ones', () => {
+await test('cleanup() removes expired entries without affecting valid ones', async () => {
   // Store two codes – we will artificially expire one by manipulating the clock
   // is not possible directly, so instead we rely on the cleanup() export being
   // a no-op for non-expired entries and verify it does not remove fresh ones.
@@ -226,7 +228,7 @@ await test('cleanup() removes expired entries without affecting valid ones', () 
   // cleanup() should not delete the fresh code.
   cleanup();
 
-  const result = consumeCode(freshCode);
+  const result = await consumeCode(freshCode);
   assert.deepEqual(
     result,
     freshPayload,


### PR DESCRIPTION
## Problem

OAuth login for MCP clients fails right after the consent screen with `invalid_grant: Authorization code is invalid or expired`.

Since round-robin routing landed (#2146), the two halves of the authorization code flow run on different workers. `POST /api/oauth/authorize/decision` mints the code into a per-process `Map` on worker A; the client's `POST /api/oauth/token` is handed to the next worker, whose map is empty.

**This is not intermittent.** Round-robin gives each new connection to the next worker in sequence, so two back-to-back requests land on *adjacent* workers and the exchange fails ~100% of the time, not `(N-1)/N`. Measured against a real 4-worker cluster:

| | token exchanges succeeded |
| --- | --- |
| before | **0 / 12** — all `invalid_grant: Authorization code is invalid or expired` |
| after | **12 / 12** |

`npm run dev` pins `WORKERS=1`, which is why this never showed up in development.

The same flow had a second instance of the same bug: the consent CSRF token and the PKCE `code_challenge` lived in an `express-session` backed by a per-worker `MemoryStore`, so a decision POST reaching another worker saw `403 CSRF token missing` — or, when CSRF happened to pass, minted a code with an **empty** `codeChallenge` that the token endpoint then rejected.

## Approach

**Codes stay on the minting worker; the consume is routed to it.** Replicating codes to every worker would fix the lookup and destroy the security property — reading a code *consumes* it, so N copies means N valid redemptions. Ownership is announced over the existing cluster bus and a worker receiving the token request asks the owner to consume it. Exactly one process ever holds a code, so single-use stays atomic with no distributed agreement.

This needed a request/reply primitive on the bus (`request()` / `respond()`), built on the existing pub/sub with correlation ids so the primary stays a dumb repeater. A handler returning `undefined` sends no reply, which is what makes the owner-unknown broadcast fallback safe: non-owners stay silent instead of racing a `null` ahead of the real owner's answer.

`consumeCode()` is now async; the single call site awaits it.

**A code is now a routing handle and a secret, dot-separated** (`handle.secret`) — 128 bits of handle, 256 bits of secret. Ownership announcements are broadcast to *every* worker and retained for the code's lifetime, so they carry only the handle, which grants nothing on its own. The secret crosses the IPC boundary once, in the single directed consume message to the owning worker, which verifies it with `timingSafeEqual` and destroys it — unavoidable in any design, since only the owner can verify, and a different exposure from a retained broadcast. A valid handle presented with a wrong secret discards the entry, so a guessing loop gets one attempt per code rather than many. Codes are opaque to clients per RFC 6749, so the shape is not a contract.

**Consent context moves into a signed ticket, not a session.** The whole context travels in the form protected by an HMAC, so any worker can verify it with no shared state. It replaces the CSRF token by being bound to the user it was issued for — a ticket cannot be forged without the signing key, and one obtained by an attacker cannot drive a victim's consent. Signing fails closed: with no JWT secret configured it refuses rather than HMAC-ing with an empty key, and verification rejects cleanly instead of raising a 500.

Side benefit: `redirect_uri`, `scope`, `code_challenge` and `nonce` are now integrity-protected instead of trusted from the POST body, so a client cannot widen scope or redirect the code between the screen and the decision.

## Tests

`server/tests/authCodeCluster.test.js` forks a real 3-worker cluster and drives the two halves of the exchange on *different* workers — mocking `node:cluster` would only test the mock. Covers cross-worker consume, replay rejection from a third worker, rejection of a forged secret by the owning worker, ownership retraction once a code is spent, and that announcements carry only the routing handle and never the full code.

`server/tests/consentTicket.test.js` covers round-trip, tamper detection on payload and signature, forging with a wrong key, expiry, malformed input, and the no-signing-key path. It initialises the secret through `TokenStorageService` the way `server.js` does, so it exercises the real resolution chain.

Both are wired into `npm run test:cluster`. Also verified end-to-end against a live 4-worker cluster: 10/10 full exchanges across both the consent-screen and remembered-consent paths, with code replay rejected every time.

## Also in this PR

- Corrects `docs/mcp-integration.md`, which told readers stateless mode was only needed for multi-replica deployments and that the sticky router keeps a client on one worker. Neither holds since #2146 — the MCP gateway's own session map has this same bug, so stateless mode is needed on any deployment running more than one worker.
- `concepts/2026-07-28 Round-Robin Worker-Local State Audit.md` records the **remaining** instances of this bug class found while investigating, with severity and recommended sequencing. **None of them are fixed here** — flagging them for follow-up:

  | Area | Symptom |
  | --- | --- |
  | MCP gateway sessions | `404 Session not found` on the first tool call after `initialize` |
  | OIDC session store | SSO login fails `Failed to verify request state` (PKCE verifier + state lost) |
  | Integration OAuth sessions | Jira / Office 365 / Google Drive / Nextcloud connect fails `invalid_state` |
  | Short links | Created link 404s on 3 of 4 workers *permanently*; writes clobber other workers' links |
  | Workflow execution registry | `404 Execution` on stream attach / cancel / checkpoint reply |
  | OCR job store | Progress stuck at 0%, download 404s |
  | Rate limiters | Per-worker counters, so the effective limit is the configured value times the worker count (≈200 login attempts/15min instead of 50) |
  | iAssistant conversation state | Context lost mid-chat; a new upstream conversation per turn |

## Notes for the reviewer

- **CodeQL raised `js/insufficient-password-hash` on an earlier revision** that keyed the store on a SHA-256 of the code. Inline suppression is not available — GitHub code scanning has no inline suppression for CodeQL, and `lgtm[...]` was LGTM.com syntax, which is retired, so the existing `lgtm[...]` comments in `pkceUtils.js` and `refreshTokenStore.js` are decorative. The handle/secret split removes the sink rather than suppressing a false positive, and is the better design for the reasons above. Both alerts are now resolved.
- **`config.JWT_SECRET` does not exist.** `JWT_SECRET` is not declared in `server/config.js`, so priority 1 of `resolveJwtSecret()` is dead code, as is the same branch at `middleware/setup.js:260` for the session secret. The value actually reaches the platform via `TokenStorageService.initializeJwtSecret()`, which reads `process.env.JWT_SECRET` directly. Not changed here — worth a follow-up.
- **`mcpServer.requireConsent` does not force per-grant consent.** `forceConsent` bypasses the trusted-client shortcut but remembered consent still short-circuits below it, so the stated intent ("explicit per-grant consent is warranted") is not achieved. Left alone because fixing it changes behaviour.
- With `WORKERS=4` all four workers race the migration lock at boot, so three log `Configuration migration failed` at error level. Harmless — one worker applies migrations — but misleading in logs. Pre-existing.

## Verification

- `npm run test:cluster` — all 6 suites pass
- `npx eslint server/` — 0 errors
- `npm run test:unit` — 245 tests pass (6 client suites fail on missing `client/node_modules` in the test container; no client code touched)
- `tests/manual/oauth-auth-code-unit.js` — 35 pass, 2 pre-existing `jwtAuth.js` structural failures unrelated to this change (confirmed present on the base commit)
- Server boots clean with `WORKERS=4`