### PR TITLE
fix(admin): stop the GitHub update check from blocking the dashboard

### DIFF
--- a/.claude/skills/document-feature/SKILL.md
+++ b/.claude/skills/document-feature/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: document-feature
-description: Use when a new feature, improvement, or breaking change has been implemented. Adds an entry to docs/releases/ so it appears in the in-product admin changelog.
+description: Use when a new feature, improvement, bug fix, or breaking change has been implemented. Adds an entry to docs/releases/ so it appears in the in-product admin changelog.
 user-invocable: true
 ---
 
 # Release Documentation
 
-When a feature, improvement, or breaking change is implemented, add an entry to the appropriate
-Markdown file under `docs/releases/`.
+When a feature, improvement, bug fix, or breaking change is implemented, add an entry to the
+appropriate Markdown file under `docs/releases/`.
 
 ## Determining the Version
 
@@ -21,18 +21,47 @@ Use the highest existing `docs/releases/` subdirectory name as a fallback.
 ```
 docs/releases/{version}/
   features.md         New capabilities (admin-facing and end-user-facing)
+  fixes.md            Corrections to behaviour that was already supposed to work
   breaking-changes.md Changes that require admin action after upgrade
 ```
 
-If the version directory does not exist yet, create it and both files with an empty heading:
+If the version directory does not exist yet, create it and all three files with an empty heading:
 
 ```markdown
 # Features — {version}
 ```
 
 ```markdown
+# Fixes — {version}
+```
+
+```markdown
 # Breaking Changes — {version}
 ```
+
+## Choosing the File
+
+Pick by what the reader gets, not by how the work was labelled or which branch it came from:
+
+| The change…                                                              | File                  |
+| ------------------------------------------------------------------------ | --------------------- |
+| lets someone do something they could not do before                        | `features.md`         |
+| makes something existing faster, clearer, or easier — nothing was broken  | `features.md`         |
+| makes something work that was supposed to work already                   | `fixes.md`            |
+| closes a security hole in shipped behaviour                              | `fixes.md`            |
+| requires an admin to act during or after the upgrade                     | `breaking-changes.md` |
+
+Two rules settle most of the hard cases:
+
+- **One entry, one file.** A change that both fixes a bug and adds a capability goes wherever its
+  headline belongs — do not write it twice. A breaking change is always documented as a breaking
+  change, even when it is also a fix.
+- **Titles say what is true now, not what was wrong.** Both files use the same voice, so
+  "Chat exports no longer lose attachments" belongs in `fixes.md` on the strength of what it does,
+  not because the title contains "no longer".
+
+When it is genuinely ambiguous, ask: would an admin reading this be *relieved* (fix) or *interested*
+(feature)? Relief goes in `fixes.md`.
 
 ## Entry Format
 
@@ -59,24 +88,36 @@ Include a configuration or API example only when admins need to take action.
 - **Concise:** one paragraph plus bullets maximum. No filler phrases.
 - **Scope:** omit internal refactors, dependency bumps, and test changes unless they have
   a visible effect.
+- **Fixes name the symptom.** An admin recognises the bug by what they saw, not by the cause, so
+  lead with the symptom and only then the reason: "The admin start page showed only grey
+  placeholders on installations without internet access — the update check had no timeout."
 
 ## Workflow
 
 1. Identify the version (see above).
-2. Read the existing `features.md` for that version to avoid duplication.
-3. Read the code changes to understand the user-visible impact.
-4. Append the new `##` entry to the appropriate file.
-5. For breaking changes: always include a **Before upgrading:** migration note.
+2. Decide which file the entry belongs in (see **Choosing the File**).
+3. Read the existing entries in that file for that version to avoid duplication.
+4. Read the code changes to understand the user-visible impact.
+5. Append the new `##` entry to that one file.
+6. For breaking changes: always include a **Before upgrading:** migration note.
 
 ## When to Use
 
 Use this skill proactively whenever you implement:
 
-- A new admin page, section, or feature
-- A change to configuration schema (new fields, renamed fields, removed fields)
-- A change to API behavior that operators rely on
-- A security improvement or bug fix that users/admins would want to know about
+- A new admin page, section, or feature → `features.md`
+- A change to configuration schema (new fields, renamed fields, removed fields) →
+  `features.md`, or `breaking-changes.md` when existing installs need action
+- A change to API behavior that operators rely on → `features.md` or `breaking-changes.md`
+- A bug fix or security fix that users/admins would want to know about → `fixes.md`
 - Anything that appears in the admin "Needs your attention" feed
 
 Skip for: pure refactors with no visible behavior change, dependency bumps, test additions,
 comment/documentation-only changes.
+
+## Plumbing
+
+The in-product changelog reads these files directly, so a new file name is not picked up on its own.
+`server/routes/admin/changelog.js` chooses which files to read and
+`client/src/features/admin/pages/AdminChangelogPage.jsx` renders each section — both must know
+about any file added here.

--- a/client/src/features/admin/hooks/useOverviewData.js
+++ b/client/src/features/admin/hooks/useOverviewData.js
@@ -11,6 +11,12 @@ import {
  * Fetches and computes data for the admin Overview dashboard.
  * Uses Promise.allSettled so individual endpoint failures don't block others.
  *
+ * Every endpoint below is server-local. Nothing that reaches the internet
+ * belongs in this batch: `allSettled` only settles once the slowest request
+ * does, so one unreachable host holds the whole dashboard on its loading
+ * skeletons. The GitHub update check lives in `useUpdateCheck` for exactly that
+ * reason (issue #2150).
+ *
  * @param {Object} [options]
  * @param {boolean} [options.contentAdminOnly] - When true, the caller is a
  *   content-admin-only user (no full admin access). Only content endpoints
@@ -76,7 +82,6 @@ export function useOverviewData({ contentAdminOnly = false } = {}) {
         sessionsResult,
         timelineResult,
         versionResult,
-        updateResult,
         overviewResult,
         auditResult
       ] = await Promise.allSettled([
@@ -84,7 +89,6 @@ export function useOverviewData({ contentAdminOnly = false } = {}) {
         makeAdminApiCall('/admin/usage/users'),
         makeAdminApiCall('/admin/usage/timeline'),
         makeAdminApiCall('/admin/version'),
-        makeAdminApiCall('/admin/version/check-update'),
         makeAdminApiCall('/admin/overview/stats'),
         makeAdminApiCall('/admin/audit-log?limit=8')
       ]);
@@ -97,7 +101,6 @@ export function useOverviewData({ contentAdminOnly = false } = {}) {
       const timelineData =
         timelineResult.status === 'fulfilled' ? timelineResult.value?.data : null;
       const versionData = versionResult.status === 'fulfilled' ? versionResult.value?.data : null;
-      const updateData = updateResult.status === 'fulfilled' ? updateResult.value?.data : null;
       const overview = overviewResult.status === 'fulfilled' ? overviewResult.value?.data : null;
 
       const appCount = Array.isArray(apps) ? apps.length : 0;
@@ -141,9 +144,7 @@ export function useOverviewData({ contentAdminOnly = false } = {}) {
           sub: t('admin.overview.version.node', 'Node {{version}}', {
             version: versionData?.node ?? '—'
           }),
-          href: '/admin/updates',
-          updateAvailable: updateData?.updateAvailable ?? false,
-          latestVersion: updateData?.latestVersion
+          href: '/admin/updates'
         }
       });
 

--- a/client/src/features/admin/hooks/useUpdateCheck.js
+++ b/client/src/features/admin/hooks/useUpdateCheck.js
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { getAdminApiErrorMessage, makeAdminApiCall } from '../../../api/adminApi';
+
+/** How long to wait before asking again while the server refreshes in the background. */
+const POLL_INTERVAL_MS = 3000;
+/** Give up polling after this many attempts so a stuck backend can't poll forever. */
+const MAX_ATTEMPTS = 5;
+
+/**
+ * Fetches `/admin/version/check-update` on its own, independent of whatever
+ * else a page is loading.
+ *
+ * The server answers this endpoint from a cache and refreshes in the
+ * background, so a cold cache comes back as `checking: true` with no result
+ * yet — this hook polls a few times to pick the result up without a reload.
+ *
+ * Keep this OUT of any request batch a page blocks its first render on: the
+ * check reaches api.github.com, which is unreachable in deployments without
+ * outbound internet access (issue #2150).
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.enabled] - Set false to skip the check entirely,
+ *   e.g. for content-admin-only users who aren't permitted on this endpoint.
+ */
+export function useUpdateCheck({ enabled = true } = {}) {
+  const [updateInfo, setUpdateInfo] = useState(null);
+
+  useEffect(() => {
+    if (!enabled) return undefined;
+
+    let cancelled = false;
+    let timer = null;
+
+    const run = async attempt => {
+      try {
+        const response = await makeAdminApiCall('/admin/version/check-update', { method: 'GET' });
+        if (cancelled) return;
+
+        const data = response?.data ?? null;
+        setUpdateInfo(data);
+
+        if (data?.checking && attempt < MAX_ATTEMPTS) {
+          timer = setTimeout(() => run(attempt + 1), POLL_INTERVAL_MS);
+        }
+      } catch (error) {
+        if (cancelled) return;
+        setUpdateInfo({ updateAvailable: false, error: getAdminApiErrorMessage(error) });
+      }
+    };
+
+    run(1);
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [enabled]);
+
+  return { updateInfo, setUpdateInfo };
+}

--- a/client/src/features/admin/pages/AdminChangelogPage.jsx
+++ b/client/src/features/admin/pages/AdminChangelogPage.jsx
@@ -354,10 +354,26 @@ function AdminChangelogPage() {
               {/* Accordion body */}
               {expanded && (
                 <div className="px-5 py-4 bg-white dark:bg-gray-900">
-                  {/* Features */}
-                  {entry.features && (
+                  {/* New & improved. Labelled only when there are fixes to tell it
+                      apart from — a lone section needs no heading. */}
+                  {entry.features && entry.features.trim() && (
                     <div className="prose dark:prose-invert max-w-none">
+                      {entry.fixes && entry.fixes.trim() && (
+                        <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">
+                          {t('admin.changelog.features', 'New & Improved')}
+                        </h2>
+                      )}
                       {renderMarkdown(entry.features)}
+                    </div>
+                  )}
+
+                  {/* Fixes */}
+                  {entry.fixes && entry.fixes.trim() && (
+                    <div className="prose dark:prose-invert max-w-none mt-6">
+                      <h2 className="text-sm font-semibold uppercase tracking-wide text-gray-500 dark:text-gray-400 mb-1">
+                        {t('admin.changelog.fixes', 'Fixes')}
+                      </h2>
+                      {renderMarkdown(entry.fixes)}
                     </div>
                   )}
 

--- a/client/src/features/admin/pages/AdminOverview.jsx
+++ b/client/src/features/admin/pages/AdminOverview.jsx
@@ -19,6 +19,7 @@ import {
   ArrowUpCircleIcon
 } from '@heroicons/react/24/outline';
 import { useOverviewData } from '../hooks/useOverviewData';
+import { useUpdateCheck } from '../hooks/useUpdateCheck';
 import { useUIConfig } from '../../../shared/contexts/UIConfigContext';
 import { useAuth } from '../../../shared/contexts/AuthContext';
 
@@ -521,6 +522,12 @@ export default function AdminOverview() {
     contentAdminOnly: isContentAdminOnly
   });
 
+  // Runs alongside the dashboard data rather than as part of it: this one
+  // reaches api.github.com, and the page must render before it answers — or not
+  // at all, in deployments without outbound internet access (issue #2150).
+  // Content admins aren't permitted on the endpoint and have no version card.
+  const { updateInfo } = useUpdateCheck({ enabled: !isContentAdminOnly });
+
   const currentLanguage = i18n.language;
   const { titleLight, titleBold, title } = uiConfig?.header ?? {};
   const instanceName =
@@ -581,7 +588,9 @@ export default function AdminOverview() {
         label: t('admin.overview.stats.version', 'Version'),
         icon: TagIcon,
         iconColor: 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-400',
-        ...stats.version
+        ...stats.version,
+        updateAvailable: updateInfo?.updateAvailable ?? false,
+        latestVersion: updateInfo?.latestVersion
       }
     ];
   }

--- a/client/src/features/admin/pages/AdminUpdatesPage.jsx
+++ b/client/src/features/admin/pages/AdminUpdatesPage.jsx
@@ -3,14 +3,16 @@ import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
 import { makeAdminApiCall } from '../../../api/adminApi';
 import ConfirmDialog from '../../../shared/components/ConfirmDialog';
+import { useUpdateCheck } from '../hooks/useUpdateCheck';
 
 function AdminUpdatesPage() {
   const { t } = useTranslation();
   const [versionInfo, setVersionInfo] = useState(null);
   const [versionLoading, setVersionLoading] = useState(true);
   const [versionError, setVersionError] = useState('');
-  const [updateInfo, setUpdateInfo] = useState(null);
-  const [updateCheckLoading, setUpdateCheckLoading] = useState(true);
+  // Independent of the version cards below, which must render even when the
+  // GitHub check never answers (issue #2150).
+  const { updateInfo, setUpdateInfo } = useUpdateCheck();
   const [updateStatus, setUpdateStatus] = useState(null);
   const [updateActionLoading, setUpdateActionLoading] = useState(false);
   const [updateActionMessage, setUpdateActionMessage] = useState('');
@@ -34,20 +36,6 @@ function AdminUpdatesPage() {
       }
     };
     fetchVersionInfo();
-  }, []);
-
-  useEffect(() => {
-    const checkForUpdates = async () => {
-      try {
-        const response = await makeAdminApiCall('/admin/version/check-update', { method: 'GET' });
-        setUpdateInfo(response.data);
-      } catch (error) {
-        setUpdateInfo({ updateAvailable: false, error: error.message });
-      } finally {
-        setUpdateCheckLoading(false);
-      }
-    };
-    checkForUpdates();
   }, []);
 
   useEffect(() => {
@@ -279,106 +267,101 @@ function AdminUpdatesPage() {
               </p>
 
               {/* Update Available Banner */}
-              {!updateCheckLoading &&
-                updateInfo &&
-                updateInfo.updateAvailable &&
-                !updateInfo.error && (
-                  <div className="mb-4 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-md p-4">
-                    <div className="flex items-start">
-                      <div className="flex-shrink-0">
-                        <Icon name="check-circle" size="md" className="text-green-500 mt-0.5" />
-                      </div>
-                      <div className="ml-3 flex-1">
-                        <h4 className="text-sm font-medium text-green-800 dark:text-green-200">
-                          {t('admin.system.updateCheckTitle', 'Update Available')}
-                        </h4>
-                        <div className="mt-2 text-sm text-green-700 dark:text-green-300">
-                          <p>
-                            {t(
-                              'admin.system.updateAvailable',
-                              'A new version of iHub Apps is available!'
-                            )}
-                          </p>
-                          <div className="mt-2 flex items-center space-x-4">
-                            <span>
-                              <strong>
-                                {t('admin.system.currentVersion', 'Current Version')}:
-                              </strong>{' '}
-                              {updateInfo.currentVersion}
-                            </span>
-                            <span>
-                              <strong>{t('admin.system.latestVersion', 'Latest Version')}:</strong>{' '}
-                              {updateInfo.latestVersion}
-                            </span>
-                          </div>
-                        </div>
-                        {updateStatus?.isContainer && (
-                          <div className="mt-3 text-sm text-green-700 dark:text-green-300">
-                            <Icon
-                              name="information-circle"
-                              size="sm"
-                              className="inline-block mr-1 -mt-0.5"
-                            />
-                            {t(
-                              'admin.system.updateContainerNotice',
-                              'In-place updates are disabled when running in a container. Pull a new container image and restart the container to update.'
-                            )}
-                          </div>
-                        )}
-                        <div className="mt-3 flex items-center space-x-3">
-                          {updateStatus?.isBinary && !updateStatus?.isContainer && (
-                            <button
-                              onClick={handleUpdateNow}
-                              disabled={updateActionLoading}
-                              className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
-                            >
-                              {updateActionLoading ? (
-                                <svg
-                                  className="animate-spin -ml-0.5 mr-1.5 h-3 w-3"
-                                  fill="none"
-                                  viewBox="0 0 24 24"
-                                >
-                                  <circle
-                                    className="opacity-25"
-                                    cx="12"
-                                    cy="12"
-                                    r="10"
-                                    stroke="currentColor"
-                                    strokeWidth="4"
-                                  />
-                                  <path
-                                    className="opacity-75"
-                                    fill="currentColor"
-                                    d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                                  />
-                                </svg>
-                              ) : (
-                                <Icon name="download" size="sm" className="mr-1.5" />
-                              )}
-                              {t('admin.system.updateNow', 'Update Now')}
-                            </button>
+              {updateInfo && updateInfo.updateAvailable && !updateInfo.error && (
+                <div className="mb-4 bg-green-50 dark:bg-green-900/30 border border-green-200 dark:border-green-800 rounded-md p-4">
+                  <div className="flex items-start">
+                    <div className="flex-shrink-0">
+                      <Icon name="check-circle" size="md" className="text-green-500 mt-0.5" />
+                    </div>
+                    <div className="ml-3 flex-1">
+                      <h4 className="text-sm font-medium text-green-800 dark:text-green-200">
+                        {t('admin.system.updateCheckTitle', 'Update Available')}
+                      </h4>
+                      <div className="mt-2 text-sm text-green-700 dark:text-green-300">
+                        <p>
+                          {t(
+                            'admin.system.updateAvailable',
+                            'A new version of iHub Apps is available!'
                           )}
-                          <a
-                            href={updateInfo.releaseUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-green-700 dark:text-green-200 bg-green-100 dark:bg-green-800/50 hover:bg-green-200 dark:hover:bg-green-700/50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
-                          >
-                            <Icon name="external-link" size="sm" className="mr-1.5" />
-                            {t('admin.system.viewRelease', 'View Release on GitHub')}
-                          </a>
+                        </p>
+                        <div className="mt-2 flex items-center space-x-4">
+                          <span>
+                            <strong>{t('admin.system.currentVersion', 'Current Version')}:</strong>{' '}
+                            {updateInfo.currentVersion}
+                          </span>
+                          <span>
+                            <strong>{t('admin.system.latestVersion', 'Latest Version')}:</strong>{' '}
+                            {updateInfo.latestVersion}
+                          </span>
                         </div>
-                        {updateActionMessage && (
-                          <div
-                            className={`mt-2 text-sm ${updateActionMessageType === 'error' ? 'text-red-700 dark:text-red-300' : 'text-green-700 dark:text-green-300'}`}
-                          >
-                            {updateActionMessage}
-                          </div>
-                        )}
                       </div>
+                      {updateStatus?.isContainer && (
+                        <div className="mt-3 text-sm text-green-700 dark:text-green-300">
+                          <Icon
+                            name="information-circle"
+                            size="sm"
+                            className="inline-block mr-1 -mt-0.5"
+                          />
+                          {t(
+                            'admin.system.updateContainerNotice',
+                            'In-place updates are disabled when running in a container. Pull a new container image and restart the container to update.'
+                          )}
+                        </div>
+                      )}
+                      <div className="mt-3 flex items-center space-x-3">
+                        {updateStatus?.isBinary && !updateStatus?.isContainer && (
+                          <button
+                            onClick={handleUpdateNow}
+                            disabled={updateActionLoading}
+                            className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-white bg-green-600 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {updateActionLoading ? (
+                              <svg
+                                className="animate-spin -ml-0.5 mr-1.5 h-3 w-3"
+                                fill="none"
+                                viewBox="0 0 24 24"
+                              >
+                                <circle
+                                  className="opacity-25"
+                                  cx="12"
+                                  cy="12"
+                                  r="10"
+                                  stroke="currentColor"
+                                  strokeWidth="4"
+                                />
+                                <path
+                                  className="opacity-75"
+                                  fill="currentColor"
+                                  d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                                />
+                              </svg>
+                            ) : (
+                              <Icon name="download" size="sm" className="mr-1.5" />
+                            )}
+                            {t('admin.system.updateNow', 'Update Now')}
+                          </button>
+                        )}
+                        <a
+                          href={updateInfo.releaseUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex items-center px-3 py-1.5 border border-transparent text-xs font-medium rounded-md text-green-700 dark:text-green-200 bg-green-100 dark:bg-green-800/50 hover:bg-green-200 dark:hover:bg-green-700/50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+                        >
+                          <Icon name="external-link" size="sm" className="mr-1.5" />
+                          {t('admin.system.viewRelease', 'View Release on GitHub')}
+                        </a>
+                      </div>
+                      {updateActionMessage && (
+                        <div
+                          className={`mt-2 text-sm ${updateActionMessageType === 'error' ? 'text-red-700 dark:text-red-300' : 'text-green-700 dark:text-green-300'}`}
+                        >
+                          {updateActionMessage}
+                        </div>
+                      )}
                     </div>
                   </div>
-                )}
+                </div>
+              )}
 
               {/* Rollback Banner */}
               {updateStatus?.hasBackup && !updateStatus?.isContainer && !updateActionLoading && (

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -646,6 +646,29 @@ For detailed configuration documentation, see the main README.md Configuration s
 - Only available for binary installations (not Docker or npm)
 - Disabled automatically when running in a container (Docker, Podman, Kubernetes)
 
+**Behaviour when GitHub is unreachable:**
+
+The version check is bounded and never blocks the Admin UI. Where outbound
+traffic to `api.github.com` is dropped rather than refused, the request would
+otherwise hang until the operating system's TCP timeout and leave the admin
+start page on its loading placeholders (issue #2150).
+
+- The request aborts after 5 seconds. Override with `VERSION_CHECK_TIMEOUT_MS`
+  (or `IHUB_VERSION_CHECK_TIMEOUT_MS`), in milliseconds, for slow links or
+  strict proxies. Values are clamped to 500 ms – 60 s.
+- Results are cached for 1 hour, failures for 5 minutes, so opening the Admin UI
+  does not trigger a fresh request to GitHub every time.
+- `GET /api/admin/version/check-update` answers from that cache and refreshes in
+  the background, so it never waits on the network. A cold cache responds with
+  `checking: true` and no result yet; the Admin UI re-requests shortly after to
+  pick up the outcome. A failed check is reported in the response's `error`
+  field, and the rest of the page renders as usual.
+
+```bash
+# Allow 15 seconds for the release lookup (default: 5000)
+export VERSION_CHECK_TIMEOUT_MS=15000
+```
+
 **Disabling the version check entirely:**
 
 Set `NO_VERSION_CHECK=true` (or `IHUB_NO_VERSION_CHECK=true`) to prevent the

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -653,10 +653,10 @@ traffic to `api.github.com` is dropped rather than refused, the request would
 otherwise hang until the operating system's TCP timeout and leave the admin
 start page on its loading placeholders (issue #2150).
 
-- The request aborts after 5 seconds. Override with `VERSION_CHECK_TIMEOUT_MS`
+- The request aborts after 1 second. Override with `VERSION_CHECK_TIMEOUT_MS`
   (or `IHUB_VERSION_CHECK_TIMEOUT_MS`), in milliseconds, for slow links or
   strict proxies. Values are clamped to 500 ms – 60 s.
-- Results are cached for 1 hour, failures for 5 minutes, so opening the Admin UI
+- Results and failures are both cached for 5 minutes, so opening the Admin UI
   does not trigger a fresh request to GitHub every time.
 - `GET /api/admin/version/check-update` answers from that cache and refreshes in
   the background, so it never waits on the network. A cold cache responds with
@@ -665,7 +665,7 @@ start page on its loading placeholders (issue #2150).
   field, and the rest of the page renders as usual.
 
 ```bash
-# Allow 15 seconds for the release lookup (default: 5000)
+# Allow 15 seconds for the release lookup (default: 1000)
 export VERSION_CHECK_TIMEOUT_MS=15000
 ```
 

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,5 +1,24 @@
 # Features — 5.5.0
 
+## The Admin Dashboard No Longer Waits for the GitHub Update Check
+
+On installations without outbound internet access, the admin start page showed nothing but grey
+loading placeholders. The dashboard was waiting for the update check against `api.github.com`, which
+never answered — where a firewall drops packets instead of refusing them, the request hung until the
+operating system's TCP timeout, minutes later. The update check now runs on its own and the page
+renders immediately.
+
+- The check aborts after 5 seconds. Set `VERSION_CHECK_TIMEOUT_MS` (or
+  `IHUB_VERSION_CHECK_TIMEOUT_MS`) to change that, for example on slow links or through a strict
+  proxy.
+- Results are cached for one hour and failures for five minutes, so opening the dashboard no longer
+  triggers a fresh request to GitHub every time. The admin endpoint answers from that cache and
+  refreshes in the background, so it never blocks on the network.
+- If the check fails or times out, the dashboard and the **Updates** page render fully — only the
+  "new version available" badge is missing. The **Updates** page shows the version cards regardless.
+- To stop the server contacting GitHub at all, `NO_VERSION_CHECK=true` still applies and skips the
+  request entirely.
+
 ## OAuth Login for MCP Clients No Longer Fails With "Authorization code is invalid or expired"
 
 Fixed a bug that made the OAuth 2.0 authorization code flow fail on any multi-worker deployment

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1,24 +1,5 @@
 # Features — 5.5.0
 
-## The Admin Dashboard No Longer Waits for the GitHub Update Check
-
-On installations without outbound internet access, the admin start page showed nothing but grey
-loading placeholders. The dashboard was waiting for the update check against `api.github.com`, which
-never answered — where a firewall drops packets instead of refusing them, the request hung until the
-operating system's TCP timeout, minutes later. The update check now runs on its own and the page
-renders immediately.
-
-- The check aborts after 5 seconds. Set `VERSION_CHECK_TIMEOUT_MS` (or
-  `IHUB_VERSION_CHECK_TIMEOUT_MS`) to change that, for example on slow links or through a strict
-  proxy.
-- Results are cached for one hour and failures for five minutes, so opening the dashboard no longer
-  triggers a fresh request to GitHub every time. The admin endpoint answers from that cache and
-  refreshes in the background, so it never blocks on the network.
-- If the check fails or times out, the dashboard and the **Updates** page render fully — only the
-  "new version available" badge is missing. The **Updates** page shows the version cards regardless.
-- To stop the server contacting GitHub at all, `NO_VERSION_CHECK=true` still applies and skips the
-  request entirely.
-
 ## OAuth Login for MCP Clients No Longer Fails With "Authorization code is invalid or expired"
 
 Fixed a bug that made the OAuth 2.0 authorization code flow fail on any multi-worker deployment

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -1,0 +1,20 @@
+# Fixes — 5.5.0
+
+## The Admin Dashboard No Longer Waits for the GitHub Update Check
+
+On installations without outbound internet access, the admin start page showed nothing but grey
+loading placeholders. The dashboard was waiting for the update check against `api.github.com`, which
+never answered — where a firewall drops packets instead of refusing them, the request hung until the
+operating system's TCP timeout, minutes later. The update check now runs on its own and the page
+renders immediately.
+
+- The check aborts after 1 second. Set `VERSION_CHECK_TIMEOUT_MS` (or
+  `IHUB_VERSION_CHECK_TIMEOUT_MS`) to change that, for example on slow links or through a strict
+  proxy.
+- Results and failures are both cached for 5 minutes, so opening the dashboard no longer triggers a
+  fresh request to GitHub every time. The admin endpoint answers from that cache and refreshes in
+  the background, so it never blocks on the network.
+- If the check fails or times out, the dashboard and the **Updates** page render fully — only the
+  "new version available" badge is missing. The **Updates** page shows the version cards regardless.
+- To stop the server contacting GitHub at all, `NO_VERSION_CHECK=true` still applies and skips the
+  request entirely.

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -90,6 +90,8 @@ For Model Context Protocol (MCP) servers, see [MCP Integration](mcp-integration.
 | `AZURE_TENANT_ID`          | Azure tenant ID for the Office 365 / Microsoft Teams cloud storage integration. | – |
 | `NTLM_LDAP_USER`           | LDAP bind user for NTLM authentication domain controller queries. Overrides `ntlmAuth.domainControllerUser` in `platform.json`. | – |
 | `NTLM_LDAP_PASSWORD`       | LDAP bind password for NTLM authentication domain controller queries. Overrides `ntlmAuth.domainControllerPassword` in `platform.json`. | – |
+| `NO_VERSION_CHECK`         | Skip the release lookup against `api.github.com` entirely (alias: `IHUB_NO_VERSION_CHECK`). Truthy: `1`, `true`, `yes`, `on`. See [Update Procedures](INSTALLATION.md#update-procedures). | – |
+| `VERSION_CHECK_TIMEOUT_MS` | Abort deadline in milliseconds for the release lookup (alias: `IHUB_VERSION_CHECK_TIMEOUT_MS`). Clamped to 500–60000. | `5000` |
 
 The concurrency of outbound requests is configured via `requestConcurrency` in `contents/config/platform.json` and can be overridden per model or tool. If this value is omitted or below `1`, requests are not throttled.
 The delay between requests can be adjusted with `requestDelayMs` in the same configuration files. A value of `0` disables the delay.

--- a/docs/server-config.md
+++ b/docs/server-config.md
@@ -91,7 +91,7 @@ For Model Context Protocol (MCP) servers, see [MCP Integration](mcp-integration.
 | `NTLM_LDAP_USER`           | LDAP bind user for NTLM authentication domain controller queries. Overrides `ntlmAuth.domainControllerUser` in `platform.json`. | – |
 | `NTLM_LDAP_PASSWORD`       | LDAP bind password for NTLM authentication domain controller queries. Overrides `ntlmAuth.domainControllerPassword` in `platform.json`. | – |
 | `NO_VERSION_CHECK`         | Skip the release lookup against `api.github.com` entirely (alias: `IHUB_NO_VERSION_CHECK`). Truthy: `1`, `true`, `yes`, `on`. See [Update Procedures](INSTALLATION.md#update-procedures). | – |
-| `VERSION_CHECK_TIMEOUT_MS` | Abort deadline in milliseconds for the release lookup (alias: `IHUB_VERSION_CHECK_TIMEOUT_MS`). Clamped to 500–60000. | `5000` |
+| `VERSION_CHECK_TIMEOUT_MS` | Abort deadline in milliseconds for the release lookup (alias: `IHUB_VERSION_CHECK_TIMEOUT_MS`). Clamped to 500–60000. | `1000` |
 
 The concurrency of outbound requests is configured via `requestConcurrency` in `contents/config/platform.json` and can be overridden per model or tool. If this value is omitted or below `1`, requests are not throttled.
 The delay between requests can be adjusted with `requestDelayMs` in the same configuration files. A value of `0` disables the delay.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -624,8 +624,9 @@ normal and neither blocks the page.
 - Upgrade to 5.5.0 or later — the check is bounded and no longer blocks the page.
 - Set `NO_VERSION_CHECK=true` to skip the release lookup entirely on air-gapped
   installations.
-- Raise `VERSION_CHECK_TIMEOUT_MS` (default `5000`) if GitHub is reachable but
-  slow, for example through a strict proxy.
+- Raise `VERSION_CHECK_TIMEOUT_MS` (default `1000`) if GitHub is reachable but
+  slow, for example through a strict proxy — a check that times out means no
+  "update available" badge, nothing worse.
 - Check the server log for `component: VersionCheck` warnings to see what the
   lookup reported.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -594,6 +594,41 @@ curl -v https://api.openai.com/v1/models
 - **Timeout Issues:** Increase `REQUEST_TIMEOUT` environment variable
 - **Proxy Issues:** Configure proxy settings in environment
 
+### Admin Start Page Shows Only Grey Loading Boxes
+
+**Symptoms:**
+- `/admin` renders animated grey placeholders and never loads the dashboard
+- Typically on installations without outbound internet access
+
+**Cause:**
+
+The dashboard's update check contacts `api.github.com`. Where a firewall drops
+packets instead of refusing them, the connection never completes. Before 5.5.0
+the page waited for that request, so it stayed on its loading placeholders until
+the operating system's TCP timeout — minutes later.
+
+**Debugging Steps:**
+
+```bash
+# Should answer immediately, even with no internet access
+curl -s -w '\n%{time_total}s\n' -b "authToken=$TOKEN" \
+     http://localhost:3000/api/admin/version/check-update
+```
+
+A failed or timed-out check is reported in the response's `error` field; a check
+still running comes back as `"checking": true` with no result yet. Both are
+normal and neither blocks the page.
+
+**Solutions:**
+
+- Upgrade to 5.5.0 or later — the check is bounded and no longer blocks the page.
+- Set `NO_VERSION_CHECK=true` to skip the release lookup entirely on air-gapped
+  installations.
+- Raise `VERSION_CHECK_TIMEOUT_MS` (default `5000`) if GitHub is reachable but
+  slow, for example through a strict proxy.
+- Check the server log for `component: VersionCheck` warnings to see what the
+  lookup reported.
+
 ---
 
 ## Performance Problems

--- a/server/routes/admin/changelog.js
+++ b/server/routes/admin/changelog.js
@@ -45,23 +45,17 @@ export default function registerAdminChangelogRoutes(app) {
       const changelog = [];
       for (const version of versions) {
         const versionDir = join(releasesDir, version);
-        let features = '';
-        let breakingChanges = '';
 
-        try {
-          features = await fs.readFile(join(versionDir, 'features.md'), 'utf8');
-        } catch {
-          // No features file
-        }
+        // A release directory may be missing any of these — older ones predate
+        // the features/fixes split, so `fixes.md` in particular is often absent.
+        const [features, fixes, breakingChanges] = await Promise.all(
+          ['features.md', 'fixes.md', 'breaking-changes.md'].map(name =>
+            fs.readFile(join(versionDir, name), 'utf8').catch(() => '')
+          )
+        );
 
-        try {
-          breakingChanges = await fs.readFile(join(versionDir, 'breaking-changes.md'), 'utf8');
-        } catch {
-          // No breaking changes file
-        }
-
-        if (features || breakingChanges) {
-          changelog.push({ version, features, breakingChanges });
+        if (features || fixes || breakingChanges) {
+          changelog.push({ version, features, fixes, breakingChanges });
         }
       }
 

--- a/server/routes/admin/version.js
+++ b/server/routes/admin/version.js
@@ -1,9 +1,12 @@
 import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import { getAppVersion } from '../../utils/versionHelper.js';
-import { httpFetch } from '../../utils/httpConfig.js';
-import { compareVersions, isVersionCheckDisabled } from '../../services/updateService.js';
-import logger from '../../utils/logger.js';
+import {
+  buildUpdateInfo,
+  getVersionCheckEntry,
+  isVersionCheckDisabled,
+  startBackgroundVersionCheck
+} from '../../services/versionCheckService.js';
 import { sendInternalError } from '../../utils/responseHelpers.js';
 
 export default function registerAdminVersionRoutes(app) {
@@ -36,16 +39,25 @@ export default function registerAdminVersionRoutes(app) {
 
   /**
    * GET /api/admin/version/check-update
-   * Checks if a newer version is available on GitHub
+   * Reports whether a newer version is available on GitHub.
+   *
+   * This handler never waits on the network (issue #2150). It answers from the
+   * version-check cache and, when that cache is cold or stale, kicks off a
+   * background refresh whose result the next request picks up. Installations
+   * without outbound internet access therefore get an immediate response
+   * instead of a request that hangs until the OS TCP timeout — which used to
+   * leave the Admin Overview stuck on loading skeletons.
    *
    * Returns:
    * - updateAvailable: boolean
    * - currentVersion: string
-   * - latestVersion: string (if available)
-   * - releaseUrl: string (if available)
-   * - error: string (if check failed)
+   * - latestVersion: string (if a check has succeeded)
+   * - releaseUrl: string (if a check has succeeded)
+   * - checking: boolean — a check is running; re-request shortly for the result
+   * - lastCheckedAt: ISO string | null — when the cached result was produced
+   * - error: string (if the last check failed)
    */
-  app.get(buildServerPath('/api/admin/version/check-update'), adminAuth, async (req, res) => {
+  app.get(buildServerPath('/api/admin/version/check-update'), adminAuth, (req, res) => {
     try {
       const currentVersion = getAppVersion();
 
@@ -53,65 +65,18 @@ export default function registerAdminVersionRoutes(app) {
         return res.json({
           updateAvailable: false,
           currentVersion,
-          versionCheckDisabled: true
+          versionCheckDisabled: true,
+          checking: false,
+          lastCheckedAt: null
         });
       }
 
-      // Fetch latest release from GitHub
-      const response = await httpFetch(
-        'https://api.github.com/repos/intrafind/ihub-apps/releases/latest',
-        {
-          headers: {
-            Accept: 'application/vnd.github.v3+json',
-            'User-Agent': 'ihub-apps'
-          }
-        }
-      );
+      const entry = getVersionCheckEntry();
+      const checking = startBackgroundVersionCheck();
 
-      if (!response.ok) {
-        // If no releases found or other error, return no update available
-        return res.json({
-          updateAvailable: false,
-          currentVersion,
-          error:
-            response.status === 404 ? 'No releases found' : `GitHub API error: ${response.status}`
-        });
-      }
-
-      const releaseData = await response.json();
-
-      // Validate tag_name exists
-      if (!releaseData.tag_name) {
-        return res.json({
-          updateAvailable: false,
-          currentVersion,
-          error: 'Invalid release data from GitHub'
-        });
-      }
-
-      const latestVersion = releaseData.tag_name.replace(/^v/, ''); // Remove 'v' prefix if present
-
-      // Simple version comparison
-      const updateAvailable = compareVersions(latestVersion, currentVersion) > 0;
-
-      res.json({
-        updateAvailable,
-        currentVersion,
-        latestVersion,
-        releaseUrl: releaseData.html_url,
-        releaseName: releaseData.name,
-        publishedAt: releaseData.published_at
-      });
+      res.json(buildUpdateInfo(entry, currentVersion, { checking }));
     } catch (error) {
-      logger.error('Error checking for updates', { component: 'AdminVersion', error });
-
-      // Return graceful response with no update available on error
-      const currentVersion = getAppVersion();
-      res.json({
-        updateAvailable: false,
-        currentVersion,
-        error: 'Failed to check for updates: ' + error.message
-      });
+      return sendInternalError(res, error, 'check for updates');
     }
   });
 }

--- a/server/services/updateService.js
+++ b/server/services/updateService.js
@@ -21,11 +21,15 @@ import { promisify } from 'util';
 import { getRootDir } from '../pathUtils.js';
 import { getAppVersion } from '../utils/versionHelper.js';
 import { httpFetch } from '../utils/httpConfig.js';
+import {
+  buildUpdateInfo,
+  isVersionCheckDisabled,
+  refreshVersionCheck
+} from './versionCheckService.js';
 import logger from '../utils/logger.js';
 
 const execAsync = promisify(execFile);
 
-const GITHUB_REPO = 'intrafind/ihub-apps';
 const UPDATE_TMP_DIR = '.update-tmp';
 const UPDATE_STAGING_DIR = '.update-staging';
 const UPDATE_BACKUP_DIR = '.update-backup';
@@ -126,19 +130,6 @@ export function isContainerInstallation() {
   return false;
 }
 
-/**
- * Check if remote version checks against GitHub are disabled.
- *
- * Opt-in via `NO_VERSION_CHECK` (or `IHUB_NO_VERSION_CHECK`) for air-gapped
- * deployments, environments where outbound traffic to api.github.com is
- * blocked, or admins who simply don't want the Admin UI to phone home.
- * Not set by default.
- */
-export function isVersionCheckDisabled() {
-  const value = process.env.NO_VERSION_CHECK || process.env.IHUB_NO_VERSION_CHECK;
-  return !!value && /^(1|true|yes|on)$/i.test(value);
-}
-
 // In-memory update state
 let updateState = {
   status: 'idle', // idle | checking | downloading | extracting | staging | applying | restarting | error
@@ -233,103 +224,58 @@ async function releaseLock() {
 }
 
 /**
- * Compare two semantic versions
- * Returns: 1 if v1 > v2, -1 if v1 < v2, 0 if equal
+ * Check for available updates from GitHub Releases, resolving the download
+ * assets for this platform.
+ *
+ * The GitHub lookup runs through versionCheckService, so it is bounded by the
+ * version-check timeout and shares that service's cache — a download started
+ * right after a check therefore reuses the release the admin was shown.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.force] - Bypass the cached release and re-query GitHub.
  */
-export function compareVersions(v1, v2) {
-  if (!v1 || !v2) return 0;
-
-  const cleanV1 = v1.split('-')[0];
-  const cleanV2 = v2.split('-')[0];
-
-  const parts1 = cleanV1.split('.').map(p => parseInt(p, 10) || 0);
-  const parts2 = cleanV2.split('.').map(p => parseInt(p, 10) || 0);
-
-  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-    const p1 = parts1[i] || 0;
-    const p2 = parts2[i] || 0;
-    if (p1 > p2) return 1;
-    if (p1 < p2) return -1;
-  }
-  return 0;
-}
-
-/**
- * Check for available updates from GitHub Releases
- */
-export async function checkForUpdate() {
+export async function checkForUpdate({ force = false } = {}) {
   setState({ status: 'checking', error: null });
+
+  const currentVersion = getAppVersion();
 
   if (isVersionCheckDisabled()) {
     setState({ status: 'idle' });
     return {
       updateAvailable: false,
-      currentVersion: getAppVersion(),
+      currentVersion,
       versionCheckDisabled: true
     };
   }
 
-  try {
-    const currentVersion = getAppVersion();
-    const platform = detectPlatform();
+  const entry = await refreshVersionCheck({ force });
+  const info = buildUpdateInfo(entry, currentVersion);
 
-    const response = await httpFetch(
-      `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`,
-      {
-        headers: {
-          Accept: 'application/vnd.github.v3+json',
-          'User-Agent': 'ihub-apps-updater'
-        }
-      }
-    );
+  setState({ status: 'idle', error: info.error ?? null });
 
-    if (!response.ok) {
-      setState({ status: 'idle' });
-      return {
-        updateAvailable: false,
-        currentVersion,
-        error:
-          response.status === 404 ? 'No releases found' : `GitHub API error: ${response.status}`
-      };
-    }
-
-    const releaseData = await response.json();
-    if (!releaseData.tag_name) {
-      setState({ status: 'idle' });
-      return { updateAvailable: false, currentVersion, error: 'Invalid release data' };
-    }
-
-    const latestVersion = releaseData.tag_name.replace(/^v/, '');
-    const updateAvailable = compareVersions(latestVersion, currentVersion) > 0;
-
-    // Find the matching asset for this platform
-    const archiveName = `ihub-apps-${releaseData.tag_name}-${platform}.tar.gz`;
-    const asset = releaseData.assets?.find(a => a.name === archiveName);
-    const checksumsAsset = releaseData.assets?.find(a => a.name === 'checksums.sha256');
-
-    setState({ status: 'idle' });
-
-    return {
-      updateAvailable,
-      currentVersion,
-      latestVersion,
-      releaseUrl: releaseData.html_url,
-      releaseName: releaseData.name,
-      publishedAt: releaseData.published_at,
-      platform,
-      assetUrl: asset?.browser_download_url || null,
-      assetSize: asset?.size || null,
-      checksumsUrl: checksumsAsset?.browser_download_url || null,
-      tagName: releaseData.tag_name
-    };
-  } catch (error) {
-    setState({ status: 'idle', error: error.message });
+  if (info.error || !entry.release) {
     return {
       updateAvailable: false,
-      currentVersion: getAppVersion(),
-      error: 'Failed to check for updates: ' + error.message
+      currentVersion,
+      error: info.error ?? 'No release information available'
     };
   }
+
+  // Find the matching asset for this platform
+  const platform = detectPlatform();
+  const tagName = entry.release.tag_name;
+  const archiveName = `ihub-apps-${tagName}-${platform}.tar.gz`;
+  const asset = entry.release.assets?.find(a => a.name === archiveName);
+  const checksumsAsset = entry.release.assets?.find(a => a.name === 'checksums.sha256');
+
+  return {
+    ...info,
+    platform,
+    assetUrl: asset?.browser_download_url || null,
+    assetSize: asset?.size || null,
+    checksumsUrl: checksumsAsset?.browser_download_url || null,
+    tagName
+  };
 }
 
 /**

--- a/server/services/versionCheckService.js
+++ b/server/services/versionCheckService.js
@@ -1,0 +1,301 @@
+/**
+ * Version Check Service
+ *
+ * Single place for "is a newer release available?" lookups against the GitHub
+ * Releases API. Every caller (Admin UI, update service, update CLI) goes
+ * through here so the outbound request is always bounded by a timeout and
+ * answered from a short-lived cache.
+ *
+ * Why (issue #2150): the Admin Overview blocked on
+ * `/api/admin/version/check-update`, which fetched api.github.com with no
+ * timeout. In deployments without outbound internet access packets are usually
+ * dropped rather than refused, so the connection never completes and the
+ * request hung until the OS TCP timeout — minutes — leaving the dashboard
+ * showing nothing but loading skeletons. The fetch now aborts after a few
+ * seconds, both results and failures are cached, and the Admin endpoint answers
+ * from that cache while refreshing in the background.
+ */
+import { publish, subscribe } from '../clusterBus.js';
+import { httpFetch } from '../utils/httpConfig.js';
+import logger from '../utils/logger.js';
+
+export const GITHUB_REPO = 'intrafind/ihub-apps';
+const LATEST_RELEASE_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+
+/** Cluster bus channel carrying a completed check to the other workers. */
+const CLUSTER_CHANNEL = 'versionCheck:result';
+
+/** Abort deadline for the GitHub request when not overridden by env. */
+const DEFAULT_TIMEOUT_MS = 5000;
+const MIN_TIMEOUT_MS = 500;
+const MAX_TIMEOUT_MS = 60000;
+
+/** How long a successful lookup is served from cache before it is refreshed. */
+export const SUCCESS_TTL_MS = 60 * 60 * 1000; // 1 hour
+/** Failures are retried sooner, but not on every single admin page load. */
+export const FAILURE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Last completed check: `{ release, error, checkedAt, expiresAt }`.
+ * `null` until the first check completes.
+ */
+let cacheEntry = null;
+
+/** Promise of the check currently running, so concurrent callers share one request. */
+let inFlight = null;
+
+/**
+ * Check if remote version checks against GitHub are disabled.
+ *
+ * Opt-in via `NO_VERSION_CHECK` (or `IHUB_NO_VERSION_CHECK`) for air-gapped
+ * deployments, environments where outbound traffic to api.github.com is
+ * blocked, or admins who simply don't want the Admin UI to phone home.
+ * Not set by default.
+ */
+export function isVersionCheckDisabled() {
+  const value = process.env.NO_VERSION_CHECK || process.env.IHUB_NO_VERSION_CHECK;
+  return !!value && /^(1|true|yes|on)$/i.test(value);
+}
+
+/**
+ * Abort deadline for the GitHub request, in milliseconds.
+ *
+ * Override with `VERSION_CHECK_TIMEOUT_MS` (or `IHUB_VERSION_CHECK_TIMEOUT_MS`)
+ * for slow links or strict proxies. Clamped so a typo can't reintroduce the
+ * effectively-unbounded wait this service exists to prevent.
+ */
+export function getVersionCheckTimeoutMs() {
+  const raw = process.env.VERSION_CHECK_TIMEOUT_MS || process.env.IHUB_VERSION_CHECK_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TIMEOUT_MS;
+  return Math.min(Math.max(parsed, MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
+}
+
+/**
+ * Compare two semantic versions
+ * Returns: 1 if v1 > v2, -1 if v1 < v2, 0 if equal
+ */
+export function compareVersions(v1, v2) {
+  if (!v1 || !v2) return 0;
+
+  const cleanV1 = v1.split('-')[0];
+  const cleanV2 = v2.split('-')[0];
+
+  const parts1 = cleanV1.split('.').map(p => parseInt(p, 10) || 0);
+  const parts2 = cleanV2.split('.').map(p => parseInt(p, 10) || 0);
+
+  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+    const p1 = parts1[i] || 0;
+    const p2 = parts2[i] || 0;
+    if (p1 > p2) return 1;
+    if (p1 < p2) return -1;
+  }
+  return 0;
+}
+
+/**
+ * An aborted request surfaces differently depending on the fetch implementation:
+ * node-fetch raises an `AbortError`, while `AbortSignal.timeout()` itself
+ * rejects with a `TimeoutError` DOMException.
+ */
+function isAbortError(error) {
+  return error?.name === 'AbortError' || error?.name === 'TimeoutError';
+}
+
+/**
+ * Keep only the release fields this codebase reads. GitHub's payload carries the
+ * full release notes and a verbose entry per asset; the trimmed shape is what
+ * gets cached and relayed to the other workers, so nothing downstream should
+ * reach for a field that is not listed here.
+ */
+function normalizeRelease(release) {
+  return {
+    tag_name: release.tag_name,
+    name: release.name ?? null,
+    html_url: release.html_url ?? null,
+    published_at: release.published_at ?? null,
+    assets: Array.isArray(release.assets)
+      ? release.assets.map(asset => ({
+          name: asset.name,
+          browser_download_url: asset.browser_download_url,
+          size: asset.size
+        }))
+      : []
+  };
+}
+
+/**
+ * Perform the actual GitHub request. Never throws — network problems, HTTP
+ * errors and timeouts all come back as `{ error }` so a failed check is just
+ * another cacheable outcome.
+ *
+ * @param {number} timeoutMs
+ * @returns {Promise<{ release?: object, error?: string }>}
+ */
+async function fetchLatestRelease(timeoutMs) {
+  try {
+    const response = await httpFetch(LATEST_RELEASE_URL, {
+      headers: {
+        Accept: 'application/vnd.github.v3+json',
+        'User-Agent': 'ihub-apps'
+      },
+      signal: AbortSignal.timeout(timeoutMs)
+    });
+
+    if (!response.ok) {
+      return {
+        error:
+          response.status === 404 ? 'No releases found' : `GitHub API error: ${response.status}`
+      };
+    }
+
+    const release = await response.json();
+    if (!release?.tag_name) {
+      return { error: 'Invalid release data from GitHub' };
+    }
+
+    return { release: normalizeRelease(release) };
+  } catch (error) {
+    if (isAbortError(error)) {
+      return {
+        error: `Version check timed out after ${timeoutMs}ms (api.github.com unreachable?)`
+      };
+    }
+    return { error: `Failed to check for updates: ${error.message}` };
+  }
+}
+
+/**
+ * Run a check (or join the one already running) and cache its outcome.
+ *
+ * @param {Object} [options]
+ * @param {boolean} [options.force] - Ignore a still-valid cache entry.
+ * @returns {Promise<{ release: object|null, error: string|null, checkedAt: number, expiresAt: number }>}
+ */
+export function refreshVersionCheck({ force = false } = {}) {
+  if (!force && cacheEntry && cacheEntry.expiresAt > Date.now()) {
+    return Promise.resolve(cacheEntry);
+  }
+  if (inFlight) return inFlight;
+
+  const timeoutMs = getVersionCheckTimeoutMs();
+  inFlight = fetchLatestRelease(timeoutMs)
+    .then(outcome => {
+      const checkedAt = Date.now();
+      cacheEntry = {
+        release: outcome.release ?? null,
+        error: outcome.error ?? null,
+        checkedAt,
+        expiresAt: checkedAt + (outcome.error ? FAILURE_TTL_MS : SUCCESS_TTL_MS)
+      };
+
+      if (outcome.error) {
+        logger.warn('Version check failed', {
+          component: 'VersionCheck',
+          error: outcome.error,
+          retryInMs: FAILURE_TTL_MS
+        });
+      } else {
+        logger.debug('Version check completed', {
+          component: 'VersionCheck',
+          latestTag: outcome.release.tag_name
+        });
+      }
+
+      // One check warms the whole cluster. Without this each worker would query
+      // GitHub separately, and an Admin UI request — distributed round-robin —
+      // could keep landing on workers that have not checked yet.
+      publish(CLUSTER_CHANNEL, cacheEntry);
+
+      return cacheEntry;
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+
+  return inFlight;
+}
+
+/** Adopt a result another worker produced, unless this worker has a newer one. */
+subscribe(CLUSTER_CHANNEL, payload => {
+  if (!payload || typeof payload.checkedAt !== 'number') return;
+  // A relay carries either a release or an error, never a half-built release.
+  if (payload.release && typeof payload.release.tag_name !== 'string') return;
+  if (cacheEntry && cacheEntry.checkedAt >= payload.checkedAt) return;
+
+  cacheEntry = {
+    release: payload.release ?? null,
+    error: payload.error ?? null,
+    checkedAt: payload.checkedAt,
+    expiresAt: payload.expiresAt
+  };
+});
+
+/** Last completed check, or `null` when no check has finished yet. */
+export function getVersionCheckEntry() {
+  return cacheEntry;
+}
+
+/** True when there is no cached check or the cached one has expired. */
+export function isVersionCheckStale() {
+  return !cacheEntry || cacheEntry.expiresAt <= Date.now();
+}
+
+/**
+ * Kick off a refresh without waiting for it. Used by request handlers that must
+ * answer immediately: they serve whatever is cached (possibly nothing) and let
+ * the next request pick up the fresh result.
+ *
+ * @returns {boolean} True when a check is running after this call, i.e. the
+ *   caller's response may be missing or stale and worth re-requesting.
+ */
+export function startBackgroundVersionCheck() {
+  if (inFlight) return true;
+  if (!isVersionCheckStale()) return false;
+
+  // fetchLatestRelease() swallows its own failures; catch anyway so an
+  // unexpected throw can never become an unhandled rejection.
+  refreshVersionCheck().catch(error => {
+    logger.debug('Background version check rejected', { component: 'VersionCheck', error });
+  });
+  return true;
+}
+
+/**
+ * Shape a cache entry into the update-info payload used by the Admin API, the
+ * update service and the CLI.
+ *
+ * @param {Object|null} entry - Cache entry from `getVersionCheckEntry()`/`refreshVersionCheck()`
+ * @param {string} currentVersion - Version this installation is running
+ * @param {Object} [options]
+ * @param {boolean} [options.checking] - A check is running; the payload may be stale or empty
+ */
+export function buildUpdateInfo(entry, currentVersion, { checking = false } = {}) {
+  const info = {
+    updateAvailable: false,
+    currentVersion,
+    checking,
+    lastCheckedAt: entry ? new Date(entry.checkedAt).toISOString() : null
+  };
+
+  if (!entry) return info;
+  if (entry.error) return { ...info, error: entry.error };
+  if (!entry.release?.tag_name) return info; // checked, but nothing usable came back
+
+  const latestVersion = entry.release.tag_name.replace(/^v/, ''); // Remove 'v' prefix if present
+
+  return {
+    ...info,
+    updateAvailable: compareVersions(latestVersion, currentVersion) > 0,
+    latestVersion,
+    releaseUrl: entry.release.html_url,
+    releaseName: entry.release.name,
+    publishedAt: entry.release.published_at
+  };
+}
+
+/** Test seam: drop cached state so each case starts from a cold cache. */
+export function resetVersionCheckCache() {
+  cacheEntry = null;
+  inFlight = null;
+}

--- a/server/services/versionCheckService.js
+++ b/server/services/versionCheckService.js
@@ -218,16 +218,24 @@ export function refreshVersionCheck({ force = false } = {}) {
 
 /**
  * A relay is adopted only when it is shaped like something this module could
- * have produced: both timestamps numeric, and either a release carrying a tag or
- * a non-empty error — never both, never neither.
+ * have produced: a finite, ordered timestamp pair, and either a release carrying
+ * a tag or a non-empty error — never both, never neither.
  *
- * The `expiresAt` check is what matters most. `undefined <= Date.now()` is
- * false, so an entry cached without a usable expiry would read as fresh
- * forever and that worker would never check for a new release again.
+ * The timestamps carry the sharp edges, and `typeof x === 'number'` is not
+ * enough to blunt them, since `NaN` and `Infinity` both pass it:
+ *  - `NaN <= Date.now()` is false, as is `undefined <= Date.now()`, so an entry
+ *    cached with either expiry would read as fresh forever and that worker would
+ *    never check for a new release again.
+ *  - `new Date(NaN).toISOString()` throws `RangeError`, which would turn the
+ *    admin endpoint's `lastCheckedAt` into a 500.
+ *
+ * A stale-looking entry is the safe direction — it just triggers a refresh — so
+ * `expiresAt` must genuinely follow `checkedAt` to be believed.
  */
 function isValidRelay(payload) {
   if (!payload) return false;
-  if (typeof payload.checkedAt !== 'number' || typeof payload.expiresAt !== 'number') return false;
+  if (!Number.isFinite(payload.checkedAt) || !Number.isFinite(payload.expiresAt)) return false;
+  if (payload.expiresAt <= payload.checkedAt) return false;
 
   const hasRelease = typeof payload.release?.tag_name === 'string';
   const hasError = typeof payload.error === 'string' && payload.error.length > 0;

--- a/server/services/versionCheckService.js
+++ b/server/services/versionCheckService.js
@@ -11,9 +11,9 @@
  * timeout. In deployments without outbound internet access packets are usually
  * dropped rather than refused, so the connection never completes and the
  * request hung until the OS TCP timeout — minutes — leaving the dashboard
- * showing nothing but loading skeletons. The fetch now aborts after a few
- * seconds, both results and failures are cached, and the Admin endpoint answers
- * from that cache while refreshing in the background.
+ * showing nothing but loading skeletons. The fetch now aborts after a second,
+ * both results and failures are cached, and the Admin endpoint answers from that
+ * cache while refreshing in the background.
  */
 import { publish, subscribe } from '../clusterBus.js';
 import { httpFetch } from '../utils/httpConfig.js';
@@ -26,14 +26,17 @@ const LATEST_RELEASE_URL = `https://api.github.com/repos/${GITHUB_REPO}/releases
 const CLUSTER_CHANNEL = 'versionCheck:result';
 
 /** Abort deadline for the GitHub request when not overridden by env. */
-const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_TIMEOUT_MS = 1000;
 const MIN_TIMEOUT_MS = 500;
 const MAX_TIMEOUT_MS = 60000;
 
-/** How long a successful lookup is served from cache before it is refreshed. */
-export const SUCCESS_TTL_MS = 60 * 60 * 1000; // 1 hour
-/** Failures are retried sooner, but not on every single admin page load. */
-export const FAILURE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+/**
+ * How long a completed check is served from cache before another is allowed —
+ * results and failures alike. Short enough that a new release shows up promptly
+ * and a network that has come back is retried soon, long enough that opening the
+ * Admin UI does not query GitHub on every page load.
+ */
+export const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
  * Last completed check: `{ release, error, checkedAt, expiresAt }`.
@@ -186,14 +189,14 @@ export function refreshVersionCheck({ force = false } = {}) {
         release: outcome.release ?? null,
         error: outcome.error ?? null,
         checkedAt,
-        expiresAt: checkedAt + (outcome.error ? FAILURE_TTL_MS : SUCCESS_TTL_MS)
+        expiresAt: checkedAt + CACHE_TTL_MS
       };
 
       if (outcome.error) {
         logger.warn('Version check failed', {
           component: 'VersionCheck',
           error: outcome.error,
-          retryInMs: FAILURE_TTL_MS
+          retryInMs: CACHE_TTL_MS
         });
       } else {
         logger.debug('Version check completed', {

--- a/server/services/versionCheckService.js
+++ b/server/services/versionCheckService.js
@@ -216,11 +216,30 @@ export function refreshVersionCheck({ force = false } = {}) {
   return inFlight;
 }
 
+/**
+ * A relay is adopted only when it is shaped like something this module could
+ * have produced: both timestamps numeric, and either a release carrying a tag or
+ * a non-empty error — never both, never neither.
+ *
+ * The `expiresAt` check is what matters most. `undefined <= Date.now()` is
+ * false, so an entry cached without a usable expiry would read as fresh
+ * forever and that worker would never check for a new release again.
+ */
+function isValidRelay(payload) {
+  if (!payload) return false;
+  if (typeof payload.checkedAt !== 'number' || typeof payload.expiresAt !== 'number') return false;
+
+  const hasRelease = typeof payload.release?.tag_name === 'string';
+  const hasError = typeof payload.error === 'string' && payload.error.length > 0;
+  return hasRelease !== hasError;
+}
+
 /** Adopt a result another worker produced, unless this worker has a newer one. */
 subscribe(CLUSTER_CHANNEL, payload => {
-  if (!payload || typeof payload.checkedAt !== 'number') return;
-  // A relay carries either a release or an error, never a half-built release.
-  if (payload.release && typeof payload.release.tag_name !== 'string') return;
+  if (!isValidRelay(payload)) {
+    logger.debug('Ignoring malformed version-check relay', { component: 'VersionCheck' });
+    return;
+  }
   if (cacheEntry && cacheEntry.checkedAt >= payload.checkedAt) return;
 
   cacheEntry = {

--- a/tests/unit/client/admin-overview-update-check.test.jsx
+++ b/tests/unit/client/admin-overview-update-check.test.jsx
@@ -1,0 +1,147 @@
+/**
+ * Regression tests for #2150: the admin homepage showed nothing but grey
+ * animated skeleton boxes in deployments without outbound internet access.
+ *
+ * `useOverviewData` batched `/admin/version/check-update` — the only endpoint
+ * that leaves the machine — into the same `Promise.allSettled` as the local
+ * dashboard queries. `allSettled` settles when the *slowest* promise does, so a
+ * request to an unreachable api.github.com held `isLoading` true indefinitely
+ * and the whole dashboard stayed on its loading skeletons.
+ *
+ * The update check now runs on its own via `useUpdateCheck`, so these tests
+ * pin: the dashboard finishes loading while the check is still pending, and the
+ * check still reports its result (including across the server's `checking`
+ * hand-off) once it arrives.
+ */
+
+import '@testing-library/jest-dom';
+import { renderHook, waitFor, act } from '@testing-library/react';
+
+const mockMakeAdminApiCall = jest.fn();
+const mockFetchAdminApps = jest.fn();
+const mockFetchAdminPrompts = jest.fn();
+const mockFetchAdminSources = jest.fn();
+
+jest.mock('../../../client/src/api/adminApi', () => ({
+  __esModule: true,
+  makeAdminApiCall: (...args) => mockMakeAdminApiCall(...args),
+  fetchAdminApps: (...args) => mockFetchAdminApps(...args),
+  fetchAdminPrompts: (...args) => mockFetchAdminPrompts(...args),
+  fetchAdminSources: (...args) => mockFetchAdminSources(...args),
+  getAdminApiErrorMessage: err => err?.message ?? 'error'
+}));
+
+jest.mock('react-i18next', () => ({
+  __esModule: true,
+  useTranslation: () => ({ t: (key, fallback) => fallback ?? key })
+}));
+
+import { useOverviewData } from '../../../client/src/features/admin/hooks/useOverviewData';
+import { useUpdateCheck } from '../../../client/src/features/admin/hooks/useUpdateCheck';
+
+const CHECK_UPDATE = '/admin/version/check-update';
+
+beforeEach(() => {
+  jest.useRealTimers();
+  mockMakeAdminApiCall.mockReset();
+  mockFetchAdminApps.mockReset();
+  mockFetchAdminPrompts.mockReset();
+  mockFetchAdminSources.mockReset();
+
+  mockFetchAdminApps.mockResolvedValue([{ id: 'chat', enabled: true }]);
+  mockFetchAdminPrompts.mockResolvedValue([]);
+  mockFetchAdminSources.mockResolvedValue([]);
+});
+
+describe('useOverviewData', () => {
+  test('finishes loading while the GitHub update check is still pending', async () => {
+    // Never settles — an unreachable api.github.com behind the endpoint.
+    mockMakeAdminApiCall.mockImplementation(url =>
+      url === CHECK_UPDATE ? new Promise(() => {}) : Promise.resolve({ data: {} })
+    );
+
+    const { result } = renderHook(() => useOverviewData());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.stats).not.toBeNull();
+  });
+
+  test('does not request the update check at all', async () => {
+    mockMakeAdminApiCall.mockResolvedValue({ data: {} });
+
+    const { result } = renderHook(() => useOverviewData());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockMakeAdminApiCall.mock.calls.map(([url]) => url)).not.toContain(CHECK_UPDATE);
+  });
+
+  test('still renders stats when a local endpoint fails', async () => {
+    mockMakeAdminApiCall.mockImplementation(url =>
+      url === '/admin/overview/stats'
+        ? Promise.reject(new Error('boom'))
+        : Promise.resolve({ data: {} })
+    );
+
+    const { result } = renderHook(() => useOverviewData());
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.stats.apps.value).toBe(1);
+  });
+});
+
+describe('useUpdateCheck', () => {
+  test('reports an available update', async () => {
+    mockMakeAdminApiCall.mockResolvedValue({
+      data: { updateAvailable: true, latestVersion: '9.9.9', checking: false }
+    });
+
+    const { result } = renderHook(() => useUpdateCheck());
+
+    await waitFor(() => expect(result.current.updateInfo?.updateAvailable).toBe(true));
+    expect(result.current.updateInfo.latestVersion).toBe('9.9.9');
+  });
+
+  test('polls again while the server reports a check in flight', async () => {
+    jest.useFakeTimers();
+    mockMakeAdminApiCall
+      .mockResolvedValueOnce({ data: { updateAvailable: false, checking: true } })
+      .mockResolvedValueOnce({
+        data: { updateAvailable: true, latestVersion: '9.9.9', checking: false }
+      });
+
+    const { result } = renderHook(() => useUpdateCheck());
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(result.current.updateInfo).toMatchObject({ checking: true });
+
+    await act(async () => {
+      jest.advanceTimersByTime(3000);
+    });
+
+    await waitFor(() => expect(result.current.updateInfo?.updateAvailable).toBe(true));
+    expect(mockMakeAdminApiCall).toHaveBeenCalledTimes(2);
+  });
+
+  test('surfaces a failed check instead of throwing', async () => {
+    mockMakeAdminApiCall.mockRejectedValue(new Error('Network Error'));
+
+    const { result } = renderHook(() => useUpdateCheck());
+
+    await waitFor(() => expect(result.current.updateInfo?.error).toBe('Network Error'));
+    expect(result.current.updateInfo.updateAvailable).toBe(false);
+  });
+
+  test('skips the request when disabled (content-admin-only users)', async () => {
+    mockMakeAdminApiCall.mockResolvedValue({ data: { updateAvailable: true } });
+
+    const { result } = renderHook(() => useUpdateCheck({ enabled: false }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(mockMakeAdminApiCall).not.toHaveBeenCalled();
+    expect(result.current.updateInfo).toBeNull();
+  });
+});

--- a/tests/unit/server/versionCheckService.test.js
+++ b/tests/unit/server/versionCheckService.test.js
@@ -1,0 +1,430 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Regression tests for #2150: the Admin Overview rendered nothing but loading
+ * skeletons in deployments without outbound internet access, because
+ * `/api/admin/version/check-update` fetched api.github.com with no timeout.
+ * Where packets are dropped rather than refused the connection never
+ * completes, so the request hung until the OS TCP timeout.
+ *
+ * These tests pin the two properties that fix it: the GitHub lookup aborts on a
+ * deadline, and the admin endpoint answers from cache without ever awaiting the
+ * network.
+ */
+import { beforeEach, describe, expect, jest, test } from '@jest/globals';
+
+jest.mock('../../../server/utils/httpConfig.js', () => ({
+  httpFetch: jest.fn()
+}));
+
+jest.mock('../../../server/utils/logger.js', () => ({
+  __esModule: true,
+  default: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+}));
+
+jest.mock('../../../server/middleware/adminAuth.js', () => ({
+  adminAuth: (req, res, next) => next()
+}));
+
+jest.mock('../../../server/utils/versionHelper.js', () => ({
+  getAppVersion: () => '1.2.3'
+}));
+
+const mockPublish = jest.fn();
+
+// `subscribe` runs while the service module is being imported, so the handler
+// store has to be created inside the factory — a module-scope const is still in
+// its temporal dead zone at that point.
+jest.mock('../../../server/clusterBus.js', () => {
+  const handlers = {};
+  return {
+    __handlers: handlers,
+    publish: (...args) => mockPublish(...args),
+    subscribe: (type, handler) => {
+      handlers[type] = handler;
+      return () => delete handlers[type];
+    }
+  };
+});
+
+import { __handlers as clusterHandlers } from '../../../server/clusterBus.js';
+import { httpFetch } from '../../../server/utils/httpConfig.js';
+import {
+  FAILURE_TTL_MS,
+  SUCCESS_TTL_MS,
+  buildUpdateInfo,
+  getVersionCheckEntry,
+  getVersionCheckTimeoutMs,
+  isVersionCheckStale,
+  refreshVersionCheck,
+  resetVersionCheckCache,
+  startBackgroundVersionCheck
+} from '../../../server/services/versionCheckService.js';
+import registerAdminVersionRoutes from '../../../server/routes/admin/version.js';
+
+const CHECK_UPDATE_PATH = '/api/admin/version/check-update';
+
+/** A GitHub release payload, trimmed to the fields the service reads. */
+const release = (tagName = 'v9.9.9') => ({
+  tag_name: tagName,
+  name: `Release ${tagName}`,
+  html_url: `https://github.com/intrafind/ihub-apps/releases/tag/${tagName}`,
+  published_at: '2026-07-01T00:00:00Z',
+  assets: []
+});
+
+const okResponse = body => ({ ok: true, status: 200, json: async () => body });
+
+/**
+ * Stands in for a connection to a host that drops packets: the promise settles
+ * only when the caller's own AbortSignal fires, exactly as node-fetch behaves.
+ */
+const dropsPackets = () => (url, options) =>
+  new Promise((resolve, reject) => {
+    options.signal.addEventListener('abort', () => {
+      const error = new Error('The operation was aborted.');
+      error.name = 'AbortError';
+      reject(error);
+    });
+  });
+
+/** Collect the route handlers the module registers, skipping middleware. */
+function captureRoutes() {
+  const routes = {};
+  registerAdminVersionRoutes({
+    get: (path, ...handlers) => {
+      routes[path] = handlers[handlers.length - 1];
+    }
+  });
+  return routes;
+}
+
+function createResponse() {
+  const res = {
+    payload: undefined,
+    statusCode: 200,
+    json(body) {
+      res.payload = body;
+      return res;
+    },
+    status(code) {
+      res.statusCode = code;
+      return res;
+    }
+  };
+  return res;
+}
+
+const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+beforeEach(() => {
+  resetVersionCheckCache();
+  httpFetch.mockReset();
+  mockPublish.mockReset();
+  delete process.env.VERSION_CHECK_TIMEOUT_MS;
+  delete process.env.IHUB_VERSION_CHECK_TIMEOUT_MS;
+  delete process.env.NO_VERSION_CHECK;
+  delete process.env.IHUB_NO_VERSION_CHECK;
+  process.env.VERSION_CHECK_TIMEOUT_MS = '500';
+});
+
+describe('versionCheckService — timeout', () => {
+  test('aborts the GitHub request on the configured deadline instead of hanging', async () => {
+    httpFetch.mockImplementation(dropsPackets());
+
+    const startedAt = Date.now();
+    const entry = await refreshVersionCheck();
+
+    expect(Date.now() - startedAt).toBeLessThan(3000);
+    expect(entry.release).toBeNull();
+    expect(entry.error).toMatch(/timed out/);
+  });
+
+  test('passes an abort signal to the fetch', async () => {
+    httpFetch.mockImplementation(dropsPackets());
+    await refreshVersionCheck();
+
+    const [url, options] = httpFetch.mock.calls[0];
+    expect(url).toBe('https://api.github.com/repos/intrafind/ihub-apps/releases/latest');
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  test('reports network failures as a cached outcome rather than throwing', async () => {
+    httpFetch.mockRejectedValue(new Error('getaddrinfo EAI_AGAIN api.github.com'));
+
+    const entry = await refreshVersionCheck();
+    expect(entry.error).toMatch(/EAI_AGAIN/);
+  });
+
+  test('clamps the configured timeout and falls back to the default', () => {
+    process.env.VERSION_CHECK_TIMEOUT_MS = '12000';
+    expect(getVersionCheckTimeoutMs()).toBe(12000);
+
+    process.env.VERSION_CHECK_TIMEOUT_MS = '10';
+    expect(getVersionCheckTimeoutMs()).toBe(500);
+
+    process.env.VERSION_CHECK_TIMEOUT_MS = '999999999';
+    expect(getVersionCheckTimeoutMs()).toBe(60000);
+
+    process.env.VERSION_CHECK_TIMEOUT_MS = 'not-a-number';
+    expect(getVersionCheckTimeoutMs()).toBe(5000);
+
+    delete process.env.VERSION_CHECK_TIMEOUT_MS;
+    expect(getVersionCheckTimeoutMs()).toBe(5000);
+  });
+});
+
+describe('versionCheckService — caching', () => {
+  test('serves a successful lookup from cache for the success TTL', async () => {
+    httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
+
+    const first = await refreshVersionCheck();
+    const second = await refreshVersionCheck();
+
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+    expect(first.expiresAt - first.checkedAt).toBe(SUCCESS_TTL_MS);
+    expect(isVersionCheckStale()).toBe(false);
+  });
+
+  test('caches a failure too, so a blocked network is not retried on every request', async () => {
+    httpFetch.mockImplementation(dropsPackets());
+
+    const entry = await refreshVersionCheck();
+    expect(entry.expiresAt - entry.checkedAt).toBe(FAILURE_TTL_MS);
+    expect(FAILURE_TTL_MS).toBeLessThan(SUCCESS_TTL_MS);
+
+    expect(startBackgroundVersionCheck()).toBe(false);
+    await refreshVersionCheck();
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('re-queries GitHub when forced', async () => {
+    httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
+
+    await refreshVersionCheck();
+    await refreshVersionCheck({ force: true });
+
+    expect(httpFetch).toHaveBeenCalledTimes(2);
+  });
+
+  test('concurrent callers share a single in-flight request', async () => {
+    httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
+
+    const results = await Promise.all([
+      refreshVersionCheck(),
+      refreshVersionCheck(),
+      refreshVersionCheck({ force: true })
+    ]);
+
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+    expect(results[1]).toBe(results[0]);
+    expect(results[2]).toBe(results[0]);
+  });
+});
+
+describe('versionCheckService — cluster mode', () => {
+  const CLUSTER_CHANNEL = 'versionCheck:result';
+
+  test('relays a completed check to the other workers', async () => {
+    httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
+    const entry = await refreshVersionCheck();
+
+    expect(mockPublish).toHaveBeenCalledWith(CLUSTER_CHANNEL, entry);
+  });
+
+  test('relays a failed check too, so every worker holds off retrying', async () => {
+    httpFetch.mockImplementation(dropsPackets());
+    await refreshVersionCheck();
+
+    expect(mockPublish).toHaveBeenCalledTimes(1);
+    expect(mockPublish.mock.calls[0][1].error).toMatch(/timed out/);
+  });
+
+  test('adopts a result from another worker instead of querying GitHub again', () => {
+    const checkedAt = Date.now();
+    clusterHandlers[CLUSTER_CHANNEL]({
+      release: { tag_name: 'v9.9.9', name: 'v9.9.9', html_url: 'url', published_at: null },
+      error: null,
+      checkedAt,
+      expiresAt: checkedAt + SUCCESS_TTL_MS
+    });
+
+    expect(isVersionCheckStale()).toBe(false);
+    expect(startBackgroundVersionCheck()).toBe(false);
+    expect(buildUpdateInfo(getVersionCheckEntry(), '1.2.3').latestVersion).toBe('9.9.9');
+    expect(httpFetch).not.toHaveBeenCalled();
+  });
+
+  test('keeps its own result when another worker relays an older one', async () => {
+    httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
+    const own = await refreshVersionCheck();
+
+    clusterHandlers[CLUSTER_CHANNEL]({
+      release: { tag_name: 'v1.0.0' },
+      error: null,
+      checkedAt: own.checkedAt - 1000,
+      expiresAt: own.expiresAt
+    });
+
+    expect(getVersionCheckEntry().release.tag_name).toBe('v9.9.9');
+  });
+
+  test('ignores a malformed relay', async () => {
+    httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
+    await refreshVersionCheck();
+
+    clusterHandlers[CLUSTER_CHANNEL](null);
+    clusterHandlers[CLUSTER_CHANNEL]({ release: { tag_name: 'v0.0.1' } });
+    clusterHandlers[CLUSTER_CHANNEL]({
+      release: { name: 'no tag here' },
+      checkedAt: Date.now() + 1000,
+      expiresAt: Date.now() + SUCCESS_TTL_MS
+    });
+
+    expect(getVersionCheckEntry().release.tag_name).toBe('v9.9.9');
+  });
+
+  test('trims the release to the fields that are cached and relayed', async () => {
+    httpFetch.mockResolvedValue(
+      okResponse({
+        ...release('v9.9.9'),
+        body: 'x'.repeat(50000),
+        author: { login: 'someone' },
+        assets: [
+          {
+            name: 'ihub-apps-v9.9.9-linux.tar.gz',
+            browser_download_url: 'https://example.invalid/asset',
+            size: 42,
+            uploader: { login: 'someone' }
+          }
+        ]
+      })
+    );
+
+    const entry = await refreshVersionCheck();
+
+    expect(Object.keys(entry.release).sort()).toEqual([
+      'assets',
+      'html_url',
+      'name',
+      'published_at',
+      'tag_name'
+    ]);
+    expect(entry.release.assets).toEqual([
+      {
+        name: 'ihub-apps-v9.9.9-linux.tar.gz',
+        browser_download_url: 'https://example.invalid/asset',
+        size: 42
+      }
+    ]);
+  });
+});
+
+describe('versionCheckService — buildUpdateInfo', () => {
+  test('flags a newer release and strips the tag prefix', async () => {
+    httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
+    const entry = await refreshVersionCheck();
+
+    expect(buildUpdateInfo(entry, '1.2.3')).toMatchObject({
+      updateAvailable: true,
+      currentVersion: '1.2.3',
+      latestVersion: '9.9.9',
+      releaseName: 'Release v9.9.9',
+      checking: false
+    });
+  });
+
+  test('reports no update when the installation is current', async () => {
+    httpFetch.mockResolvedValue(okResponse(release('v1.2.3')));
+    const entry = await refreshVersionCheck();
+
+    expect(buildUpdateInfo(entry, '1.2.3').updateAvailable).toBe(false);
+  });
+
+  test('carries the error forward and leaves updateAvailable false', () => {
+    const entry = { release: null, error: 'boom', checkedAt: Date.now(), expiresAt: Date.now() };
+
+    expect(buildUpdateInfo(entry, '1.2.3')).toMatchObject({
+      updateAvailable: false,
+      error: 'boom'
+    });
+  });
+
+  test('handles a cold cache without a result', () => {
+    expect(buildUpdateInfo(null, '1.2.3', { checking: true })).toEqual({
+      updateAvailable: false,
+      currentVersion: '1.2.3',
+      checking: true,
+      lastCheckedAt: null
+    });
+  });
+
+  test('does not throw on an entry with neither a usable release nor an error', () => {
+    const checkedAt = Date.now();
+    const entry = { release: {}, error: null, checkedAt, expiresAt: checkedAt + SUCCESS_TTL_MS };
+
+    const info = buildUpdateInfo(entry, '1.2.3');
+    expect(info.updateAvailable).toBe(false);
+    expect(info).not.toHaveProperty('latestVersion');
+  });
+});
+
+describe('GET /api/admin/version/check-update', () => {
+  test('answers without awaiting the GitHub request that never completes', async () => {
+    httpFetch.mockImplementation(dropsPackets());
+    const routes = captureRoutes();
+    const res = createResponse();
+
+    // Not awaited: the handler must have responded before it returns, or the
+    // Admin Overview waits on api.github.com again.
+    routes[CHECK_UPDATE_PATH]({ query: {} }, res);
+
+    expect(res.payload).toEqual({
+      updateAvailable: false,
+      currentVersion: '1.2.3',
+      checking: true,
+      lastCheckedAt: null
+    });
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+
+    // The check it kicked off still records its failure in the background.
+    await delay(800);
+    expect(getVersionCheckEntry()?.error).toMatch(/timed out/);
+  });
+
+  test('serves the cached result once a check has completed', async () => {
+    httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
+    await refreshVersionCheck();
+
+    const res = createResponse();
+    captureRoutes()[CHECK_UPDATE_PATH]({ query: {} }, res);
+
+    expect(res.payload).toMatchObject({
+      updateAvailable: true,
+      latestVersion: '9.9.9',
+      checking: false
+    });
+    expect(res.payload.lastCheckedAt).not.toBeNull();
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not contact GitHub at all when version checks are disabled', () => {
+    process.env.NO_VERSION_CHECK = 'true';
+    httpFetch.mockImplementation(dropsPackets());
+
+    const res = createResponse();
+    captureRoutes()[CHECK_UPDATE_PATH]({ query: {} }, res);
+
+    expect(res.payload).toEqual({
+      updateAvailable: false,
+      currentVersion: '1.2.3',
+      versionCheckDisabled: true,
+      checking: false,
+      lastCheckedAt: null
+    });
+    expect(httpFetch).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/server/versionCheckService.test.js
+++ b/tests/unit/server/versionCheckService.test.js
@@ -51,8 +51,7 @@ jest.mock('../../../server/clusterBus.js', () => {
 
 import { httpFetch } from '../../../server/utils/httpConfig.js';
 import {
-  FAILURE_TTL_MS,
-  SUCCESS_TTL_MS,
+  CACHE_TTL_MS,
   buildUpdateInfo,
   getVersionCheckEntry,
   getVersionCheckTimeoutMs,
@@ -182,15 +181,15 @@ describe('versionCheckService — timeout', () => {
     expect(getVersionCheckTimeoutMs()).toBe(60000);
 
     process.env.VERSION_CHECK_TIMEOUT_MS = 'not-a-number';
-    expect(getVersionCheckTimeoutMs()).toBe(5000);
+    expect(getVersionCheckTimeoutMs()).toBe(1000);
 
     delete process.env.VERSION_CHECK_TIMEOUT_MS;
-    expect(getVersionCheckTimeoutMs()).toBe(5000);
+    expect(getVersionCheckTimeoutMs()).toBe(1000);
   });
 });
 
 describe('versionCheckService — caching', () => {
-  test('serves a successful lookup from cache for the success TTL', async () => {
+  test('serves a successful lookup from cache for the cache TTL', async () => {
     httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
 
     const first = await refreshVersionCheck();
@@ -198,7 +197,7 @@ describe('versionCheckService — caching', () => {
 
     expect(httpFetch).toHaveBeenCalledTimes(1);
     expect(second).toBe(first);
-    expect(first.expiresAt - first.checkedAt).toBe(SUCCESS_TTL_MS);
+    expect(first.expiresAt - first.checkedAt).toBe(CACHE_TTL_MS);
     expect(isVersionCheckStale()).toBe(false);
   });
 
@@ -206,8 +205,7 @@ describe('versionCheckService — caching', () => {
     httpFetch.mockImplementation(dropsPackets());
 
     const entry = await refreshVersionCheck();
-    expect(entry.expiresAt - entry.checkedAt).toBe(FAILURE_TTL_MS);
-    expect(FAILURE_TTL_MS).toBeLessThan(SUCCESS_TTL_MS);
+    expect(entry.expiresAt - entry.checkedAt).toBe(CACHE_TTL_MS);
 
     expect(startBackgroundVersionCheck()).toBe(false);
     await refreshVersionCheck();
@@ -276,7 +274,7 @@ describe('versionCheckService — cluster mode', () => {
       release: { tag_name: 'v9.9.9', name: 'v9.9.9', html_url: 'url', published_at: null },
       error: null,
       checkedAt,
-      expiresAt: checkedAt + SUCCESS_TTL_MS
+      expiresAt: checkedAt + CACHE_TTL_MS
     });
 
     expect(isVersionCheckStale()).toBe(false);
@@ -328,7 +326,7 @@ describe('versionCheckService — cluster mode', () => {
     ['a non-numeric expiry', { checkedAt: Date.now(), expiresAt: 'whenever' }],
     ['a NaN expiry', { checkedAt: Date.now(), expiresAt: NaN }],
     ['an infinite expiry', { checkedAt: Date.now(), expiresAt: Infinity }],
-    ['a NaN check time', { checkedAt: NaN, expiresAt: Date.now() + SUCCESS_TTL_MS }],
+    ['a NaN check time', { checkedAt: NaN, expiresAt: Date.now() + CACHE_TTL_MS }],
     ['an expiry that precedes the check', { checkedAt: Date.now(), expiresAt: Date.now() - 1000 }]
   ])('%s cannot wedge the cache as permanently fresh', (_label, timestamps) => {
     relayHandler()({ release: { tag_name: 'v9.9.9' }, error: null, ...timestamps });
@@ -415,7 +413,7 @@ describe('versionCheckService — buildUpdateInfo', () => {
 
   test('does not throw on an entry with neither a usable release nor an error', () => {
     const checkedAt = Date.now();
-    const entry = { release: {}, error: null, checkedAt, expiresAt: checkedAt + SUCCESS_TTL_MS };
+    const entry = { release: {}, error: null, checkedAt, expiresAt: checkedAt + CACHE_TTL_MS };
 
     const info = buildUpdateInfo(entry, '1.2.3');
     expect(info.updateAvailable).toBe(false);

--- a/tests/unit/server/versionCheckService.test.js
+++ b/tests/unit/server/versionCheckService.test.js
@@ -49,7 +49,6 @@ jest.mock('../../../server/clusterBus.js', () => {
   };
 });
 
-import { __handlers as clusterHandlers } from '../../../server/clusterBus.js';
 import { httpFetch } from '../../../server/utils/httpConfig.js';
 import {
   FAILURE_TTL_MS,
@@ -229,12 +228,15 @@ describe('versionCheckService — cluster mode', () => {
   const CLUSTER_CHANNEL = 'versionCheck:result';
 
   /**
-   * The service registers its relay handler while being imported. Resolve it
-   * through an assertion so a broken registration fails as "expected a
-   * function" rather than as a TypeError at the call site.
+   * The service registers its relay handler while being imported. The store it
+   * lands in belongs to the clusterBus mock, so reach it through the mock
+   * registry rather than importing a named export the real module does not
+   * have. The assertion makes a broken registration fail as "expected a
+   * function" instead of as a TypeError at the call site.
    */
   function relayHandler() {
-    const handler = clusterHandlers[CLUSTER_CHANNEL];
+    const { __handlers: handlers } = jest.requireMock('../../../server/clusterBus.js');
+    const handler = handlers[CLUSTER_CHANNEL];
     expect(handler).toEqual(expect.any(Function));
     return handler;
   }

--- a/tests/unit/server/versionCheckService.test.js
+++ b/tests/unit/server/versionCheckService.test.js
@@ -118,6 +118,20 @@ function createResponse() {
 
 const delay = ms => new Promise(resolve => setTimeout(resolve, ms));
 
+/**
+ * Wait for a background check to record its outcome. Polls rather than sleeping
+ * a fixed interval, so it returns as soon as the abort fires and still tolerates
+ * a slow CI runner. The budget derives from the configured timeout — the thing
+ * actually being waited on.
+ */
+async function waitForCheckToSettle() {
+  const deadline = Date.now() + getVersionCheckTimeoutMs() * 4;
+  while (!getVersionCheckEntry() && Date.now() < deadline) {
+    await delay(20);
+  }
+  return getVersionCheckEntry();
+}
+
 beforeEach(() => {
   resetVersionCheckCache();
   httpFetch.mockReset();
@@ -289,15 +303,35 @@ describe('versionCheckService — cluster mode', () => {
     httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
     await refreshVersionCheck();
 
+    const newer = Date.now() + 1000;
     relayHandler()(null);
-    relayHandler()({ release: { tag_name: 'v0.0.1' } });
+    relayHandler()({ release: { tag_name: 'v0.0.1' } }); // no timestamps
+    relayHandler()({ release: { name: 'no tag' }, checkedAt: newer, expiresAt: newer }); // no tag
+    relayHandler()({ checkedAt: newer, expiresAt: newer }); // neither release nor error
     relayHandler()({
-      release: { name: 'no tag here' },
-      checkedAt: Date.now() + 1000,
-      expiresAt: Date.now() + SUCCESS_TTL_MS
+      // both a release and an error — not a shape this module produces
+      release: { tag_name: 'v0.0.1' },
+      error: 'boom',
+      checkedAt: newer,
+      expiresAt: newer
     });
 
     expect(getVersionCheckEntry().release.tag_name).toBe('v9.9.9');
+  });
+
+  test('a relay with no usable expiry cannot wedge the cache as permanently fresh', () => {
+    // `undefined <= Date.now()` is false, so adopting this entry would leave the
+    // cache looking fresh forever and the worker would never check again.
+    relayHandler()({
+      release: { tag_name: 'v9.9.9' },
+      error: null,
+      checkedAt: Date.now(),
+      expiresAt: 'whenever'
+    });
+
+    expect(getVersionCheckEntry()).toBeNull();
+    expect(isVersionCheckStale()).toBe(true);
+    expect(startBackgroundVersionCheck()).toBe(true);
   });
 
   test('trims the release to the fields that are cached and relayed', async () => {
@@ -404,8 +438,7 @@ describe('GET /api/admin/version/check-update', () => {
     expect(httpFetch).toHaveBeenCalledTimes(1);
 
     // The check it kicked off still records its failure in the background.
-    await delay(800);
-    expect(getVersionCheckEntry()?.error).toMatch(/timed out/);
+    expect((await waitForCheckToSettle())?.error).toMatch(/timed out/);
   });
 
   test('serves the cached result once a check has completed', async () => {

--- a/tests/unit/server/versionCheckService.test.js
+++ b/tests/unit/server/versionCheckService.test.js
@@ -319,15 +319,19 @@ describe('versionCheckService — cluster mode', () => {
     expect(getVersionCheckEntry().release.tag_name).toBe('v9.9.9');
   });
 
-  test('a relay with no usable expiry cannot wedge the cache as permanently fresh', () => {
-    // `undefined <= Date.now()` is false, so adopting this entry would leave the
-    // cache looking fresh forever and the worker would never check again.
-    relayHandler()({
-      release: { tag_name: 'v9.9.9' },
-      error: null,
-      checkedAt: Date.now(),
-      expiresAt: 'whenever'
-    });
+  // Any of these expiries compares false against `Date.now()`, so adopting one
+  // would leave the cache looking fresh forever and the worker would never check
+  // again. `NaN` and `Infinity` matter as much as `undefined` here: both pass
+  // `typeof x === 'number'`, and either would also make the endpoint's
+  // `lastCheckedAt` throw a RangeError out of `toISOString()`.
+  test.each([
+    ['a non-numeric expiry', { checkedAt: Date.now(), expiresAt: 'whenever' }],
+    ['a NaN expiry', { checkedAt: Date.now(), expiresAt: NaN }],
+    ['an infinite expiry', { checkedAt: Date.now(), expiresAt: Infinity }],
+    ['a NaN check time', { checkedAt: NaN, expiresAt: Date.now() + SUCCESS_TTL_MS }],
+    ['an expiry that precedes the check', { checkedAt: Date.now(), expiresAt: Date.now() - 1000 }]
+  ])('%s cannot wedge the cache as permanently fresh', (_label, timestamps) => {
+    relayHandler()({ release: { tag_name: 'v9.9.9' }, error: null, ...timestamps });
 
     expect(getVersionCheckEntry()).toBeNull();
     expect(isVersionCheckStale()).toBe(true);

--- a/tests/unit/server/versionCheckService.test.js
+++ b/tests/unit/server/versionCheckService.test.js
@@ -228,6 +228,17 @@ describe('versionCheckService — caching', () => {
 describe('versionCheckService — cluster mode', () => {
   const CLUSTER_CHANNEL = 'versionCheck:result';
 
+  /**
+   * The service registers its relay handler while being imported. Resolve it
+   * through an assertion so a broken registration fails as "expected a
+   * function" rather than as a TypeError at the call site.
+   */
+  function relayHandler() {
+    const handler = clusterHandlers[CLUSTER_CHANNEL];
+    expect(handler).toEqual(expect.any(Function));
+    return handler;
+  }
+
   test('relays a completed check to the other workers', async () => {
     httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
     const entry = await refreshVersionCheck();
@@ -245,7 +256,7 @@ describe('versionCheckService — cluster mode', () => {
 
   test('adopts a result from another worker instead of querying GitHub again', () => {
     const checkedAt = Date.now();
-    clusterHandlers[CLUSTER_CHANNEL]({
+    relayHandler()({
       release: { tag_name: 'v9.9.9', name: 'v9.9.9', html_url: 'url', published_at: null },
       error: null,
       checkedAt,
@@ -262,7 +273,7 @@ describe('versionCheckService — cluster mode', () => {
     httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
     const own = await refreshVersionCheck();
 
-    clusterHandlers[CLUSTER_CHANNEL]({
+    relayHandler()({
       release: { tag_name: 'v1.0.0' },
       error: null,
       checkedAt: own.checkedAt - 1000,
@@ -276,9 +287,9 @@ describe('versionCheckService — cluster mode', () => {
     httpFetch.mockResolvedValue(okResponse(release('v9.9.9')));
     await refreshVersionCheck();
 
-    clusterHandlers[CLUSTER_CHANNEL](null);
-    clusterHandlers[CLUSTER_CHANNEL]({ release: { tag_name: 'v0.0.1' } });
-    clusterHandlers[CLUSTER_CHANNEL]({
+    relayHandler()(null);
+    relayHandler()({ release: { tag_name: 'v0.0.1' } });
+    relayHandler()({
       release: { name: 'no tag here' },
       checkedAt: Date.now() + 1000,
       expiresAt: Date.now() + SUCCESS_TTL_MS


### PR DESCRIPTION
Fixes #2150

## Problem

On installations without outbound internet access the admin start page rendered nothing but grey animated placeholders.

`useOverviewData` batched `/admin/version/check-update` into the same `Promise.allSettled` as the local dashboard queries, and that endpoint fetched `api.github.com` with **no timeout**. Where a firewall drops packets rather than refusing them, the connection never completes — so the request hung until the OS TCP timeout (minutes), and `allSettled`, which settles only with its slowest promise, held `isLoading` true the whole time.

Two independent faults, so both are fixed: the check had no deadline, and the page waited for it.

## Server

New `server/services/versionCheckService.js` owns the release lookup for every caller (Admin UI, update service, update CLI):

- **Timeout** — the fetch aborts after 1s. `VERSION_CHECK_TIMEOUT_MS` / `IHUB_VERSION_CHECK_TIMEOUT_MS` overrides it, clamped to 500 ms–60 s so a typo can't reintroduce an unbounded wait.
- **Cached** — a completed check, result or failure alike, is cached for 5 minutes, and concurrent callers share a single in-flight request. Opening the dashboard no longer triggers a fresh GitHub request every time.
- **Cluster-aware** — a completed check is relayed over the cluster bus, so one worker's lookup warms all of them instead of each worker querying GitHub and Admin UI requests landing on workers that haven't checked yet. Relays are validated before adoption: finite, ordered timestamps and either a tagged release or an error, since an entry cached with an unusable expiry would read as fresh forever and that worker would never check again.
- **Asynchronous endpoint** — `GET /api/admin/version/check-update` answers purely from the cache and kicks off a background refresh when it is cold or stale. It never awaits the network. A cold cache responds `checking: true`; a failure is reported in `error`.

`compareVersions` and `isVersionCheckDisabled` moved into the new service along with the lookup they belong to, and updateService's near-duplicate copy of the GitHub fetch is gone (its `checkForUpdate` still resolves platform assets, now on top of the shared, bounded lookup — so the CLI's `--update=check` can no longer hang either).

## Client

- The check moved out of the dashboard batch into `client/src/features/admin/hooks/useUpdateCheck.js`, which fetches on its own and polls a few times across the server's `checking` hand-off so the badge still appears without a reload.
- `AdminOverview` and `AdminUpdatesPage` render fully regardless of whether the check ever answers; only the "update available" badge depends on it.
- `useOverviewData` now contains nothing that leaves the machine, with a comment saying why.

## Also here: changelog fixes/features split

Requested alongside the fix, and needed for this PR's own release note to land in the right place.

- The `document-feature` skill now writes bug fixes to `docs/releases/{version}/fixes.md` instead of `features.md`, with a table for choosing between the two files and the rule that one change means one entry in one file. `features.md` had become the dumping ground for both, so "what's new" was unreadable.
- A new file name is not picked up on its own: `server/routes/admin/changelog.js` now reads `fixes.md` and `AdminChangelogPage.jsx` renders it as its own section, labelling the features block only when there are fixes to distinguish it from (so single-section releases look unchanged). Older release directories without a `fixes.md` are unaffected.
- This release's version-check entry moved to `docs/releases/5.5.0/fixes.md`.

Note: `docs/releases/5.5.0/features.md` still holds ~64 pre-existing entries, most of which read as fixes. Re-sorting them is deliberately left out of this PR — it is 64 subjective calls and would swamp the diff.

## Verification

- `tests/unit/server/versionCheckService.test.js` (27 cases) — abort on deadline, cache TTL for results and failures, in-flight dedupe, cluster relay/convergence/validation, release normalization, and that the route handler responds *before* returning while the fetch is still hanging.
- `tests/unit/client/admin-overview-update-check.test.jsx` (7 cases) — `useOverviewData` finishes loading while the check is pending and never requests it; `useUpdateCheck` polling, error and disabled paths.
- Full suites green: `npm run test:quick` (322 unit tests + adapter/cluster suites), lint and Prettier clean, client build passes.
- End-to-end against a running server with a black-holed proxy standing in for a firewalled network: the endpoint answers in 5–30 ms instead of hanging, the background check records the timeout, all 4 workers converge on one relayed result, and with the network reachable the real check returns `updateAvailable: true` for v5.4.18 well inside the 1s budget.
- Changelog endpoint checked against a running server: 5.5.0 returns features + fixes + breaking, 5.4.0 (no `fixes.md`) still returns normally.

## Docs

Changelog entry in `docs/releases/5.5.0/fixes.md`, the new env var in `docs/server-config.md`, behaviour-when-unreachable in `docs/INSTALLATION.md`, and a symptom entry in `docs/troubleshooting.md`.

## Notes

No config migration needed — the timeout is env-only, matching the existing `NO_VERSION_CHECK`. The endpoint's response gains `checking` and `lastCheckedAt`; existing fields are unchanged, so nothing reading it breaks. The changelog API response gains a `fixes` field alongside `features` and `breakingChanges`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015CtMSsWn2KhXoD4bAY5AfT
