### PR TITLE
feat(integrations): step-by-step connection diagnostics for iFinder and iAssistant

### DIFF
--- a/client/src/features/admin/components/IFinderConfig.jsx
+++ b/client/src/features/admin/components/IFinderConfig.jsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
 import { makeAdminApiCall } from '../../../api/adminApi';
 import { getBasePath } from '../../../utils/runtimeBasePath.js';
+import IntegrationTestResults from './IntegrationTestResults';
 
 const ALGORITHM_OPTIONS = ['RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512'];
 
@@ -38,6 +39,18 @@ function IFinderConfig() {
   const [testing, setTesting] = useState({ iFinder: false, iAssistant: false });
   const [testResults, setTestResults] = useState({ iFinder: null, iAssistant: null });
   const [message, setMessage] = useState('');
+  // Options for the connection diagnostics. The signed JWT and the conversation
+  // round-trip are opt-in: the first exposes a usable credential, the second
+  // writes to iAssistant.
+  const [testOptions, setTestOptions] = useState({
+    includeToken: false,
+    conversationRoundTrip: false,
+    query: 'test',
+    userEmail: '',
+    userUsername: '',
+    userDomain: ''
+  });
+  const [showTestOptions, setShowTestOptions] = useState(false);
 
   useEffect(() => {
     const fetchConfig = async () => {
@@ -167,6 +180,31 @@ function IFinderConfig() {
     }
   };
 
+  const handleTestOptionChange = (field, value) => {
+    setTestOptions(prev => ({ ...prev, [field]: value }));
+  };
+
+  /**
+   * Build the request body for the diagnostics endpoints. Only user fields the
+   * admin actually filled in are sent, so the server keeps defaulting to the
+   * calling admin for the rest.
+   */
+  const buildTestPayload = () => {
+    const payload = { includeToken: testOptions.includeToken };
+
+    if (testOptions.query.trim() && testOptions.query.trim() !== 'test') {
+      payload.query = testOptions.query.trim();
+    }
+
+    const user = {};
+    if (testOptions.userEmail.trim()) user.email = testOptions.userEmail.trim();
+    if (testOptions.userUsername.trim()) user.username = testOptions.userUsername.trim();
+    if (testOptions.userDomain.trim()) user.domain = testOptions.userDomain.trim();
+    if (Object.keys(user).length > 0) payload.user = user;
+
+    return payload;
+  };
+
   const handleTestIFinder = async () => {
     setTesting(prev => ({ ...prev, iFinder: true }));
     setTestResults(prev => ({ ...prev, iFinder: null }));
@@ -174,7 +212,8 @@ function IFinderConfig() {
 
     try {
       const response = await makeAdminApiCall('/admin/integrations/ifinder/_test', {
-        method: 'POST'
+        method: 'POST',
+        body: buildTestPayload()
       });
 
       setTestResults(prev => ({ ...prev, iFinder: response.data }));
@@ -211,7 +250,11 @@ function IFinderConfig() {
 
     try {
       const response = await makeAdminApiCall('/admin/integrations/iassistant/_test', {
-        method: 'POST'
+        method: 'POST',
+        body: {
+          ...buildTestPayload(),
+          conversationRoundTrip: testOptions.conversationRoundTrip
+        }
       });
 
       setTestResults(prev => ({ ...prev, iAssistant: response.data }));
@@ -688,67 +731,164 @@ function IFinderConfig() {
             </>
           )}
 
+          {/* Diagnostics options */}
+          {iFinderConfig.enabled && (
+            <div className="mb-4">
+              <button
+                type="button"
+                onClick={() => setShowTestOptions(prev => !prev)}
+                className="inline-flex items-center text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
+              >
+                <Icon
+                  name={showTestOptions ? 'chevron-up' : 'chevron-down'}
+                  size="sm"
+                  className="mr-1"
+                />
+                {t('admin.iFinder.diagnostics.title', 'Diagnostics options')}
+              </button>
+
+              {showTestOptions && (
+                <div className="mt-3 p-4 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50 space-y-4">
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {t(
+                      'admin.iFinder.diagnostics.description',
+                      'The connection test signs a JWT for your own admin account and calls the same endpoints the integration uses at runtime. Use these options to test as a different user or to get a reproducible curl command.'
+                    )}
+                  </p>
+
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                        {t('admin.iFinder.diagnostics.userEmail', 'Test as email')}
+                      </label>
+                      <input
+                        type="text"
+                        value={testOptions.userEmail}
+                        onChange={e => handleTestOptionChange('userEmail', e.target.value)}
+                        placeholder={t(
+                          'admin.iFinder.diagnostics.currentAdmin',
+                          'your admin account'
+                        )}
+                        className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                        {t('admin.iFinder.diagnostics.userUsername', 'Test as username')}
+                      </label>
+                      <input
+                        type="text"
+                        value={testOptions.userUsername}
+                        onChange={e => handleTestOptionChange('userUsername', e.target.value)}
+                        placeholder={t(
+                          'admin.iFinder.diagnostics.currentAdmin',
+                          'your admin account'
+                        )}
+                        className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                        {t('admin.iFinder.diagnostics.userDomain', 'Test as domain')}
+                      </label>
+                      <input
+                        type="text"
+                        value={testOptions.userDomain}
+                        onChange={e => handleTestOptionChange('userDomain', e.target.value)}
+                        placeholder="EXAMPLE"
+                        className="w-full px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                      />
+                    </div>
+                  </div>
+                  <p className="text-xs text-gray-500 dark:text-gray-400">
+                    {t(
+                      'admin.iFinder.diagnostics.userHelp',
+                      'Leave empty to test with your own account. Fill these in to check how the JWT subject is built for a specific user — for example whether iFinder expects DOMAIN\\username instead of an email address.'
+                    )}
+                  </p>
+
+                  <div>
+                    <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
+                      {t('admin.iFinder.diagnostics.query', 'Test search query')}
+                    </label>
+                    <input
+                      type="text"
+                      value={testOptions.query}
+                      onChange={e => handleTestOptionChange('query', e.target.value)}
+                      className="w-full md:w-1/3 px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
+                    />
+                  </div>
+
+                  <div className="space-y-3">
+                    <div className="flex items-start">
+                      <input
+                        type="checkbox"
+                        id="iFinderTestIncludeToken"
+                        checked={testOptions.includeToken}
+                        onChange={e => handleTestOptionChange('includeToken', e.target.checked)}
+                        className="mt-0.5 h-4 w-4 text-indigo-600 border-gray-300 dark:border-gray-600 rounded focus:ring-indigo-500"
+                      />
+                      <div className="ml-2">
+                        <label
+                          htmlFor="iFinderTestIncludeToken"
+                          className="block text-sm text-gray-700 dark:text-gray-300"
+                        >
+                          {t('admin.iFinder.diagnostics.includeToken', 'Include the signed JWT')}
+                        </label>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {t(
+                            'admin.iFinder.diagnostics.includeTokenHelp',
+                            'Returns the token itself plus a ready-to-run curl command. The token is a working credential for the tested user — treat it like a password and do not paste it into tickets.'
+                          )}
+                        </p>
+                      </div>
+                    </div>
+
+                    <div className="flex items-start">
+                      <input
+                        type="checkbox"
+                        id="iFinderTestConversationRoundTrip"
+                        checked={testOptions.conversationRoundTrip}
+                        onChange={e =>
+                          handleTestOptionChange('conversationRoundTrip', e.target.checked)
+                        }
+                        className="mt-0.5 h-4 w-4 text-indigo-600 border-gray-300 dark:border-gray-600 rounded focus:ring-indigo-500"
+                      />
+                      <div className="ml-2">
+                        <label
+                          htmlFor="iFinderTestConversationRoundTrip"
+                          className="block text-sm text-gray-700 dark:text-gray-300"
+                        >
+                          {t(
+                            'admin.iFinder.diagnostics.conversationRoundTrip',
+                            'Run conversation round-trip (iAssistant)'
+                          )}
+                        </label>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {t(
+                            'admin.iFinder.diagnostics.conversationRoundTripHelp',
+                            'Creates an ephemeral test conversation in iAssistant and deletes it again. Verifies write access, not just authentication.'
+                          )}
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
           {/* Test Results Display */}
           {(testResults.iFinder || testResults.iAssistant) && (
-            <div className="mb-4 p-4 rounded-md border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900/50">
-              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">
+            <div className="mb-4 space-y-3">
+              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
                 {t('admin.iFinder.testResults.title', 'Test Results')}
               </h4>
               {testResults.iFinder && (
-                <div className="mb-2">
-                  <div className="flex items-center mb-1">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300 mr-2">
-                      iFinder:
-                    </span>
-                    <span
-                      className={`text-sm font-medium ${
-                        testResults.iFinder.success
-                          ? 'text-green-600 dark:text-green-400'
-                          : 'text-red-600 dark:text-red-400'
-                      }`}
-                    >
-                      {testResults.iFinder.success
-                        ? t('admin.iFinder.testResults.success', 'Success')
-                        : t('admin.iFinder.testResults.failed', 'Failed')}
-                    </span>
-                  </div>
-                  <p className="text-xs text-gray-600 dark:text-gray-400">
-                    {testResults.iFinder.message}
-                  </p>
-                  {testResults.iFinder.details && (
-                    <pre className="mt-2 text-xs text-gray-600 dark:text-gray-400 overflow-x-auto">
-                      {JSON.stringify(testResults.iFinder.details, null, 2)}
-                    </pre>
-                  )}
-                </div>
+                <IntegrationTestResults title="iFinder" result={testResults.iFinder} />
               )}
               {testResults.iAssistant && (
-                <div>
-                  <div className="flex items-center mb-1">
-                    <span className="text-sm font-medium text-gray-700 dark:text-gray-300 mr-2">
-                      iAssistant:
-                    </span>
-                    <span
-                      className={`text-sm font-medium ${
-                        testResults.iAssistant.success
-                          ? 'text-green-600 dark:text-green-400'
-                          : 'text-red-600 dark:text-red-400'
-                      }`}
-                    >
-                      {testResults.iAssistant.success
-                        ? t('admin.iFinder.testResults.success', 'Success')
-                        : t('admin.iFinder.testResults.failed', 'Failed')}
-                    </span>
-                  </div>
-                  <p className="text-xs text-gray-600 dark:text-gray-400">
-                    {testResults.iAssistant.message}
-                  </p>
-                  {testResults.iAssistant.details && (
-                    <pre className="mt-2 text-xs text-gray-600 dark:text-gray-400 overflow-x-auto">
-                      {JSON.stringify(testResults.iAssistant.details, null, 2)}
-                    </pre>
-                  )}
-                </div>
+                <IntegrationTestResults title="iAssistant" result={testResults.iAssistant} />
               )}
             </div>
           )}

--- a/client/src/features/admin/components/IFinderConfig.jsx
+++ b/client/src/features/admin/components/IFinderConfig.jsx
@@ -45,7 +45,6 @@ function IFinderConfig() {
   const [testOptions, setTestOptions] = useState({
     includeToken: false,
     conversationRoundTrip: false,
-    query: 'test',
     userEmail: '',
     userUsername: '',
     userDomain: ''
@@ -191,10 +190,6 @@ function IFinderConfig() {
    */
   const buildTestPayload = () => {
     const payload = { includeToken: testOptions.includeToken };
-
-    if (testOptions.query.trim() && testOptions.query.trim() !== 'test') {
-      payload.query = testOptions.query.trim();
-    }
 
     const user = {};
     if (testOptions.userEmail.trim()) user.email = testOptions.userEmail.trim();
@@ -806,18 +801,6 @@ function IFinderConfig() {
                       'Leave empty to test with your own account. Fill these in to check how the JWT subject is built for a specific user — for example whether iFinder expects DOMAIN\\username instead of an email address.'
                     )}
                   </p>
-
-                  <div>
-                    <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1">
-                      {t('admin.iFinder.diagnostics.query', 'Test search query')}
-                    </label>
-                    <input
-                      type="text"
-                      value={testOptions.query}
-                      onChange={e => handleTestOptionChange('query', e.target.value)}
-                      className="w-full md:w-1/3 px-3 py-2 text-sm border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100"
-                    />
-                  </div>
 
                   <div className="space-y-3">
                     <div className="flex items-start">

--- a/client/src/features/admin/components/IntegrationTestResults.jsx
+++ b/client/src/features/admin/components/IntegrationTestResults.jsx
@@ -69,6 +69,7 @@ function StepRow({ step }) {
   const style = STATUS_STYLES[step.status] || STATUS_STYLES.skip;
   const hasBody = Boolean(step.details || step.hints?.length);
   const [expanded, setExpanded] = useState(step.status === 'fail' || step.status === 'warn');
+  const bodyId = `integration-step-${step.id}`;
 
   return (
     <div className="border-b border-gray-200 dark:border-gray-700 last:border-b-0">
@@ -76,6 +77,8 @@ function StepRow({ step }) {
         type="button"
         onClick={() => hasBody && setExpanded(prev => !prev)}
         disabled={!hasBody}
+        aria-expanded={hasBody ? expanded : undefined}
+        aria-controls={hasBody ? bodyId : undefined}
         className={`w-full flex items-start gap-3 px-3 py-2.5 text-left ${
           hasBody ? 'hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer' : 'cursor-default'
         }`}
@@ -106,7 +109,7 @@ function StepRow({ step }) {
       </button>
 
       {expanded && hasBody && (
-        <div className="px-3 pb-3 pl-11 space-y-3">
+        <div id={bodyId} className="px-3 pb-3 pl-11 space-y-3">
           {step.hints?.length > 0 && (
             // A passing step can still carry hints (e.g. "verify this URL from the
             // iFinder host too"). Those are notes, not problems, so they must not
@@ -192,7 +195,9 @@ function IntegrationTestResults({ title, result }) {
             {summary && (
               <span className="text-xs text-gray-500 dark:text-gray-400">
                 {t('admin.iFinder.testResults.stepSummary', {
-                  defaultValue: '{{ok}} ok, {{warn}} warnings, {{fail}} failed · {{duration}}ms',
+                  // Label before count, so the line reads correctly for one as
+                  // well as several ("warnings 1", not "1 warnings").
+                  defaultValue: 'ok {{ok}} · warnings {{warn}} · failed {{fail}} · {{duration}}ms',
                   ok: summary.ok,
                   warn: summary.warn,
                   fail: summary.fail,

--- a/client/src/features/admin/components/IntegrationTestResults.jsx
+++ b/client/src/features/admin/components/IntegrationTestResults.jsx
@@ -210,7 +210,11 @@ function IntegrationTestResults({ title, result }) {
       {steps?.length > 0 ? (
         <div className="bg-white dark:bg-gray-800">
           {steps.map(step => (
-            <StepRow key={step.id} step={step} />
+            // The key includes the status so a step whose outcome changed between
+            // runs remounts and re-applies the default expansion (fail/warn open,
+            // ok collapsed). A step with an unchanged outcome keeps whatever the
+            // admin expanded or collapsed by hand.
+            <StepRow key={`${step.id}-${step.status}`} step={step} />
           ))}
         </div>
       ) : (

--- a/client/src/features/admin/components/IntegrationTestResults.jsx
+++ b/client/src/features/admin/components/IntegrationTestResults.jsx
@@ -1,0 +1,247 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Icon from '../../../shared/components/Icon';
+
+/**
+ * Renders the step-by-step result of an integration connection test
+ * (`POST /api/admin/integrations/{ifinder|iassistant}/_test`).
+ *
+ * Each step shows its status, the observed facts and — when something failed —
+ * the hints the server derived, so an admin can act without reading server logs.
+ * Failed and warning steps start expanded; successful ones stay collapsed.
+ */
+
+const STATUS_STYLES = {
+  ok: {
+    icon: 'check-circle',
+    badge:
+      'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300 border-green-200 dark:border-green-800',
+    iconColor: 'text-green-600 dark:text-green-400'
+  },
+  warn: {
+    icon: 'exclamation-triangle',
+    badge:
+      'bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300 border-amber-200 dark:border-amber-800',
+    iconColor: 'text-amber-600 dark:text-amber-400'
+  },
+  fail: {
+    icon: 'close',
+    badge:
+      'bg-red-100 text-red-800 dark:bg-red-900/40 dark:text-red-300 border-red-200 dark:border-red-800',
+    iconColor: 'text-red-600 dark:text-red-400'
+  },
+  skip: {
+    icon: 'minus-circle',
+    badge:
+      'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-300 border-gray-200 dark:border-gray-600',
+    iconColor: 'text-gray-400 dark:text-gray-500'
+  }
+};
+
+function CopyButton({ value, label }) {
+  const { t } = useTranslation();
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="inline-flex items-center px-2 py-1 text-xs font-medium rounded border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700"
+    >
+      <Icon name={copied ? 'check' : 'clipboard'} size="sm" className="mr-1" />
+      {copied ? t('admin.iFinder.testResults.copied', 'Copied') : label}
+    </button>
+  );
+}
+
+function StepRow({ step }) {
+  const { t } = useTranslation();
+  const style = STATUS_STYLES[step.status] || STATUS_STYLES.skip;
+  const hasBody = Boolean(step.details || step.hints?.length);
+  const [expanded, setExpanded] = useState(step.status === 'fail' || step.status === 'warn');
+
+  return (
+    <div className="border-b border-gray-200 dark:border-gray-700 last:border-b-0">
+      <button
+        type="button"
+        onClick={() => hasBody && setExpanded(prev => !prev)}
+        disabled={!hasBody}
+        className={`w-full flex items-start gap-3 px-3 py-2.5 text-left ${
+          hasBody ? 'hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer' : 'cursor-default'
+        }`}
+      >
+        <Icon name={style.icon} size="md" className={`mt-0.5 flex-shrink-0 ${style.iconColor}`} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-baseline gap-2 flex-wrap">
+            <span className="text-sm font-medium text-gray-900 dark:text-gray-100">
+              {step.label}
+            </span>
+            {typeof step.durationMs === 'number' && (
+              <span className="text-xs text-gray-400 dark:text-gray-500">{step.durationMs}ms</span>
+            )}
+          </div>
+          {step.message && (
+            <p className="mt-0.5 text-sm text-gray-600 dark:text-gray-300 break-words">
+              {step.message}
+            </p>
+          )}
+        </div>
+        {hasBody && (
+          <Icon
+            name={expanded ? 'chevron-up' : 'chevron-down'}
+            size="sm"
+            className="mt-1 flex-shrink-0 text-gray-400"
+          />
+        )}
+      </button>
+
+      {expanded && hasBody && (
+        <div className="px-3 pb-3 pl-11 space-y-3">
+          {step.hints?.length > 0 && (
+            // A passing step can still carry hints (e.g. "verify this URL from the
+            // iFinder host too"). Those are notes, not problems, so they must not
+            // be styled like a warning.
+            <div
+              className={`rounded-md border p-3 ${
+                step.status === 'ok' || step.status === 'skip'
+                  ? 'bg-indigo-50 dark:bg-indigo-900/20 border-indigo-200 dark:border-indigo-800'
+                  : 'bg-amber-50 dark:bg-amber-900/20 border-amber-200 dark:border-amber-800'
+              }`}
+            >
+              <p
+                className={`text-xs font-semibold uppercase tracking-wide ${
+                  step.status === 'ok' || step.status === 'skip'
+                    ? 'text-indigo-800 dark:text-indigo-300'
+                    : 'text-amber-800 dark:text-amber-300'
+                }`}
+              >
+                {step.status === 'ok' || step.status === 'skip'
+                  ? t('admin.iFinder.testResults.notes', 'Notes')
+                  : t('admin.iFinder.testResults.whatToCheck', 'What to check')}
+              </p>
+              <ul className="mt-1.5 space-y-1 list-disc list-outside ml-4">
+                {step.hints.map(hint => (
+                  <li
+                    key={hint}
+                    className={`text-sm ${
+                      step.status === 'ok' || step.status === 'skip'
+                        ? 'text-indigo-900 dark:text-indigo-200'
+                        : 'text-amber-900 dark:text-amber-200'
+                    }`}
+                  >
+                    {hint}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {step.details && (
+            <div>
+              <div className="flex items-center justify-between mb-1">
+                <p className="text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                  {t('admin.iFinder.testResults.observed', 'Observed')}
+                </p>
+                <CopyButton
+                  value={JSON.stringify(step.details, null, 2)}
+                  label={t('admin.iFinder.testResults.copyDetails', 'Copy')}
+                />
+              </div>
+              <pre className="text-xs bg-gray-50 dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded p-2 overflow-x-auto text-gray-700 dark:text-gray-300">
+                {JSON.stringify(step.details, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function IntegrationTestResults({ title, result }) {
+  const { t } = useTranslation();
+  if (!result) return null;
+
+  const { success, message, summary, steps, jwt, request } = result;
+  const headerStyle = success ? STATUS_STYLES.ok : STATUS_STYLES.fail;
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden">
+      <div className="flex items-start gap-3 px-3 py-3 bg-gray-50 dark:bg-gray-900/50 border-b border-gray-200 dark:border-gray-700">
+        <Icon name={headerStyle.icon} size="md" className={`mt-0.5 ${headerStyle.iconColor}`} />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">{title}</span>
+            <span
+              className={`px-2 py-0.5 text-xs font-medium rounded-full border ${headerStyle.badge}`}
+            >
+              {success
+                ? t('admin.iFinder.testResults.success', 'Success')
+                : t('admin.iFinder.testResults.failed', 'Failed')}
+            </span>
+            {summary && (
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                {t('admin.iFinder.testResults.stepSummary', {
+                  defaultValue: '{{ok}} ok, {{warn}} warnings, {{fail}} failed · {{duration}}ms',
+                  ok: summary.ok,
+                  warn: summary.warn,
+                  fail: summary.fail,
+                  duration: summary.durationMs
+                })}
+              </span>
+            )}
+          </div>
+          {message && (
+            <p className="mt-1 text-sm text-gray-700 dark:text-gray-300 break-words">{message}</p>
+          )}
+        </div>
+      </div>
+
+      {steps?.length > 0 ? (
+        <div className="bg-white dark:bg-gray-800">
+          {steps.map(step => (
+            <StepRow key={step.id} step={step} />
+          ))}
+        </div>
+      ) : (
+        result.details && (
+          <pre className="text-xs bg-white dark:bg-gray-800 p-3 overflow-x-auto text-gray-700 dark:text-gray-300">
+            {JSON.stringify(result.details, null, 2)}
+          </pre>
+        )
+      )}
+
+      {(request?.curl || jwt?.token) && (
+        <div className="flex flex-wrap items-center gap-2 px-3 py-2.5 bg-gray-50 dark:bg-gray-900/50 border-t border-gray-200 dark:border-gray-700">
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            {t('admin.iFinder.testResults.reproduce', 'Reproduce outside iHub:')}
+          </span>
+          {request?.curl && (
+            <CopyButton
+              value={request.curl}
+              label={t('admin.iFinder.testResults.copyCurl', 'Copy curl command')}
+            />
+          )}
+          {jwt?.token && (
+            <CopyButton
+              value={jwt.token}
+              label={t('admin.iFinder.testResults.copyToken', 'Copy JWT')}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default IntegrationTestResults;

--- a/docs/ifinder-iassistant-admin-guide.md
+++ b/docs/ifinder-iassistant-admin-guide.md
@@ -680,6 +680,13 @@ IASSISTANT_BASE_URL=https://iassistant.company.com
 
 ## Testing and Validation
 
+> **Use the built-in diagnostics first.** **Admin → iFinder Integration → Test iFinder** /
+> **Test iAssistant** performs every check below in one run — DNS, TLS, JWT generation, JWKS
+> reachability and a real API request — and shows the decoded token, the URLs used and what to check
+> for each failure. See [Connection Diagnostics](#0-start-here-connection-diagnostics). The manual
+> commands in this section remain useful for verifying reachability **from the iFinder host**, which
+> iHub cannot do for you.
+
 ### 1. Connection Testing
 
 **Test iFinder Connectivity:**
@@ -789,6 +796,66 @@ Use a JWT decoder tool to verify token structure:
 - [ ] Logging and monitoring operational
 
 ## Troubleshooting
+
+### 0. Start Here: Connection Diagnostics
+
+Before digging through logs, run the built-in diagnostics under **Admin → iFinder Integration →
+Test iFinder** / **Test iAssistant**. Instead of a single pass/fail message it walks the whole
+connection path and reports what it observed at every step, so you can see exactly where it breaks:
+
+| Step                       | What it proves                                                                                         |
+| -------------------------- | ------------------------------------------------------------------------------------------------------ |
+| Configuration              | Which key signs the JWT, which subject field is used, which endpoints and profile are configured         |
+| Base URL                   | Scheme, hostname, port, and whether the hostname is fully qualified                                      |
+| DNS resolution             | Whether the iHub server can resolve the hostname, and to which addresses                                 |
+| TCP / TLS connection       | Whether the port answers, plus the certificate subject, issuer, expiry, and trust result                 |
+| JWT generation             | The decoded header and payload, and the subject that was actually derived for the user                   |
+| JWT signature              | That iHub can verify its own token with the matching public key                                          |
+| Issuer reachable           | The issuer and JWKS URL **iFinder itself has to call back to** (OIDC key pair mode)                       |
+| JWKS endpoint              | That the endpoint publishes keys and that the token's `kid` is among them                                 |
+| API request                | The exact URL and method, the response status, the response headers, and a body excerpt                  |
+
+Every failing step lists concrete things to check. Expand a step to see the raw observations as JSON.
+
+#### Diagnostics Options
+
+Expand **Diagnostics options** above the buttons for:
+
+- **Test as email / username / domain** — mint the test JWT for a specific user instead of your own
+  admin account. Use this to confirm how the subject claim is built, for example whether iFinder
+  expects `DOMAIN\username` rather than an email address.
+- **Test search query** — the term used for the iFinder test request (default `test`).
+- **Include the signed JWT** — returns the token itself plus a ready-to-run `curl` command. The token
+  is a working credential for the tested user, so treat it like a password. Without this option the
+  `curl` command references `$TOKEN` and is safe to share.
+- **Run conversation round-trip** — additionally creates and deletes an ephemeral iAssistant
+  conversation, which verifies write access rather than only authentication.
+
+#### Reading the Two Classic Failures
+
+**iFinder answers 500.** The request reached iFinder, so the cause is on its side — most often that
+iFinder cannot resolve or reach the JWKS URL of iHub while validating your token. Check the **Issuer
+reachable** step: if the advertised issuer is `localhost` or a short single-label hostname, iFinder
+can never fetch the keys. Set the externally reachable URL under **Admin → Authentication → OAuth
+Server** and verify it from the iFinder host with `curl -sv https://ihub.example.com/.well-known/jwks.json`.
+
+**iFinder answers 401 with an empty body.** The diagnostics print the claims that were sent
+(`sub`, `iss`, `aud`, `alg`, `kid`) so you can compare them against the trust configuration in
+iFinder, surface the `WWW-Authenticate` header when there is one, and remind you of the usual
+suspects: an issuer that does not match exactly (a trailing slash is enough), a `kid` that is not in
+the JWKS, a subject in the wrong format, or clock skew on the iHub server.
+
+The same checks are available over the API:
+
+```bash
+curl -X POST https://ihub.example.com/api/admin/integrations/ifinder/_test \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -d '{"includeToken": false, "user": {"username": "jdoe", "domain": "EXAMPLE"}}'
+```
+
+The response contains `success`, a `summary` of step counts, and the ordered `steps` array with
+`status` (`ok` / `warn` / `fail` / `skip`), `message`, `details`, and `hints` per step.
 
 ### 1. Common Connection Issues
 

--- a/docs/ifinder-iassistant-admin-guide.md
+++ b/docs/ifinder-iassistant-admin-guide.md
@@ -824,7 +824,6 @@ Expand **Diagnostics options** above the buttons for:
 - **Test as email / username / domain** — mint the test JWT for a specific user instead of your own
   admin account. Use this to confirm how the subject claim is built, for example whether iFinder
   expects `DOMAIN\username` rather than an email address.
-- **Test search query** — the term used for the iFinder test request (default `test`).
 - **Include the signed JWT** — returns the token itself plus a ready-to-run `curl` command. The token
   is a working credential for the tested user, so treat it like a password. Without this option the
   `curl` command references `$TOKEN` and is safe to share.
@@ -853,6 +852,11 @@ curl -X POST https://ihub.example.com/api/admin/integrations/ifinder/_test \
   -H "Authorization: Bearer $ADMIN_TOKEN" \
   -d '{"includeToken": false, "user": {"username": "jdoe", "domain": "EXAMPLE"}}'
 ```
+
+The search term and the search profile are not accepted as parameters: the diagnostics
+deliberately exercise the configured profile with a fixed query, so that no value from the
+request can influence which URL iHub contacts. To test a different profile, change the
+**Default Search Profile** setting.
 
 The response contains `success`, a `summary` of step counts, and the ordered `steps` array with
 `status` (`ok` / `warn` / `fail` / `skip`), `message`, `details`, and `hints` per step.

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -927,3 +927,30 @@ in an in-app PDF preview with every cited passage highlighted, scrolled to the f
   reports "Passage not found" instead of failing.
 - Documents without a downloadable version are unaffected: the passage button and preview entry
   only appear where iFinder exposes document access.
+
+## Connection Diagnostics for iFinder and iAssistant
+
+The **Test iFinder** and **Test iAssistant** buttons under Admin → iFinder Integration now run a
+step-by-step diagnostic instead of returning a single pass/fail message. Each step reports what it
+observed and, when it fails, what to check — so connecting iHub to iFinder no longer requires
+reading server logs and guessing.
+
+- Checks the whole path: the configured URL (including a warning when the hostname is not fully
+  qualified), DNS resolution, the TCP/TLS handshake with certificate subject, issuer, expiry and
+  trust result, JWT generation, local signature verification, JWKS reachability, and a real API
+  request against iFinder's search endpoint or iAssistant's profile list.
+- Shows the decoded JWT — header, payload, and the subject that was actually derived for the user —
+  so it can be compared against the trust configuration on the iFinder side. A 401 now also surfaces
+  the `WWW-Authenticate` header and names the usual causes: issuer mismatch, a `kid` missing from
+  the JWKS, a subject in the wrong format, or clock skew.
+- Flags the issuer and JWKS URL that **iFinder itself must call back to**. A `localhost` or
+  single-label hostname there is reported as a failure, because iFinder can never fetch the signing
+  keys from it — the most common reason iFinder answers 500 during token validation.
+- Detects an iAssistant profile ID that does not exist and lists the profiles the tested user can
+  actually see.
+- Diagnostics options allow testing as a specific user (email, username, domain) to verify how the
+  JWT subject is built, choosing the test search query, optionally returning the signed JWT together
+  with a ready-to-run `curl` command, and running an iAssistant conversation round-trip to verify
+  write access. Without the token option the `curl` command references `$TOKEN` and is safe to share.
+- A previous behaviour is fixed: an iAssistant network failure used to be reported as "configuration
+  is valid" and counted as a success. Unreachable now reads as unreachable.

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -949,8 +949,11 @@ reading server logs and guessing.
 - Detects an iAssistant profile ID that does not exist and lists the profiles the tested user can
   actually see.
 - Diagnostics options allow testing as a specific user (email, username, domain) to verify how the
-  JWT subject is built, choosing the test search query, optionally returning the signed JWT together
-  with a ready-to-run `curl` command, and running an iAssistant conversation round-trip to verify
-  write access. Without the token option the `curl` command references `$TOKEN` and is safe to share.
+  JWT subject is built, optionally returning the signed JWT together with a ready-to-run `curl`
+  command, and running an iAssistant conversation round-trip to verify write access. Without the
+  token option the `curl` command references `$TOKEN` and is safe to share.
+- The search term and profile are fixed rather than configurable per run, so no value from the
+  request can influence which URL iHub contacts. The diagnostics always exercise the configured
+  search profile, which is what an admin wants to verify anyway.
 - A previous behaviour is fixed: an iAssistant network failure used to be reported as "configuration
   is valid" and counted as a success. Unreachable now reads as unreachable.

--- a/server/routes/admin/integrationTest.js
+++ b/server/routes/admin/integrationTest.js
@@ -248,14 +248,15 @@ async function runTransportSteps(report, { rawUrl, urlLabel, timeout }) {
   }
 
   await report.run('tcp', 'TCP / TLS connection', async () => {
+    // The probe always verifies certificates. Where the admin has whitelisted the
+    // domain under Admin > Platform > SSL, a rejection here is not a broken
+    // integration — real requests still go through — so the whitelist changes how
+    // the result is *interpreted*, never how strictly it was measured.
     const probe = await probeTcpTls({
       hostname: urlInfo.hostname,
       port: urlInfo.port,
       protocol: urlInfo.protocol,
-      timeout: Math.min(timeout, 15000),
-      // Verify exactly as an outbound request would: only an explicit admin
-      // whitelist entry relaxes it, never the probe itself.
-      rejectUnauthorized: !transport.ignoreInvalidCertificates
+      timeout: Math.min(timeout, 15000)
     });
 
     const details = {
@@ -263,18 +264,33 @@ async function runTransportSteps(report, { rawUrl, urlLabel, timeout }) {
       connected: probe.connected,
       remoteAddress: probe.remoteAddress,
       durationMs: probe.durationMs,
-      certificateValidation: transport.ignoreInvalidCertificates
-        ? 'relaxed for this domain by the Admin > Platform > SSL whitelist'
-        : 'enforced against the trust store of the iHub server',
+      certificateValidation: 'always enforced by this probe against the iHub trust store',
+      sslWhitelisted: transport.ignoreInvalidCertificates,
       note: transport.viaProxy
         ? `This probe connects directly. Real requests go through the proxy ${transport.proxyUrl}, so a failure here does not necessarily break the integration.`
         : 'Direct connection from the iHub server (no proxy configured for this URL).',
       ...(probe.tls ? { tls: probe.tls } : {})
     };
 
+    const opensslHint = `Inspect what the host presents: openssl s_client -connect ${urlInfo.hostname}:${urlInfo.port}${
+      urlInfo.isIpLiteral ? '' : ` -servername ${urlInfo.hostname}`
+    }`;
+
     // A certificate rejection is not an unreachable host: the handshake got far
     // enough to receive a certificate, so only trust is missing.
     if (!probe.connected && probe.certificateRejected) {
+      if (transport.ignoreInvalidCertificates) {
+        return {
+          status: STATUS.WARN,
+          message: `Reached ${urlInfo.hostname}:${urlInfo.port}; its TLS certificate is not trusted by the iHub trust store (${probe.error}), but this domain is whitelisted so requests still succeed`,
+          details,
+          hints: [
+            'The integration works because the domain is whitelisted under Admin > Platform > SSL. That bypass applies to iHub only — browsers and other clients still reject this certificate.',
+            'Add the issuing CA to the trust store of the iHub server to fix it properly and drop the whitelist entry.',
+            opensslHint
+          ]
+        };
+      }
       return {
         status: STATUS.FAIL,
         message: `Reached ${urlInfo.hostname}:${urlInfo.port}, but its TLS certificate was rejected: ${probe.error}`,
@@ -282,9 +298,7 @@ async function runTransportSteps(report, { rawUrl, urlLabel, timeout }) {
         hints: [
           'Add the CA that issued the certificate to the trust store of the iHub server, so both iHub and the browser trust it.',
           'As a temporary workaround the domain can be whitelisted under Admin > Platform > SSL. That only relaxes iHub, not other clients.',
-          `Verify what the host presents: openssl s_client -connect ${urlInfo.hostname}:${urlInfo.port}${
-            urlInfo.isIpLiteral ? '' : ` -servername ${urlInfo.hostname}`
-          }`
+          opensslHint
         ]
       };
     }
@@ -305,31 +319,14 @@ async function runTransportSteps(report, { rawUrl, urlLabel, timeout }) {
       };
     }
 
-    const tlsHints = [];
-    let status = STATUS.OK;
+    // Reaching here with TLS means the certificate passed verification, so there
+    // is no untrusted or expired case left to report.
     let message = `Connected to ${urlInfo.hostname}:${urlInfo.port} in ${probe.durationMs}ms`;
-
     if (probe.tls) {
-      message += ` (${probe.tls.protocol}, certificate for ${probe.tls.subject || 'unknown subject'})`;
-      if (!probe.tls.authorized) {
-        // Only reachable when the SSL whitelist relaxed verification for this
-        // domain; otherwise an untrusted certificate already aborted above.
-        status = STATUS.WARN;
-        message = `Connected, but the TLS certificate of ${urlInfo.hostname} is not trusted: ${probe.tls.authorizationError}`;
-        tlsHints.push(
-          `Add the CA that issued "${probe.tls.issuer || 'the certificate'}" to the trust store of the iHub server.`,
-          'This domain is whitelisted under Admin > Platform > SSL, so requests still go through — but only from iHub. Other clients will keep rejecting it.'
-        );
-        if (probe.tls.selfSigned) {
-          tlsHints.push('The certificate is self-signed.');
-        }
-      } else if (probe.tls.expired) {
-        status = STATUS.WARN;
-        tlsHints.push(`The certificate expired on ${probe.tls.validTo}.`);
-      }
+      message += ` (${probe.tls.protocol}, certificate for ${probe.tls.subject || 'unknown subject'} issued by ${probe.tls.issuer || 'unknown issuer'}, valid to ${probe.tls.validTo || 'unknown'})`;
     }
 
-    return { status, message, details, hints: tlsHints };
+    return { status: STATUS.OK, message, details };
   });
 
   return urlInfo;

--- a/server/routes/admin/integrationTest.js
+++ b/server/routes/admin/integrationTest.js
@@ -42,6 +42,34 @@ const OVERRIDABLE_USER_FIELDS = ['id', 'email', 'username', 'name', 'domain'];
 const MAX_OVERRIDE_LENGTH = 320;
 
 /**
+ * Characters a search profile id may contain. iFinder profile ids are slugs
+ * ("searchprofile-standard") or base64 of one, so this covers every legitimate
+ * value while keeping request-body input out of the URL path entirely — no
+ * slashes, dots or encoded traversal sequences can reach the endpoint template.
+ */
+const SEARCH_PROFILE_PATTERN = /^[A-Za-z0-9_:@=+-]{1,200}$/;
+
+/**
+ * Build the URL for an integration request.
+ *
+ * The origin and path always come from the trusted platform configuration, and
+ * every caller-supplied value goes through `searchParams`, so request-body input
+ * can never influence which host is contacted.
+ *
+ * @param {string} baseUrl - Configured base URL
+ * @param {string} path - Endpoint path (already templated)
+ * @param {Object} [query] - Query parameters
+ * @returns {string} Absolute URL
+ */
+function buildIntegrationUrl(baseUrl, path, query = {}) {
+  const url = new URL(`${baseUrl.replace(/\/+$/, '')}${path}`);
+  for (const [key, value] of Object.entries(query)) {
+    if (value !== undefined && value !== null) url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+/**
  * Accept only known string fields from the request body, so the override cannot
  * be used to smuggle arbitrary structures into JWT generation.
  * @param {Object} raw - `user` object from the request body
@@ -223,7 +251,10 @@ async function runTransportSteps(report, { rawUrl, urlLabel, timeout }) {
       hostname: urlInfo.hostname,
       port: urlInfo.port,
       protocol: urlInfo.protocol,
-      timeout: Math.min(timeout, 15000)
+      timeout: Math.min(timeout, 15000),
+      // Verify exactly as an outbound request would: only an explicit admin
+      // whitelist entry relaxes it, never the probe itself.
+      rejectUnauthorized: !transport.ignoreInvalidCertificates
     });
 
     const details = {
@@ -231,11 +262,31 @@ async function runTransportSteps(report, { rawUrl, urlLabel, timeout }) {
       connected: probe.connected,
       remoteAddress: probe.remoteAddress,
       durationMs: probe.durationMs,
+      certificateValidation: transport.ignoreInvalidCertificates
+        ? 'relaxed for this domain by the Admin > Platform > SSL whitelist'
+        : 'enforced against the trust store of the iHub server',
       note: transport.viaProxy
         ? `This probe connects directly. Real requests go through the proxy ${transport.proxyUrl}, so a failure here does not necessarily break the integration.`
         : 'Direct connection from the iHub server (no proxy configured for this URL).',
       ...(probe.tls ? { tls: probe.tls } : {})
     };
+
+    // A certificate rejection is not an unreachable host: the handshake got far
+    // enough to receive a certificate, so only trust is missing.
+    if (!probe.connected && probe.certificateRejected) {
+      return {
+        status: STATUS.FAIL,
+        message: `Reached ${urlInfo.hostname}:${urlInfo.port}, but its TLS certificate was rejected: ${probe.error}`,
+        details,
+        hints: [
+          'Add the CA that issued the certificate to the trust store of the iHub server, so both iHub and the browser trust it.',
+          'As a temporary workaround the domain can be whitelisted under Admin > Platform > SSL. That only relaxes iHub, not other clients.',
+          `Verify what the host presents: openssl s_client -connect ${urlInfo.hostname}:${urlInfo.port}${
+            urlInfo.isIpLiteral ? '' : ` -servername ${urlInfo.hostname}`
+          }`
+        ]
+      };
+    }
 
     if (!probe.connected) {
       return {
@@ -260,22 +311,16 @@ async function runTransportSteps(report, { rawUrl, urlLabel, timeout }) {
     if (probe.tls) {
       message += ` (${probe.tls.protocol}, certificate for ${probe.tls.subject || 'unknown subject'})`;
       if (!probe.tls.authorized) {
-        status = transport.ignoreInvalidCertificates ? STATUS.WARN : STATUS.FAIL;
-        message = `TLS certificate of ${urlInfo.hostname} is not trusted: ${probe.tls.authorizationError}`;
+        // Only reachable when the SSL whitelist relaxed verification for this
+        // domain; otherwise an untrusted certificate already aborted above.
+        status = STATUS.WARN;
+        message = `Connected, but the TLS certificate of ${urlInfo.hostname} is not trusted: ${probe.tls.authorizationError}`;
         tlsHints.push(
-          `Add the CA that issued "${probe.tls.issuer || 'the certificate'}" to the trust store of the iHub server.`
+          `Add the CA that issued "${probe.tls.issuer || 'the certificate'}" to the trust store of the iHub server.`,
+          'This domain is whitelisted under Admin > Platform > SSL, so requests still go through — but only from iHub. Other clients will keep rejecting it.'
         );
         if (probe.tls.selfSigned) {
           tlsHints.push('The certificate is self-signed.');
-        }
-        if (transport.ignoreInvalidCertificates) {
-          tlsHints.push(
-            'This domain is whitelisted under Admin > Platform > SSL, so requests still go through — but only from iHub. Other clients will keep rejecting it.'
-          );
-        } else {
-          tlsHints.push(
-            'As a temporary workaround the domain can be whitelisted under Admin > Platform > SSL.'
-          );
         }
       } else if (probe.tls.expired) {
         status = STATUS.WARN;
@@ -323,6 +368,15 @@ async function runJwtSteps(report, { user, iFinderConfig, userOverride, includeT
     if (subjectField === 'email' && !String(info.subject).includes('@')) {
       hints.push(
         `JWT Subject Field is "email" but the subject "${info.subject}" is not an email address — the user has no email, so iHub fell back to the username or id. iFinder has to know the subject in exactly this form.`
+      );
+    }
+
+    // The scope claim is read back from the signed token, so it is the value
+    // iFinder will really see. Flag the implicit fallback, which does not match
+    // the scope the shipped platform default configures.
+    if (!iFinderConfig.defaultScope) {
+      hints.push(
+        `No Default Scope is configured, so the token was signed with the built-in fallback scope "${info.scope}". Set the scope explicitly on this page — the shipped default is "fa_index_read".`
       );
     }
 
@@ -819,9 +873,27 @@ export default function registerIntegrationTestRoutes(app) {
         const platformConfig = configCache.getPlatform() || {};
         const iFinderConfig = platformConfig.iFinder || {};
         const config = iFinderService.getConfig();
-        const searchProfile =
-          (typeof req.body?.searchProfile === 'string' && req.body.searchProfile.trim()) ||
-          config.defaultSearchProfile;
+        // The override only ever reaches a URL path segment, so it is validated
+        // against the shape of a profile id rather than merely encoded.
+        const requestedProfile =
+          typeof req.body?.searchProfile === 'string' ? req.body.searchProfile.trim() : '';
+        if (requestedProfile && !SEARCH_PROFILE_PATTERN.test(requestedProfile)) {
+          report.add({
+            id: 'configuration',
+            label: 'Configuration',
+            status: STATUS.FAIL,
+            message: 'The requested search profile is not a valid profile id',
+            details: { requestedSearchProfile: requestedProfile },
+            hints: [
+              'A search profile id may only contain letters, digits and the characters _ : @ = + - (for example "searchprofile-standard", or its base64 form).'
+            ]
+          });
+          return respond(res, report, {
+            integration: 'iFinder',
+            details: { invalidParameter: 'searchProfile' }
+          });
+        }
+        const searchProfile = requestedProfile || config.defaultSearchProfile;
         const signingKey = describeSigningKey(iFinderConfig);
         const timeout = config.timeout || 30000;
 
@@ -847,7 +919,10 @@ export default function registerIntegrationTestRoutes(app) {
           jwtAudience: iFinderConfig.audience || 'ifinder-api',
           jwtIssuer: iFinderConfig.issuer || 'ihub-apps',
           tokenExpirationSeconds: iFinderConfig.tokenExpirationSeconds || 3600,
-          defaultScope: iFinderConfig.defaultScope || 'fi_index_read',
+          // Deliberately not defaulted here: duplicating the fallback would risk
+          // reporting a scope other than the one actually signed. The scope that
+          // ends up in the token is reported by the JWT step from the real claim.
+          defaultScope: iFinderConfig.defaultScope || '(not configured)',
           signingKeyMode: signingKey.mode,
           signingKeySource: signingKey.description
         };
@@ -951,7 +1026,10 @@ export default function registerIntegrationTestRoutes(app) {
             '{profileId}',
             encodeURIComponent(searchProfile)
           );
-          const searchUrl = `${config.baseUrl.replace(/\/+$/, '')}${searchEndpoint}?query=${encodeURIComponent(testQuery)}&size=1`;
+          const searchUrl = buildIntegrationUrl(config.baseUrl, searchEndpoint, {
+            query: testQuery,
+            size: 1
+          });
 
           const result = await runApiRequestStep(report, {
             id: 'search',
@@ -1197,7 +1275,10 @@ export default function registerIntegrationTestRoutes(app) {
             'Skipped because the base URL or the JWT could not be prepared.'
           );
         } else {
-          const profilesUrl = `${config.baseUrl.replace(/\/+$/, '')}/public-api/rag/api/v0/profiles`;
+          const profilesUrl = buildIntegrationUrl(
+            config.baseUrl,
+            '/public-api/rag/api/v0/profiles'
+          );
           const requestContext = {
             useOidcKeyPair: Boolean(iFinderConfig.useOidcKeyPair),
             jwksUrl: oidc.applicable ? oidc.jwksUrl : undefined,

--- a/server/routes/admin/integrationTest.js
+++ b/server/routes/admin/integrationTest.js
@@ -8,7 +8,6 @@ import { throttledFetch } from '../../requestThrottler.js';
 import configCache from '../../configCache.js';
 import logger from '../../utils/logger.js';
 import tokenStorageService from '../../services/TokenStorageService.js';
-import { isValidSearchProfileId } from '../../utils/pathSecurity.js';
 import {
   DiagnosticsReport,
   STATUS,
@@ -42,20 +41,34 @@ import {
 const OVERRIDABLE_USER_FIELDS = ['id', 'email', 'username', 'name', 'domain'];
 const MAX_OVERRIDE_LENGTH = 320;
 
+/** Search term used for the iFinder test request. Constant on purpose — see buildIntegrationUrl. */
+const TEST_SEARCH_QUERY = 'test';
+
 /**
  * Build the URL for an integration request.
  *
- * The origin and path always come from the trusted platform configuration, and
- * every caller-supplied value goes through `searchParams`, so request-body input
- * can never influence which host is contacted.
+ * Every component comes from the trusted platform configuration — nothing from
+ * the request body, the query string or a header ever reaches an outbound URL in
+ * this module. The origin is additionally re-asserted against the configured base
+ * URL, so even a future change to an endpoint template cannot redirect a
+ * diagnostics request at a different host.
  *
  * @param {string} baseUrl - Configured base URL
- * @param {string} path - Endpoint path (already templated)
- * @param {Object} [query] - Query parameters
+ * @param {string} path - Endpoint path from configuration
+ * @param {Object} [query] - Query parameters built from configuration/constants
  * @returns {string} Absolute URL
+ * @throws {Error} If the result would leave the configured origin
  */
 function buildIntegrationUrl(baseUrl, path, query = {}) {
-  const url = new URL(`${baseUrl.replace(/\/+$/, '')}${path}`);
+  const base = new URL(baseUrl.replace(/\/+$/, ''));
+  const url = new URL(`${base.origin}${base.pathname.replace(/\/+$/, '')}${path}`);
+
+  if (url.origin !== base.origin) {
+    throw new Error(
+      `Refusing to send a diagnostics request to ${url.origin}, which is not the configured ${base.origin}`
+    );
+  }
+
   for (const [key, value] of Object.entries(query)) {
     if (value !== undefined && value !== null) url.searchParams.set(key, String(value));
   }
@@ -112,31 +125,38 @@ function buildTestUser(req, override) {
 /**
  * The issuer URL iHub advertises for its own OIDC metadata.
  *
- * When `platform.oauth.issuer` is unset the well-known routes derive it from the
- * incoming request, so the diagnostics do the same to report the URL iFinder
- * will really be pointed at.
+ * Returns two separate values on purpose:
+ *
+ * - `fetchableIssuer` is non-null only when `platform.oauth.issuer` is configured.
+ *   It is the only value this module ever requests, so no header can influence
+ *   which host iHub contacts.
+ * - `issuer` is what the admin is *shown*. When nothing is configured the
+ *   well-known routes derive the issuer from the request, so the diagnostics
+ *   report the same derivation to reveal the URL iFinder would be pointed at.
+ *   It is display-only and must never reach an HTTP request.
+ *
  * @param {import('express').Request} req
- * @returns {Object} `{ issuer, source }`
+ * @returns {Object} `{ issuer, fetchableIssuer, source, fromTrustedConfig }`
  */
 function resolveIssuerUrl(req) {
   const platform = configCache.getPlatform() || {};
   const configured = platform.oauth?.issuer;
   if (configured && configured.startsWith('http')) {
+    const issuer = configured.replace(/\/+$/, '');
     return {
-      issuer: configured.replace(/\/+$/, ''),
+      issuer,
+      fetchableIssuer: issuer,
       source: 'platform.oauth.issuer',
       fromTrustedConfig: true
     };
   }
 
-  // Derived from the Host header of this request, exactly as the well-known
-  // routes do. It is reported so the admin sees the URL iFinder would be pointed
-  // at, but it is caller-controlled and must never be fetched — see the JWKS step.
   const protocol = req.protocol || (req.secure ? 'https' : 'http');
   const host = req.get('host');
   const basePath = buildServerPath('').replace(/\/$/, '');
   return {
     issuer: `${protocol}://${host}${basePath}`,
+    fetchableIssuer: null,
     source: 'auto-detected from the Host header of this request',
     fromTrustedConfig: false
   };
@@ -448,8 +468,12 @@ async function runJwtSteps(report, { user, iFinderConfig, userOverride, includeT
  * @returns {Promise<Object>} `{ jwksUrl, issuer }`
  */
 async function runOidcCallbackSteps(report, { req, iFinderConfig, jwtInfo, timeout }) {
-  const { issuer, source, fromTrustedConfig } = resolveIssuerUrl(req);
+  const { issuer, fetchableIssuer, source, fromTrustedConfig } = resolveIssuerUrl(req);
+  // Display value: may be derived from the request, so it is only ever printed.
   const jwksUrl = `${issuer}/.well-known/jwks.json`;
+  // Request value: null unless the issuer came from platform config, so nothing
+  // taken from the request can decide which host the JWKS probe contacts.
+  const fetchableJwksUrl = fetchableIssuer ? `${fetchableIssuer}/.well-known/jwks.json` : null;
   const discoveryUrl = `${issuer}/.well-known/openid-configuration`;
 
   if (!iFinderConfig.useOidcKeyPair) {
@@ -545,11 +569,11 @@ async function runOidcCallbackSteps(report, { req, iFinderConfig, jwtInfo, timeo
     // or a load balancer without hairpin NAT — so an unreachable endpoint is a
     // warning to re-check from the iFinder host. Only the *content* of a
     // successful response is conclusive.
-    const unreachableHint = `Re-run the check from the iFinder host: curl -sv ${jwksUrl}. If it answers there, the integration is fine and only iHub cannot reach its own external URL.`;
+    const unreachableHint = `Re-run the check from the iFinder host: curl -sv ${fetchableJwksUrl}. If it answers there, the integration is fine and only iHub cannot reach its own external URL.`;
 
     let response;
     try {
-      response = await throttledFetch('iFinderTest', jwksUrl, {
+      response = await throttledFetch('iFinderTest', fetchableJwksUrl, {
         method: 'GET',
         headers: { Accept: 'application/json' },
         timeout
@@ -807,12 +831,6 @@ export default function registerIntegrationTestRoutes(app) {
    *               includeToken:
    *                 type: boolean
    *                 description: Include the signed JWT and an executable curl command in the result
-   *               query:
-   *                 type: string
-   *                 description: Search term used for the test request (default "test")
-   *               searchProfile:
-   *                 type: string
-   *                 description: Override the search profile for this test
    *               user:
    *                 type: object
    *                 description: Mint the test JWT for these user fields instead of the calling admin
@@ -883,35 +901,16 @@ export default function registerIntegrationTestRoutes(app) {
         const includeToken = req.body?.includeToken === true;
         const userOverride = sanitizeUserOverride(req.body?.user);
         const testUser = buildTestUser(req, userOverride);
-        const testQuery =
-          typeof req.body?.query === 'string' && req.body.query.trim() !== ''
-            ? req.body.query.trim().slice(0, 200)
-            : 'test';
 
         const platformConfig = configCache.getPlatform() || {};
         const iFinderConfig = platformConfig.iFinder || {};
         const config = iFinderService.getConfig();
-        // The override only ever reaches a URL path segment, so it is validated
-        // against the shape of a profile id rather than merely encoded.
-        const requestedProfile =
-          typeof req.body?.searchProfile === 'string' ? req.body.searchProfile.trim() : '';
-        if (requestedProfile && !isValidSearchProfileId(requestedProfile)) {
-          report.add({
-            id: 'configuration',
-            label: 'Configuration',
-            status: STATUS.FAIL,
-            message: 'The requested search profile is not a valid profile id',
-            details: { requestedSearchProfile: requestedProfile },
-            hints: [
-              'A search profile id may only contain letters, digits and the characters _ : @ = + - (for example "searchprofile-standard", or its base64 form).'
-            ]
-          });
-          return respond(res, report, {
-            integration: 'iFinder',
-            details: { invalidParameter: 'searchProfile' }
-          });
-        }
-        const searchProfile = requestedProfile || config.defaultSearchProfile;
+        // Both the search term and the profile are fixed here rather than taken
+        // from the request. A diagnostic should exercise the configured state, and
+        // keeping request input out of the URL entirely is a stronger guarantee
+        // than validating it: no caller-supplied value can reach an outbound URL.
+        const testQuery = TEST_SEARCH_QUERY;
+        const searchProfile = config.defaultSearchProfile;
         const signingKey = describeSigningKey(iFinderConfig);
         const timeout = config.timeout || 30000;
 

--- a/server/routes/admin/integrationTest.js
+++ b/server/routes/admin/integrationTest.js
@@ -8,6 +8,7 @@ import { throttledFetch } from '../../requestThrottler.js';
 import configCache from '../../configCache.js';
 import logger from '../../utils/logger.js';
 import tokenStorageService from '../../services/TokenStorageService.js';
+import { isValidSearchProfileId } from '../../utils/pathSecurity.js';
 import {
   DiagnosticsReport,
   STATUS,
@@ -40,14 +41,6 @@ import {
 /** Fields of a user object that may be overridden to test as somebody else. */
 const OVERRIDABLE_USER_FIELDS = ['id', 'email', 'username', 'name', 'domain'];
 const MAX_OVERRIDE_LENGTH = 320;
-
-/**
- * Characters a search profile id may contain. iFinder profile ids are slugs
- * ("searchprofile-standard") or base64 of one, so this covers every legitimate
- * value while keeping request-body input out of the URL path entirely — no
- * slashes, dots or encoded traversal sequences can reach the endpoint template.
- */
-const SEARCH_PROFILE_PATTERN = /^[A-Za-z0-9_:@=+-]{1,200}$/;
 
 /**
  * Build the URL for an integration request.
@@ -129,15 +122,23 @@ function resolveIssuerUrl(req) {
   const platform = configCache.getPlatform() || {};
   const configured = platform.oauth?.issuer;
   if (configured && configured.startsWith('http')) {
-    return { issuer: configured.replace(/\/+$/, ''), source: 'platform.oauth.issuer' };
+    return {
+      issuer: configured.replace(/\/+$/, ''),
+      source: 'platform.oauth.issuer',
+      fromTrustedConfig: true
+    };
   }
 
+  // Derived from the Host header of this request, exactly as the well-known
+  // routes do. It is reported so the admin sees the URL iFinder would be pointed
+  // at, but it is caller-controlled and must never be fetched — see the JWKS step.
   const protocol = req.protocol || (req.secure ? 'https' : 'http');
   const host = req.get('host');
   const basePath = buildServerPath('').replace(/\/$/, '');
   return {
     issuer: `${protocol}://${host}${basePath}`,
-    source: 'auto-detected from this request'
+    source: 'auto-detected from the Host header of this request',
+    fromTrustedConfig: false
   };
 }
 
@@ -450,7 +451,7 @@ async function runJwtSteps(report, { user, iFinderConfig, userOverride, includeT
  * @returns {Promise<Object>} `{ jwksUrl, issuer }`
  */
 async function runOidcCallbackSteps(report, { req, iFinderConfig, jwtInfo, timeout }) {
-  const { issuer, source } = resolveIssuerUrl(req);
+  const { issuer, source, fromTrustedConfig } = resolveIssuerUrl(req);
   const jwksUrl = `${issuer}/.well-known/jwks.json`;
   const discoveryUrl = `${issuer}/.well-known/openid-configuration`;
 
@@ -519,6 +520,26 @@ async function runOidcCallbackSteps(report, { req, iFinderConfig, jwtInfo, timeo
         'Align Admin > Authentication > OAuth Server with the externally reachable URL of iHub.'
       ]
     });
+  }
+
+  // The issuer is only fetched when it comes from platform config. Auto-detection
+  // derives it from the Host header, which the caller controls, so fetching it
+  // would turn this endpoint into a server-side request forgery primitive: the
+  // header alone would decide which host iHub contacts. The computed URL is still
+  // reported, since seeing it is what tells the admin to pin it explicitly.
+  if (!fromTrustedConfig) {
+    report.add({
+      id: 'jwks',
+      label: 'JWKS endpoint serves the signing key',
+      status: STATUS.WARN,
+      message: `Not checked: the issuer URL is auto-detected, so ${jwksUrl} was not requested`,
+      details: { url: jwksUrl, issuerSource: source },
+      hints: [
+        'Configure the OAuth Issuer URL under Admin > Authentication > OAuth Server. iHub then knows its own externally reachable URL, this check runs against it, and the "iss" claim stops depending on which host name a client happens to use.',
+        `Until then, verify it by hand from the iFinder host: curl -sv ${jwksUrl}`
+      ]
+    });
+    return { issuer, jwksUrl, applicable: true };
   }
 
   await report.run('jwks', 'JWKS endpoint serves the signing key', async () => {
@@ -877,7 +898,7 @@ export default function registerIntegrationTestRoutes(app) {
         // against the shape of a profile id rather than merely encoded.
         const requestedProfile =
           typeof req.body?.searchProfile === 'string' ? req.body.searchProfile.trim() : '';
-        if (requestedProfile && !SEARCH_PROFILE_PATTERN.test(requestedProfile)) {
+        if (requestedProfile && !isValidSearchProfileId(requestedProfile)) {
           report.add({
             id: 'configuration',
             label: 'Configuration',

--- a/server/routes/admin/integrationTest.js
+++ b/server/routes/admin/integrationTest.js
@@ -2,31 +2,760 @@ import { adminAuth } from '../../middleware/adminAuth.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import iFinderService from '../../services/integrations/iFinderService.js';
 import iAssistantService from '../../services/integrations/iAssistantService.js';
-import { getIFinderAuthorizationHeader } from '../../utils/iFinderJwt.js';
+import conversationApiService from '../../services/integrations/ConversationApiService.js';
+import { getIFinderAuthorizationHeader, validateIFinderJWT } from '../../utils/iFinderJwt.js';
 import { throttledFetch } from '../../requestThrottler.js';
+import configCache from '../../configCache.js';
 import logger from '../../utils/logger.js';
-import { sendErrorResponse } from '../../utils/responseHelpers.js';
 import tokenStorageService from '../../services/TokenStorageService.js';
+import {
+  DiagnosticsReport,
+  STATUS,
+  buildCurlCommand,
+  decodeJwt,
+  describeHttpFailure,
+  describeNetworkError,
+  describeTransport,
+  inspectUrl,
+  pickResponseHeaders,
+  previewToken,
+  probeTcpTls,
+  redactHeaders,
+  resolveHostname,
+  truncateBody
+} from '../../services/integrations/integrationDiagnostics.js';
 
 /**
- * Admin routes for testing integrations (iFinder, iAssistant)
+ * Admin routes for testing integrations (iFinder, iAssistant).
+ *
+ * Both endpoints run a sequence of diagnostic steps instead of a single
+ * pass/fail probe, because the failures admins actually hit while connecting
+ * iHub to iFinder are indistinguishable from the outside: a 500 raised inside
+ * iFinder while it tries to resolve the JWKS hostname of iHub, and a 401 with an
+ * empty body, both used to surface as "test failed". Each step therefore reports
+ * the URLs used, the resolved addresses, the TLS peer, the decoded JWT claims,
+ * and hints naming what to check.
  */
+
+/** Fields of a user object that may be overridden to test as somebody else. */
+const OVERRIDABLE_USER_FIELDS = ['id', 'email', 'username', 'name', 'domain'];
+const MAX_OVERRIDE_LENGTH = 320;
+
+/**
+ * Accept only known string fields from the request body, so the override cannot
+ * be used to smuggle arbitrary structures into JWT generation.
+ * @param {Object} raw - `user` object from the request body
+ * @returns {Object} Sanitized override (may be empty)
+ */
+function sanitizeUserOverride(raw) {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+
+  const override = {};
+  for (const field of OVERRIDABLE_USER_FIELDS) {
+    const value = raw[field];
+    if (typeof value === 'string' && value.trim() !== '') {
+      override[field] = value.trim().slice(0, MAX_OVERRIDE_LENGTH);
+    }
+  }
+
+  if (Array.isArray(raw.groups)) {
+    const groups = raw.groups
+      .filter(group => typeof group === 'string' && group.trim() !== '')
+      .map(group => group.trim().slice(0, MAX_OVERRIDE_LENGTH))
+      .slice(0, 50);
+    if (groups.length > 0) override.groups = groups;
+  }
+
+  return override;
+}
+
+/**
+ * Build the user the test JWT is minted for: the calling admin by default, with
+ * any explicitly supplied fields layered on top.
+ * @param {import('express').Request} req
+ * @param {Object} override - Result of sanitizeUserOverride
+ * @returns {Object} User object
+ */
+function buildTestUser(req, override) {
+  const base = {
+    id: req.user?.id || 'test-admin',
+    email: req.user?.email || 'admin@test.com',
+    username: req.user?.username || 'admin',
+    name: req.user?.name || 'Test Admin',
+    groups: req.user?.groups || ['admin']
+  };
+  if (req.user?.domain) base.domain = req.user.domain;
+  return { ...base, ...override };
+}
+
+/**
+ * The issuer URL iHub advertises for its own OIDC metadata.
+ *
+ * When `platform.oauth.issuer` is unset the well-known routes derive it from the
+ * incoming request, so the diagnostics do the same to report the URL iFinder
+ * will really be pointed at.
+ * @param {import('express').Request} req
+ * @returns {Object} `{ issuer, source }`
+ */
+function resolveIssuerUrl(req) {
+  const platform = configCache.getPlatform() || {};
+  const configured = platform.oauth?.issuer;
+  if (configured && configured.startsWith('http')) {
+    return { issuer: configured.replace(/\/+$/, ''), source: 'platform.oauth.issuer' };
+  }
+
+  const protocol = req.protocol || (req.secure ? 'https' : 'http');
+  const host = req.get('host');
+  const basePath = buildServerPath('').replace(/\/$/, '');
+  return {
+    issuer: `${protocol}://${host}${basePath}`,
+    source: 'auto-detected from this request'
+  };
+}
+
+/**
+ * Describe which key signs the iFinder JWT, without ever revealing it.
+ * @param {Object} iFinderConfig
+ * @returns {Object} `{ mode, available, description }`
+ */
+function describeSigningKey(iFinderConfig) {
+  if (iFinderConfig.useOidcKeyPair) {
+    const keyPair = tokenStorageService.getRSAKeyPair();
+    return {
+      mode: 'oidcKeyPair',
+      available: Boolean(keyPair?.privateKey),
+      description: 'iHub OIDC RSA key pair (published via /.well-known/jwks.json)'
+    };
+  }
+  if (process.env.IFINDER_PRIVATE_KEY) {
+    return {
+      mode: 'privateKey',
+      available: true,
+      description: 'IFINDER_PRIVATE_KEY environment variable'
+    };
+  }
+  if (iFinderConfig.privateKeyRef) {
+    return {
+      mode: 'privateKey',
+      available: true,
+      description: `credential store reference "${iFinderConfig.privateKeyRef}"`
+    };
+  }
+  return { mode: 'privateKey', available: false, description: 'not configured' };
+}
+
+/**
+ * Inspect a configured URL, resolve its hostname and probe the port.
+ *
+ * Steps are appended to `report`; the inspection is returned so the caller can
+ * stop early when the URL itself is unusable.
+ * @param {DiagnosticsReport} report
+ * @param {Object} params
+ * @param {string} params.rawUrl
+ * @param {string} params.urlLabel - Human name of the setting ("iFinder base")
+ * @param {number} params.timeout
+ * @returns {Promise<Object>} URL inspection result
+ */
+async function runTransportSteps(report, { rawUrl, urlLabel, timeout }) {
+  const urlInfo = inspectUrl(rawUrl);
+  const hints = [...urlInfo.errors, ...urlInfo.warnings];
+
+  report.add({
+    id: 'url',
+    label: `${urlLabel} URL`,
+    status: !urlInfo.valid ? STATUS.FAIL : urlInfo.warnings.length > 0 ? STATUS.WARN : STATUS.OK,
+    message: urlInfo.valid
+      ? `${urlInfo.protocol}://${urlInfo.hostname}:${urlInfo.port}${urlInfo.pathname}`
+      : `Configured URL cannot be used: ${urlInfo.errors.join(' ')}`,
+    details: {
+      configured: urlInfo.raw,
+      protocol: urlInfo.protocol,
+      hostname: urlInfo.hostname,
+      port: urlInfo.port,
+      portSource: urlInfo.defaultPort ? 'scheme default' : 'explicit in URL',
+      path: urlInfo.pathname,
+      fullyQualifiedHostname: urlInfo.isFqdn || urlInfo.isIpLiteral,
+      ipLiteral: urlInfo.isIpLiteral
+    },
+    hints
+  });
+
+  if (!urlInfo.valid) return urlInfo;
+
+  const dnsStep = await report.run('dns', 'DNS resolution', async () => {
+    const result = await resolveHostname(urlInfo.hostname);
+    if (!result.resolved) {
+      return {
+        status: STATUS.FAIL,
+        message: `Cannot resolve "${urlInfo.hostname}" from the iHub server (${result.code || 'lookup failed'})`,
+        details: { hostname: urlInfo.hostname, error: result.error, code: result.code },
+        hints: describeNetworkError(
+          { code: result.code, message: result.error },
+          {
+            hostname: urlInfo.hostname
+          }
+        )
+      };
+    }
+    const addresses = result.addresses.map(entry => entry.address);
+    return {
+      status: STATUS.OK,
+      message: result.literal
+        ? `${urlInfo.hostname} is a literal IP address, no lookup needed`
+        : `${urlInfo.hostname} resolves to ${addresses.join(', ')}`,
+      details: { hostname: urlInfo.hostname, addresses, literal: result.literal }
+    };
+  });
+
+  const transport = describeTransport(urlInfo.url);
+
+  if (dnsStep.status === STATUS.FAIL) {
+    report.skip(
+      'tcp',
+      'TCP / TLS connection',
+      'Skipped because the hostname could not be resolved.'
+    );
+    return urlInfo;
+  }
+
+  await report.run('tcp', 'TCP / TLS connection', async () => {
+    const probe = await probeTcpTls({
+      hostname: urlInfo.hostname,
+      port: urlInfo.port,
+      protocol: urlInfo.protocol,
+      timeout: Math.min(timeout, 15000)
+    });
+
+    const details = {
+      target: `${urlInfo.hostname}:${urlInfo.port}`,
+      connected: probe.connected,
+      remoteAddress: probe.remoteAddress,
+      durationMs: probe.durationMs,
+      note: transport.viaProxy
+        ? `This probe connects directly. Real requests go through the proxy ${transport.proxyUrl}, so a failure here does not necessarily break the integration.`
+        : 'Direct connection from the iHub server (no proxy configured for this URL).',
+      ...(probe.tls ? { tls: probe.tls } : {})
+    };
+
+    if (!probe.connected) {
+      return {
+        status: transport.viaProxy ? STATUS.WARN : STATUS.FAIL,
+        message: probe.error,
+        details,
+        hints: describeNetworkError(
+          { code: probe.code, message: probe.error },
+          {
+            hostname: urlInfo.hostname,
+            port: urlInfo.port,
+            timeout
+          }
+        )
+      };
+    }
+
+    const tlsHints = [];
+    let status = STATUS.OK;
+    let message = `Connected to ${urlInfo.hostname}:${urlInfo.port} in ${probe.durationMs}ms`;
+
+    if (probe.tls) {
+      message += ` (${probe.tls.protocol}, certificate for ${probe.tls.subject || 'unknown subject'})`;
+      if (!probe.tls.authorized) {
+        status = transport.ignoreInvalidCertificates ? STATUS.WARN : STATUS.FAIL;
+        message = `TLS certificate of ${urlInfo.hostname} is not trusted: ${probe.tls.authorizationError}`;
+        tlsHints.push(
+          `Add the CA that issued "${probe.tls.issuer || 'the certificate'}" to the trust store of the iHub server.`
+        );
+        if (probe.tls.selfSigned) {
+          tlsHints.push('The certificate is self-signed.');
+        }
+        if (transport.ignoreInvalidCertificates) {
+          tlsHints.push(
+            'This domain is whitelisted under Admin > Platform > SSL, so requests still go through — but only from iHub. Other clients will keep rejecting it.'
+          );
+        } else {
+          tlsHints.push(
+            'As a temporary workaround the domain can be whitelisted under Admin > Platform > SSL.'
+          );
+        }
+      } else if (probe.tls.expired) {
+        status = STATUS.WARN;
+        tlsHints.push(`The certificate expired on ${probe.tls.validTo}.`);
+      }
+    }
+
+    return { status, message, details, hints: tlsHints };
+  });
+
+  return urlInfo;
+}
+
+/**
+ * Mint the test JWT, decode it, and verify it locally.
+ *
+ * The decoded claims are what an admin needs in order to compare the token
+ * against the trust configuration on the iFinder side — the "how does the JWT
+ * look like / which user is sent" part of the puzzle.
+ *
+ * @param {DiagnosticsReport} report
+ * @param {Object} params
+ * @param {Object} params.user - Test user
+ * @param {Object} params.iFinderConfig - platform.iFinder
+ * @param {Object} params.userOverride - Explicitly overridden user fields
+ * @param {boolean} params.includeToken - Whether the raw JWT may be returned
+ * @returns {Promise<Object|null>} `{ authHeader, token, info }` or null on failure
+ */
+async function runJwtSteps(report, { user, iFinderConfig, userOverride, includeToken }) {
+  let authHeader;
+  let token;
+  let info;
+
+  const generation = await report.run('jwt', 'JWT generation', () => {
+    authHeader = getIFinderAuthorizationHeader(user);
+    token = authHeader.replace(/^Bearer\s+/i, '');
+    info = decodeJwt(token);
+
+    const subjectField = iFinderConfig.jwtSubjectField || 'email';
+    const hints = [];
+
+    // The subject resolution falls back through email → username → id. When the
+    // configured field was empty the token still gets signed, and iFinder then
+    // rejects a subject the admin never intended to send.
+    if (subjectField === 'email' && !String(info.subject).includes('@')) {
+      hints.push(
+        `JWT Subject Field is "email" but the subject "${info.subject}" is not an email address — the user has no email, so iHub fell back to the username or id. iFinder has to know the subject in exactly this form.`
+      );
+    }
+
+    return {
+      status: hints.length > 0 ? STATUS.WARN : STATUS.OK,
+      message: `Signed ${info.algorithm} token for sub="${info.subject}"`,
+      details: {
+        subject: info.subject,
+        subjectField,
+        subjectResolvedFrom:
+          subjectField === 'custom' || /\$\{/.test(subjectField)
+            ? `template "${subjectField}"`
+            : `user.${subjectField}`,
+        testUser: {
+          id: user.id,
+          email: user.email,
+          username: user.username,
+          name: user.name,
+          domain: user.domain,
+          groups: user.groups
+        },
+        overriddenFields: Object.keys(userOverride),
+        header: info.header,
+        payload: info.payload,
+        issuedAt: info.issuedAt,
+        expiresAt: info.expiresAt,
+        lifetimeSeconds: info.lifetimeSeconds,
+        tokenPreview: previewToken(token),
+        ...(includeToken ? { token } : {})
+      },
+      hints
+    };
+  });
+
+  if (generation.status === STATUS.FAIL) {
+    // report.run converted the exception into a failed step; attach the two
+    // things that can break signing so the message is actionable.
+    generation.hints = [
+      'Check the signing key: OIDC key pair mode needs an initialized iHub RSA key pair, private key mode needs IFINDER_PRIVATE_KEY or iFinder.privateKeyRef in PEM format.',
+      'A subject that cannot be resolved also fails here — see the JWT Subject Field setting.'
+    ];
+    return null;
+  }
+
+  await report.run('jwtVerify', 'JWT signature (verified locally)', () => {
+    const decoded = validateIFinderJWT(token);
+    return {
+      status: STATUS.OK,
+      message: 'iHub can verify its own token with the matching public key',
+      details: { verifiedClaims: decoded }
+    };
+  });
+
+  return { authHeader, token, info };
+}
+
+/**
+ * Check the OIDC metadata iFinder has to fetch in order to validate the token.
+ *
+ * This is the step that explains the "iFinder returned 500 because it could not
+ * resolve the name" class of failure: iFinder calls back to the issuer URL that
+ * iHub advertises, and a short hostname or a localhost URL only resolves on the
+ * iHub host itself.
+ *
+ * @param {DiagnosticsReport} report
+ * @param {Object} params
+ * @param {import('express').Request} params.req
+ * @param {Object} params.iFinderConfig
+ * @param {Object|undefined} params.jwtInfo - decodeJwt result of the test token
+ * @param {number} params.timeout
+ * @returns {Promise<Object>} `{ jwksUrl, issuer }`
+ */
+async function runOidcCallbackSteps(report, { req, iFinderConfig, jwtInfo, timeout }) {
+  const { issuer, source } = resolveIssuerUrl(req);
+  const jwksUrl = `${issuer}/.well-known/jwks.json`;
+  const discoveryUrl = `${issuer}/.well-known/openid-configuration`;
+
+  if (!iFinderConfig.useOidcKeyPair) {
+    report.skip(
+      'oidcIssuer',
+      'Issuer reachable for iFinder',
+      'Not applicable: JWT is signed with a dedicated private key, so iFinder verifies with the public key deployed in iFinder instead of fetching JWKS.'
+    );
+    return { issuer, jwksUrl, applicable: false };
+  }
+
+  const issuerInfo = inspectUrl(issuer, { remoteCallback: true });
+  report.add({
+    id: 'oidcIssuer',
+    label: 'Issuer reachable for iFinder',
+    status: issuerInfo.valid
+      ? issuerInfo.warnings.length > 0
+        ? STATUS.WARN
+        : STATUS.OK
+      : STATUS.FAIL,
+    message: issuerInfo.valid
+      ? `iFinder will fetch the signing keys from ${jwksUrl}`
+      : `iFinder cannot use the advertised issuer ${issuer}: ${issuerInfo.errors.join(' ')}`,
+    details: {
+      issuer,
+      issuerSource: source,
+      jwksUrl,
+      discoveryUrl,
+      tokenIssuerClaim: jwtInfo?.issuer,
+      fullyQualifiedHostname: issuerInfo.isFqdn || issuerInfo.isIpLiteral
+    },
+    hints: [
+      ...issuerInfo.errors,
+      ...issuerInfo.warnings,
+      `Verify from the iFinder host that the URL is reachable: curl -sv ${jwksUrl}`,
+      'Set the URL explicitly under Admin > Authentication > OAuth Server when auto-detection picks the wrong host.'
+    ]
+  });
+
+  // iFinder derives the JWKS location from the "iss" claim. A claim that is not
+  // an absolute URL makes discovery structurally impossible, which is a harder
+  // failure than a claim that merely points somewhere else.
+  const tokenIssuer = jwtInfo?.issuer;
+  if (tokenIssuer && !/^https?:\/\//.test(tokenIssuer)) {
+    report.add({
+      id: 'oidcIssuerMatch',
+      label: 'Issuer claim is a discoverable URL',
+      status: STATUS.FAIL,
+      message: `The token carries iss="${tokenIssuer}", which is not a URL — iFinder has no JWKS endpoint to discover`,
+      details: { tokenIssuerClaim: tokenIssuer, metadataIssuer: issuer, jwksUrl },
+      hints: [
+        `Set the OAuth Issuer URL under Admin > Authentication > OAuth Server to the externally reachable URL of iHub (for example ${issuer}). OIDC key pair mode uses it as the "iss" claim.`,
+        'Without it iHub falls back to the plain "ihub-apps" issuer, which iFinder cannot resolve — that is what surfaces as a 500 or a 401 during token validation.'
+      ]
+    });
+  } else if (tokenIssuer && issuer && tokenIssuer.replace(/\/+$/, '') !== issuer) {
+    report.add({
+      id: 'oidcIssuerMatch',
+      label: 'Issuer claim matches metadata URL',
+      status: STATUS.WARN,
+      message: `The token says iss="${tokenIssuer}" but the metadata is served from ${issuer}`,
+      details: { tokenIssuerClaim: tokenIssuer, metadataIssuer: issuer },
+      hints: [
+        'iFinder resolves the JWKS location from the "iss" claim. If the two differ, validation fails with a 401 or a 500.',
+        'Align Admin > Authentication > OAuth Server with the externally reachable URL of iHub.'
+      ]
+    });
+  }
+
+  await report.run('jwks', 'JWKS endpoint serves the signing key', async () => {
+    // This probe runs from the iHub server against iHub's own external URL. It
+    // can fail for reasons that do not affect iFinder at all — split-horizon DNS
+    // or a load balancer without hairpin NAT — so an unreachable endpoint is a
+    // warning to re-check from the iFinder host. Only the *content* of a
+    // successful response is conclusive.
+    const unreachableHint = `Re-run the check from the iFinder host: curl -sv ${jwksUrl}. If it answers there, the integration is fine and only iHub cannot reach its own external URL.`;
+
+    let response;
+    try {
+      response = await throttledFetch('iFinderTest', jwksUrl, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        timeout
+      });
+    } catch (error) {
+      return {
+        status: STATUS.WARN,
+        message: `${jwksUrl} is not reachable from the iHub server: ${error.message}`,
+        details: { url: jwksUrl, error: error.message, code: error.code },
+        hints: [
+          unreachableHint,
+          ...describeNetworkError(error, { hostname: inspectUrl(jwksUrl).hostname })
+        ]
+      };
+    }
+
+    const bodyText = await response.text();
+    if (!response.ok) {
+      return {
+        status: STATUS.WARN,
+        message: `${jwksUrl} returned ${response.status} when called from the iHub server`,
+        details: { url: jwksUrl, status: response.status, body: truncateBody(bodyText, 500) },
+        hints: [
+          unreachableHint,
+          'If it fails from the iFinder host too, iFinder cannot validate any token. Check whether a reverse proxy in front of iHub blocks /.well-known/ paths.'
+        ]
+      };
+    }
+
+    let parsed;
+    try {
+      parsed = JSON.parse(bodyText);
+    } catch {
+      return {
+        status: STATUS.WARN,
+        message: `${jwksUrl} did not return JSON`,
+        details: { url: jwksUrl, body: truncateBody(bodyText, 500) },
+        hints: [
+          'A reverse proxy or an SSO login page is answering instead of iHub.',
+          unreachableHint
+        ]
+      };
+    }
+
+    const keys = Array.isArray(parsed.keys) ? parsed.keys : [];
+    const keyIds = keys.map(key => key.kid).filter(Boolean);
+
+    if (keys.length === 0) {
+      return {
+        status: STATUS.FAIL,
+        message: 'The JWKS endpoint publishes no keys',
+        details: { url: jwksUrl, note: parsed.note, keyIds },
+        hints: [
+          'Set "jwt.algorithm" to RS256 under Admin > Authentication: with the symmetric HS256 algorithm iHub cannot publish a public key, and iFinder has no way to verify the signature.'
+        ]
+      };
+    }
+
+    if (jwtInfo?.keyId && !keyIds.includes(jwtInfo.keyId)) {
+      return {
+        status: STATUS.FAIL,
+        message: `The token is signed with kid="${jwtInfo.keyId}", which the JWKS endpoint does not publish`,
+        details: { url: jwksUrl, tokenKeyId: jwtInfo.keyId, publishedKeyIds: keyIds },
+        hints: [
+          'iFinder will reject the token because it cannot find a matching key.',
+          'This happens when the RSA key pair was rotated but a cached JWKS is still served, or when a reverse proxy caches /.well-known/jwks.json. Clear the cache and retry.'
+        ]
+      };
+    }
+
+    return {
+      status: STATUS.OK,
+      message: `Signing key kid="${jwtInfo?.keyId ?? keyIds[0]}" is published at ${jwksUrl}`,
+      details: { url: jwksUrl, publishedKeyIds: keyIds, tokenKeyId: jwtInfo?.keyId },
+      hints: [
+        'Reachable from the iHub server. iFinder must be able to reach the very same URL — verify it from the iFinder host as well.'
+      ]
+    };
+  });
+
+  return { issuer, jwksUrl, applicable: true };
+}
+
+/**
+ * Execute the request an integration really performs at runtime and report it in
+ * full: URL, method, redacted headers, a reproducible curl command, the response
+ * status, the interesting response headers and a body excerpt.
+ *
+ * @param {DiagnosticsReport} report
+ * @param {Object} params
+ * @returns {Promise<Object>} `{ ok, request, response }`
+ */
+async function runApiRequestStep(
+  report,
+  { id, label, url, method = 'GET', headers, body, token, includeToken, timeout, jwtInfo, context }
+) {
+  const requestInfo = {
+    method,
+    url,
+    headers: redactHeaders(headers),
+    ...(body ? { body } : {}),
+    curl: buildCurlCommand({
+      url,
+      method,
+      headers,
+      body,
+      token: includeToken ? token : undefined
+    })
+  };
+
+  // `report.run` only keeps the reportable fields, so the parsed payload is
+  // captured here for the caller's follow-up assertions.
+  let parsedBody;
+
+  const step = await report.run(id, label, async () => {
+    const startedAt = Date.now();
+    let response;
+    try {
+      response = await throttledFetch('iFinderTest', url, { method, headers, body, timeout });
+    } catch (error) {
+      const parsed = inspectUrl(url);
+      return {
+        status: STATUS.FAIL,
+        message: `Request failed before a response arrived: ${error.message}`,
+        details: { request: requestInfo, error: error.message, code: error.code },
+        hints: describeNetworkError(error, {
+          hostname: parsed.hostname,
+          port: parsed.port,
+          timeout
+        })
+      };
+    }
+
+    const durationMs = Date.now() - startedAt;
+    const responseHeaders = pickResponseHeaders(response.headers);
+    const bodyText = await response.text();
+
+    if (!response.ok) {
+      return {
+        status: STATUS.FAIL,
+        message: `${method} ${url} returned ${response.status} ${response.statusText || ''}`.trim(),
+        details: {
+          request: requestInfo,
+          status: response.status,
+          statusText: response.statusText,
+          durationMs,
+          responseHeaders,
+          responseBody: truncateBody(bodyText)
+        },
+        hints: describeHttpFailure({
+          status: response.status,
+          body: bodyText,
+          headers: responseHeaders,
+          jwt: jwtInfo || {},
+          context
+        })
+      };
+    }
+
+    try {
+      parsedBody = bodyText ? JSON.parse(bodyText) : {};
+    } catch {
+      parsedBody = undefined;
+    }
+
+    return {
+      status: STATUS.OK,
+      message: `${method} ${url} returned ${response.status} in ${durationMs}ms`,
+      details: {
+        request: requestInfo,
+        status: response.status,
+        durationMs,
+        responseHeaders,
+        responsePreview: truncateBody(bodyText, 800)
+      }
+    };
+  });
+
+  return {
+    ok: step.status === STATUS.OK,
+    request: requestInfo,
+    parsed: parsedBody,
+    status: step.status
+  };
+}
+
+/**
+ * Send a diagnostics report as the endpoint response.
+ * @param {import('express').Response} res
+ * @param {DiagnosticsReport} report
+ * @param {Object} params
+ * @param {string} params.integration - 'iFinder' | 'iAssistant'
+ * @param {string} [params.successMessage]
+ * @param {Object} [params.jwt] - JWT block for the response
+ * @param {Object} [params.request] - Primary request that was executed
+ * @param {Object} [params.details] - Flat summary retained for existing consumers
+ */
+function respond(res, report, { integration, successMessage, jwt, request, details }) {
+  const summary = report.summary();
+  const success = !report.hasFailure();
+  const firstFailure = report.steps.find(step => step.status === STATUS.FAIL);
+
+  const message = success
+    ? summary.warn > 0
+      ? `${successMessage} (${summary.warn} warning${summary.warn === 1 ? '' : 's'})`
+      : successMessage
+    : `${firstFailure.label}: ${firstFailure.message}`;
+
+  logger.info(`${integration} integration test finished`, {
+    component: 'IntegrationTest',
+    success,
+    summary,
+    failedStep: firstFailure?.id
+  });
+
+  return res.json({
+    success,
+    message,
+    integration,
+    summary,
+    steps: report.steps,
+    ...(jwt ? { jwt } : {}),
+    ...(request ? { request } : {}),
+    details: {
+      ...details,
+      failedStep: firstFailure?.id,
+      steps: summary
+    }
+  });
+}
 
 export default function registerIntegrationTestRoutes(app) {
   /**
    * @swagger
    * /admin/integrations/ifinder/_test:
    *   post:
-   *     summary: Test iFinder integration
-   *     description: Tests the iFinder connection and JWT authentication (admin access required)
+   *     summary: Run iFinder connection diagnostics
+   *     description: >
+   *       Runs a sequence of diagnostic steps against the configured iFinder instance
+   *       (URL validation, DNS resolution, TCP/TLS probe, JWT generation and local
+   *       verification, OIDC/JWKS callback reachability, search API request) and returns
+   *       every observed detail plus remediation hints (admin access required).
    *     tags:
    *       - Admin - Integrations
    *     security:
    *       - bearerAuth: []
    *       - sessionAuth: []
+   *     requestBody:
+   *       required: false
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               includeToken:
+   *                 type: boolean
+   *                 description: Include the signed JWT and an executable curl command in the result
+   *               query:
+   *                 type: string
+   *                 description: Search term used for the test request (default "test")
+   *               searchProfile:
+   *                 type: string
+   *                 description: Override the search profile for this test
+   *               user:
+   *                 type: object
+   *                 description: Mint the test JWT for these user fields instead of the calling admin
+   *                 properties:
+   *                   id: { type: string }
+   *                   email: { type: string }
+   *                   username: { type: string }
+   *                   name: { type: string }
+   *                   domain: { type: string }
+   *                   groups:
+   *                     type: array
+   *                     items: { type: string }
    *     responses:
    *       200:
-   *         description: iFinder integration test results
+   *         description: Diagnostics result
    *         content:
    *           application/json:
    *             schema:
@@ -34,182 +763,270 @@ export default function registerIntegrationTestRoutes(app) {
    *               properties:
    *                 success:
    *                   type: boolean
-   *                   description: Whether the test was successful
+   *                   description: True when no step failed
    *                 message:
    *                   type: string
-   *                   description: Test result message
+   *                   description: Summary, or the first failing step
+   *                 summary:
+   *                   type: object
+   *                   description: Step counts per status plus total duration
+   *                 steps:
+   *                   type: array
+   *                   description: Ordered diagnostic steps
+   *                   items:
+   *                     type: object
+   *                     properties:
+   *                       id: { type: string }
+   *                       label: { type: string }
+   *                       status:
+   *                         type: string
+   *                         enum: [ok, warn, fail, skip]
+   *                       message: { type: string }
+   *                       durationMs: { type: number }
+   *                       details: { type: object }
+   *                       hints:
+   *                         type: array
+   *                         items: { type: string }
+   *                 jwt:
+   *                   type: object
+   *                   description: Decoded header, payload and claims of the test token
+   *                 request:
+   *                   type: object
+   *                   description: The API request that was executed, including a curl command
    *                 details:
    *                   type: object
-   *                   description: Additional test details
+   *                   description: Flat result summary
    *       401:
    *         description: Admin authentication required
    *       500:
-   *         description: Test failed
+   *         description: Test failed unexpectedly
    */
   app.post(
     buildServerPath('/api/admin/integrations/ifinder/_test'),
     adminAuth,
     async (req, res) => {
+      const report = new DiagnosticsReport();
+
       try {
-        const config = iFinderService.getConfig();
+        const includeToken = req.body?.includeToken === true;
+        const userOverride = sanitizeUserOverride(req.body?.user);
+        const testUser = buildTestUser(req, userOverride);
+        const testQuery =
+          typeof req.body?.query === 'string' && req.body.query.trim() !== ''
+            ? req.body.query.trim().slice(0, 200)
+            : 'test';
 
-        // Check if iFinder is enabled
-        const platformConfig = iFinderService.platform || {};
+        const platformConfig = configCache.getPlatform() || {};
         const iFinderConfig = platformConfig.iFinder || {};
+        const config = iFinderService.getConfig();
+        const searchProfile =
+          (typeof req.body?.searchProfile === 'string' && req.body.searchProfile.trim()) ||
+          config.defaultSearchProfile;
+        const signingKey = describeSigningKey(iFinderConfig);
+        const timeout = config.timeout || 30000;
 
-        if (!iFinderConfig.enabled) {
-          return res.json({
-            success: false,
-            message: 'iFinder integration is not enabled',
-            details: {
-              enabled: false
-            }
-          });
-        }
-
-        // Validate required configuration
-        if (!iFinderConfig.baseUrl) {
-          return res.json({
-            success: false,
-            message: 'iFinder base URL is not configured',
-            details: {
-              missingConfig: 'baseUrl'
-            }
-          });
-        }
-
-        // Validate JWT signing configuration based on mode
-        if (iFinderConfig.useOidcKeyPair) {
-          // When using OIDC keypair mode, verify OIDC RSA keypair is available
-          const rsaKeyPair = tokenStorageService.getRSAKeyPair();
-          if (!rsaKeyPair || !rsaKeyPair.privateKey) {
-            return res.json({
-              success: false,
-              message:
-                'iHub OIDC RSA key pair is not initialized. Cannot sign iFinder JWT with OIDC keypair.',
-              details: {
-                missingConfig: 'oidcKeyPair',
-                useOidcKeyPair: true
-              }
-            });
-          }
-        } else {
-          // When using dedicated iFinder private key, verify it's configured.
-          // The key now lives in the central credential store (referenced by
-          // privateKeyRef) or the IFINDER_PRIVATE_KEY env var.
-          if (!iFinderConfig.privateKeyRef && !process.env.IFINDER_PRIVATE_KEY) {
-            return res.json({
-              success: false,
-              message: 'iFinder private key is not configured',
-              details: {
-                missingConfig: 'privateKey',
-                useOidcKeyPair: false
-              }
-            });
-          }
-        }
-
-        // Create a test user for JWT generation
-        const testUser = {
-          id: req.user?.id || 'test-admin',
-          email: req.user?.email || 'admin@test.com',
-          username: req.user?.username || 'admin',
-          name: req.user?.name || 'Test Admin',
-          groups: req.user?.groups || ['admin']
-        };
-
-        // Try to generate JWT token
-        let authHeader;
-        try {
-          authHeader = getIFinderAuthorizationHeader(testUser);
-          logger.info('iFinder JWT token generated successfully for test', {
-            component: 'IntegrationTest',
-            userId: testUser.id
-          });
-        } catch (error) {
-          logger.error('iFinder JWT generation failed', {
-            component: 'IntegrationTest',
-            error
-          });
-          return res.json({
-            success: false,
-            message: 'Failed to generate JWT token',
-            details: {
-              error: error.message,
-              step: 'jwt_generation'
-            }
-          });
-        }
-
-        // Try to make a simple search request to verify connectivity
-        const searchEndpoint = config.endpoints.search.replace(
-          '{profileId}',
-          encodeURIComponent(config.defaultSearchProfile)
-        );
-        const searchUrl = `${config.baseUrl.replace(/\/+$/, '')}${searchEndpoint}?query=test&size=1`;
-
-        logger.info('Testing iFinder connection', {
+        logger.info('Running iFinder integration diagnostics', {
           component: 'IntegrationTest',
           baseUrl: config.baseUrl,
-          searchProfile: config.defaultSearchProfile
+          searchProfile,
+          useOidcKeyPair: Boolean(iFinderConfig.useOidcKeyPair),
+          includeToken,
+          overriddenUserFields: Object.keys(userOverride),
+          requestedBy: req.user?.id
         });
 
-        const response = await throttledFetch('iFinderTest', searchUrl, {
-          method: 'GET',
-          headers: {
-            Authorization: authHeader,
-            Accept: 'application/json'
-          },
-          timeout: config.timeout
-        });
+        const configDetails = {
+          enabled: Boolean(iFinderConfig.enabled),
+          baseUrl: config.baseUrl,
+          searchEndpoint: config.endpoints.search,
+          documentEndpoint: config.endpoints.document,
+          searchProfile,
+          timeoutMs: timeout,
+          jwtSubjectField: iFinderConfig.jwtSubjectField || 'email',
+          jwtAlgorithm: iFinderConfig.useOidcKeyPair ? 'RS256' : iFinderConfig.algorithm || 'RS256',
+          jwtAudience: iFinderConfig.audience || 'ifinder-api',
+          jwtIssuer: iFinderConfig.issuer || 'ihub-apps',
+          tokenExpirationSeconds: iFinderConfig.tokenExpirationSeconds || 3600,
+          defaultScope: iFinderConfig.defaultScope || 'fi_index_read',
+          signingKeyMode: signingKey.mode,
+          signingKeySource: signingKey.description
+        };
 
-        if (!response.ok) {
-          const errorText = await response.text();
-          logger.warn('iFinder test request failed', {
-            component: 'IntegrationTest',
-            status: response.status,
-            error: errorText
+        if (!iFinderConfig.enabled) {
+          report.add({
+            id: 'configuration',
+            label: 'Configuration',
+            status: STATUS.FAIL,
+            message: 'The iFinder integration is disabled',
+            details: configDetails,
+            hints: ['Enable the integration at the top of this page and save.']
           });
+          return respond(res, report, {
+            integration: 'iFinder',
+            details: { enabled: false, ...configDetails }
+          });
+        }
 
-          return res.json({
-            success: false,
-            message: `iFinder API returned status ${response.status}`,
+        if (!iFinderConfig.baseUrl && !config.baseUrl) {
+          report.add({
+            id: 'configuration',
+            label: 'Configuration',
+            status: STATUS.FAIL,
+            message: 'No iFinder base URL is configured',
+            details: configDetails,
+            hints: [
+              'Set the iFinder Base URL on this page, or provide the IFINDER_API_URL environment variable.'
+            ]
+          });
+          return respond(res, report, {
+            integration: 'iFinder',
+            details: { missingConfig: 'baseUrl', ...configDetails }
+          });
+        }
+
+        if (!signingKey.available) {
+          report.add({
+            id: 'configuration',
+            label: 'Configuration',
+            status: STATUS.FAIL,
+            message: iFinderConfig.useOidcKeyPair
+              ? 'The iHub OIDC RSA key pair is not initialized, so no iFinder JWT can be signed'
+              : 'No iFinder private key is configured',
+            details: configDetails,
+            hints: iFinderConfig.useOidcKeyPair
+              ? [
+                  'Set "jwt.algorithm" to RS256 under Admin > Authentication so iHub generates an RSA key pair, then restart the server.'
+                ]
+              : [
+                  'Store the private key as the iFinder credential (iFinder.privateKeyRef) or provide the IFINDER_PRIVATE_KEY environment variable in PEM format.',
+                  'Alternatively enable "Use OIDC key pair" to sign with the key pair iHub already publishes via JWKS.'
+                ]
+          });
+          return respond(res, report, {
+            integration: 'iFinder',
             details: {
-              status: response.status,
-              error: errorText,
-              step: 'api_request'
+              missingConfig: iFinderConfig.useOidcKeyPair ? 'oidcKeyPair' : 'privateKey',
+              ...configDetails
             }
           });
         }
 
-        const data = await response.json();
-
-        logger.info('iFinder test successful', {
-          component: 'IntegrationTest',
-          totalHits: data.metadata?.total_hits
+        report.add({
+          id: 'configuration',
+          label: 'Configuration',
+          status: STATUS.OK,
+          message: `Signing with ${signingKey.description}, subject from "${configDetails.jwtSubjectField}"`,
+          details: configDetails
         });
 
-        return res.json({
-          success: true,
-          message: 'iFinder integration is working correctly',
+        const urlInfo = await runTransportSteps(report, {
+          rawUrl: config.baseUrl,
+          urlLabel: 'iFinder base',
+          timeout
+        });
+
+        const jwtResult = await runJwtSteps(report, {
+          user: testUser,
+          iFinderConfig,
+          userOverride,
+          includeToken
+        });
+
+        const oidc = await runOidcCallbackSteps(report, {
+          req,
+          iFinderConfig,
+          jwtInfo: jwtResult?.info,
+          timeout
+        });
+
+        let request;
+        if (!urlInfo.valid || !jwtResult) {
+          report.skip(
+            'search',
+            'iFinder search API request',
+            'Skipped because the base URL or the JWT could not be prepared.'
+          );
+        } else {
+          const searchEndpoint = config.endpoints.search.replace(
+            '{profileId}',
+            encodeURIComponent(searchProfile)
+          );
+          const searchUrl = `${config.baseUrl.replace(/\/+$/, '')}${searchEndpoint}?query=${encodeURIComponent(testQuery)}&size=1`;
+
+          const result = await runApiRequestStep(report, {
+            id: 'search',
+            label: 'iFinder search API request',
+            url: searchUrl,
+            method: 'GET',
+            headers: { Authorization: jwtResult.authHeader, Accept: 'application/json' },
+            token: jwtResult.token,
+            includeToken,
+            timeout,
+            jwtInfo: jwtResult.info,
+            context: {
+              useOidcKeyPair: Boolean(iFinderConfig.useOidcKeyPair),
+              jwksUrl: oidc.applicable ? oidc.jwksUrl : undefined,
+              searchProfile
+            }
+          });
+          request = result.request;
+
+          if (result.ok) {
+            report.add({
+              id: 'searchResult',
+              label: 'Search result',
+              status: STATUS.OK,
+              message: `iFinder answered the query "${testQuery}" with ${result.parsed?.metadata?.total_hits ?? 0} hit(s)`,
+              details: {
+                query: testQuery,
+                searchProfile,
+                totalHits: result.parsed?.metadata?.total_hits ?? 0,
+                tookMs: result.parsed?.metadata?.took
+              },
+              hints:
+                (result.parsed?.metadata?.total_hits ?? 0) === 0
+                  ? [
+                      `The connection works but the query "${testQuery}" matched nothing. Confirm the search profile "${searchProfile}" contains documents the user "${jwtResult.info.subject}" is allowed to see.`
+                    ]
+                  : []
+            });
+          }
+        }
+
+        return respond(res, report, {
+          integration: 'iFinder',
+          successMessage: 'iFinder integration is working correctly',
+          jwt: jwtResult
+            ? {
+                subject: jwtResult.info.subject,
+                header: jwtResult.info.header,
+                payload: jwtResult.info.payload,
+                preview: previewToken(jwtResult.token),
+                ...(includeToken ? { token: jwtResult.token } : {})
+              }
+            : undefined,
+          request,
           details: {
-            baseUrl: config.baseUrl,
-            searchProfile: config.defaultSearchProfile,
-            jwtGeneration: 'success',
-            apiConnection: 'success',
-            responseTime: data.metadata?.took,
-            totalResults: data.metadata?.total_hits || 0
+            ...configDetails,
+            jwtGeneration: jwtResult ? 'success' : 'failed',
+            jwksUrl: oidc.applicable ? oidc.jwksUrl : undefined
           }
         });
       } catch (error) {
-        logger.error('iFinder test error', { component: 'IntegrationTest', error });
-        return res.json({
-          success: false,
+        logger.error('iFinder integration test error', { component: 'IntegrationTest', error });
+        report.add({
+          id: 'unexpected',
+          label: 'Unexpected error',
+          status: STATUS.FAIL,
           message: error.message || 'iFinder integration test failed',
-          details: {
-            error: error.message,
-            step: 'unknown'
-          }
+          details: { error: error.message, stack: error.stack?.split('\n').slice(0, 5).join('\n') },
+          hints: [
+            'Check the iHub server log (component "IntegrationTest") for the full stack trace.'
+          ]
+        });
+        return respond(res, report, {
+          integration: 'iFinder',
+          details: { error: error.message }
         });
       }
     }
@@ -219,177 +1036,312 @@ export default function registerIntegrationTestRoutes(app) {
    * @swagger
    * /admin/integrations/iassistant/_test:
    *   post:
-   *     summary: Test iAssistant integration
-   *     description: Tests the iAssistant connection and configuration (admin access required)
+   *     summary: Run iAssistant connection diagnostics
+   *     description: >
+   *       Runs a sequence of diagnostic steps against the iAssistant Conversation API
+   *       (URL validation, DNS resolution, TCP/TLS probe, JWT generation and local
+   *       verification, OIDC/JWKS callback reachability, profile listing, and optionally a
+   *       full conversation round-trip) and returns every observed detail plus remediation
+   *       hints (admin access required).
    *     tags:
    *       - Admin - Integrations
    *     security:
    *       - bearerAuth: []
    *       - sessionAuth: []
+   *     requestBody:
+   *       required: false
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             properties:
+   *               includeToken:
+   *                 type: boolean
+   *                 description: Include the signed JWT and an executable curl command in the result
+   *               conversationRoundTrip:
+   *                 type: boolean
+   *                 description: Additionally create and delete an ephemeral conversation
+   *               user:
+   *                 type: object
+   *                 description: Mint the test JWT for these user fields instead of the calling admin
+   *                 properties:
+   *                   id: { type: string }
+   *                   email: { type: string }
+   *                   username: { type: string }
+   *                   name: { type: string }
+   *                   domain: { type: string }
+   *                   groups:
+   *                     type: array
+   *                     items: { type: string }
    *     responses:
    *       200:
-   *         description: iAssistant integration test results
-   *         content:
-   *           application/json:
-   *             schema:
-   *               type: object
-   *               properties:
-   *                 success:
-   *                   type: boolean
-   *                   description: Whether the test was successful
-   *                 message:
-   *                   type: string
-   *                   description: Test result message
-   *                 details:
-   *                   type: object
-   *                   description: Additional test details
+   *         description: Diagnostics result, same shape as the iFinder diagnostics
    *       401:
    *         description: Admin authentication required
    *       500:
-   *         description: Test failed
+   *         description: Test failed unexpectedly
    */
   app.post(
     buildServerPath('/api/admin/integrations/iassistant/_test'),
     adminAuth,
     async (req, res) => {
+      const report = new DiagnosticsReport();
+
       try {
+        const includeToken = req.body?.includeToken === true;
+        const conversationRoundTrip = req.body?.conversationRoundTrip === true;
+        const userOverride = sanitizeUserOverride(req.body?.user);
+        const testUser = buildTestUser(req, userOverride);
+
+        const platformConfig = configCache.getPlatform() || {};
+        const iFinderConfig = platformConfig.iFinder || {};
         const config = iAssistantService.getConfig();
+        const signingKey = describeSigningKey(iFinderConfig);
+        const timeout = config.timeout || 60000;
 
-        // Validate required configuration
-        if (!config.baseUrl) {
-          return res.json({
-            success: false,
-            message: 'iAssistant base URL is not configured',
-            details: {
-              missingConfig: 'baseUrl'
-            }
-          });
-        }
-
-        if (!config.defaultProfileId) {
-          return res.json({
-            success: false,
-            message: 'iAssistant default profile ID is not configured',
-            details: {
-              missingConfig: 'defaultProfileId'
-            }
-          });
-        }
-
-        // Create a test user for JWT generation
-        const testUser = {
-          id: req.user?.id || 'test-admin',
-          email: req.user?.email || 'admin@test.com',
-          username: req.user?.username || 'admin',
-          name: req.user?.name || 'Test Admin',
-          groups: req.user?.groups || ['admin']
-        };
-
-        // Try to generate JWT token (iAssistant uses iFinder JWT)
-        let authHeader;
-        try {
-          authHeader = getIFinderAuthorizationHeader(testUser);
-          logger.info('iAssistant JWT token generated successfully for test', {
-            component: 'IntegrationTest',
-            userId: testUser.id
-          });
-        } catch (error) {
-          logger.error('iAssistant JWT generation failed', {
-            component: 'IntegrationTest',
-            error
-          });
-          return res.json({
-            success: false,
-            message: 'Failed to generate JWT token',
-            details: {
-              error: error.message,
-              step: 'jwt_generation'
-            }
-          });
-        }
-
-        // Try to make a simple request to verify connectivity
-        // iAssistant conversation API endpoint
-        const conversationUrl = `${config.baseUrl.replace(/\/+$/, '')}/public-api/rag/api/v0/conversations`;
-
-        logger.info('Testing iAssistant connection', {
+        logger.info('Running iAssistant integration diagnostics', {
           component: 'IntegrationTest',
           baseUrl: config.baseUrl,
-          profileId: config.defaultProfileId
+          profileId: config.defaultProfileId,
+          conversationRoundTrip,
+          includeToken,
+          requestedBy: req.user?.id
         });
 
-        try {
-          const response = await throttledFetch('iAssistantTest', conversationUrl, {
-            method: 'GET',
-            headers: {
-              Authorization: authHeader,
-              Accept: 'application/json'
-            },
-            timeout: config.timeout || 30000
+        const configDetails = {
+          baseUrl: config.baseUrl,
+          baseUrlSource: 'inherited from the iFinder base URL',
+          apiBasePath: '/public-api/rag/api/v0',
+          profileId: config.defaultProfileId,
+          searchProfile: config.defaultSearchProfile,
+          timeoutMs: timeout,
+          jwtSubjectField: iFinderConfig.jwtSubjectField || 'email',
+          signingKeyMode: signingKey.mode,
+          signingKeySource: signingKey.description
+        };
+
+        if (!config.baseUrl) {
+          report.add({
+            id: 'configuration',
+            label: 'Configuration',
+            status: STATUS.FAIL,
+            message: 'No base URL is configured',
+            details: configDetails,
+            hints: [
+              'iAssistant reuses the iFinder Base URL. Configure it in the iFinder Connection section above.'
+            ]
           });
+          return respond(res, report, {
+            integration: 'iAssistant',
+            details: { missingConfig: 'baseUrl', ...configDetails }
+          });
+        }
 
-          if (!response.ok) {
-            const errorText = await response.text();
-            logger.warn('iAssistant test request failed', {
-              component: 'IntegrationTest',
-              status: response.status,
-              error: errorText
-            });
+        if (!signingKey.available) {
+          report.add({
+            id: 'configuration',
+            label: 'Configuration',
+            status: STATUS.FAIL,
+            message: 'No signing key is available for the iAssistant JWT',
+            details: configDetails,
+            hints: [
+              'iAssistant authenticates with the same JWT as iFinder. Configure the iFinder signing key first.'
+            ]
+          });
+          return respond(res, report, {
+            integration: 'iAssistant',
+            details: { missingConfig: 'signingKey', ...configDetails }
+          });
+        }
 
-            // If health endpoint doesn't exist, the service might still be working
-            // Just report that we couldn't verify via health endpoint
-            return res.json({
-              success: false,
-              message: `iAssistant health check returned status ${response.status}`,
-              details: {
-                status: response.status,
-                error: errorText,
-                step: 'health_check',
-                note: 'Configuration appears valid but health endpoint returned an error. The service may still be functional.'
-              }
+        report.add({
+          id: 'configuration',
+          label: 'Configuration',
+          status: config.defaultProfileId ? STATUS.OK : STATUS.WARN,
+          message: config.defaultProfileId
+            ? `Profile "${config.defaultProfileId}" on ${config.baseUrl}`
+            : 'No default profile id configured',
+          details: configDetails,
+          hints: config.defaultProfileId
+            ? []
+            : [
+                'Apps without an explicit profile fall back to the default profile id. Set it in the iAssistant Settings section, or provide IASSISTANT_PROFILE_ID.'
+              ]
+        });
+
+        const urlInfo = await runTransportSteps(report, {
+          rawUrl: config.baseUrl,
+          urlLabel: 'iAssistant base',
+          timeout
+        });
+
+        const jwtResult = await runJwtSteps(report, {
+          user: testUser,
+          iFinderConfig,
+          userOverride,
+          includeToken
+        });
+
+        const oidc = await runOidcCallbackSteps(report, {
+          req,
+          iFinderConfig,
+          jwtInfo: jwtResult?.info,
+          timeout
+        });
+
+        let request;
+        if (!urlInfo.valid || !jwtResult) {
+          report.skip(
+            'profiles',
+            'iAssistant profile list',
+            'Skipped because the base URL or the JWT could not be prepared.'
+          );
+        } else {
+          const profilesUrl = `${config.baseUrl.replace(/\/+$/, '')}/public-api/rag/api/v0/profiles`;
+          const requestContext = {
+            useOidcKeyPair: Boolean(iFinderConfig.useOidcKeyPair),
+            jwksUrl: oidc.applicable ? oidc.jwksUrl : undefined,
+            profileId: config.defaultProfileId
+          };
+
+          const result = await runApiRequestStep(report, {
+            id: 'profiles',
+            label: 'iAssistant profile list',
+            url: profilesUrl,
+            method: 'GET',
+            headers: { Authorization: jwtResult.authHeader, Accept: 'application/json' },
+            token: jwtResult.token,
+            includeToken,
+            timeout,
+            jwtInfo: jwtResult.info,
+            context: requestContext
+          });
+          request = result.request;
+
+          if (result.ok) {
+            // The payload shape differs between iAssistant versions, so accept
+            // either a bare array or a wrapper object.
+            const rawProfiles = Array.isArray(result.parsed)
+              ? result.parsed
+              : result.parsed?.profiles || result.parsed?.items || [];
+            const profileIds = rawProfiles
+              .map(profile => (typeof profile === 'string' ? profile : profile?.id))
+              .filter(Boolean);
+            const configured = config.defaultProfileId;
+            const known = !configured || profileIds.length === 0 || profileIds.includes(configured);
+
+            report.add({
+              id: 'profileExists',
+              label: 'Configured profile exists',
+              status: known ? STATUS.OK : STATUS.FAIL,
+              message: known
+                ? configured
+                  ? `Profile "${configured}" is available`
+                  : `iAssistant offers ${profileIds.length} profile(s)`
+                : `Profile "${configured}" is not among the profiles iAssistant returns`,
+              details: { configuredProfileId: configured, availableProfileIds: profileIds },
+              hints: known
+                ? []
+                : [
+                    `Set the Default Profile ID to one of: ${profileIds.join(', ') || '(none returned)'}.`,
+                    `Profile ids are case sensitive, and the user "${jwtResult.info.subject}" only sees the profiles they are permitted to use.`
+                  ]
             });
           }
 
-          const data = await response.json();
+          if (!conversationRoundTrip) {
+            report.skip(
+              'conversation',
+              'Conversation round-trip',
+              'Not requested. Enable "Run conversation round-trip" to additionally create and delete an ephemeral conversation.'
+            );
+          } else if (!result.ok) {
+            report.skip(
+              'conversation',
+              'Conversation round-trip',
+              'Skipped because the profile list request already failed.'
+            );
+          } else {
+            await report.run('conversation', 'Conversation round-trip', async () => {
+              const conversation = await conversationApiService.createConversation({
+                user: testUser,
+                baseUrl: config.baseUrl,
+                searchProfile: config.defaultSearchProfile,
+                labels: ['ihub-connection-test'],
+                ephemeral: true
+              });
 
-          logger.info('iAssistant test successful', {
-            component: 'IntegrationTest',
-            response: data
-          });
+              const conversationId = conversation?.id || conversation?.conversation?.id;
+              let deleted = false;
+              if (conversationId) {
+                try {
+                  await conversationApiService.deleteConversation(conversationId, {
+                    user: testUser,
+                    baseUrl: config.baseUrl
+                  });
+                  deleted = true;
+                } catch (error) {
+                  logger.warn('Could not delete the test conversation', {
+                    component: 'IntegrationTest',
+                    conversationId,
+                    error: error.message
+                  });
+                }
+              }
 
-          return res.json({
-            success: true,
-            message: 'iAssistant integration is working correctly',
-            details: {
-              baseUrl: config.baseUrl,
-              profileId: config.defaultProfileId,
-              jwtGeneration: 'success',
-              healthCheck: 'success',
-              responseData: data
-            }
-          });
-        } catch (fetchError) {
-          // If the health endpoint doesn't exist or fails, just validate configuration
-          logger.info('iAssistant health endpoint not available, validating configuration only', {
-            component: 'IntegrationTest',
-            error: fetchError.message
-          });
-
-          return res.json({
-            success: true,
-            message: 'iAssistant configuration is valid (health endpoint not available)',
-            details: {
-              baseUrl: config.baseUrl,
-              profileId: config.defaultProfileId,
-              jwtGeneration: 'success',
-              configValidation: 'success',
-              note: 'Could not verify connectivity via health endpoint, but configuration appears valid.'
-            }
-          });
+              return {
+                status: STATUS.OK,
+                message: `Created an ephemeral conversation${deleted ? ' and deleted it again' : ''}`,
+                details: {
+                  conversationId,
+                  searchProfile: config.defaultSearchProfile,
+                  cleanedUp: deleted
+                },
+                hints: deleted
+                  ? []
+                  : [
+                      `The test conversation ${conversationId || '(unknown id)'} could not be deleted. It is marked ephemeral, so iAssistant should clean it up on its own.`
+                    ]
+              };
+            });
+          }
         }
+
+        return respond(res, report, {
+          integration: 'iAssistant',
+          successMessage: 'iAssistant integration is working correctly',
+          jwt: jwtResult
+            ? {
+                subject: jwtResult.info.subject,
+                header: jwtResult.info.header,
+                payload: jwtResult.info.payload,
+                preview: previewToken(jwtResult.token),
+                ...(includeToken ? { token: jwtResult.token } : {})
+              }
+            : undefined,
+          request,
+          details: {
+            ...configDetails,
+            jwtGeneration: jwtResult ? 'success' : 'failed',
+            jwksUrl: oidc.applicable ? oidc.jwksUrl : undefined
+          }
+        });
       } catch (error) {
-        logger.error('iAssistant test error', { component: 'IntegrationTest', error });
-        return sendErrorResponse(res, 500, error.message || 'iAssistant integration test failed');
+        logger.error('iAssistant integration test error', { component: 'IntegrationTest', error });
+        report.add({
+          id: 'unexpected',
+          label: 'Unexpected error',
+          status: STATUS.FAIL,
+          message: error.message || 'iAssistant integration test failed',
+          details: { error: error.message, stack: error.stack?.split('\n').slice(0, 5).join('\n') },
+          hints: [
+            'Check the iHub server log (component "IntegrationTest") for the full stack trace.'
+          ]
+        });
+        return respond(res, report, {
+          integration: 'iAssistant',
+          details: { error: error.message }
+        });
       }
     }
   );

--- a/server/services/integrations/integrationDiagnostics.js
+++ b/server/services/integrations/integrationDiagnostics.js
@@ -261,31 +261,27 @@ export async function resolveHostname(hostname) {
  * Open a TCP (and for https a TLS) connection to check reachability and collect
  * certificate facts.
  *
- * Certificate verification follows the platform SSL policy, so the probe behaves
- * exactly like a real outbound request: it never trusts more than the rest of the
- * server does. A certificate the trust store rejects therefore aborts the
- * handshake, and the probe reports that as `certificateRejected` together with
- * Node's specific reason (self-signed, expired, unknown CA, hostname mismatch).
- * That still distinguishes "unreachable" from "reachable but not trusted", which
- * are very different fixes, without ever disabling validation to find out.
+ * Certificate verification is ALWAYS enforced — there is deliberately no option
+ * to relax it. A diagnostic never needs to trust a certificate the server itself
+ * would reject: when the trust store rejects one, the handshake aborts and the
+ * probe reports `certificateRejected` with Node's specific reason (self-signed,
+ * expired, unknown CA, hostname mismatch). That already distinguishes
+ * "unreachable" from "reachable but not trusted", which are very different fixes.
+ *
+ * Callers that have relaxed TLS for a domain via the Admin > Platform > SSL
+ * whitelist should keep enforcing it here and use
+ * `describeTransport().ignoreInvalidCertificates` only to interpret the result —
+ * i.e. to explain that real requests still succeed even though the system trust
+ * store says no. Interpreting a rejection is strictly better than not detecting it.
  *
  * @param {Object} params
  * @param {string} params.hostname
  * @param {number} params.port
  * @param {string} params.protocol - 'http' or 'https'
  * @param {number} [params.timeout=10000]
- * @param {boolean} [params.rejectUnauthorized=true] - Pass the platform SSL policy
- *   for this URL (see `describeTransport().ignoreInvalidCertificates`). Only an
- *   explicit admin whitelist entry may relax it.
  * @returns {Promise<Object>} Probe result
  */
-export function probeTcpTls({
-  hostname,
-  port,
-  protocol,
-  timeout = 10000,
-  rejectUnauthorized = true
-}) {
+export function probeTcpTls({ hostname, port, protocol, timeout = 10000 }) {
   const useTls = protocol === 'https';
   const startedAt = Date.now();
 
@@ -309,7 +305,9 @@ export function probeTcpTls({
           // RFC 6066 forbids an IP address as the SNI server name, and Node warns
           // about it. Only send SNI for real hostnames.
           ...(net.isIP(hostname) === 0 ? { servername: hostname } : {}),
-          rejectUnauthorized
+          // Never relaxed. See the function comment: a rejection is reported and
+          // interpreted, not avoided by trusting the certificate.
+          rejectUnauthorized: true
         })
       : net.connect({ host: hostname, port });
 

--- a/server/services/integrations/integrationDiagnostics.js
+++ b/server/services/integrations/integrationDiagnostics.js
@@ -52,7 +52,9 @@ export class DiagnosticsReport {
    * @param {string} step.status - One of STATUS
    * @param {string} [step.message] - One-line result summary
    * @param {Object} [step.details] - Raw observed facts, rendered as JSON
-   * @param {string[]} [step.hints] - What the admin should check on failure
+   * @param {string[]} [step.hints] - What the admin should check on failure.
+   *   Deduplicated, since several classifiers can independently suggest the same
+   *   check and a repeated line reads like a bug.
    * @param {number} [step.durationMs]
    * @returns {Object} The recorded step
    */
@@ -60,7 +62,7 @@ export class DiagnosticsReport {
     const step = { id, label, status, message };
     if (typeof durationMs === 'number') step.durationMs = durationMs;
     if (details && Object.keys(details).length > 0) step.details = details;
-    if (hints && hints.length > 0) step.hints = hints;
+    if (hints && hints.length > 0) step.hints = [...new Set(hints)];
     this.steps.push(step);
     return step;
   }
@@ -259,19 +261,31 @@ export async function resolveHostname(hostname) {
  * Open a TCP (and for https a TLS) connection to check reachability and collect
  * certificate facts.
  *
- * The TLS handshake runs with `rejectUnauthorized: false` on purpose: we want
- * the certificate details even when verification fails, and then report the
- * verification result separately. That distinguishes "unreachable" from
- * "reachable but the certificate is not trusted", which are very different fixes.
+ * Certificate verification follows the platform SSL policy, so the probe behaves
+ * exactly like a real outbound request: it never trusts more than the rest of the
+ * server does. A certificate the trust store rejects therefore aborts the
+ * handshake, and the probe reports that as `certificateRejected` together with
+ * Node's specific reason (self-signed, expired, unknown CA, hostname mismatch).
+ * That still distinguishes "unreachable" from "reachable but not trusted", which
+ * are very different fixes, without ever disabling validation to find out.
  *
  * @param {Object} params
  * @param {string} params.hostname
  * @param {number} params.port
  * @param {string} params.protocol - 'http' or 'https'
  * @param {number} [params.timeout=10000]
+ * @param {boolean} [params.rejectUnauthorized=true] - Pass the platform SSL policy
+ *   for this URL (see `describeTransport().ignoreInvalidCertificates`). Only an
+ *   explicit admin whitelist entry may relax it.
  * @returns {Promise<Object>} Probe result
  */
-export function probeTcpTls({ hostname, port, protocol, timeout = 10000 }) {
+export function probeTcpTls({
+  hostname,
+  port,
+  protocol,
+  timeout = 10000,
+  rejectUnauthorized = true
+}) {
   const useTls = protocol === 'https';
   const startedAt = Date.now();
 
@@ -289,7 +303,14 @@ export function probeTcpTls({ hostname, port, protocol, timeout = 10000 }) {
     };
 
     const socket = useTls
-      ? tls.connect({ host: hostname, port, servername: hostname, rejectUnauthorized: false })
+      ? tls.connect({
+          host: hostname,
+          port,
+          // RFC 6066 forbids an IP address as the SNI server name, and Node warns
+          // about it. Only send SNI for real hostnames.
+          ...(net.isIP(hostname) === 0 ? { servername: hostname } : {}),
+          rejectUnauthorized
+        })
       : net.connect({ host: hostname, port });
 
     socket.setTimeout(timeout);
@@ -303,7 +324,15 @@ export function probeTcpTls({ hostname, port, protocol, timeout = 10000 }) {
     );
 
     socket.on('error', error =>
-      finish({ connected: false, error: error.message, code: error.code })
+      finish({
+        connected: false,
+        // A TLS-level rejection means the TCP connection and the handshake
+        // succeeded far enough to receive a certificate, so the host is
+        // reachable and only trust is the problem.
+        certificateRejected: isCertificateError(error),
+        error: error.message,
+        code: error.code
+      })
     );
 
     const onConnect = () => {
@@ -337,6 +366,38 @@ export function probeTcpTls({ hostname, port, protocol, timeout = 10000 }) {
 
     socket.on(useTls ? 'secureConnect' : 'connect', onConnect);
   });
+}
+
+/**
+ * OpenSSL verification failures Node surfaces as `error.code`. Matching them lets
+ * the diagnostics say "reachable but the certificate was rejected" instead of
+ * lumping a trust problem in with an unreachable host.
+ */
+const CERTIFICATE_ERROR_CODES = new Set([
+  'CERT_HAS_EXPIRED',
+  'CERT_NOT_YET_VALID',
+  'CERT_REVOKED',
+  'CERT_SIGNATURE_FAILURE',
+  'CERT_UNTRUSTED',
+  'DEPTH_ZERO_SELF_SIGNED_CERT',
+  'ERR_TLS_CERT_ALTNAME_INVALID',
+  'HOSTNAME_MISMATCH',
+  'SELF_SIGNED_CERT_IN_CHAIN',
+  'UNABLE_TO_GET_ISSUER_CERT',
+  'UNABLE_TO_GET_ISSUER_CERT_LOCALLY',
+  'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+]);
+
+/**
+ * True when a connection error is a certificate verification failure rather than
+ * a transport failure.
+ * @param {Error} error
+ * @returns {boolean}
+ */
+export function isCertificateError(error) {
+  if (!error) return false;
+  if (CERTIFICATE_ERROR_CODES.has(error.code)) return true;
+  return /certificate|self.signed|unable to verify|altnames/i.test(error.message || '');
 }
 
 /**

--- a/server/services/integrations/integrationDiagnostics.js
+++ b/server/services/integrations/integrationDiagnostics.js
@@ -1,0 +1,657 @@
+/**
+ * Shared diagnostics helpers for the admin integration tests (iFinder, iAssistant).
+ *
+ * The admin "Test iFinder" / "Test iAssistant" buttons used to return a single
+ * pass/fail message. When a connection did not work that told an admin almost
+ * nothing: a 500 from iFinder because iFinder itself could not resolve the
+ * hostname iHub advertised, and a 401 with an empty body, both look identical.
+ *
+ * These helpers turn a test into a sequence of named steps. Every step reports a
+ * status, a human message, the raw facts it observed (URLs, resolved IPs,
+ * certificate subject, decoded JWT claims) and — when it fails — concrete hints
+ * about what to check. Nothing here is iFinder-specific, so the same primitives
+ * back both integration tests.
+ */
+import dns from 'dns';
+import net from 'net';
+import tls from 'tls';
+import jwt from 'jsonwebtoken';
+import {
+  getProxyConfig,
+  getSSLConfig,
+  matchesProxyPattern,
+  shouldBypassProxy,
+  shouldIgnoreSSLForURL
+} from '../../utils/httpConfig.js';
+
+export const STATUS = {
+  OK: 'ok',
+  WARN: 'warn',
+  FAIL: 'fail',
+  SKIP: 'skip'
+};
+
+/**
+ * Collects the ordered steps of one integration test run.
+ *
+ * A step is either recorded directly with `add()` or produced by `run()`, which
+ * measures the duration and converts a thrown error into a failed step so a
+ * single unexpected exception cannot swallow the steps already collected.
+ */
+export class DiagnosticsReport {
+  constructor() {
+    this.steps = [];
+    this.startedAt = Date.now();
+  }
+
+  /**
+   * Record a finished step.
+   * @param {Object} step
+   * @param {string} step.id - Stable identifier, used by the UI as a key
+   * @param {string} step.label - Short human label ("DNS resolution")
+   * @param {string} step.status - One of STATUS
+   * @param {string} [step.message] - One-line result summary
+   * @param {Object} [step.details] - Raw observed facts, rendered as JSON
+   * @param {string[]} [step.hints] - What the admin should check on failure
+   * @param {number} [step.durationMs]
+   * @returns {Object} The recorded step
+   */
+  add({ id, label, status, message = '', details = undefined, hints = undefined, durationMs }) {
+    const step = { id, label, status, message };
+    if (typeof durationMs === 'number') step.durationMs = durationMs;
+    if (details && Object.keys(details).length > 0) step.details = details;
+    if (hints && hints.length > 0) step.hints = hints;
+    this.steps.push(step);
+    return step;
+  }
+
+  /**
+   * Run `fn` as a step. `fn` returns `{ status, message, details, hints }`;
+   * anything it throws becomes a failed step.
+   * @param {string} id
+   * @param {string} label
+   * @param {() => Promise<Object>|Object} fn
+   * @returns {Promise<Object>} The recorded step
+   */
+  async run(id, label, fn) {
+    const startedAt = Date.now();
+    try {
+      const result = (await fn()) || {};
+      return this.add({
+        id,
+        label,
+        status: result.status || STATUS.OK,
+        message: result.message,
+        details: result.details,
+        hints: result.hints,
+        durationMs: Date.now() - startedAt
+      });
+    } catch (error) {
+      return this.add({
+        id,
+        label,
+        status: STATUS.FAIL,
+        message: error?.message || String(error),
+        details: { error: error?.message || String(error), code: error?.code },
+        durationMs: Date.now() - startedAt
+      });
+    }
+  }
+
+  /** Record a step that was not applicable for this configuration. */
+  skip(id, label, message) {
+    return this.add({ id, label, status: STATUS.SKIP, message });
+  }
+
+  /** @returns {boolean} True when at least one step failed */
+  hasFailure() {
+    return this.steps.some(step => step.status === STATUS.FAIL);
+  }
+
+  /** @returns {Object} Status counts plus the total wall time of the run */
+  summary() {
+    const counts = { ok: 0, warn: 0, fail: 0, skip: 0 };
+    for (const step of this.steps) {
+      if (counts[step.status] !== undefined) counts[step.status] += 1;
+    }
+    return { ...counts, total: this.steps.length, durationMs: Date.now() - this.startedAt };
+  }
+}
+
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1', '0.0.0.0', '[::1]']);
+
+/**
+ * True for RFC1918 / link-local / unique-local addresses, which are reachable
+ * inside a network but usually not from a peer in another network segment.
+ * @param {string} host
+ * @returns {boolean}
+ */
+export function isPrivateAddress(host) {
+  if (!host) return false;
+  const value = host.replace(/^\[|\]$/g, '').toLowerCase();
+  if (/^10\./.test(value)) return true;
+  if (/^192\.168\./.test(value)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(value)) return true;
+  if (/^169\.254\./.test(value)) return true;
+  if (/^f[cd][0-9a-f]{2}:/.test(value)) return true;
+  if (/^fe80:/.test(value)) return true;
+  return false;
+}
+
+/**
+ * Parse a configured URL and flag the shapes that break integrations.
+ *
+ * The `remoteCallback` mode is for URLs that a *different* machine has to call
+ * (the OIDC issuer iFinder fetches JWKS from). There a short hostname or a
+ * loopback address is a hard failure rather than a cosmetic warning — it is the
+ * exact reason an iFinder token validation returns 500 with "could not resolve".
+ *
+ * @param {string} rawUrl
+ * @param {Object} [options]
+ * @param {boolean} [options.remoteCallback=false] - URL must be resolvable by another host
+ * @returns {Object} Inspection result including `warnings` and `errors`
+ */
+export function inspectUrl(rawUrl, { remoteCallback = false } = {}) {
+  const warnings = [];
+  const errors = [];
+
+  if (!rawUrl || typeof rawUrl !== 'string' || rawUrl.trim() === '') {
+    return { valid: false, raw: rawUrl || '', errors: ['URL is empty'], warnings };
+  }
+
+  if (rawUrl !== rawUrl.trim()) {
+    warnings.push(
+      'URL has leading or trailing whitespace. This usually comes from copy & paste and can break request routing.'
+    );
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(rawUrl.trim());
+  } catch {
+    return {
+      valid: false,
+      raw: rawUrl,
+      errors: [
+        `"${rawUrl}" is not a valid absolute URL. It must include the scheme, e.g. https://ifinder.example.com`
+      ],
+      warnings
+    };
+  }
+
+  if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    errors.push(`Unsupported scheme "${parsed.protocol}". Use http:// or https://.`);
+  }
+
+  const hostname = parsed.hostname.replace(/^\[|\]$/g, '');
+  const isIpLiteral = net.isIP(hostname) !== 0;
+  const isLoopback = LOOPBACK_HOSTNAMES.has(hostname.toLowerCase());
+  const isPrivate = isPrivateAddress(hostname);
+  // A hostname without a dot is a single-label name. It resolves only for hosts
+  // whose DNS search domain happens to complete it, which is why it works from
+  // the iHub shell and then fails inside iFinder.
+  const isFqdn = !isIpLiteral && hostname.includes('.');
+
+  if (parsed.protocol === 'http:' && !isLoopback) {
+    warnings.push(
+      'Uses http://. The JWT is sent in a header over an unencrypted connection. Use https:// outside of local testing.'
+    );
+  }
+
+  if (isLoopback) {
+    const text =
+      'Points at localhost. Only processes on this same machine can reach it — any other host, including iFinder, cannot.';
+    if (remoteCallback) errors.push(text);
+    else warnings.push(text);
+  } else if (!isFqdn && !isIpLiteral) {
+    const text = `"${hostname}" is a short (single-label) hostname. It only resolves where a matching DNS search domain is configured. Use the fully qualified domain name, e.g. ${hostname}.example.com.`;
+    if (remoteCallback) errors.push(text);
+    else warnings.push(text);
+  } else if (isPrivate && remoteCallback) {
+    warnings.push(
+      `${hostname} is a private address. Make sure it is routable from the iFinder server, not just from iHub.`
+    );
+  }
+
+  const port = parsed.port ? Number(parsed.port) : parsed.protocol === 'https:' ? 443 : 80;
+
+  return {
+    valid: errors.length === 0,
+    raw: rawUrl,
+    url: parsed.toString(),
+    origin: parsed.origin,
+    protocol: parsed.protocol.replace(':', ''),
+    hostname,
+    port,
+    defaultPort: !parsed.port,
+    pathname: parsed.pathname,
+    isIpLiteral,
+    isFqdn,
+    isLoopback,
+    isPrivate,
+    warnings,
+    errors
+  };
+}
+
+/**
+ * Resolve a hostname through the OS resolver — the same path node-fetch takes.
+ * @param {string} hostname
+ * @returns {Promise<Object>} `{ resolved, addresses, error, code }`
+ */
+export async function resolveHostname(hostname) {
+  if (net.isIP(hostname) !== 0) {
+    return {
+      resolved: true,
+      literal: true,
+      addresses: [{ address: hostname, family: net.isIP(hostname) }]
+    };
+  }
+  try {
+    const addresses = await dns.promises.lookup(hostname, { all: true, verbatim: true });
+    return { resolved: true, literal: false, addresses };
+  } catch (error) {
+    return { resolved: false, literal: false, error: error.message, code: error.code };
+  }
+}
+
+/**
+ * Open a TCP (and for https a TLS) connection to check reachability and collect
+ * certificate facts.
+ *
+ * The TLS handshake runs with `rejectUnauthorized: false` on purpose: we want
+ * the certificate details even when verification fails, and then report the
+ * verification result separately. That distinguishes "unreachable" from
+ * "reachable but the certificate is not trusted", which are very different fixes.
+ *
+ * @param {Object} params
+ * @param {string} params.hostname
+ * @param {number} params.port
+ * @param {string} params.protocol - 'http' or 'https'
+ * @param {number} [params.timeout=10000]
+ * @returns {Promise<Object>} Probe result
+ */
+export function probeTcpTls({ hostname, port, protocol, timeout = 10000 }) {
+  const useTls = protocol === 'https';
+  const startedAt = Date.now();
+
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = result => {
+      if (settled) return;
+      settled = true;
+      try {
+        socket.destroy();
+      } catch {
+        // socket already gone
+      }
+      resolve({ ...result, durationMs: Date.now() - startedAt });
+    };
+
+    const socket = useTls
+      ? tls.connect({ host: hostname, port, servername: hostname, rejectUnauthorized: false })
+      : net.connect({ host: hostname, port });
+
+    socket.setTimeout(timeout);
+
+    socket.on('timeout', () =>
+      finish({
+        connected: false,
+        error: `Connection to ${hostname}:${port} timed out after ${timeout}ms`,
+        code: 'ETIMEDOUT'
+      })
+    );
+
+    socket.on('error', error =>
+      finish({ connected: false, error: error.message, code: error.code })
+    );
+
+    const onConnect = () => {
+      if (!useTls) {
+        finish({ connected: true, remoteAddress: socket.remoteAddress });
+        return;
+      }
+
+      const cert = socket.getPeerCertificate() || {};
+      const now = Date.now();
+      const validTo = cert.valid_to ? Date.parse(cert.valid_to) : NaN;
+      finish({
+        connected: true,
+        remoteAddress: socket.remoteAddress,
+        tls: {
+          authorized: socket.authorized,
+          authorizationError: socket.authorizationError
+            ? String(socket.authorizationError)
+            : undefined,
+          protocol: socket.getProtocol(),
+          subject: cert.subject?.CN,
+          subjectAltName: cert.subjectaltname,
+          issuer: cert.issuer?.CN || cert.issuer?.O,
+          validFrom: cert.valid_from,
+          validTo: cert.valid_to,
+          expired: Number.isFinite(validTo) ? validTo < now : undefined,
+          selfSigned: Boolean(cert.subject?.CN && cert.subject.CN === cert.issuer?.CN)
+        }
+      });
+    };
+
+    socket.on(useTls ? 'secureConnect' : 'connect', onConnect);
+  });
+}
+
+/**
+ * Report how an outbound request to `url` is actually transported.
+ *
+ * Mirrors the decisions `createAgent()` makes. It matters for diagnostics
+ * because the TCP/TLS probe always connects directly: when a proxy is in play a
+ * direct probe can fail while the real request succeeds, and vice versa.
+ *
+ * @param {string} url
+ * @returns {Object} `{ viaProxy, proxyUrl, ignoreInvalidCertificates }`
+ */
+export function describeTransport(url) {
+  const proxyConfig = getProxyConfig();
+  const isHttps = url.startsWith('https://');
+  const candidateProxy = isHttps ? proxyConfig.https : proxyConfig.http;
+
+  let viaProxy = Boolean(proxyConfig.enabled && candidateProxy);
+  if (viaProxy && proxyConfig.noProxy && shouldBypassProxy(url, proxyConfig.noProxy)) {
+    viaProxy = false;
+  }
+  if (
+    viaProxy &&
+    proxyConfig.urlPatterns?.length > 0 &&
+    !matchesProxyPattern(url, proxyConfig.urlPatterns)
+  ) {
+    viaProxy = false;
+  }
+
+  return {
+    viaProxy,
+    proxyUrl: viaProxy ? candidateProxy : undefined,
+    ignoreInvalidCertificates: shouldIgnoreSSLForURL(url, getSSLConfig())
+  };
+}
+
+/**
+ * Decode a JWT without verifying it, and surface the claims an admin needs to
+ * compare against the iFinder side of the trust configuration.
+ * @param {string} token
+ * @returns {Object} `{ header, payload, subject, issuer, audience, ... }`
+ */
+export function decodeJwt(token) {
+  const decoded = jwt.decode(token, { complete: true });
+  if (!decoded) {
+    return { decoded: false, error: 'Token could not be decoded — it is not a well-formed JWT.' };
+  }
+
+  const { header, payload } = decoded;
+  const toIso = value =>
+    typeof value === 'number' ? new Date(value * 1000).toISOString() : undefined;
+
+  return {
+    decoded: true,
+    header,
+    payload,
+    subject: payload.sub,
+    issuer: payload.iss,
+    audience: payload.aud,
+    scope: payload.scope,
+    algorithm: header.alg,
+    keyId: header.kid,
+    issuedAt: toIso(payload.iat),
+    expiresAt: toIso(payload.exp),
+    lifetimeSeconds:
+      typeof payload.exp === 'number' && typeof payload.iat === 'number'
+        ? payload.exp - payload.iat
+        : undefined
+  };
+}
+
+/**
+ * Shorten a token for display so it can be recognised in logs without being
+ * usable if the screenshot leaks.
+ * @param {string} token
+ * @returns {string}
+ */
+export function previewToken(token) {
+  if (!token || typeof token !== 'string') return '';
+  if (token.length <= 24) return token;
+  return `${token.slice(0, 12)}…${token.slice(-8)} (${token.length} chars)`;
+}
+
+/**
+ * Replace the credential in an Authorization header with a placeholder.
+ * @param {Object} headers
+ * @returns {Object} Copy with Authorization redacted
+ */
+export function redactHeaders(headers = {}) {
+  const result = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (/^authorization$/i.test(key) && typeof value === 'string') {
+      const [scheme] = value.split(' ');
+      result[key] = `${scheme} <jwt>`;
+    } else {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
+function shellQuote(value) {
+  return `'${String(value).replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Build a copy-pasteable curl command that reproduces a request.
+ *
+ * When `token` is omitted the command references `$TOKEN`, so it is safe to
+ * paste into a ticket and the admin can export the variable themselves.
+ *
+ * @param {Object} params
+ * @param {string} params.url
+ * @param {string} [params.method='GET']
+ * @param {Object} [params.headers] - Authorization is replaced by the token handling
+ * @param {string} [params.token] - Raw JWT to inline
+ * @param {string} [params.body]
+ * @returns {string} curl command
+ */
+export function buildCurlCommand({ url, method = 'GET', headers = {}, token, body }) {
+  const parts = ['curl', '-i', '-X', method, shellQuote(url)];
+
+  for (const [key, value] of Object.entries(headers)) {
+    if (/^authorization$/i.test(key)) continue;
+    parts.push('-H', shellQuote(`${key}: ${value}`));
+  }
+
+  parts.push(
+    '-H',
+    token ? shellQuote(`Authorization: Bearer ${token}`) : `"Authorization: Bearer $TOKEN"`
+  );
+
+  if (body) parts.push('--data-raw', shellQuote(body));
+
+  return parts.join(' ');
+}
+
+/** Response headers worth keeping — the rest is noise for this purpose. */
+const INTERESTING_RESPONSE_HEADERS = [
+  'www-authenticate',
+  'content-type',
+  'x-request-id',
+  'x-correlation-id',
+  'retry-after',
+  'server',
+  'location',
+  'date'
+];
+
+/**
+ * Pick the response headers that help explain a failure.
+ * `www-authenticate` in particular usually carries the real reason a 401 happened.
+ * @param {Object} headers - node-fetch Headers instance
+ * @returns {Object}
+ */
+export function pickResponseHeaders(headers) {
+  const result = {};
+  if (!headers || typeof headers.get !== 'function') return result;
+  for (const name of INTERESTING_RESPONSE_HEADERS) {
+    const value = headers.get(name);
+    if (value) result[name] = value;
+  }
+  return result;
+}
+
+/**
+ * Truncate a response body so a large HTML error page does not flood the UI.
+ * @param {string} body
+ * @param {number} [max=2000]
+ * @returns {string}
+ */
+export function truncateBody(body, max = 2000) {
+  if (!body) return '';
+  if (body.length <= max) return body;
+  return `${body.slice(0, max)}\n… (truncated, ${body.length} chars total)`;
+}
+
+/**
+ * Turn a transport-level error into an explanation plus next steps.
+ * @param {Error} error
+ * @param {Object} context
+ * @param {string} [context.hostname]
+ * @param {number} [context.port]
+ * @param {number} [context.timeout]
+ * @returns {string[]} Hints
+ */
+export function describeNetworkError(error, { hostname, port, timeout } = {}) {
+  const code = error?.code || '';
+  const message = error?.message || String(error);
+  const hints = [];
+
+  if (code === 'ENOTFOUND' || /getaddrinfo/i.test(message)) {
+    hints.push(
+      `DNS lookup for "${hostname}" failed on the iHub server. Verify the hostname, use the fully qualified domain name, and check /etc/hosts or the DNS resolver of the iHub container.`
+    );
+  } else if (code === 'ECONNREFUSED') {
+    hints.push(
+      `Nothing is listening on ${hostname}:${port}. Check the port, and whether iFinder is exposed on a different one (443 vs 8443).`
+    );
+  } else if (
+    code === 'ETIMEDOUT' ||
+    code === 'ERR_SOCKET_CONNECTION_TIMEOUT' ||
+    /timeout/i.test(message)
+  ) {
+    hints.push(
+      `The connection to ${hostname}:${port} timed out${timeout ? ` after ${timeout}ms` : ''}. A firewall dropping the packets is the usual cause; also confirm whether the traffic needs to go through an HTTP proxy.`
+    );
+  } else if (code === 'EHOSTUNREACH' || code === 'ENETUNREACH') {
+    hints.push(
+      `No network route from the iHub server to ${hostname}. Check routing and network policies.`
+    );
+  } else if (
+    /self.signed|unable to verify|CERT_|DEPTH_ZERO/i.test(message) ||
+    code?.startsWith?.('CERT')
+  ) {
+    hints.push(
+      'The TLS certificate of the target was rejected. Add the issuing CA to the trust store of the iHub server, or whitelist the domain under Admin > Platform > SSL.'
+    );
+  } else if (code === 'EPROTO' || /wrong version number/i.test(message)) {
+    hints.push(
+      'TLS handshake failed. The scheme is probably wrong — an https:// URL against a plain HTTP port, or the other way round.'
+    );
+  }
+
+  hints.push('Check the iHub server log (component "IntegrationTest") for the full stack trace.');
+  return hints;
+}
+
+/**
+ * Explain an HTTP error status in terms of the iFinder/iAssistant trust setup.
+ *
+ * @param {Object} params
+ * @param {number} params.status
+ * @param {string} [params.body] - Response body (already truncated)
+ * @param {Object} [params.headers] - Picked response headers
+ * @param {Object} [params.jwt] - Result of decodeJwt for the token that was sent
+ * @param {Object} [params.context]
+ * @param {boolean} [params.context.useOidcKeyPair]
+ * @param {string} [params.context.jwksUrl]
+ * @param {string} [params.context.searchProfile]
+ * @param {string} [params.context.profileId]
+ * @returns {string[]} Hints
+ */
+export function describeHttpFailure({
+  status,
+  body = '',
+  headers = {},
+  jwt: jwtInfo = {},
+  context = {}
+}) {
+  const hints = [];
+  const wwwAuthenticate = headers['www-authenticate'];
+
+  if (status === 401) {
+    if (wwwAuthenticate) {
+      hints.push(
+        `The server answered with WWW-Authenticate: ${wwwAuthenticate} — it usually names the exact reason.`
+      );
+    }
+    hints.push(
+      `iFinder rejected the token. Compare the claims iHub sent with what iFinder expects: sub="${jwtInfo.subject ?? '?'}", iss="${jwtInfo.issuer ?? '?'}", aud=${JSON.stringify(jwtInfo.audience ?? null)}, alg="${jwtInfo.algorithm ?? '?'}"${jwtInfo.keyId ? `, kid="${jwtInfo.keyId}"` : ''}.`
+    );
+    if (context.useOidcKeyPair) {
+      hints.push(
+        `In OIDC key pair mode iFinder validates the signature by fetching ${context.jwksUrl || 'the JWKS endpoint of the issuer'}. iFinder must be able to resolve and reach that URL, and the "kid" above must appear in it.`
+      );
+      hints.push(
+        'Make sure the trusted issuer configured in iFinder is exactly the "iss" value above — a trailing slash or an http/https mismatch is enough to fail.'
+      );
+    } else {
+      hints.push(
+        'In private key mode iFinder verifies with the matching public key. Confirm the public key deployed in iFinder belongs to the private key configured here, and that the algorithm matches.'
+      );
+    }
+    hints.push(
+      'Check the JWT Subject Field: iFinder has to know the subject as a user. An email where iFinder expects DOMAIN\\username (or vice versa) also produces a 401.'
+    );
+    hints.push(
+      'Verify the clock of the iHub server — a skew larger than the leeway of iFinder invalidates iat/exp.'
+    );
+  } else if (status === 403) {
+    hints.push(
+      `The token was accepted but access was denied. Check the scope ("${jwtInfo.scope ?? '?'}") and whether the user "${jwtInfo.subject ?? '?'}" is permitted on the search profile.`
+    );
+  } else if (status === 404) {
+    hints.push(
+      'The endpoint or the profile does not exist. Verify the base URL does not already contain /public-api (iHub appends the API path itself) and that the profile id is spelled exactly as in iFinder.'
+    );
+    if (context.searchProfile) hints.push(`Search profile used: "${context.searchProfile}".`);
+    if (context.profileId) hints.push(`iAssistant profile id used: "${context.profileId}".`);
+  } else if (status === 405) {
+    hints.push(
+      'The endpoint exists but rejects this method. The configured endpoint path is most likely wrong.'
+    );
+  } else if (status === 500 || status === 502 || status === 503 || status === 504) {
+    hints.push(
+      'The target answered with a server error, so the request reached it. Its own log holds the cause — the classic one is that iFinder cannot resolve or reach the JWKS/issuer URL of iHub while validating the token.'
+    );
+    if (context.jwksUrl) {
+      hints.push(
+        `Verify from the iFinder host that ${context.jwksUrl} resolves and responds, for example: curl -sv ${context.jwksUrl}`
+      );
+    }
+    hints.push(
+      'A short hostname is the usual culprit: it resolves on the iHub host but not inside iFinder. Always configure fully qualified domain names.'
+    );
+  } else if (status === 415) {
+    hints.push('The target rejected the content type. This points at a mismatched API version.');
+  }
+
+  if (/^\s*<(!doctype|html)/i.test(body)) {
+    hints.push(
+      'The response body is HTML, not JSON. A reverse proxy, load balancer or SSO login page is answering instead of the API.'
+    );
+  }
+
+  return hints;
+}

--- a/server/tests/integrationDiagnostics.test.js
+++ b/server/tests/integrationDiagnostics.test.js
@@ -29,6 +29,7 @@ import {
   resolveHostname,
   truncateBody
 } from '../services/integrations/integrationDiagnostics.js';
+import { isValidSearchProfileId } from '../utils/pathSecurity.js';
 
 describe('inspectUrl', () => {
   it('accepts a plain https FQDN without complaints', () => {
@@ -413,6 +414,47 @@ describe('DiagnosticsReport', () => {
       hints: ['check DNS', 'check the server log', 'check DNS']
     });
     assert.deepEqual(report.steps[0].hints, ['check DNS', 'check the server log']);
+  });
+});
+
+describe('isValidSearchProfileId', () => {
+  it('accepts slug and base64 profile ids', () => {
+    for (const id of [
+      'searchprofile-standard',
+      'c2VhcmNocHJvZmlsZS1zdGFuZGFyZA==',
+      'profile_1',
+      'tenant:profile',
+      'profile@site',
+      'a+b'
+    ]) {
+      assert.equal(isValidSearchProfileId(id), true, id);
+    }
+  });
+
+  it('rejects anything that could escape the URL path segment', () => {
+    for (const id of [
+      '../../../etc/passwd',
+      'a/b',
+      'a\\b',
+      '..',
+      'profile..name',
+      'pro file',
+      'profile?x=1',
+      'profile#frag',
+      'profile%2F..',
+      '__proto__',
+      ''
+    ]) {
+      assert.equal(isValidSearchProfileId(id), false, JSON.stringify(id));
+    }
+  });
+
+  it('rejects non-strings and over-long ids', () => {
+    assert.equal(isValidSearchProfileId(undefined), false);
+    assert.equal(isValidSearchProfileId(null), false);
+    assert.equal(isValidSearchProfileId(42), false);
+    assert.equal(isValidSearchProfileId('a'.repeat(201)), false);
+    assert.equal(isValidSearchProfileId('a'.repeat(200)), true);
   });
 });
 

--- a/server/tests/integrationDiagnostics.test.js
+++ b/server/tests/integrationDiagnostics.test.js
@@ -1,0 +1,404 @@
+/**
+ * Tests for the diagnostics helpers behind the admin iFinder / iAssistant
+ * connection tests.
+ *
+ * The cases pin the checks that exist because of real support pain:
+ *   - a single-label hostname passes locally but is unresolvable for iFinder,
+ *     which is what produced a 500 from iFinder ("could not resolve the name");
+ *   - a 401 with an empty body has to yield the claims and the trust settings
+ *     to compare, not just "failed";
+ *   - the raw JWT must never leak into the parts of the result that are meant
+ *     to be shareable.
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import jwt from 'jsonwebtoken';
+import {
+  DiagnosticsReport,
+  STATUS,
+  buildCurlCommand,
+  decodeJwt,
+  describeHttpFailure,
+  describeNetworkError,
+  inspectUrl,
+  isPrivateAddress,
+  previewToken,
+  redactHeaders,
+  resolveHostname,
+  truncateBody
+} from '../services/integrations/integrationDiagnostics.js';
+
+describe('inspectUrl', () => {
+  it('accepts a plain https FQDN without complaints', () => {
+    const result = inspectUrl('https://ifinder.example.com');
+    assert.equal(result.valid, true);
+    assert.equal(result.hostname, 'ifinder.example.com');
+    assert.equal(result.port, 443);
+    assert.equal(result.isFqdn, true);
+    assert.deepEqual(result.warnings, []);
+  });
+
+  it('keeps an explicit port and reports it as explicit', () => {
+    const result = inspectUrl('https://ifinder.example.com:8443/base');
+    assert.equal(result.port, 8443);
+    assert.equal(result.defaultPort, false);
+    assert.equal(result.pathname, '/base');
+  });
+
+  it('warns about a single-label hostname', () => {
+    const result = inspectUrl('https://ifinder');
+    assert.equal(result.valid, true);
+    assert.equal(result.isFqdn, false);
+    assert.match(result.warnings.join(' '), /single-label/);
+  });
+
+  it('rejects a single-label hostname for a URL another host must call', () => {
+    const result = inspectUrl('https://ifinder', { remoteCallback: true });
+    assert.equal(result.valid, false);
+    assert.match(result.errors.join(' '), /fully qualified domain name/);
+  });
+
+  it('rejects localhost as a remote callback URL', () => {
+    const result = inspectUrl('http://localhost:3000', { remoteCallback: true });
+    assert.equal(result.valid, false);
+    assert.match(result.errors.join(' '), /localhost/);
+  });
+
+  it('accepts localhost for a local URL but flags it', () => {
+    const result = inspectUrl('http://localhost:3000');
+    assert.equal(result.valid, true);
+    assert.match(result.warnings.join(' '), /localhost/);
+  });
+
+  it('warns about plaintext http to a remote host', () => {
+    const result = inspectUrl('http://ifinder.example.com');
+    assert.match(result.warnings.join(' '), /unencrypted/);
+  });
+
+  it('flags surrounding whitespace from copy & paste', () => {
+    const result = inspectUrl('  https://ifinder.example.com  ');
+    assert.equal(result.valid, true);
+    assert.equal(result.hostname, 'ifinder.example.com');
+    assert.match(result.warnings.join(' '), /whitespace/);
+  });
+
+  it('reports a missing scheme as invalid instead of guessing one', () => {
+    const result = inspectUrl('ifinder.example.com');
+    assert.equal(result.valid, false);
+    assert.match(result.errors.join(' '), /not a valid absolute URL/);
+  });
+
+  it('reports an empty URL', () => {
+    assert.equal(inspectUrl('').valid, false);
+    assert.equal(inspectUrl(undefined).valid, false);
+  });
+
+  it('treats an IP literal as resolvable and not short', () => {
+    const result = inspectUrl('https://10.1.2.3:8443');
+    assert.equal(result.isIpLiteral, true);
+    assert.equal(result.isFqdn, false);
+    assert.equal(result.isPrivate, true);
+    assert.equal(result.valid, true);
+  });
+});
+
+describe('isPrivateAddress', () => {
+  it('detects RFC1918 and link-local ranges', () => {
+    for (const address of [
+      '10.0.0.1',
+      '192.168.1.1',
+      '172.16.0.1',
+      '172.31.255.255',
+      '169.254.1.1'
+    ]) {
+      assert.equal(isPrivateAddress(address), true, address);
+    }
+  });
+
+  it('does not flag public addresses or the 172.32 boundary', () => {
+    for (const address of ['8.8.8.8', '172.32.0.1', '172.15.0.1', '11.0.0.1']) {
+      assert.equal(isPrivateAddress(address), false, address);
+    }
+  });
+});
+
+describe('resolveHostname', () => {
+  it('short-circuits IP literals without a lookup', async () => {
+    const result = await resolveHostname('127.0.0.1');
+    assert.equal(result.resolved, true);
+    assert.equal(result.literal, true);
+    assert.equal(result.addresses[0].address, '127.0.0.1');
+  });
+
+  it('reports an unresolvable hostname instead of throwing', async () => {
+    const result = await resolveHostname('nonexistent-host.invalid');
+    assert.equal(result.resolved, false);
+    assert.ok(result.code, 'expected a DNS error code');
+  });
+});
+
+describe('decodeJwt', () => {
+  const secret = 'test-secret';
+
+  it('exposes the claims an admin has to compare with iFinder', () => {
+    const token = jwt.sign({ sub: 'user@example.com', scope: 'fa_index_read' }, secret, {
+      algorithm: 'HS256',
+      issuer: 'https://ihub.example.com',
+      audience: 'ifinder-api',
+      expiresIn: 3600,
+      keyid: 'abc123'
+    });
+
+    const info = decodeJwt(token);
+    assert.equal(info.decoded, true);
+    assert.equal(info.subject, 'user@example.com');
+    assert.equal(info.issuer, 'https://ihub.example.com');
+    assert.equal(info.audience, 'ifinder-api');
+    assert.equal(info.scope, 'fa_index_read');
+    assert.equal(info.algorithm, 'HS256');
+    assert.equal(info.keyId, 'abc123');
+    assert.equal(info.lifetimeSeconds, 3600);
+    assert.match(info.issuedAt, /^\d{4}-\d{2}-\d{2}T/);
+    assert.match(info.expiresAt, /^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('does not throw on a malformed token', () => {
+    const info = decodeJwt('not-a-jwt');
+    assert.equal(info.decoded, false);
+    assert.ok(info.error);
+  });
+});
+
+describe('token and header redaction', () => {
+  it('previews a token without exposing the signature', () => {
+    const token = `${'a'.repeat(40)}.${'b'.repeat(40)}.${'c'.repeat(40)}`;
+    const preview = previewToken(token);
+    assert.ok(preview.includes('…'));
+    assert.ok(!preview.includes('c'.repeat(20)));
+    assert.match(preview, /122 chars/);
+  });
+
+  it('replaces the Authorization credential but keeps other headers', () => {
+    const redacted = redactHeaders({
+      Authorization: 'Bearer header.payload.signature',
+      Accept: 'application/json'
+    });
+    assert.equal(redacted.Authorization, 'Bearer <jwt>');
+    assert.equal(redacted.Accept, 'application/json');
+  });
+
+  it('truncates an oversized body and says so', () => {
+    const truncated = truncateBody('x'.repeat(5000), 100);
+    assert.equal(truncated.startsWith('x'.repeat(100)), true);
+    assert.match(truncated, /truncated, 5000 chars total/);
+    assert.equal(truncateBody('short', 100), 'short');
+  });
+});
+
+describe('buildCurlCommand', () => {
+  it('uses a $TOKEN placeholder when the token is withheld', () => {
+    const command = buildCurlCommand({
+      url: 'https://ifinder.example.com/search?query=test',
+      headers: { Authorization: 'Bearer secret.jwt.value', Accept: 'application/json' }
+    });
+    assert.ok(!command.includes('secret.jwt.value'));
+    assert.match(command, /Authorization: Bearer \$TOKEN/);
+    assert.match(command, /'Accept: application\/json'/);
+  });
+
+  it('inlines the token when it was explicitly requested', () => {
+    const command = buildCurlCommand({
+      url: 'https://ifinder.example.com/search',
+      token: 'secret.jwt.value'
+    });
+    assert.match(command, /Authorization: Bearer secret\.jwt\.value/);
+  });
+
+  it('escapes single quotes so the command stays one argument', () => {
+    const command = buildCurlCommand({ url: "https://example.com/?q=it's" });
+    assert.ok(command.includes(`'\\''`));
+  });
+
+  it('includes method and body for write requests', () => {
+    const command = buildCurlCommand({
+      url: 'https://example.com/conversations',
+      method: 'POST',
+      body: '{"a":1}'
+    });
+    assert.match(command, /-X POST/);
+    assert.match(command, /--data-raw '\{"a":1\}'/);
+  });
+});
+
+describe('describeNetworkError', () => {
+  it('points at DNS for ENOTFOUND', () => {
+    const hints = describeNetworkError(
+      { code: 'ENOTFOUND', message: 'getaddrinfo ENOTFOUND x' },
+      {
+        hostname: 'ifinder'
+      }
+    );
+    assert.match(hints.join(' '), /DNS lookup for "ifinder" failed/);
+    assert.match(hints.join(' '), /fully qualified domain name/);
+  });
+
+  it('points at the port for ECONNREFUSED', () => {
+    const hints = describeNetworkError(
+      { code: 'ECONNREFUSED', message: 'connect ECONNREFUSED' },
+      {
+        hostname: 'ifinder.example.com',
+        port: 8443
+      }
+    );
+    assert.match(hints.join(' '), /Nothing is listening on ifinder\.example\.com:8443/);
+  });
+
+  it('points at firewalls and proxies for a timeout', () => {
+    const hints = describeNetworkError(
+      { code: 'ETIMEDOUT', message: 'timeout' },
+      {
+        hostname: 'h',
+        port: 443,
+        timeout: 30000
+      }
+    );
+    assert.match(hints.join(' '), /firewall/);
+    assert.match(hints.join(' '), /30000ms/);
+  });
+
+  it('points at the trust store for certificate errors', () => {
+    const hints = describeNetworkError({ message: 'self signed certificate in chain' });
+    assert.match(hints.join(' '), /trust store/);
+  });
+
+  it('always mentions the server log', () => {
+    const hints = describeNetworkError({ code: 'EUNKNOWN', message: 'boom' });
+    assert.match(hints.join(' '), /server log/);
+  });
+});
+
+describe('describeHttpFailure', () => {
+  const jwtInfo = {
+    subject: 'user@example.com',
+    issuer: 'https://ihub.example.com',
+    audience: 'ifinder-api',
+    algorithm: 'RS256',
+    keyId: 'abc123',
+    scope: 'fa_index_read'
+  };
+
+  it('turns a bare 401 into the claims and settings to compare', () => {
+    const hints = describeHttpFailure({
+      status: 401,
+      body: '',
+      headers: {},
+      jwt: jwtInfo,
+      context: { useOidcKeyPair: true, jwksUrl: 'https://ihub.example.com/.well-known/jwks.json' }
+    });
+    const text = hints.join(' ');
+    assert.match(text, /sub="user@example\.com"/);
+    assert.match(text, /iss="https:\/\/ihub\.example\.com"/);
+    assert.match(text, /kid="abc123"/);
+    assert.match(text, /jwks\.json/);
+    assert.match(text, /JWT Subject Field/);
+    assert.match(text, /clock/);
+  });
+
+  it('surfaces the WWW-Authenticate header when the server sent one', () => {
+    const hints = describeHttpFailure({
+      status: 401,
+      headers: { 'www-authenticate': 'Bearer error="invalid_token"' },
+      jwt: jwtInfo
+    });
+    assert.match(hints.join(' '), /invalid_token/);
+  });
+
+  it('mentions the deployed public key in private key mode', () => {
+    const hints = describeHttpFailure({
+      status: 401,
+      jwt: jwtInfo,
+      context: { useOidcKeyPair: false }
+    });
+    assert.match(hints.join(' '), /public key deployed in iFinder/);
+    assert.ok(!hints.join(' ').includes('JWKS'));
+  });
+
+  it('blames scope and permissions for a 403', () => {
+    const hints = describeHttpFailure({ status: 403, jwt: jwtInfo });
+    assert.match(hints.join(' '), /fa_index_read/);
+    assert.match(hints.join(' '), /search profile/);
+  });
+
+  it('warns about a doubled API path for a 404', () => {
+    const hints = describeHttpFailure({
+      status: 404,
+      jwt: jwtInfo,
+      context: { searchProfile: 'searchprofile-standard' }
+    });
+    assert.match(hints.join(' '), /\/public-api/);
+    assert.match(hints.join(' '), /searchprofile-standard/);
+  });
+
+  it('explains a 500 as a remote-side failure and names the JWKS callback', () => {
+    const hints = describeHttpFailure({
+      status: 500,
+      jwt: jwtInfo,
+      context: { jwksUrl: 'https://ihub.example.com/.well-known/jwks.json' }
+    });
+    const text = hints.join(' ');
+    assert.match(text, /answered with a server error/);
+    assert.match(text, /cannot resolve or reach the JWKS/);
+    assert.match(text, /Short hostname|short hostname/);
+  });
+
+  it('detects an HTML error page from a proxy', () => {
+    const hints = describeHttpFailure({ status: 502, body: '<!DOCTYPE html><html>...' });
+    assert.match(hints.join(' '), /HTML, not JSON/);
+  });
+});
+
+describe('DiagnosticsReport', () => {
+  it('records steps in order with durations and a status summary', async () => {
+    const report = new DiagnosticsReport();
+    report.add({ id: 'a', label: 'A', status: STATUS.OK, message: 'fine' });
+    await report.run('b', 'B', () => ({ status: STATUS.WARN, message: 'hmm', hints: ['look'] }));
+    report.skip('c', 'C', 'not applicable');
+
+    assert.deepEqual(
+      report.steps.map(step => step.id),
+      ['a', 'b', 'c']
+    );
+    assert.equal(typeof report.steps[1].durationMs, 'number');
+    assert.deepEqual(report.steps[1].hints, ['look']);
+    assert.equal(report.hasFailure(), false);
+
+    const summary = report.summary();
+    assert.equal(summary.ok, 1);
+    assert.equal(summary.warn, 1);
+    assert.equal(summary.skip, 1);
+    assert.equal(summary.total, 3);
+  });
+
+  it('converts a thrown error into a failed step and keeps going', async () => {
+    const report = new DiagnosticsReport();
+    await report.run('boom', 'Boom', () => {
+      const error = new Error('exploded');
+      error.code = 'EBOOM';
+      throw error;
+    });
+    await report.run('after', 'After', () => ({ status: STATUS.OK }));
+
+    assert.equal(report.steps[0].status, STATUS.FAIL);
+    assert.equal(report.steps[0].message, 'exploded');
+    assert.equal(report.steps[0].details.code, 'EBOOM');
+    assert.equal(report.steps[1].status, STATUS.OK);
+    assert.equal(report.hasFailure(), true);
+  });
+
+  it('omits empty details and hints so the UI has nothing to expand', () => {
+    const report = new DiagnosticsReport();
+    report.add({ id: 'a', label: 'A', status: STATUS.OK, details: {}, hints: [] });
+    assert.equal('details' in report.steps[0], false);
+    assert.equal('hints' in report.steps[0], false);
+  });
+});

--- a/server/tests/integrationDiagnostics.test.js
+++ b/server/tests/integrationDiagnostics.test.js
@@ -488,15 +488,19 @@ describe('isCertificateError', () => {
 });
 
 describe('probeTcpTls certificate validation', () => {
-  it('verifies certificates by default rather than trusting anything', async () => {
-    // badssl.com is not reachable from every CI network, so this asserts the
-    // contract that matters and can be checked offline: the default must be
-    // strict, i.e. the caller has to opt out explicitly.
+  it('always enforces certificate verification, with no way to relax it', () => {
+    // An external badssl-style host is not reachable from every CI network, so
+    // this pins the contract that can be checked offline: verification is
+    // hardcoded on, and there is no parameter a caller could use to turn it off.
     const source = probeTcpTls.toString();
-    assert.match(source, /rejectUnauthorized = true/);
+    assert.match(source, /rejectUnauthorized:\s*true/);
     assert.ok(
       !/rejectUnauthorized:\s*false/.test(source),
-      'probeTcpTls must never hardcode rejectUnauthorized: false'
+      'probeTcpTls must never set rejectUnauthorized: false'
+    );
+    assert.ok(
+      !/rejectUnauthorized\s*=/.test(source),
+      'probeTcpTls must not accept rejectUnauthorized as a caller-supplied option'
     );
   });
 

--- a/server/tests/integrationDiagnostics.test.js
+++ b/server/tests/integrationDiagnostics.test.js
@@ -29,7 +29,6 @@ import {
   resolveHostname,
   truncateBody
 } from '../services/integrations/integrationDiagnostics.js';
-import { isValidSearchProfileId } from '../utils/pathSecurity.js';
 
 describe('inspectUrl', () => {
   it('accepts a plain https FQDN without complaints', () => {
@@ -414,47 +413,6 @@ describe('DiagnosticsReport', () => {
       hints: ['check DNS', 'check the server log', 'check DNS']
     });
     assert.deepEqual(report.steps[0].hints, ['check DNS', 'check the server log']);
-  });
-});
-
-describe('isValidSearchProfileId', () => {
-  it('accepts slug and base64 profile ids', () => {
-    for (const id of [
-      'searchprofile-standard',
-      'c2VhcmNocHJvZmlsZS1zdGFuZGFyZA==',
-      'profile_1',
-      'tenant:profile',
-      'profile@site',
-      'a+b'
-    ]) {
-      assert.equal(isValidSearchProfileId(id), true, id);
-    }
-  });
-
-  it('rejects anything that could escape the URL path segment', () => {
-    for (const id of [
-      '../../../etc/passwd',
-      'a/b',
-      'a\\b',
-      '..',
-      'profile..name',
-      'pro file',
-      'profile?x=1',
-      'profile#frag',
-      'profile%2F..',
-      '__proto__',
-      ''
-    ]) {
-      assert.equal(isValidSearchProfileId(id), false, JSON.stringify(id));
-    }
-  });
-
-  it('rejects non-strings and over-long ids', () => {
-    assert.equal(isValidSearchProfileId(undefined), false);
-    assert.equal(isValidSearchProfileId(null), false);
-    assert.equal(isValidSearchProfileId(42), false);
-    assert.equal(isValidSearchProfileId('a'.repeat(201)), false);
-    assert.equal(isValidSearchProfileId('a'.repeat(200)), true);
   });
 });
 

--- a/server/tests/integrationDiagnostics.test.js
+++ b/server/tests/integrationDiagnostics.test.js
@@ -21,8 +21,10 @@ import {
   describeHttpFailure,
   describeNetworkError,
   inspectUrl,
+  isCertificateError,
   isPrivateAddress,
   previewToken,
+  probeTcpTls,
   redactHeaders,
   resolveHostname,
   truncateBody
@@ -400,5 +402,72 @@ describe('DiagnosticsReport', () => {
     report.add({ id: 'a', label: 'A', status: STATUS.OK, details: {}, hints: [] });
     assert.equal('details' in report.steps[0], false);
     assert.equal('hints' in report.steps[0], false);
+  });
+
+  it('deduplicates hints, keeping first-seen order', () => {
+    const report = new DiagnosticsReport();
+    report.add({
+      id: 'a',
+      label: 'A',
+      status: STATUS.FAIL,
+      hints: ['check DNS', 'check the server log', 'check DNS']
+    });
+    assert.deepEqual(report.steps[0].hints, ['check DNS', 'check the server log']);
+  });
+});
+
+describe('isCertificateError', () => {
+  it('recognises OpenSSL verification failures by code', () => {
+    for (const code of [
+      'DEPTH_ZERO_SELF_SIGNED_CERT',
+      'CERT_HAS_EXPIRED',
+      'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+      'ERR_TLS_CERT_ALTNAME_INVALID'
+    ]) {
+      assert.equal(isCertificateError({ code, message: '' }), true, code);
+    }
+  });
+
+  it('recognises them by message when no code is present', () => {
+    assert.equal(isCertificateError({ message: 'self signed certificate in chain' }), true);
+    assert.equal(
+      isCertificateError({ message: "Hostname/IP does not match certificate's altnames" }),
+      true
+    );
+  });
+
+  it('does not classify transport failures as certificate failures', () => {
+    for (const code of ['ECONNREFUSED', 'ETIMEDOUT', 'ENOTFOUND', 'EHOSTUNREACH']) {
+      assert.equal(isCertificateError({ code, message: 'connect failed' }), false, code);
+    }
+    assert.equal(isCertificateError(null), false);
+    assert.equal(isCertificateError(undefined), false);
+  });
+});
+
+describe('probeTcpTls certificate validation', () => {
+  it('verifies certificates by default rather than trusting anything', async () => {
+    // badssl.com is not reachable from every CI network, so this asserts the
+    // contract that matters and can be checked offline: the default must be
+    // strict, i.e. the caller has to opt out explicitly.
+    const source = probeTcpTls.toString();
+    assert.match(source, /rejectUnauthorized = true/);
+    assert.ok(
+      !/rejectUnauthorized:\s*false/.test(source),
+      'probeTcpTls must never hardcode rejectUnauthorized: false'
+    );
+  });
+
+  it('reports a refused port as unreachable, not as a certificate problem', async () => {
+    // Port 1 is reserved and never listening.
+    const probe = await probeTcpTls({
+      hostname: '127.0.0.1',
+      port: 1,
+      protocol: 'http',
+      timeout: 3000
+    });
+    assert.equal(probe.connected, false);
+    assert.equal(probe.certificateRejected, false);
+    assert.ok(probe.code);
   });
 });

--- a/server/utils/pathSecurity.js
+++ b/server/utils/pathSecurity.js
@@ -20,6 +20,19 @@ import { promises as fs } from 'fs';
 export const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
 /**
+ * Regular expression for an iFinder search profile id.
+ *
+ * Deliberately a different character class than SAFE_ID_PATTERN:
+ * - `=` and `+` are allowed because profile ids are frequently passed base64
+ *   encoded (e.g. "c2VhcmNocHJvZmlsZS1zdGFuZGFyZA=="), and `:` / `@` appear in
+ *   qualified profile names.
+ * - `.` is NOT allowed. Profile ids are interpolated into an API URL path, so
+ *   excluding dots removes traversal sequences entirely rather than relying on
+ *   encoding to neutralize them.
+ */
+export const SEARCH_PROFILE_ID_PATTERN = /^[a-zA-Z0-9_:@=+-]+$/;
+
+/**
  * Property names that must be rejected to prevent prototype pollution.
  * These names have special meaning in JavaScript's prototype chain.
  */
@@ -79,6 +92,33 @@ export function validateIdForPath(id, idType, res) {
     return false;
   }
   return true;
+}
+
+/**
+ * Validates an iFinder search profile id that will be interpolated into an API
+ * URL path.
+ *
+ * @param {string} id - Search profile id to validate
+ * @returns {boolean} - True if valid
+ */
+export function isValidSearchProfileId(id) {
+  if (!id || typeof id !== 'string') {
+    return false;
+  }
+
+  if (id.length > 200) {
+    return false;
+  }
+
+  if (id.includes('..') || id.includes('/') || id.includes('\\')) {
+    return false;
+  }
+
+  if (DANGEROUS_KEYS.has(id)) {
+    return false;
+  }
+
+  return SEARCH_PROFILE_ID_PATTERN.test(id);
 }
 
 /**

--- a/server/utils/pathSecurity.js
+++ b/server/utils/pathSecurity.js
@@ -20,19 +20,6 @@ import { promises as fs } from 'fs';
 export const SAFE_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
 
 /**
- * Regular expression for an iFinder search profile id.
- *
- * Deliberately a different character class than SAFE_ID_PATTERN:
- * - `=` and `+` are allowed because profile ids are frequently passed base64
- *   encoded (e.g. "c2VhcmNocHJvZmlsZS1zdGFuZGFyZA=="), and `:` / `@` appear in
- *   qualified profile names.
- * - `.` is NOT allowed. Profile ids are interpolated into an API URL path, so
- *   excluding dots removes traversal sequences entirely rather than relying on
- *   encoding to neutralize them.
- */
-export const SEARCH_PROFILE_ID_PATTERN = /^[a-zA-Z0-9_:@=+-]+$/;
-
-/**
  * Property names that must be rejected to prevent prototype pollution.
  * These names have special meaning in JavaScript's prototype chain.
  */
@@ -92,33 +79,6 @@ export function validateIdForPath(id, idType, res) {
     return false;
   }
   return true;
-}
-
-/**
- * Validates an iFinder search profile id that will be interpolated into an API
- * URL path.
- *
- * @param {string} id - Search profile id to validate
- * @returns {boolean} - True if valid
- */
-export function isValidSearchProfileId(id) {
-  if (!id || typeof id !== 'string') {
-    return false;
-  }
-
-  if (id.length > 200) {
-    return false;
-  }
-
-  if (id.includes('..') || id.includes('/') || id.includes('\\')) {
-    return false;
-  }
-
-  if (DANGEROUS_KEYS.has(id)) {
-    return false;
-  }
-
-  return SEARCH_PROFILE_ID_PATTERN.test(id);
 }
 
 /**

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1934,7 +1934,6 @@
         "userDomain": "Test als Domäne",
         "currentAdmin": "Ihr Admin-Konto",
         "userHelp": "Leer lassen, um mit dem eigenen Konto zu testen. Ausfüllen, um zu prüfen, wie das JWT-Subject für einen bestimmten Benutzer gebildet wird — zum Beispiel ob iFinder DOMAIN\\benutzername statt einer E-Mail-Adresse erwartet.",
-        "query": "Test-Suchbegriff",
         "includeToken": "Signiertes JWT mit ausgeben",
         "includeTokenHelp": "Gibt das Token selbst sowie einen direkt ausführbaren curl-Befehl zurück. Das Token ist ein gültiger Zugang für den getesteten Benutzer — behandeln Sie es wie ein Passwort und fügen Sie es nicht in Tickets ein.",
         "conversationRoundTrip": "Konversations-Testlauf ausführen (iAssistant)",

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1915,7 +1915,30 @@
         "title": "Testergebnisse",
         "success": "Erfolgreich",
         "failed": "Fehlgeschlagen",
-        "details": "Details"
+        "details": "Details",
+        "whatToCheck": "Was zu prüfen ist",
+        "observed": "Beobachtet",
+        "copyDetails": "Kopieren",
+        "copied": "Kopiert",
+        "reproduce": "Außerhalb von iHub nachstellen:",
+        "copyCurl": "curl-Befehl kopieren",
+        "copyToken": "JWT kopieren",
+        "stepSummary": "{{ok}} ok, {{warn}} Warnungen, {{fail}} fehlgeschlagen · {{duration}}ms",
+        "notes": "Hinweise"
+      },
+      "diagnostics": {
+        "title": "Diagnose-Optionen",
+        "description": "Der Verbindungstest signiert ein JWT für Ihr eigenes Admin-Konto und ruft dieselben Endpunkte auf, die die Integration im Betrieb verwendet. Mit diesen Optionen können Sie als anderer Benutzer testen oder einen reproduzierbaren curl-Befehl erhalten.",
+        "userEmail": "Test als E-Mail",
+        "userUsername": "Test als Benutzername",
+        "userDomain": "Test als Domäne",
+        "currentAdmin": "Ihr Admin-Konto",
+        "userHelp": "Leer lassen, um mit dem eigenen Konto zu testen. Ausfüllen, um zu prüfen, wie das JWT-Subject für einen bestimmten Benutzer gebildet wird — zum Beispiel ob iFinder DOMAIN\\benutzername statt einer E-Mail-Adresse erwartet.",
+        "query": "Test-Suchbegriff",
+        "includeToken": "Signiertes JWT mit ausgeben",
+        "includeTokenHelp": "Gibt das Token selbst sowie einen direkt ausführbaren curl-Befehl zurück. Das Token ist ein gültiger Zugang für den getesteten Benutzer — behandeln Sie es wie ein Passwort und fügen Sie es nicht in Tickets ein.",
+        "conversationRoundTrip": "Konversations-Testlauf ausführen (iAssistant)",
+        "conversationRoundTripHelp": "Erstellt eine ephemere Testkonversation in iAssistant und löscht sie wieder. Prüft Schreibzugriff, nicht nur die Authentifizierung."
       }
     },
     "integrations": {

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1923,7 +1923,7 @@
         "reproduce": "Außerhalb von iHub nachstellen:",
         "copyCurl": "curl-Befehl kopieren",
         "copyToken": "JWT kopieren",
-        "stepSummary": "{{ok}} ok, {{warn}} Warnungen, {{fail}} fehlgeschlagen · {{duration}}ms",
+        "stepSummary": "ok {{ok}} · Warnungen {{warn}} · fehlgeschlagen {{fail}} · {{duration}}ms",
         "notes": "Hinweise"
       },
       "diagnostics": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1662,7 +1662,30 @@
         "title": "Test Results",
         "success": "Success",
         "failed": "Failed",
-        "details": "Details"
+        "details": "Details",
+        "whatToCheck": "What to check",
+        "observed": "Observed",
+        "copyDetails": "Copy",
+        "copied": "Copied",
+        "reproduce": "Reproduce outside iHub:",
+        "copyCurl": "Copy curl command",
+        "copyToken": "Copy JWT",
+        "stepSummary": "{{ok}} ok, {{warn}} warnings, {{fail}} failed · {{duration}}ms",
+        "notes": "Notes"
+      },
+      "diagnostics": {
+        "title": "Diagnostics options",
+        "description": "The connection test signs a JWT for your own admin account and calls the same endpoints the integration uses at runtime. Use these options to test as a different user or to get a reproducible curl command.",
+        "userEmail": "Test as email",
+        "userUsername": "Test as username",
+        "userDomain": "Test as domain",
+        "currentAdmin": "your admin account",
+        "userHelp": "Leave empty to test with your own account. Fill these in to check how the JWT subject is built for a specific user — for example whether iFinder expects DOMAIN\\username instead of an email address.",
+        "query": "Test search query",
+        "includeToken": "Include the signed JWT",
+        "includeTokenHelp": "Returns the token itself plus a ready-to-run curl command. The token is a working credential for the tested user — treat it like a password and do not paste it into tickets.",
+        "conversationRoundTrip": "Run conversation round-trip (iAssistant)",
+        "conversationRoundTripHelp": "Creates an ephemeral test conversation in iAssistant and deletes it again. Verifies write access, not just authentication."
       }
     },
     "integrations": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1670,7 +1670,7 @@
         "reproduce": "Reproduce outside iHub:",
         "copyCurl": "Copy curl command",
         "copyToken": "Copy JWT",
-        "stepSummary": "{{ok}} ok, {{warn}} warnings, {{fail}} failed · {{duration}}ms",
+        "stepSummary": "ok {{ok}} · warnings {{warn}} · failed {{fail}} · {{duration}}ms",
         "notes": "Notes"
       },
       "diagnostics": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1681,7 +1681,6 @@
         "userDomain": "Test as domain",
         "currentAdmin": "your admin account",
         "userHelp": "Leave empty to test with your own account. Fill these in to check how the JWT subject is built for a specific user — for example whether iFinder expects DOMAIN\\username instead of an email address.",
-        "query": "Test search query",
         "includeToken": "Include the signed JWT",
         "includeTokenHelp": "Returns the token itself plus a ready-to-run curl command. The token is a working credential for the tested user — treat it like a password and do not paste it into tickets.",
         "conversationRoundTrip": "Run conversation round-trip (iAssistant)",


### PR DESCRIPTION
Closes #2151

> **Note:** this description was refreshed at `a6278b6` to match the code after the review round. Five follow-up commits changed the TLS probe, closed an SSRF flow, and removed two diagnostics options — see [Review round](#review-round) at the bottom.

## Problem

The **Test iFinder** / **Test iAssistant** buttons returned a single pass/fail message. That made the failures admins actually hit while connecting iHub to iFinder indistinguishable from one another:

- a **500** raised inside iFinder while it tried to resolve the JWKS hostname iHub advertised, and
- a **401** with an empty body

both surfaced as "test failed". Neither told the admin how the JWT looked, which user it carried, or which URLs were involved.

## What changed

Both endpoints now run an ordered sequence of diagnostic steps. Every step reports its status, what it observed (as inspectable JSON) and — on failure — concrete things to check.

| Step | What it proves |
| --- | --- |
| Configuration | Signing key source, subject field, endpoints, profile, timeouts |
| Base URL | Scheme, hostname, port; warns when the hostname is not fully qualified |
| DNS resolution | Whether the iHub server resolves the hostname, and to which addresses |
| TCP / TLS | Port reachability, and whether the certificate passes the iHub trust store — with subject, issuer and expiry when it does |
| JWT generation | Decoded header + payload, and the subject actually derived for the user |
| JWT signature | That iHub can verify its own token with the matching public key |
| Issuer reachable | The issuer and JWKS URL **iFinder must call back to** (OIDC key pair mode) |
| JWKS endpoint | That keys are published and the token's `kid` is among them |
| API request | Full URL, method, redacted headers, status, response headers, body excerpt |
| Profile exists | (iAssistant) whether the configured profile id is one the user can see |

### Root-cause detection for the two reported failures

- **The 500.** iFinder derives the JWKS location from the `iss` claim. If the advertised issuer is `localhost` or a single-label hostname, iFinder can never fetch the keys — the step **fails** with that explanation rather than looking fine. An `iss` that is not a URL at all (the `ihub-apps` fallback when `platform.oauth.issuer` is unset) also fails, since discovery is then structurally impossible.
- **The 401.** The hints name the claims to compare against iFinder's trust configuration (`sub`, `iss`, `aud`, `alg`, `kid`), surface `WWW-Authenticate` when present, and list the usual causes: issuer mismatch down to a trailing slash, a `kid` missing from the JWKS, a subject in the wrong format, clock skew.

Transport errors are classified too — `ENOTFOUND`, `ECONNREFUSED`, timeouts, certificate rejection and scheme mismatches each get their own explanation.

**TLS.** The probe always enforces certificate verification; there is no option to relax it. A rejected certificate is reported and *interpreted* rather than avoided: not whitelisted → **FAIL** with the trust-store fix; whitelisted under Admin → Platform → SSL → **WARN** explaining that requests still succeed for iHub while browsers keep rejecting it.

**JWKS.** The endpoint is only requested when `platform.oauth.issuer` is configured. With auto-detection the step reports the computed URL and states it was not requested — the URL would be derived from the request's `Host` header, and it never told the admin anything reliable about what iFinder will fetch anyway. When it *is* requested, an unreachable endpoint is a **warning**, not a failure: the probe runs from iHub against iHub's own external URL, which can legitimately fail under split-horizon DNS or without hairpin NAT. Only the content of a successful response (no keys published, `kid` absent) is conclusive.

### Diagnostics options

- **Test as email / username / domain** — mint the token for a specific user to verify how the subject is built (e.g. `DOMAIN\username` vs email).
- **Include the signed JWT** — returns the token plus a ready-to-run `curl` command. Opt-in, since the token is a working credential; without it the command references `$TOKEN` and is safe to share.
- **Run conversation round-trip** — creates and deletes an ephemeral iAssistant conversation to verify write access, not just authentication. Opt-in because it writes.

The search term and search profile are deliberately **not** parameters: the diagnostics exercise the configured profile with a fixed query, so no value from the request can influence which URL iHub contacts. To test a different profile, change the Default Search Profile setting.

### Bug fixed along the way

The iAssistant test caught network failures and reported "configuration is valid (health endpoint not available)" with `success: true` — an unreachable service counted as a pass. Unreachable now reads as unreachable.

## Compatibility

Additive. `success`, `message` and `details` keep their existing shape and meaning; `summary`, `steps`, `jwt` and `request` are new. The request body is optional, so existing callers work unchanged.

## Security

- The endpoints remain behind `adminAuth` (verified: unauthenticated → 403).
- **No value from the request reaches an outbound URL.** The search URL is built from platform config only; the JWKS URL is fetched only when the issuer comes from config; `buildIntegrationUrl` additionally asserts the result stays on the configured origin. This closed a `js/request-forgery` alert — see [Review round](#review-round).
- Certificate verification is always enforced in the TLS probe, with no code path able to disable it.
- The raw JWT is returned only when `includeToken: true` is explicitly requested; otherwise the response carries a truncated preview, and `Authorization` is redacted to `Bearer <jwt>` in the echoed request.
- The `user` override is allow-listed to known string fields with length caps, so it cannot inject arbitrary structures into token generation. It affects the JWT only, never a URL.
- No signing key material is ever returned — only a description of where it comes from.

## Testing

- **New:** `server/tests/integrationDiagnostics.test.js` — 45 tests over URL inspection, private-address ranges, hostname resolution, JWT decoding, token/header redaction, curl construction and shell quoting, certificate-error classification, the strict-TLS contract, network-error and HTTP-failure classification, and the report/summary mechanics. All pass.
- **Manual end-to-end** against a running server with the local admin account, covering: integration disabled, missing base URL, missing private key, short hostname (DNS failure → skipped TCP), `localhost` issuer rejection, `iss` not a URL, a mock iFinder returning 401 with `WWW-Authenticate`, the success path with search hits, iAssistant profile-mismatch detection, and the conversation round-trip. Also verified `domain\username` subject resolution (`BMG\jdoe`), that unauthenticated requests get 403, that a self-signed certificate yields FAIL when not whitelisted and WARN when whitelisted, that no outbound `.well-known` request is made when the issuer is auto-detected, and that `query` / `searchProfile` sent in the body do not appear in the request URL.
- `npm run test:quick` passes; `npx eslint` clean on all changed files; `npx vite build` succeeds; Prettier clean.
- Two pre-existing failures in `iFinderAdapter.test.js` and `iFinderService.discover.test.js` were confirmed to fail identically on a clean tree — unrelated to this change.

## Docs

- `docs/ifinder-iassistant-admin-guide.md` — new "Start Here: Connection Diagnostics" troubleshooting section covering the step table, the options, how to read the 500 and the 401, and the API form; the "Testing and Validation" section now points at the diagnostics first.
- `docs/releases/5.5.0/features.md` — changelog entry for the admin changelog.
- i18n keys added for `en` and `de`.

## Review round

Copilot and CodeQL raised six issues; all are addressed. Two were genuine bugs in this PR:

- **Stale expand/collapse state** across re-runs — `useState` only initializes on mount, so a step that changed outcome kept the previous expansion. Rows are now keyed by `id` + `status`.
- **SSRF** — the JWKS probe fetched a URL derived from the `Host` header. Fixed, then found to be part of a broader `js/request-forgery` alert (see below).

Smaller: hint dedupe at the source, `aria-expanded` on the collapsible step toggle, and plural agreement in the summary chip.

**Two corrections I made to my own earlier claims on this PR**, recorded because the threads contain the wrong version first:

1. I twice reported the blocking critical CodeQL alert as fixed when it was not. Parameterizing `rejectUnauthorized` with a `true` default still let `false` reach the sink from the caller; it is now hardcoded.
2. The alert that actually kept CI red was neither the certificate one nor the JWKS `Host` header. Fetching the check-run annotations identified it as `js/request-forgery` (severity 9.8 → critical) at `server/utils/httpConfig.js:495` — the shared `httpFetch`, in a file this PR never touched, which is why no inline alert ever pointed at it. Three request values were reaching an outbound URL (`req.body.query`, `req.body.searchProfile`, `req.get('host')`); all three are gone.

**One finding deliberately left open for a maintainer:** `server/utils/iFinderJwt.js:293` falls back to `fi_index_read` where the shipped default, migration V014, the client, and that file's own JSDoc all say `fa_index_read`. Changing it alters which scope affected installs request from iFinder, which I cannot validate here, so the diagnostics report the actual signed value and warn about the mismatch instead. Details in [this thread](https://github.com/intrafind/ihub-apps/pull/2153#discussion_r3675931065).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jdzq2BHfyqFUpnS9dATe29