### PR TITLE
feat(apps): let apps invoke other apps as tools (concierge pattern)

### DIFF
--- a/client/src/features/admin/components/AppFormEditor.jsx
+++ b/client/src/features/admin/components/AppFormEditor.jsx
@@ -5,6 +5,7 @@ import ToolsConfigSection from './app-form/ToolsConfigSection';
 import McpToolsConfigSection from './app-form/McpToolsConfigSection';
 import SkillsConfigSection from './app-form/SkillsConfigSection';
 import WorkflowsConfigSection from './app-form/WorkflowsConfigSection';
+import AppsConfigSection from './app-form/AppsConfigSection';
 import IframeConfigSection from './app-form/IframeConfigSection';
 import RedirectConfigSection from './app-form/RedirectConfigSection';
 import Icon from '../../../shared/components/Icon';
@@ -254,6 +255,15 @@ function AppFormEditor({
               <WorkflowsConfigSection
                 selectedWorkflows={app.workflows || []}
                 onWorkflowsChange={workflows => handleInputChange('workflows', workflows)}
+              />
+            )}
+
+            {/* Apps-as-Tools Configuration */}
+            {featureFlags.isEnabled('appAsTool', false) && (
+              <AppsConfigSection
+                appId={app.id}
+                selectedApps={app.apps || []}
+                onAppsChange={apps => handleInputChange('apps', apps)}
               />
             )}
 

--- a/client/src/features/admin/components/app-form/AppsConfigSection.jsx
+++ b/client/src/features/admin/components/app-form/AppsConfigSection.jsx
@@ -1,0 +1,33 @@
+import { useTranslation } from 'react-i18next';
+import AppsSelector from '../../../../shared/components/AppsSelector';
+
+function AppsConfigSection({ appId, selectedApps, onAppsChange }) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="bg-white dark:bg-gray-800 shadow px-4 py-5 sm:rounded-lg sm:p-6">
+      <div className="md:grid md:grid-cols-3 md:gap-6">
+        <div className="md:col-span-1">
+          <h3 className="text-lg font-medium leading-6 text-gray-900 dark:text-gray-100">
+            {t('admin.apps.edit.appsAsTools', 'Apps as Tools')}
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.apps.edit.appsAsToolsDesc',
+              'Let this app delegate to other apps. The model can call each selected app as a tool and use its answer (concierge pattern).'
+            )}
+          </p>
+        </div>
+        <div className="mt-5 md:mt-0 md:col-span-2">
+          <AppsSelector
+            selectedApps={selectedApps}
+            onAppsChange={onAppsChange}
+            excludeAppId={appId}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default AppsConfigSection;

--- a/client/src/shared/components/AppsSelector.jsx
+++ b/client/src/shared/components/AppsSelector.jsx
@@ -120,7 +120,9 @@ function AppsSelector({ selectedApps = [], onAppsChange, excludeAppId }) {
                   type="button"
                   onClick={() => handleRemoveApp(id)}
                   className="ml-1 flex-shrink-0 text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300"
-                  aria-label={`Remove ${displayName}`}
+                  aria-label={t('admin.apps.edit.removeAppTool', 'Remove {{name}}', {
+                    name: displayName
+                  })}
                 >
                   <Icon name="x" className="w-3 h-3" />
                 </button>

--- a/client/src/shared/components/AppsSelector.jsx
+++ b/client/src/shared/components/AppsSelector.jsx
@@ -1,0 +1,198 @@
+import { useState, useRef, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import Icon from './Icon';
+import { fetchAdminApps } from '../../api/endpoints/admin';
+import { getLocalizedContent } from '../../utils/localizeContent';
+
+/**
+ * AppsSelector - Multi-select component for choosing apps another app may
+ * invoke as tools (app-as-tool / concierge pattern). Mirrors WorkflowsSelector
+ * but reads from the admin apps endpoint and stores selections as app id
+ * strings in app.apps.
+ *
+ * @param {Object} props
+ * @param {string[]} props.selectedApps - Array of selected app id strings
+ * @param {Function} props.onAppsChange - Callback receiving updated array of app id strings
+ * @param {string} [props.excludeAppId] - App id to hide from the picker (the app being edited)
+ */
+function AppsSelector({ selectedApps = [], onAppsChange, excludeAppId }) {
+  const { t, i18n } = useTranslation();
+  const [searchTerm, setSearchTerm] = useState('');
+  const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+  const [availableApps, setAvailableApps] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const dropdownRef = useRef(null);
+  const searchInputRef = useRef(null);
+
+  useEffect(() => {
+    const loadApps = async () => {
+      try {
+        setIsLoading(true);
+        const apps = await fetchAdminApps();
+        // Only enabled chat apps can answer a delegated message — redirect and
+        // iframe apps have no chat pipeline to run.
+        const callable = (Array.isArray(apps) ? apps : []).filter(
+          a => a.enabled !== false && (!a.type || a.type === 'chat')
+        );
+        setAvailableApps(callable);
+      } catch (error) {
+        console.error('Failed to fetch apps:', error);
+        setAvailableApps([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    loadApps();
+  }, []);
+
+  const localize = value => getLocalizedContent(value, i18n.language) || '';
+
+  const filteredApps = availableApps.filter(app => {
+    if (excludeAppId && app.id === excludeAppId) return false;
+    const name = localize(app.name) || app.id;
+    const description = localize(app.description);
+    const searchableText = `${app.id} ${name} ${description}`.toLowerCase();
+    const matchesSearch = searchableText.includes(searchTerm.toLowerCase());
+    const notSelected = !selectedApps.includes(app.id);
+    return matchesSearch && notSelected;
+  });
+
+  useEffect(() => {
+    const handleClickOutside = event => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target)) {
+        setIsDropdownOpen(false);
+        setSearchTerm('');
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  useEffect(() => {
+    if (isDropdownOpen && searchInputRef.current) {
+      searchInputRef.current.focus();
+    }
+  }, [isDropdownOpen]);
+
+  const handleAddApp = app => {
+    const id = typeof app === 'string' ? app : app.id;
+    if (!selectedApps.includes(id)) {
+      onAppsChange([...selectedApps, id]);
+    }
+    setSearchTerm('');
+    setIsDropdownOpen(false);
+  };
+
+  const handleRemoveApp = idToRemove => {
+    onAppsChange(selectedApps.filter(id => id !== idToRemove));
+  };
+
+  const handleSearchChange = e => {
+    setSearchTerm(e.target.value);
+    setIsDropdownOpen(true);
+  };
+
+  const handleSearchKeyDown = e => {
+    if (e.key === 'Enter' && filteredApps.length > 0) {
+      e.preventDefault();
+      handleAddApp(filteredApps[0]);
+    } else if (e.key === 'Escape') {
+      setIsDropdownOpen(false);
+      setSearchTerm('');
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      {selectedApps.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {selectedApps.map(id => {
+            const app = availableApps.find(a => a.id === id);
+            const displayName = app ? localize(app.name) || app.id : id;
+            return (
+              <span
+                key={id}
+                className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-indigo-100 dark:bg-indigo-900/50 text-indigo-800 dark:text-indigo-300"
+              >
+                <Icon name="chat" className="w-3 h-3" />
+                {displayName}
+                <button
+                  type="button"
+                  onClick={() => handleRemoveApp(id)}
+                  className="ml-1 flex-shrink-0 text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300"
+                  aria-label={`Remove ${displayName}`}
+                >
+                  <Icon name="x" className="w-3 h-3" />
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      <div className="relative" ref={dropdownRef}>
+        <div className="relative">
+          <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+            <Icon name="search" className="h-5 w-5 text-gray-400 dark:text-gray-500" />
+          </div>
+          <input
+            ref={searchInputRef}
+            type="text"
+            placeholder={t('admin.apps.edit.searchApps', 'Search apps to add...')}
+            value={searchTerm}
+            onChange={handleSearchChange}
+            onKeyDown={handleSearchKeyDown}
+            onFocus={() => setIsDropdownOpen(true)}
+            className="block w-full pl-10 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+            autoComplete="off"
+          />
+        </div>
+
+        {isDropdownOpen && (
+          <div className="absolute z-10 mt-1 w-full bg-white dark:bg-gray-800 border border-gray-300 dark:border-gray-600 rounded-lg shadow-lg max-h-60 overflow-auto">
+            {isLoading ? (
+              <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
+                {t('common.loading', 'Loading...')}
+              </div>
+            ) : filteredApps.length > 0 ? (
+              filteredApps.map(app => {
+                const name = localize(app.name) || app.id;
+                const description = localize(app.description);
+                return (
+                  <button
+                    type="button"
+                    key={app.id}
+                    onClick={() => handleAddApp(app)}
+                    className="w-full text-left px-3 py-3 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 focus:bg-gray-100 dark:focus:bg-gray-700 focus:outline-none border-b border-gray-100 dark:border-gray-700 last:border-b-0"
+                  >
+                    <div className="font-medium text-gray-900 dark:text-gray-100">{name}</div>
+                    {description && (
+                      <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">
+                        {description}
+                      </div>
+                    )}
+                  </button>
+                );
+              })
+            ) : (
+              <div className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
+                {searchTerm
+                  ? t('admin.apps.edit.appsAsToolsNoResults', 'No apps match your search')
+                  : t('admin.apps.edit.appsAsToolsNoApps', 'No apps available')}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      <p className="text-sm text-gray-500 dark:text-gray-400">
+        {t(
+          'admin.apps.edit.appsAsToolsHelper',
+          'Each selected app becomes a tool (app__<id>) the model can call. Users only reach apps they have permission for, and a called app cannot call further apps.'
+        )}
+      </p>
+    </div>
+  );
+}
+
+export default AppsSelector;

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -18,7 +18,7 @@ leave durable artifacts behind.
 | **Inbox** | Markdown checklist at `contents/data/agent-inboxes/<id>.md`. Users add work; agents read/mark-done via `read_inbox`/`write_inbox`. |
 | **Service-account identity** | Agent runs execute as `agent:<profileId>` principals. Groups in `profile.serviceAccount.groups` determine what apps/tools/models the agent can use. `isAdmin` is forced false. |
 | **Dynamic tasks** | Agents may call `create_task` to enqueue work onto `state.data._taskQueue`. A drain-mode loop processes the queue until empty (bounded by `dynamicTasks.maxDepth` and the existing 200-iteration cap). |
-| **App-as-tool** | When `features.appAsTool: true` and a node has `config.apps: [appId, ...]`, the LLM sees `app__<appId>` synthetic tools that call into `ChatService.invokeAppInternal`. App→App nesting is forbidden. |
+| **App-as-tool** | When `features.appAsTool: true` and a node has `config.apps: [appId, ...]`, the LLM sees `app__<appId>` synthetic tools that call into `ChatService.invokeAppInternal` via the shared gateway (`server/services/chat/appToolsGateway.js`). Regular chat apps can use the same mechanism through their own `apps: [...]` config field (see [App Configuration](apps.md#apps-as-tools-concierge-pattern)). App→App nesting is forbidden. |
 | **HITL** | Explicit `human` nodes in the workflow pause until an operator in `profile.hitl.approverGroups` approves via `POST /api/agents/runs/:runId/approve`. |
 | **Artifacts** | Agents call `write_artifact({ name, content })` to persist to `contents/data/agent-artifacts/<execId>/`. Each run can produce multiple artifacts. |
 

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -549,6 +549,7 @@ Each app is defined with the following essential properties:
 | `imageGeneration`       | Object  | Optional. Default image generation parameters for this app. See [Image Generation](#image-generation-configuration) below |
 | `thinking`              | Object  | Optional. Extended thinking configuration for supported models. See [Thinking Configuration](#thinking-configuration) below |
 | `tools`                 | Array   | Optional. Array of tool identifiers available in this app                                                                |
+| `apps`                  | Array   | Optional. Array of app IDs this app may invoke as tools (`app__<id>`). Requires the `appAsTool` platform feature. See [Apps as Tools](#apps-as-tools-concierge-pattern) below |
 | `websearch`             | Object  | Optional. Unified web search configuration. See [Web Search Configuration](#web-search-configuration) below             |
 | `sources`               | Array   | Optional. Array of source reference IDs for knowledge base access                                                       |
 | `allowInheritance`      | Boolean | Optional. Allow child apps to inherit configuration from this app. Default: `false`                                      |
@@ -893,6 +894,40 @@ The `skills` array specifies which skill identifiers are available for an app. S
 | `skills`                       | Array   | -       | Array of skill identifier strings. Each string must match a skill defined in the skills directory |
 | `skillSettings.autoActivate`   | Boolean | -       | When `true`, all listed skills are activated automatically when the app opens        |
 | `skillSettings.maxActiveSkills`| Number  | -       | Maximum number of skills that can be active at the same time (1-10)                 |
+
+#### Apps as Tools (Concierge Pattern)
+
+The `apps` array lets an app delegate to other apps. Each listed app is exposed to the model
+as a synthetic tool named `app__<appId>` — its description is the target app's description and
+its parameters are derived from the target app's `variables` (plus a required `message`
+parameter). When the model calls the tool, the target app runs its full chat pipeline
+**server-side and in-process** (own system prompt, own preferred model, own tools and
+sources — no REST round-trip) and returns its answer as the tool result.
+
+This enables a "concierge" bot that routes requests to specialist bots:
+
+```json
+{
+  "id": "concierge",
+  "name": { "en": "Concierge" },
+  "description": { "en": "Routes your request to the right assistant" },
+  "system": {
+    "en": "You are a concierge. Delegate domain questions to the available app tools and synthesize their answers. State which specialist you consulted."
+  },
+  "apps": ["hr-bot", "it-support-bot", "travel-bot"]
+}
+```
+
+Requirements and behavior:
+
+| Aspect            | Behavior                                                                                                          |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Feature flag      | The `appAsTool` platform feature must be enabled (Admin → Features). Off by default.                               |
+| Permissions       | Users can only reach target apps their groups allow — the same check as opening the app directly. Apps the user may not access are not offered to the model at all. |
+| Nesting           | One level only. A called app runs without `app__*` tools, so chains like A → B → C (or loops) cannot form. Self-references are ignored. |
+| Model             | Each target app resolves its own model (`preferredModel` or platform default). The target model must support tools only if the target app itself uses tools. The calling app's model must support tool calling. |
+| Statelessness     | Each call is a fresh, single-turn invocation of the target app — no chat history is shared in either direction.    |
+| Tool description  | Write target app descriptions as if instructing the concierge's model when to pick that specialist — the description **is** the tool description. |
 
 #### iAssistant Configuration
 

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -957,3 +957,20 @@ reading server logs and guessing.
   search profile, which is what an admin wants to verify anyway.
 - A previous behaviour is fixed: an iAssistant network failure used to be reported as "configuration
   is valid" and counted as a success. Unreachable now reads as unreachable.
+
+## Apps Can Now Call Other Apps as Tools (Concierge Pattern)
+
+A chat app can delegate to other apps: list app IDs in the new `apps` field and the model
+sees each one as a callable tool (`app__<id>`). The called app answers with its own system
+prompt, model, tools, and sources — entirely server-side, with no REST round-trip — and the
+calling app weaves the answer into its response. This enables a concierge bot that routes
+requests to specialist bots.
+
+- Configure via the new **Apps as Tools** section in the admin app editor, or the `apps`
+  array in the app JSON.
+- Requires the **App-as-Tool** platform feature (Admin → Features; previously agent-only,
+  off by default).
+- Users can only reach apps their groups permit — the same permission check as opening the
+  app directly; apps a user may not access are never offered to the model.
+- Delegation is limited to one level: a called app cannot call further apps, so loops
+  cannot form.

--- a/server/featureRegistry.js
+++ b/server/featureRegistry.js
@@ -149,8 +149,8 @@ export const featureRegistry = [
     id: 'appAsTool',
     name: { en: 'App-as-Tool', de: 'App-als-Tool' },
     description: {
-      en: 'Allow agents to invoke iHub apps as synthetic tools (app__<id>). Requires Agent Factory.',
-      de: 'Agenten erlauben, iHub-Apps als synthetische Tools (app__<id>) aufzurufen. Erfordert Agent Factory.'
+      en: 'Allow apps and agents to invoke other iHub apps as synthetic tools (app__<id>) — e.g. a concierge app delegating to specialist apps.',
+      de: 'Apps und Agenten erlauben, andere iHub-Apps als synthetische Tools (app__<id>) aufzurufen — z. B. eine Concierge-App, die an Spezial-Apps delegiert.'
     },
     category: 'preview',
     default: false,

--- a/server/services/chat/RequestBuilder.js
+++ b/server/services/chat/RequestBuilder.js
@@ -1,5 +1,6 @@
 import configCache from '../../configCache.js';
 import { createCompletionRequest } from '../../adapters/index.js';
+import { isFeatureEnabled } from '../../featureRegistry.js';
 import { getToolsForApp, resolveAppNativeWebSearch } from '../../toolLoader.js';
 import ErrorHandler from '../../utils/ErrorHandler.js';
 import ApiKeyVerifier from '../../utils/ApiKeyVerifier.js';
@@ -126,12 +127,13 @@ function filterModelsForApp(models, app) {
   }
 
   // Filter by tools requirement (app.tools, app.apps — apps invoked as tools —
-  // or websearch config all require tool support)
-  if (
-    (app?.tools && app.tools.length > 0) ||
-    (app?.apps && app.apps.length > 0) ||
-    app?.websearch?.enabled
-  ) {
+  // or websearch config all require tool support). app.apps only counts while
+  // the appAsTool feature is enabled: with the flag off no app__* tools are
+  // generated, so a configured-but-inactive delegation must not shrink the
+  // model list.
+  const appToolsActive =
+    app?.apps && app.apps.length > 0 && isFeatureEnabled('appAsTool', configCache.getFeatures());
+  if ((app?.tools && app.tools.length > 0) || appToolsActive || app?.websearch?.enabled) {
     availableModels = availableModels.filter(model => model.supportsTools);
   }
 

--- a/server/services/chat/RequestBuilder.js
+++ b/server/services/chat/RequestBuilder.js
@@ -125,8 +125,13 @@ function filterModelsForApp(models, app) {
     availableModels = availableModels.filter(model => app.allowedModels.includes(model.id));
   }
 
-  // Filter by tools requirement (app.tools array or websearch config both require tool support)
-  if ((app?.tools && app.tools.length > 0) || app?.websearch?.enabled) {
+  // Filter by tools requirement (app.tools, app.apps — apps invoked as tools —
+  // or websearch config all require tool support)
+  if (
+    (app?.tools && app.tools.length > 0) ||
+    (app?.apps && app.apps.length > 0) ||
+    app?.websearch?.enabled
+  ) {
     availableModels = availableModels.filter(model => model.supportsTools);
   }
 

--- a/server/services/chat/ToolExecutor.js
+++ b/server/services/chat/ToolExecutor.js
@@ -387,7 +387,16 @@ class ToolExecutor {
     };
   }
 
-  async executeToolCall(toolCall, tools, chatId, buildLogData, user, app, userFileData = null) {
+  async executeToolCall(
+    toolCall,
+    tools,
+    chatId,
+    buildLogData,
+    user,
+    app,
+    userFileData = null,
+    clientLanguage = undefined
+  ) {
     const toolId =
       tools.find(t => normalizeToolName(t.id) === toolCall.function.name)?.id ||
       toolCall.function.name;
@@ -495,8 +504,17 @@ class ToolExecutor {
         }
       }
 
-      // Regular tool execution
-      const result = await runTool(toolId, { ...args, chatId, user, appConfig: app });
+      // Regular tool execution. `language` is a default the tool may use
+      // (e.g. app-as-tool passes it to the callee run); explicit LLM-provided
+      // args of the same name win via the spread, while chatId/user/appConfig
+      // spread last so the LLM can never override them.
+      const result = await runTool(toolId, {
+        language: clientLanguage,
+        ...args,
+        chatId,
+        user,
+        appConfig: app
+      });
       actionTracker.trackToolCallEnd(chatId, { toolName: toolId, toolOutput: result });
 
       await logInteraction(
@@ -1189,7 +1207,8 @@ class ToolExecutor {
           buildLogData,
           user,
           app,
-          userFileData
+          userFileData,
+          clientLanguage
         );
 
         if (toolResult.clarification) {
@@ -1600,7 +1619,8 @@ class ToolExecutor {
             buildLogData,
             user,
             app,
-            userFileData
+            userFileData,
+            clientLanguage
           );
 
           if (toolResult.clarification) {

--- a/server/services/chat/appToolsGateway.js
+++ b/server/services/chat/appToolsGateway.js
@@ -1,22 +1,39 @@
 /**
- * App-as-Tool Gateway
+ * App Tools Gateway
  *
- * Translates iHub Apps into synthetic tools an agent can call. Each registered
- * app surfaces as a tool named `app__<appId>` whose parameters are derived from
- * `app.variables` and whose description is the localized app description.
+ * The shared internal interface for invoking iHub Apps programmatically —
+ * server-side, without going through the REST API. Every caller that wants
+ * another app to answer a message routes through here:
  *
- * Invocation routes through `ChatService.invokeAppInternal()`, which runs the
- * standard chat pipeline against an in-memory sink.
+ *  - **Chat apps** (`app.apps: [...]`): `getToolsForApp()` surfaces the listed
+ *    apps as synthetic `app__<appId>` tools; `runTool()` dispatches them to
+ *    `invokeAppTool()` (the "concierge" pattern — a bot delegating to
+ *    specialist bots).
+ *  - **Agent workflow nodes** (`node.config.apps`): PromptNodeExecutor
+ *    registers the same synthetic tools and calls `invokeAppTool()` directly.
  *
- * App→App nesting is disallowed: when the calling principal is itself an agent,
- * `app__*` tools are stripped from the prepared tool list before LLM dispatch.
+ * Each tool's parameters are derived from `app.variables` and its description
+ * is the localized app description. Invocation routes through
+ * `ChatService.invokeAppInternal()`, which runs the standard chat pipeline
+ * (model resolution, system prompt, tool loop) against an in-memory sink.
+ *
+ * Guard rails:
+ *  - `features.appAsTool` must be enabled.
+ *  - Principals that carry resolved `permissions` (regular chat users) may
+ *    only invoke apps they are allowed to access — the same check
+ *    `chatAuthRequired` applies on the HTTP route. Bare agent principals
+ *    (no `permissions` object) are operator-configured and skip this check.
+ *  - App→App nesting is disallowed: the callee runs with
+ *    `isInvokedViaAppAsTool: true`, which suppresses further `app__*` tools
+ *    (see `getToolsForApp`) and is rejected outright by `invokeAppTool()`.
  */
 
 import configCache from '../../configCache.js';
 import { isFeatureEnabled } from '../../featureRegistry.js';
 import logger from '../../utils/logger.js';
-import ChatService from '../../services/chat/ChatService.js';
+import ChatService from './ChatService.js';
 import { getLocalizedString } from '../../utils/localize.js';
+import { canUserAccessResource } from '../../utils/authorization.js';
 
 const chatService = new ChatService();
 
@@ -69,21 +86,49 @@ function localizedDescription(app, language = 'en') {
 }
 
 /**
+ * Whether the principal is allowed to invoke the given app. Principals with
+ * resolved permissions (regular users, incl. materialized anonymous users)
+ * get the same check the chat HTTP route applies. Principals WITHOUT a
+ * permissions object (bare agent principals) pass — which apps an agent may
+ * call is operator-configured on the workflow node.
+ *
+ * @param {Object} user
+ * @param {string} appId
+ * @returns {boolean}
+ */
+export function isAppInvocationAllowed(user, appId) {
+  if (!user || !user.permissions) return true;
+  return canUserAccessResource(user, 'apps', appId);
+}
+
+/**
  * Build the synthetic tool descriptors for a list of app IDs.
  *
  * @param {string[]} appIds
  * @param {string} language
+ * @param {Object} [options]
+ * @param {Object} [options.user] - When given (and it carries resolved
+ *   permissions), apps the user may not access are omitted so the LLM never
+ *   sees tools it cannot call.
  * @returns {Promise<Array>} tool descriptors
  */
-export async function getAppAsTools(appIds, language = 'en') {
+export async function getAppAsTools(appIds, language = 'en', { user } = {}) {
   const tools = [];
   for (const appId of appIds) {
     const app = getAppById(appId);
     if (!app) {
-      logger.warn('App-as-tool: app not found', { component: 'AppAsToolGateway', appId });
+      logger.warn('App-as-tool: app not found', { component: 'AppToolsGateway', appId });
       continue;
     }
     if (app.enabled === false) continue;
+    if (user && !isAppInvocationAllowed(user, appId)) {
+      logger.info('App-as-tool: app filtered by user permissions', {
+        component: 'AppToolsGateway',
+        appId,
+        userId: user.id
+      });
+      continue;
+    }
     // name / description MUST be plain strings — Google's function_declarations
     // schema rejects nested objects ("Starting an object on a scalar field").
     // Other adapters' converters also pass these straight through. Resolve
@@ -117,16 +162,24 @@ export function stripAppToolsForAgent(tools, user) {
 }
 
 /**
- * Invoke a synthetic app tool. Called by PromptNodeExecutor.executeToolCall
- * when the tool id matches `app__<appId>`.
+ * Invoke a synthetic app tool. Called by `runTool()` for chat apps and by
+ * PromptNodeExecutor.executeToolCall for agent runs when the tool id matches
+ * `app__<appId>`.
+ *
+ * Returns a SLIM payload — callers feed the result back into an LLM tool
+ * message, so it must stay small: `{ content, citations?, usage?,
+ * finishReason? }` or `{ error, message }`.
  *
  * @param {Object} opts
  * @param {string} opts.toolId
  * @param {Object} opts.args
  * @param {Object} opts.user
  * @param {string} opts.chatId
- * @param {string} opts.executionId
+ * @param {string} [opts.executionId]
  * @param {AbortSignal} [opts.abortSignal]
+ * @param {string} [opts.modelOverride]
+ * @param {string} [opts.language]    caller's language, applied to the callee run
+ * @param {string} [opts.callerAppId] id of the app making the call (audit only)
  */
 export async function invokeAppTool({
   toolId,
@@ -135,12 +188,26 @@ export async function invokeAppTool({
   chatId,
   executionId,
   abortSignal,
-  modelOverride
+  modelOverride,
+  language,
+  callerAppId
 }) {
   if (!toolId || !toolId.startsWith('app__')) {
     throw new Error(`Invalid app tool id: ${toolId}`);
   }
   const appId = toolId.slice('app__'.length);
+
+  // App→App nesting guard. `getToolsForApp` / `stripAppToolsForAgent` already
+  // suppress `app__*` tools for nested principals; this rejects anything that
+  // slips through (e.g. a hallucinated tool call).
+  if (user?.isInvokedViaAppAsTool === true) {
+    return {
+      error: true,
+      message:
+        'Nested app-to-app calls are not allowed (an app invoked as a tool cannot invoke further apps)'
+    };
+  }
+
   const app = getAppById(appId);
   if (!app) {
     return { error: true, message: `App ${appId} not found` };
@@ -156,6 +223,12 @@ export async function invokeAppTool({
     return { error: true, message: 'features.appAsTool is disabled on this platform' };
   }
 
+  // Enforce the calling user's app permissions — invoking an app through a
+  // tool must not grant more access than opening it directly would.
+  if (!isAppInvocationAllowed(user, appId)) {
+    return { error: true, message: `You do not have permission to access app ${appId}` };
+  }
+
   const messageBody = args.message || JSON.stringify(args);
   const messages = [{ role: 'user', content: messageBody }];
   const variables = { ...args };
@@ -165,10 +238,11 @@ export async function invokeAppTool({
   const nestedUser = { ...(user || {}), isInvokedViaAppAsTool: true };
 
   logger.info('Invoking app via App-as-tool gateway', {
-    component: 'AppAsToolGateway',
+    component: 'AppToolsGateway',
     appId,
+    callerAppId: callerAppId || null,
     callerUserId: user?.id,
-    runId: executionId,
+    runId: executionId || chatId,
     modelOverride: modelOverride || null
   });
 
@@ -180,6 +254,7 @@ export async function invokeAppTool({
       variables,
       abortSignal,
       runId: executionId || chatId,
+      ...(language ? { language } : {}),
       // Propagate the calling agent's model into the app so the operator's
       // model choice flows through the whole call tree instead of every
       // app silently running on whatever bedrock-nova-* the app config
@@ -191,10 +266,10 @@ export async function invokeAppTool({
 
     // Return a SLIM payload to the caller. The internal result from
     // `invokeAppInternal` can carry adapter-specific debug fields, full raw
-    // responses with chain-of-thought, and other large extras. Agents call
+    // responses with chain-of-thought, and other large extras. Callers invoke
     // this gateway from inside an LLM tool loop, so whatever we return
     // gets JSON.stringify'd into a tool message and fed back to the model.
-    // Returning the unfiltered object blows up the agent's context (the
+    // Returning the unfiltered object blows up the caller's context (the
     // user observed 10KB+ of Gemini thought text leaking in). Keep only:
     //   - content: the actual answer the app produced
     //   - citations: any source URLs the app cited
@@ -219,7 +294,7 @@ export async function invokeAppTool({
     };
   } catch (err) {
     logger.error('App-as-tool invocation failed', {
-      component: 'AppAsToolGateway',
+      component: 'AppToolsGateway',
       appId,
       error: err.message
     });
@@ -227,4 +302,4 @@ export async function invokeAppTool({
   }
 }
 
-export default { getAppAsTools, stripAppToolsForAgent, invokeAppTool };
+export default { getAppAsTools, stripAppToolsForAgent, invokeAppTool, isAppInvocationAllowed };

--- a/server/services/workflow/executors/PromptNodeExecutor.js
+++ b/server/services/workflow/executors/PromptNodeExecutor.js
@@ -34,7 +34,7 @@ import path from 'path';
 import logger from '../../../utils/logger.js';
 import { getAgentToolIds } from '../../../agents/runtime/agentToolRegistrar.js';
 import { readMemoryBodyForPrompt } from '../../../agents/memory/memoryFile.js';
-import { getAppAsTools, stripAppToolsForAgent } from '../../../agents/runtime/appAsToolGateway.js';
+import { getAppAsTools, stripAppToolsForAgent } from '../../chat/appToolsGateway.js';
 import { writeArtifactDirect } from '../../../agents/runtime/artifactStore.js';
 import { isFeatureEnabled } from '../../../featureRegistry.js';
 
@@ -1942,7 +1942,7 @@ export class PromptNodeExecutor extends BaseNodeExecutor {
     if (typeof toolId === 'string' && toolId.startsWith('app__')) {
       const appCallStartMs = Date.now();
       try {
-        const { invokeAppTool } = await import('../../../agents/runtime/appAsToolGateway.js');
+        const { invokeAppTool } = await import('../../chat/appToolsGateway.js');
         // Propagate the calling node's model to the app so the operator's
         // model choice flows down. Without this every app silently runs on
         // whatever bedrock-nova-* it was configured with, regardless of

--- a/server/tests/appToolsGateway.test.js
+++ b/server/tests/appToolsGateway.test.js
@@ -1,0 +1,305 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Tests for the shared App Tools Gateway (`services/chat/appToolsGateway.js`)
+ * and its wiring into the chat-app tool pipeline (`toolLoader.js`):
+ *
+ *  - synthetic `app__<id>` descriptor generation (incl. permission filtering)
+ *  - invokeAppTool guard rails: nesting, feature flag, user permissions
+ *  - slim result shaping around ChatService.invokeAppInternal
+ *  - getToolsForApp surfacing `app.apps` as tools (feature-gated, self-call
+ *    filtered, suppressed for nested principals)
+ *  - runTool dispatch of the `app__` prefix
+ */
+
+const appsFixture = [
+  {
+    id: 'concierge',
+    name: { en: 'Concierge' },
+    description: { en: 'Routes requests to specialist bots' },
+    apps: ['specialist', 'hidden-app', 'concierge', 'missing-app', 'disabled-app'],
+    enabled: true
+  },
+  {
+    id: 'specialist',
+    name: { en: 'Specialist' },
+    description: { en: 'Answers domain questions' },
+    enabled: true,
+    variables: [{ name: 'tone', type: 'string', label: { en: 'Tone of the answer' } }]
+  },
+  {
+    id: 'hidden-app',
+    name: { en: 'Hidden' },
+    description: { en: 'Restricted app' },
+    enabled: true
+  },
+  {
+    id: 'disabled-app',
+    name: { en: 'Disabled' },
+    description: { en: 'Turned off' },
+    enabled: false
+  }
+];
+
+// Mutable feature config the mocked configCache serves.
+const featuresConfig = { value: { appAsTool: true } };
+
+const invokeAppInternalMock = jest.fn();
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: {
+    getApps: () => ({ data: appsFixture }),
+    getFeatures: () => featuresConfig.value,
+    getTools: () => ({ data: [] }),
+    getModels: () => ({ data: [] }),
+    getPlatform: () => ({}),
+    getSources: () => ({ data: [] }),
+    getWorkflowById: () => null
+  }
+}));
+
+jest.unstable_mockModule('../services/chat/ChatService.js', () => ({
+  default: class ChatServiceMock {
+    async invokeAppInternal(opts) {
+      return invokeAppInternalMock(opts);
+    }
+  }
+}));
+
+jest.unstable_mockModule('../services/mcp/McpClientManager.js', () => ({
+  default: { listAllTools: async () => [], callTool: async () => ({}) }
+}));
+
+jest.unstable_mockModule('../sources/index.js', () => ({
+  createSourceManager: () => ({ generateTools: () => [], getToolFunction: () => null })
+}));
+
+jest.unstable_mockModule('../services/skillLoader.js', () => ({
+  getSkillContent: async () => null,
+  getSkillResource: async () => null
+}));
+
+jest.unstable_mockModule('../actionTracker.js', () => ({
+  actionTracker: { trackSkillActivation: () => {}, emit: () => {} }
+}));
+
+jest.unstable_mockModule('../utils/logger.js', () => ({
+  default: { error: () => {}, warn: () => {}, info: () => {}, debug: () => {} }
+}));
+
+const { getAppAsTools, invokeAppTool, isAppInvocationAllowed } =
+  await import('../services/chat/appToolsGateway.js');
+const { getToolsForApp, runTool } = await import('../toolLoader.js');
+
+const wildcardUser = () => ({ id: 'u-admin', permissions: { apps: new Set(['*']) } });
+const restrictedUser = () => ({
+  id: 'u-restricted',
+  permissions: { apps: new Set(['concierge', 'specialist']) }
+});
+const bareAgent = () => ({ id: 'agent:helper', isAgent: true });
+
+beforeEach(() => {
+  featuresConfig.value = { appAsTool: true };
+  invokeAppInternalMock.mockReset();
+  invokeAppInternalMock.mockResolvedValue({
+    status: 'ok',
+    finalMessage: { role: 'assistant', content: '  the specialist answer  ' },
+    toolCalls: [],
+    citations: [],
+    usage: { promptTokens: 11, completionTokens: 7 },
+    finishReason: 'stop'
+  });
+});
+
+describe('isAppInvocationAllowed', () => {
+  it('enforces permissions for principals that carry them', () => {
+    expect(isAppInvocationAllowed(restrictedUser(), 'specialist')).toBe(true);
+    expect(isAppInvocationAllowed(restrictedUser(), 'hidden-app')).toBe(false);
+    expect(isAppInvocationAllowed(wildcardUser(), 'hidden-app')).toBe(true);
+  });
+
+  it('passes bare principals without a permissions object (agents)', () => {
+    expect(isAppInvocationAllowed(bareAgent(), 'hidden-app')).toBe(true);
+    expect(isAppInvocationAllowed(null, 'hidden-app')).toBe(true);
+  });
+});
+
+describe('getAppAsTools', () => {
+  it('builds descriptors for known enabled apps and derives parameters from variables', async () => {
+    const tools = await getAppAsTools(['specialist', 'missing-app', 'disabled-app'], 'en');
+    expect(tools).toHaveLength(1);
+    const [tool] = tools;
+    expect(tool.id).toBe('app__specialist');
+    expect(tool.isAppAsTool).toBe(true);
+    expect(tool.name).toBe('App: Specialist');
+    expect(tool.description).toBe('Answers domain questions');
+    expect(tool.parameters.required).toEqual(['message']);
+    expect(Object.keys(tool.parameters.properties)).toEqual(
+      expect.arrayContaining(['message', 'tone'])
+    );
+  });
+
+  it('omits apps the calling user may not access', async () => {
+    const tools = await getAppAsTools(['specialist', 'hidden-app'], 'en', {
+      user: restrictedUser()
+    });
+    expect(tools.map(t => t.id)).toEqual(['app__specialist']);
+  });
+
+  it('keeps all apps for principals without permissions (agents)', async () => {
+    const tools = await getAppAsTools(['specialist', 'hidden-app'], 'en', { user: bareAgent() });
+    expect(tools.map(t => t.id)).toEqual(['app__specialist', 'app__hidden-app']);
+  });
+});
+
+describe('invokeAppTool', () => {
+  it('invokes the app through ChatService with a nested-marked principal', async () => {
+    const result = await invokeAppTool({
+      toolId: 'app__specialist',
+      args: { message: 'How do I file a claim?', tone: 'formal' },
+      user: restrictedUser(),
+      chatId: 'chat-1',
+      language: 'de',
+      callerAppId: 'concierge'
+    });
+
+    expect(invokeAppInternalMock).toHaveBeenCalledTimes(1);
+    const call = invokeAppInternalMock.mock.calls[0][0];
+    expect(call.appId).toBe('specialist');
+    expect(call.language).toBe('de');
+    expect(call.messages).toEqual([{ role: 'user', content: 'How do I file a claim?' }]);
+    expect(call.variables).toEqual({ tone: 'formal' });
+    expect(call.user.isInvokedViaAppAsTool).toBe(true);
+    expect(call.user.id).toBe('u-restricted');
+
+    // Slim payload: trimmed content, no empty citations key, usage passed through.
+    expect(result).toEqual({
+      content: 'the specialist answer',
+      usage: { promptTokens: 11, completionTokens: 7 },
+      finishReason: 'stop'
+    });
+  });
+
+  it('rejects nested app-to-app calls', async () => {
+    const nestedUser = { ...wildcardUser(), isInvokedViaAppAsTool: true };
+    const result = await invokeAppTool({
+      toolId: 'app__specialist',
+      args: { message: 'hi' },
+      user: nestedUser,
+      chatId: 'chat-1'
+    });
+    expect(result.error).toBe(true);
+    expect(result.message).toMatch(/nested/i);
+    expect(invokeAppInternalMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when the appAsTool feature is disabled', async () => {
+    featuresConfig.value = { appAsTool: false };
+    const result = await invokeAppTool({
+      toolId: 'app__specialist',
+      args: { message: 'hi' },
+      user: wildcardUser(),
+      chatId: 'chat-1'
+    });
+    expect(result.error).toBe(true);
+    expect(result.message).toMatch(/appAsTool/);
+    expect(invokeAppInternalMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects apps the calling user may not access', async () => {
+    const result = await invokeAppTool({
+      toolId: 'app__hidden-app',
+      args: { message: 'hi' },
+      user: restrictedUser(),
+      chatId: 'chat-1'
+    });
+    expect(result.error).toBe(true);
+    expect(result.message).toMatch(/permission/);
+    expect(invokeAppInternalMock).not.toHaveBeenCalled();
+  });
+
+  it('reports unknown and disabled apps as tool errors', async () => {
+    const missing = await invokeAppTool({
+      toolId: 'app__missing-app',
+      args: { message: 'hi' },
+      user: wildcardUser(),
+      chatId: 'chat-1'
+    });
+    expect(missing.error).toBe(true);
+
+    const disabled = await invokeAppTool({
+      toolId: 'app__disabled-app',
+      args: { message: 'hi' },
+      user: wildcardUser(),
+      chatId: 'chat-1'
+    });
+    expect(disabled.error).toBe(true);
+    expect(invokeAppInternalMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces callee pipeline errors as slim error payloads', async () => {
+    invokeAppInternalMock.mockResolvedValueOnce({
+      status: 'error',
+      error: { message: 'model exploded' },
+      finalMessage: null,
+      toolCalls: []
+    });
+    const result = await invokeAppTool({
+      toolId: 'app__specialist',
+      args: { message: 'hi' },
+      user: wildcardUser(),
+      chatId: 'chat-1'
+    });
+    expect(result).toEqual({ error: true, message: 'model exploded' });
+  });
+});
+
+describe('getToolsForApp (app.apps wiring)', () => {
+  const conciergeApp = appsFixture[0];
+
+  it('surfaces configured apps as app__ tools, excluding self-references', async () => {
+    const tools = await getToolsForApp(conciergeApp, 'en', { user: wildcardUser() });
+    const appToolIds = tools.filter(t => t.isAppAsTool).map(t => t.id);
+    // 'concierge' (self), 'missing-app' and 'disabled-app' are dropped.
+    expect(appToolIds).toEqual(['app__specialist', 'app__hidden-app']);
+  });
+
+  it('filters app tools by the calling user permissions', async () => {
+    const tools = await getToolsForApp(conciergeApp, 'en', { user: restrictedUser() });
+    const appToolIds = tools.filter(t => t.isAppAsTool).map(t => t.id);
+    expect(appToolIds).toEqual(['app__specialist']);
+  });
+
+  it('generates no app tools when the feature is disabled', async () => {
+    featuresConfig.value = { appAsTool: false };
+    const tools = await getToolsForApp(conciergeApp, 'en', { user: wildcardUser() });
+    expect(tools.filter(t => t.isAppAsTool)).toHaveLength(0);
+  });
+
+  it('generates no app tools for principals already serving an app-as-tool call', async () => {
+    const nestedUser = { ...wildcardUser(), isInvokedViaAppAsTool: true };
+    const tools = await getToolsForApp(conciergeApp, 'en', { user: nestedUser });
+    expect(tools.filter(t => t.isAppAsTool)).toHaveLength(0);
+  });
+});
+
+describe('runTool (app__ dispatch)', () => {
+  it('routes app__ tool ids through the gateway, separating args from context', async () => {
+    const result = await runTool('app__specialist', {
+      message: 'Summarize the incident',
+      tone: 'brief',
+      chatId: 'chat-9',
+      user: wildcardUser(),
+      appConfig: { id: 'concierge' },
+      language: 'en'
+    });
+
+    expect(invokeAppInternalMock).toHaveBeenCalledTimes(1);
+    const call = invokeAppInternalMock.mock.calls[0][0];
+    expect(call.appId).toBe('specialist');
+    expect(call.messages).toEqual([{ role: 'user', content: 'Summarize the incident' }]);
+    // Context params must not leak into the callee's variables.
+    expect(call.variables).toEqual({ tone: 'brief' });
+    expect(result.content).toBe('the specialist answer');
+  });
+});

--- a/server/toolLoader.js
+++ b/server/toolLoader.js
@@ -418,6 +418,33 @@ export async function getToolsForApp(app, language = null, context = {}) {
     }
   }
 
+  // App-as-tool: surface other apps as synthetic `app__<id>` tools (the
+  // "concierge" pattern — a bot delegating to specialist bots). Skipped for
+  // principals that are themselves serving an app-as-tool call, so App→App
+  // chains stop at one level of nesting.
+  if (
+    Array.isArray(app.apps) &&
+    app.apps.length > 0 &&
+    context.user?.isInvokedViaAppAsTool !== true &&
+    isFeatureEnabled('appAsTool', configCache.getFeatures())
+  ) {
+    try {
+      const { getAppAsTools } = await import('./services/chat/appToolsGateway.js');
+      // Never expose an app to itself — a direct self-call can only loop.
+      const targetAppIds = app.apps.filter(id => typeof id === 'string' && id && id !== app.id);
+      const appAsTools = await getAppAsTools(targetAppIds, language || 'en', {
+        user: context.user
+      });
+      appTools = appTools.concat(appAsTools);
+    } catch (error) {
+      logger.error('Error generating app-as-tool tools', {
+        component: 'ToolLoader',
+        appId: app.id,
+        error
+      });
+    }
+  }
+
   // Add skill activation tools if the skills feature is enabled and the app has skills configured
   if (
     isFeatureEnabled('skills', configCache.getFeatures()) &&
@@ -566,6 +593,22 @@ export async function runTool(toolId, params = {}) {
       return `Resource '${filePath}' not found in skill '${skillName}' or access denied.`;
     }
     return content;
+  }
+
+  // App-as-tool (`app__<appId>`): invoke another iHub app through the shared
+  // gateway. Runs the callee's full chat pipeline in-process (no REST hop);
+  // permission, feature-flag, and nesting guards live in the gateway.
+  if (toolId.startsWith('app__')) {
+    const { invokeAppTool } = await import('./services/chat/appToolsGateway.js');
+    const { chatId, user, appConfig, language, ...args } = params;
+    return await invokeAppTool({
+      toolId,
+      args,
+      user,
+      chatId,
+      language,
+      callerAppId: appConfig?.id
+    });
   }
 
   // Check if this is a workflow tool (starts with 'workflow_')

--- a/server/validators/appConfigSchema.js
+++ b/server/validators/appConfigSchema.js
@@ -399,6 +399,9 @@ const baseAppConfigSchema = z.object({
   websearch: websearchSchema,
   tools: z.array(z.string()).optional(),
   workflows: z.array(z.string()).optional(),
+  // Other app ids this app may invoke as synthetic `app__<id>` tools
+  // (requires the `appAsTool` platform feature; see appToolsGateway).
+  apps: z.array(z.string()).optional(),
   skills: z.array(z.string()).optional(),
   skillSettings: z
     .object({

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1867,7 +1867,13 @@
         "extractAudioFromVideo": "Audiospur extrahieren (für Transkription / Audiomodelle)",
         "maxVideoSize": "Maximale Videodateigröße (MB)",
         "supportedVideoFormats": "Unterstützte Videoformate",
-        "transcriptionDefaultEnabled": "Standardmäßig aktiv (Nutzer können es pro Chat umschalten)"
+        "transcriptionDefaultEnabled": "Standardmäßig aktiv (Nutzer können es pro Chat umschalten)",
+        "appsAsTools": "Apps als Tools",
+        "appsAsToolsDesc": "Erlaubt dieser App, an andere Apps zu delegieren. Das Modell kann jede ausgewählte App als Tool aufrufen und deren Antwort verwenden (Concierge-Muster).",
+        "appsAsToolsHelper": "Jede ausgewählte App wird zu einem Tool (app__<id>), das das Modell aufrufen kann. Nutzer erreichen nur Apps, für die sie berechtigt sind; eine aufgerufene App kann keine weiteren Apps aufrufen.",
+        "searchApps": "Apps suchen und hinzufügen...",
+        "appsAsToolsNoResults": "Keine Apps entsprechen Ihrer Suche",
+        "appsAsToolsNoApps": "Keine Apps verfügbar"
       }
     },
     "features": {

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1873,7 +1873,8 @@
         "appsAsToolsHelper": "Jede ausgewählte App wird zu einem Tool (app__<id>), das das Modell aufrufen kann. Nutzer erreichen nur Apps, für die sie berechtigt sind; eine aufgerufene App kann keine weiteren Apps aufrufen.",
         "searchApps": "Apps suchen und hinzufügen...",
         "appsAsToolsNoResults": "Keine Apps entsprechen Ihrer Suche",
-        "appsAsToolsNoApps": "Keine Apps verfügbar"
+        "appsAsToolsNoApps": "Keine Apps verfügbar",
+        "removeAppTool": "{{name}} entfernen"
       }
     },
     "features": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1620,7 +1620,8 @@
         "appsAsToolsHelper": "Each selected app becomes a tool (app__<id>) the model can call. Users only reach apps they have permission for, and a called app cannot call further apps.",
         "searchApps": "Search apps to add...",
         "appsAsToolsNoResults": "No apps match your search",
-        "appsAsToolsNoApps": "No apps available"
+        "appsAsToolsNoApps": "No apps available",
+        "removeAppTool": "Remove {{name}}"
       }
     },
     "features": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1614,7 +1614,13 @@
         "extractAudioFromVideo": "Extract audio track (for transcription / audio models)",
         "maxVideoSize": "Max Video File Size (MB)",
         "supportedVideoFormats": "Supported Video Formats",
-        "transcriptionDefaultEnabled": "On by default (users can toggle it per chat)"
+        "transcriptionDefaultEnabled": "On by default (users can toggle it per chat)",
+        "appsAsTools": "Apps as Tools",
+        "appsAsToolsDesc": "Let this app delegate to other apps. The model can call each selected app as a tool and use its answer (concierge pattern).",
+        "appsAsToolsHelper": "Each selected app becomes a tool (app__<id>) the model can call. Users only reach apps they have permission for, and a called app cannot call further apps.",
+        "searchApps": "Search apps to add...",
+        "appsAsToolsNoResults": "No apps match your search",
+        "appsAsToolsNoApps": "No apps available"
       }
     },
     "features": {


### PR DESCRIPTION
# App-as-Tool for Chat Apps (Concierge Pattern)

## What

Chat apps can now invoke other apps as tools — **server-side, in-process, no REST round-trip**. A new optional `apps: [appId, ...]` field in the app config surfaces each listed app to the model as a synthetic `app__<id>` tool. When the model calls one, the target app runs its full chat pipeline (own system prompt, own preferred model, own tools/sources) via `ChatService.invokeAppInternal()` and returns its answer as the tool result.

This enables the concierge use case: a router bot that delegates to specialist bots and synthesizes their answers.

```json
{
  "id": "concierge",
  "system": { "en": "You are a concierge. Delegate domain questions to the available app tools." },
  "apps": ["hr-bot", "it-support-bot", "travel-bot"]
}
```

## The interface question

The internal invocation interface already existed — `ChatService.invokeAppInternal()` + the App-as-tool gateway, built for the Agent Factory — but it lived in `server/agents/runtime/`, reachable only from agent workflow nodes. Rather than duplicating it for chat apps, this PR **promotes the gateway to `server/services/chat/appToolsGateway.js`** as the single shared interface for programmatic app invocation. Both consumers now route through it:

- **Agent workflow nodes** (`node.config.apps`) — unchanged behavior, imports updated
- **Chat apps** (`app.apps`) — new: `getToolsForApp()` generates the `app__` descriptors, `runTool()` dispatches them to the gateway

## Guard rails

| Concern | Behavior |
| --- | --- |
| Feature flag | Gated by the existing `appAsTool` platform feature (off by default, preview). Description updated to cover apps and agents. |
| Permissions | Principals with resolved permissions (regular users, incl. materialized anonymous) may only invoke apps their groups allow — the same check `chatAuthRequired` applies on the HTTP route. Disallowed apps are never even offered to the model. Bare agent principals (no `permissions` object) keep today's operator-configured behavior. |
| Recursion | One level of nesting only. The callee runs with `isInvokedViaAppAsTool: true`, which suppresses `app__*` tool generation, and the gateway rejects nested calls outright as defense in depth. Self-references are dropped at generation time. |
| Context blow-up | The gateway returns a slim `{ content, citations?, usage?, finishReason? }` payload, never raw provider responses. |
| Model compatibility | `filterModelsForApp` now treats `app.apps` like `app.tools` (calling app needs a tool-capable model). |

## Also in this PR

- Caller language now threads through `ToolExecutor` into tool params (spread-ordered so LLM args win and `chatId`/`user`/`appConfig` can't be spoofed), so the callee app answers in the caller's language.
- Admin UI: new **Apps as Tools** section in the app editor (behind the `appAsTool` flag) with a searchable app picker; en/de translations.
- Docs: concierge-pattern section in `docs/apps.md`, updated App-as-tool row in `docs/agents.md`, changelog entry in `docs/releases/5.5.0/features.md`.

## Testing

- **16 new tests** (`server/tests/appToolsGateway.test.js`): descriptor generation, permission filtering, nesting rejection, feature-flag rejection, slim result shaping, `getToolsForApp` wiring, `runTool` dispatch.
- **Full server suite**: failed-suite set is byte-identical to the `main` baseline (127 pre-existing infra failures, e.g. plain-script test files); this PR adds 16 passing tests and breaks nothing.
- **No-mock smoke test** against the real config stack: permission filtering, nesting suppression, and disabled-app rejection verified end-to-end; an allowed call travels `runTool → gateway → invokeAppInternal → RequestBuilder` up to provider API-key verification (the only step a keyless dev container can't pass) and returns a clean slim error.
- Server boots cleanly (`node server/server.js`, migrations apply, workers listen).
- `npm run lint:fix` / `format:fix`: 0 errors; changed files warning-free.

## Notes for reviewers

- `server/agents/runtime/appAsToolGateway.js` → `server/services/chat/appToolsGateway.js` is a `git mv` plus enhancement (rename detected at 60% similarity). No behavioral change for agents beyond the shared guard rails.
- Sub-app invocations are stateless single-turn calls — no chat history crosses the boundary in either direction.
- Chat-app calls deliberately do **not** propagate the caller's model (each specialist keeps its own tuned model); agent runs keep their existing `modelOverride` propagation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JNN2Mu2aEBTWyidDZG3p47

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNN2Mu2aEBTWyidDZG3p47)_