### PR TITLE
feat(sources): select iFinder documents by ID or query via the central integration

### DIFF
--- a/client/src/features/admin/components/SourceConfigForm.jsx
+++ b/client/src/features/admin/components/SourceConfigForm.jsx
@@ -7,6 +7,13 @@ import { makeAdminApiCall } from '../../../api/adminApi';
 
 const IDLE_TEST_STATE = { loading: false, data: null, error: null };
 
+// Number inputs yield '' when cleared; store undefined instead of NaN so the
+// server-side schema defaults apply on save.
+const parseOptionalInt = value => {
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
 function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
   const { t } = useTranslation();
   const [formData, setFormData] = useState(source || {});
@@ -607,7 +614,7 @@ function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
                 <input
                   type="number"
                   value={formData.config?.maxResults || 10}
-                  onChange={e => handleConfigChange('maxResults', parseInt(e.target.value))}
+                  onChange={e => handleConfigChange('maxResults', parseOptionalInt(e.target.value))}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                   min="1"
                   max="100"
@@ -627,7 +634,7 @@ function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
                 <input
                   type="number"
                   value={formData.config?.maxLength || 10000}
-                  onChange={e => handleConfigChange('maxLength', parseInt(e.target.value))}
+                  onChange={e => handleConfigChange('maxLength', parseOptionalInt(e.target.value))}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
                   min="1"
                 />

--- a/client/src/features/admin/components/SourceConfigForm.jsx
+++ b/client/src/features/admin/components/SourceConfigForm.jsx
@@ -3,11 +3,18 @@ import { useTranslation } from 'react-i18next';
 import Icon from '../../../shared/components/Icon';
 import DynamicLanguageEditor from '../../../shared/components/DynamicLanguageEditor';
 import FileUploader from './FileUploader';
+import { makeAdminApiCall } from '../../../api/adminApi';
+
+const IDLE_TEST_STATE = { loading: false, data: null, error: null };
 
 function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
   const { t } = useTranslation();
   const [formData, setFormData] = useState(source || {});
   const [validationErrors, setValidationErrors] = useState({});
+  // Results of the iFinder "Connect" (document metadata) and query preview
+  // checks — cleared whenever the fields they depend on change.
+  const [docTest, setDocTest] = useState(IDLE_TEST_STATE);
+  const [queryTest, setQueryTest] = useState(IDLE_TEST_STATE);
 
   useEffect(() => {
     if (source) {
@@ -37,7 +44,76 @@ function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
       ...formData.config,
       [configField]: value
     };
+
+    if (formData.type === 'ifinder') {
+      if (['documentId', 'searchProfile'].includes(configField)) {
+        setDocTest(IDLE_TEST_STATE);
+      }
+      if (['query', 'searchProfile', 'maxResults'].includes(configField)) {
+        setQueryTest(IDLE_TEST_STATE);
+      }
+      if (validationErrors.ifinderContent) {
+        setValidationErrors(prev => {
+          const { ifinderContent: _removed, ...rest } = prev;
+          return rest;
+        });
+      }
+    }
+
     handleChange('config', newConfig);
+  };
+
+  const handleIFinderConnect = async () => {
+    const documentId = formData.config?.documentId?.trim();
+    if (!documentId) return;
+
+    setDocTest({ loading: true, data: null, error: null });
+    try {
+      const response = await makeAdminApiCall('/admin/sources/_ifinder/metadata', {
+        method: 'POST',
+        body: {
+          documentId,
+          searchProfile: formData.config?.searchProfile?.trim() || undefined
+        }
+      });
+      setDocTest({ loading: false, data: response.data?.metadata || null, error: null });
+    } catch (err) {
+      setDocTest({
+        loading: false,
+        data: null,
+        error:
+          err.response?.data?.error ||
+          err.message ||
+          t('admin.sources.ifinderMetadataFailed', 'Failed to load document metadata')
+      });
+    }
+  };
+
+  const handleIFinderQueryTest = async () => {
+    const query = formData.config?.query?.trim();
+    if (!query) return;
+
+    setQueryTest({ loading: true, data: null, error: null });
+    try {
+      const response = await makeAdminApiCall('/admin/sources/_ifinder/search', {
+        method: 'POST',
+        body: {
+          query,
+          searchProfile: formData.config?.searchProfile?.trim() || undefined,
+          maxResults: formData.config?.maxResults || 10
+        }
+      });
+      setQueryTest({ loading: false, data: response.data || null, error: null });
+    } catch (err) {
+      setQueryTest({
+        loading: false,
+        data: null,
+        error:
+          err.response?.data?.error ||
+          err.message ||
+          t('admin.sources.ifinderQueryFailed', 'Failed to run search query')
+      });
+    }
   };
 
   const validateForm = () => {
@@ -82,11 +158,17 @@ function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
         }
       }
     } else if (formData.type === 'ifinder') {
-      if (!formData.config?.baseUrl?.trim()) {
-        errors.baseUrl = t('admin.sources.validation.baseUrlRequired', 'Base URL is required');
-      }
-      if (!formData.config?.apiKey?.trim()) {
-        errors.apiKey = t('admin.sources.validation.apiKeyRequired', 'API key is required');
+      // Tool sources may leave both empty — the model supplies them at call
+      // time. Prompt sources must know up front what to load.
+      if (formData.exposeAs !== 'tool') {
+        const hasDocumentId = formData.config?.documentId?.trim();
+        const hasQuery = formData.config?.query?.trim();
+        if (!hasDocumentId && !hasQuery) {
+          errors.ifinderContent = t(
+            'admin.sources.validation.ifinderContentRequired',
+            'Provide a document ID or a search query so the source knows which documents to load'
+          );
+        }
       }
     } else if (formData.type === 'page') {
       if (!formData.config?.pageId?.trim()) {
@@ -106,8 +188,22 @@ function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
   const handleSubmit = e => {
     e.preventDefault();
     if (validateForm()) {
-      onSave(formData);
+      onSave(prepareForSave(formData));
     }
+  };
+
+  // Drop empty optional iFinder fields so the stored config stays clean
+  const prepareForSave = data => {
+    if (data.type !== 'ifinder' || !data.config) {
+      return data;
+    }
+    const config = { ...data.config };
+    ['documentId', 'query', 'searchProfile'].forEach(field => {
+      if (typeof config[field] === 'string' && config[field].trim() === '') {
+        delete config[field];
+      }
+    });
+    return { ...data, config };
   };
 
   const getDefaultConfigForType = type => {
@@ -131,12 +227,10 @@ function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
         };
       case 'ifinder':
         return {
-          baseUrl: '',
-          apiKey: '',
-          searchProfile: 'default',
+          documentId: '',
+          query: '',
+          searchProfile: '',
           maxResults: 10,
-          queryTemplate: '',
-          filters: {},
           maxLength: 10000
         };
       case 'page':
@@ -151,6 +245,8 @@ function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
 
   const handleTypeChange = newType => {
     const newConfig = getDefaultConfigForType(newType);
+    setDocTest(IDLE_TEST_STATE);
+    setQueryTest(IDLE_TEST_STATE);
     setFormData(prev => ({
       ...prev,
       type: newType,
@@ -276,54 +372,232 @@ function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
       case 'ifinder':
         return (
           <div className="space-y-6">
+            <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 flex items-start">
+              <Icon
+                name="information-circle"
+                className="h-5 w-5 text-blue-600 mt-0.5 mr-2 flex-shrink-0"
+              />
+              <p className="text-sm text-blue-700">
+                {t(
+                  'admin.sources.ifinderConnectionInfo',
+                  'The iFinder connection (URL and authentication) is managed centrally in the iFinder integration settings under Admin → Providers. Here you only choose which documents this source loads: pin a single document by ID, or use a search query to load the top matching documents.'
+                )}
+              </p>
+            </div>
+
+            {validationErrors.ifinderContent && (
+              <div className="bg-red-50 border border-red-200 rounded-lg p-3">
+                <p className="text-sm text-red-600">{validationErrors.ifinderContent}</p>
+              </div>
+            )}
+
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
-                {t('admin.sources.baseUrl', 'iFinder Base URL')} *
+                {t('admin.sources.ifinderDocumentId', 'Document ID')}
               </label>
-              <input
-                type="url"
-                value={formData.config?.baseUrl || ''}
-                onChange={e => handleConfigChange('baseUrl', e.target.value)}
-                className={`w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 ${
-                  validationErrors.baseUrl ? 'border-red-300' : 'border-gray-300'
-                }`}
-                placeholder="https://ifinder.example.com"
-              />
-              {validationErrors.baseUrl && (
-                <p className="mt-1 text-sm text-red-600">{validationErrors.baseUrl}</p>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={formData.config?.documentId || ''}
+                  onChange={e => handleConfigChange('documentId', e.target.value)}
+                  className="flex-1 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                  placeholder={t(
+                    'admin.sources.ifinderDocumentIdPlaceholder',
+                    'e.g. 5f2c9a1b3d4e…'
+                  )}
+                />
+                <button
+                  type="button"
+                  onClick={handleIFinderConnect}
+                  disabled={!formData.config?.documentId?.trim() || docTest.loading}
+                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center whitespace-nowrap"
+                >
+                  <Icon
+                    name={docTest.loading ? 'arrow-path' : 'link'}
+                    className={`h-4 w-4 mr-2 ${docTest.loading ? 'animate-spin' : ''}`}
+                  />
+                  {docTest.loading
+                    ? t('admin.sources.ifinderConnecting', 'Connecting...')
+                    : t('admin.sources.ifinderConnect', 'Connect')}
+                </button>
+              </div>
+              <p className="mt-1 text-sm text-gray-500">
+                {t(
+                  'admin.sources.ifinderDocumentIdHelp',
+                  'Pin this source to one specific iFinder document. Use Connect to load its metadata and verify it is the right one.'
+                )}
+              </p>
+
+              {docTest.error && (
+                <div className="mt-3 bg-red-50 border border-red-200 rounded-lg p-3 flex items-start">
+                  <Icon name="x-circle" className="h-5 w-5 text-red-500 mr-2 flex-shrink-0" />
+                  <p className="text-sm text-red-700">{docTest.error}</p>
+                </div>
               )}
+
+              {docTest.data && (
+                <div className="mt-3 bg-green-50 border border-green-200 rounded-lg p-4">
+                  <div className="flex items-center mb-2">
+                    <Icon name="check-circle" className="h-5 w-5 text-green-600 mr-2" />
+                    <span className="font-medium text-green-800">
+                      {docTest.data.title ||
+                        docTest.data.filename ||
+                        t('admin.sources.ifinderUntitledDocument', 'Untitled document')}
+                    </span>
+                  </div>
+                  <dl className="grid grid-cols-1 md:grid-cols-2 gap-x-4 gap-y-1 text-sm text-gray-700">
+                    {[
+                      [t('admin.sources.ifinderMetaAuthor', 'Author'), docTest.data.author],
+                      [
+                        t('admin.sources.ifinderMetaMediaType', 'Media type'),
+                        docTest.data.mediaType
+                      ],
+                      [t('admin.sources.ifinderMetaFilename', 'File name'), docTest.data.filename],
+                      [t('admin.sources.ifinderMetaSize', 'Size'), docTest.data.sizeFormatted],
+                      [t('admin.sources.ifinderMetaLanguage', 'Language'), docTest.data.language],
+                      [
+                        t('admin.sources.ifinderMetaModified', 'Modified'),
+                        docTest.data.modificationDate
+                      ],
+                      [t('admin.sources.ifinderMetaSource', 'Source'), docTest.data.sourceName],
+                      [
+                        t('admin.sources.ifinderMetaProfile', 'Search profile'),
+                        docTest.data.searchProfile
+                      ]
+                    ]
+                      .filter(([, value]) => value !== null && value !== undefined && value !== '')
+                      .map(([label, value]) => (
+                        <div key={label} className="flex min-w-0">
+                          <dt className="font-medium mr-1 flex-shrink-0">{label}:</dt>
+                          <dd className="truncate">{String(value)}</dd>
+                        </div>
+                      ))}
+                  </dl>
+                  {docTest.data.link && (
+                    <a
+                      href={docTest.data.link}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 inline-flex items-center text-sm text-indigo-600 hover:text-indigo-800"
+                    >
+                      <Icon name="link" className="h-4 w-4 mr-1" />
+                      {t('admin.sources.ifinderOpenDocument', 'Open document')}
+                    </a>
+                  )}
+                </div>
+              )}
+            </div>
+
+            <div className="relative">
+              <div className="absolute inset-0 flex items-center" aria-hidden="true">
+                <div className="w-full border-t border-gray-200" />
+              </div>
+              <div className="relative flex justify-center">
+                <span className="bg-white px-3 text-sm text-gray-500">
+                  {t('admin.sources.ifinderOr', 'or')}
+                </span>
+              </div>
             </div>
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
-                {t('admin.sources.apiKey', 'API Key')} *
+                {t('admin.sources.ifinderQuery', 'Search Query')}
               </label>
-              <input
-                type="password"
-                value={formData.config?.apiKey || ''}
-                onChange={e => handleConfigChange('apiKey', e.target.value)}
-                className={`w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 ${
-                  validationErrors.apiKey ? 'border-red-300' : 'border-gray-300'
-                }`}
-                placeholder="Enter API key"
-              />
-              {validationErrors.apiKey && (
-                <p className="mt-1 text-sm text-red-600">{validationErrors.apiKey}</p>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={formData.config?.query || ''}
+                  onChange={e => handleConfigChange('query', e.target.value)}
+                  className="flex-1 border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                  placeholder={t(
+                    'admin.sources.ifinderQueryPlaceholder',
+                    'e.g. product manual OR title:"user guide"'
+                  )}
+                />
+                <button
+                  type="button"
+                  onClick={handleIFinderQueryTest}
+                  disabled={!formData.config?.query?.trim() || queryTest.loading}
+                  className="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg disabled:opacity-50 disabled:cursor-not-allowed flex items-center whitespace-nowrap"
+                >
+                  <Icon
+                    name={queryTest.loading ? 'arrow-path' : 'magnifying-glass'}
+                    className={`h-4 w-4 mr-2 ${queryTest.loading ? 'animate-spin' : ''}`}
+                  />
+                  {queryTest.loading
+                    ? t('admin.sources.ifinderTestingQuery', 'Searching...')
+                    : t('admin.sources.ifinderTestQuery', 'Test Query')}
+                </button>
+              </div>
+              <p className="mt-1 text-sm text-gray-500">
+                {t(
+                  'admin.sources.ifinderQueryHelp',
+                  'Documents matching this query are loaded as source content, up to the configured maximum. Ignored when a document ID is set.'
+                )}
+              </p>
+
+              {queryTest.error && (
+                <div className="mt-3 bg-red-50 border border-red-200 rounded-lg p-3 flex items-start">
+                  <Icon name="x-circle" className="h-5 w-5 text-red-500 mr-2 flex-shrink-0" />
+                  <p className="text-sm text-red-700">{queryTest.error}</p>
+                </div>
+              )}
+
+              {queryTest.data && (
+                <div className="mt-3 bg-green-50 border border-green-200 rounded-lg p-4">
+                  <div className="flex items-center mb-2">
+                    <Icon name="check-circle" className="h-5 w-5 text-green-600 mr-2" />
+                    <span className="font-medium text-green-800">
+                      {t(
+                        'admin.sources.ifinderQueryMatches',
+                        '{{total}} documents found — the first {{shown}} would be loaded',
+                        {
+                          total: queryTest.data.totalFound ?? 0,
+                          shown: queryTest.data.results?.length ?? 0
+                        }
+                      )}
+                    </span>
+                  </div>
+                  {queryTest.data.results?.length > 0 && (
+                    <ul className="divide-y divide-green-200">
+                      {queryTest.data.results.map(result => (
+                        <li key={result.documentId} className="py-2">
+                          <p className="text-sm font-medium text-gray-900">
+                            {result.title ||
+                              result.filename ||
+                              t('admin.sources.ifinderUntitledDocument', 'Untitled document')}
+                          </p>
+                          <p className="text-xs text-gray-500 truncate">
+                            {[result.documentId, result.mediaType, result.sizeFormatted]
+                              .filter(Boolean)
+                              .join(' · ')}
+                          </p>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
               )}
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
                   {t('admin.sources.searchProfile', 'Search Profile')}
                 </label>
                 <input
                   type="text"
-                  value={formData.config?.searchProfile || 'default'}
+                  value={formData.config?.searchProfile || ''}
                   onChange={e => handleConfigChange('searchProfile', e.target.value)}
                   className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-                  placeholder="default"
+                  placeholder={t('admin.sources.searchProfilePlaceholder', 'Platform default')}
                 />
+                <p className="mt-1 text-sm text-gray-500">
+                  {t(
+                    'admin.sources.searchProfileHelp',
+                    'Leave empty to use the profile configured in the iFinder integration.'
+                  )}
+                </p>
               </div>
 
               <div>
@@ -338,6 +612,31 @@ function SourceConfigForm({ source, onChange, onSave, saving, isEditing }) {
                   min="1"
                   max="100"
                 />
+                <p className="mt-1 text-sm text-gray-500">
+                  {t(
+                    'admin.sources.maxResultsHelp',
+                    'Number of documents loaded when using a search query.'
+                  )}
+                </p>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-2">
+                  {t('admin.sources.maxLength', 'Max Content Length')}
+                </label>
+                <input
+                  type="number"
+                  value={formData.config?.maxLength || 10000}
+                  onChange={e => handleConfigChange('maxLength', parseInt(e.target.value))}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+                  min="1"
+                />
+                <p className="mt-1 text-sm text-gray-500">
+                  {t(
+                    'admin.sources.maxLengthHelp',
+                    'Maximum characters loaded per document; longer content is truncated.'
+                  )}
+                </p>
               </div>
             </div>
           </div>

--- a/docs/releases/5.5.0/breaking-changes.md
+++ b/docs/releases/5.5.0/breaking-changes.md
@@ -30,3 +30,21 @@ the local API server once packaged — so no functioning deployment is affected.
 
 **Before upgrading:** No action needed. If you had scripts or documentation referencing
 `electron:dev`/`electron:build`, remove those references — the commands no longer exist.
+
+## iFinder Source Configuration Schema Simplified
+
+The `config` block of `ifinder` sources no longer accepts `baseUrl`, `apiKey`, `queryTemplate`,
+or `filters`. These fields were never used when loading documents — the connection has always
+come from the central iFinder integration — but they are now rejected on save instead of being
+stored silently. Document selection moves to the new `documentId` / `query` fields, and sources
+exposed as prompt context must set one of them.
+
+- Migration V083 cleans stored sources automatically: it removes the dead connection fields,
+  carries a non-empty `queryTemplate` over to `query`, and drops the auto-injected
+  `searchProfile: "default"` so the platform-wide profile applies.
+
+**Before upgrading:** No action needed for stored configurations; the migration converts them
+automatically. If external tooling creates or updates iFinder sources through
+`/api/admin/sources`, remove the `baseUrl`/`apiKey`/`queryTemplate`/`filters` fields from its
+payloads and set `documentId` or `query` instead. Verify the central iFinder integration
+(Admin → Providers → iFinder) is configured, since sources rely on it for connectivity.

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -974,3 +974,22 @@ requests to specialist bots.
   app directly; apps a user may not access are never offered to the model.
 - Delegation is limited to one level: a called app cannot call further apps, so loops
   cannot form.
+
+## iFinder Sources Select Documents Instead of Carrying Connection Settings
+
+iFinder knowledge sources no longer ask for a base URL and API key — the connection comes from
+the central iFinder integration (Admin → Providers → iFinder). A source now only defines which
+documents it loads, and the admin form can verify the selection against the live iFinder before
+saving.
+
+- Pin a source to one document by ID, or give it a search query that loads the top N matching
+  documents (configurable, 1–100) as source content — each document arrives clearly delimited
+  with its title and link.
+- A **Connect** button next to the document ID loads the document's metadata (title, author,
+  media type, size, modification date, link) so admins can confirm it is the right document.
+- A **Test Query** button shows how many documents match and which ones would be loaded.
+- The search profile is optional and falls back to the platform-wide default profile.
+- Documents are always fetched with the identity of the current user, so a source never exposes
+  content the user could not open in iFinder directly.
+- Sources exposed as tools may leave both fields empty; the assistant supplies a query or
+  document ID when it calls the tool.

--- a/docs/sources.md
+++ b/docs/sources.md
@@ -99,6 +99,15 @@ Fetch and process content from web URLs with intelligent content extraction.
 
 Integration with iFinder document management system for enterprise document access.
 
+The connection itself (base URL, JWT authentication) is **not** configured per source — it comes from the central iFinder integration in the platform configuration (Admin → Providers → iFinder, or the `iFinder` section in `platform.json`). A source only selects **which documents** to load:
+
+- **Pinned document**: set `documentId` to load one specific document
+- **Query-based**: set `query` to search iFinder and load the top `maxResults` matching documents
+
+If both are set, `documentId` wins. Sources exposed as `prompt` require one of the two; sources exposed as `tool` may leave both empty — the assistant supplies a query or document ID when it calls the tool.
+
+Documents are always fetched with the identity of the current user (per-user JWT), so users only ever see content they are allowed to access in iFinder.
+
 **Use Cases:**
 - Enterprise document repositories
 - Searchable knowledge bases
@@ -106,20 +115,21 @@ Integration with iFinder document management system for enterprise document acce
 - Dynamic document retrieval
 
 **Features:**
-- User authentication support
-- Document search functionality
-- Specific document retrieval by ID
+- User authentication support (per-user JWT via the central integration)
+- Load a fixed document by ID, or the top N documents for a search query
 - Configurable search profiles
 - Content length limits
 
 **Configuration Options:**
-- `baseUrl`: iFinder instance URL
-- `apiKey`: API authentication key
-- `searchProfile`: Search profile ('default' or custom)
-- `maxResults`: Maximum search results (1-100)
-- `queryTemplate`: Search query template
-- `filters`: Search filters object
-- `maxLength`: Maximum content length
+- `documentId`: Pin the source to one specific document
+- `query`: Search query that selects the documents to load
+- `searchProfile`: Search profile (optional — defaults to the platform-wide profile)
+- `maxResults`: Number of documents loaded for a query (1-100, default 10)
+- `maxLength`: Maximum content length per document (default 10000)
+
+**Admin UI helpers:**
+- **Connect** button next to the document ID loads the document's metadata (title, author, type, size, dates) so you can verify it is the right document before saving.
+- **Test Query** button runs the search and shows which documents the query would load.
 
 ### 4. Page Sources
 
@@ -320,6 +330,8 @@ PUT    /api/admin/sources/:id       # Update source
 DELETE /api/admin/sources/:id       # Delete source
 POST   /api/admin/sources/:id/test  # Test source
 POST   /api/admin/sources/:id/preview # Preview content
+POST   /api/admin/sources/_ifinder/metadata # Load iFinder document metadata (verify a document ID)
+POST   /api/admin/sources/_ifinder/search   # Preview which documents an iFinder query would load
 ```
 
 ## Examples
@@ -374,7 +386,32 @@ POST   /api/admin/sources/:id/preview # Preview content
 }
 ```
 
-### Example 3: iFinder Document Source
+### Example 3: iFinder Document Sources
+
+The iFinder connection comes from the central integration (Admin → Providers → iFinder); the source only selects documents.
+
+A source pinned to one document:
+
+```json
+{
+  "id": "employee-handbook",
+  "name": {
+    "en": "Employee Handbook"
+  },
+  "description": {
+    "en": "The current employee handbook"
+  },
+  "type": "ifinder",
+  "enabled": true,
+  "exposeAs": "prompt",
+  "config": {
+    "documentId": "a1b2c3d4e5f6",
+    "maxLength": 20000
+  }
+}
+```
+
+A query-based source loading the top 5 matching documents:
 
 ```json
 {
@@ -389,8 +426,7 @@ POST   /api/admin/sources/:id/preview # Preview content
   "enabled": true,
   "exposeAs": "tool",
   "config": {
-    "baseUrl": "https://ifinder.company.com",
-    "apiKey": "${IFINDER_API_KEY}",
+    "query": "category:knowledge",
     "searchProfile": "knowledge",
     "maxResults": 5,
     "maxLength": 10000
@@ -484,10 +520,11 @@ POST   /api/admin/sources/:id/preview # Preview content
 **Symptoms:** "Authentication failed" or "Connection timeout" errors.
 
 **Solutions:**
-- Verify iFinder instance URL and API key
+- Verify the central iFinder integration (Admin → Providers → iFinder): base URL and JWT signing key
+- Run the step-by-step integration diagnostics on the providers page
 - Check network connectivity to iFinder server
-- Ensure user has proper permissions
-- Test with a simple search query
+- Ensure the logged-in user has proper permissions in iFinder (documents are loaded with the user's identity)
+- Use the Connect / Test Query buttons on the source form to verify the document selection
 - Review iFinder server logs
 
 #### 5. Content Too Large
@@ -533,7 +570,8 @@ Sources support caching to improve performance:
 | "No handler registered for type" | Unknown source type | Use: filesystem, url, ifinder, or page |
 | "Source ID already exists" | Duplicate source ID | Choose unique source identifier |
 | "Invalid URL: Only HTTP and HTTPS protocols allowed" | Invalid URL protocol | Use http:// or https:// URLs |
-| "iFinder test failed: Authentication failed" | Invalid iFinder credentials | Check API key and base URL |
+| "iFinder test failed: Authentication failed" | iFinder integration misconfigured | Check the central iFinder integration (base URL, JWT key) |
+| "iFinder sources exposed as prompt context require either a document ID or a search query" | No document selection configured | Set `documentId` or `query` in the source config |
 
 ### Debugging Tips
 

--- a/server/migrations/V083__simplify_ifinder_source_config.js
+++ b/server/migrations/V083__simplify_ifinder_source_config.js
@@ -1,0 +1,82 @@
+// server/migrations/V083__simplify_ifinder_source_config.js
+export const version = '083';
+export const description = 'simplify_ifinder_source_config';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/sources.json');
+}
+
+/**
+ * iFinder sources no longer carry their own connection settings — the base URL
+ * and JWT authentication come from the central iFinder integration in
+ * platform.json. The per-source `baseUrl`/`apiKey` fields were never read by
+ * the handler, and `queryTemplate`/`filters` never reached it either. The new
+ * schema rejects unknown keys, so stored configs must be cleaned up.
+ */
+export async function up(ctx) {
+  const sources = await ctx.readJson('config/sources.json');
+
+  if (!Array.isArray(sources)) {
+    ctx.warn('config/sources.json is not an array — skipping');
+    return;
+  }
+
+  let changed = 0;
+
+  for (const source of sources) {
+    if (source?.type !== 'ifinder' || typeof source.config !== 'object' || source.config === null) {
+      continue;
+    }
+
+    const config = source.config;
+    let touched = false;
+
+    // Connection settings now come from the central iFinder integration.
+    for (const key of ['baseUrl', 'apiKey']) {
+      if (key in config) {
+        delete config[key];
+        touched = true;
+      }
+    }
+
+    // queryTemplate never reached the handler; carry its value over to the
+    // new `query` field, which selects the documents to load.
+    if ('queryTemplate' in config) {
+      if (
+        typeof config.queryTemplate === 'string' &&
+        config.queryTemplate.trim() !== '' &&
+        !config.query
+      ) {
+        config.query = config.queryTemplate.trim();
+      }
+      delete config.queryTemplate;
+      touched = true;
+    }
+
+    // Dead schema-only field, never used by the handler.
+    if ('filters' in config) {
+      delete config.filters;
+      touched = true;
+    }
+
+    // 'default' was auto-injected by the old schema rather than chosen by an
+    // admin; dropping it lets the platform-wide search profile apply.
+    // Explicitly configured profiles are kept.
+    if (config.searchProfile === 'default') {
+      delete config.searchProfile;
+      touched = true;
+    }
+
+    if (touched) {
+      source.updated = new Date().toISOString();
+      changed++;
+    }
+  }
+
+  if (changed > 0) {
+    await ctx.writeJson('config/sources.json', sources);
+  }
+  ctx.log(
+    `Simplified ${changed} iFinder source config(s) — connection settings now come from the central iFinder integration`
+  );
+}

--- a/server/routes/admin/sources.js
+++ b/server/routes/admin/sources.js
@@ -22,6 +22,15 @@ import logger from '../../utils/logger.js';
 import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
 import { getLocalizedString } from '../../utils/localize.js';
+import iFinderService from '../../services/integrations/iFinderService.js';
+
+/**
+ * Character allowlist for iFinder document IDs. The ID is embedded in a quoted
+ * `_id:"…"` search expression, so anything beyond word characters, dots and
+ * hyphens is rejected to prevent query injection (same rule as
+ * iFinderService.resolveDocumentLink).
+ */
+const IFINDER_DOCUMENT_ID_PATTERN = /^[\w.\-]+$/;
 
 /**
  * Initialize source manager singleton
@@ -161,40 +170,33 @@ function getSourceManager() {
  *           description: Whether to clean HTML content
  *     IFinderConfig:
  *       type: object
- *       required:
- *         - baseUrl
- *         - apiKey
+ *       description: >
+ *         Selects which iFinder documents the source loads. Connection settings
+ *         (base URL, JWT authentication) come from the central iFinder
+ *         integration in the platform configuration. Sources exposed as prompt
+ *         context require either documentId or query; tool sources may leave
+ *         both empty and let the model supply them at call time.
  *       properties:
- *         baseUrl:
+ *         documentId:
  *           type: string
- *           format: uri
- *           description: iFinder base URL
- *         apiKey:
+ *           description: Pin the source to one specific iFinder document
+ *         query:
  *           type: string
- *           minLength: 1
- *           description: iFinder API key
+ *           description: Search query that selects the documents to load
  *         searchProfile:
  *           type: string
- *           default: default
- *           description: Search profile to use
+ *           description: Search profile to use (defaults to the platform-wide profile)
  *         maxResults:
  *           type: number
  *           minimum: 1
  *           maximum: 100
  *           default: 10
- *           description: Maximum number of search results
- *         queryTemplate:
- *           type: string
- *           default: ""
- *           description: Query template for searches
- *         filters:
- *           type: object
- *           description: Additional search filters
+ *           description: Number of documents loaded for a query
  *         maxLength:
  *           type: number
  *           minimum: 1
  *           default: 10000
- *           description: Maximum content length
+ *           description: Maximum content length per document
  *     PageConfig:
  *       type: object
  *       required:
@@ -621,6 +623,220 @@ export default function registerAdminSourcesRoutes(app) {
         res.json(types);
       } catch (error) {
         sendFailedOperationError(res, 'fetch source types', error);
+      }
+    }
+  );
+
+  /**
+   * @swagger
+   * /api/admin/sources/_ifinder/metadata:
+   *   post:
+   *     summary: Load iFinder document metadata
+   *     description: >
+   *       Fetch the metadata of a single iFinder document (title, author, type,
+   *       size, dates) so an admin can verify a document ID while configuring a
+   *       source — before the source is saved. Uses the central iFinder
+   *       integration with the requesting admin's identity (admin access required)
+   *     tags: [Admin - Sources]
+   *     security:
+   *       - bearerAuth: []
+   *       - sessionAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - documentId
+   *             properties:
+   *               documentId:
+   *                 type: string
+   *                 description: iFinder document ID to look up
+   *               searchProfile:
+   *                 type: string
+   *                 description: Optional search profile (defaults to the platform-wide profile)
+   *     responses:
+   *       200:
+   *         description: Document metadata retrieved successfully
+   *       400:
+   *         description: Invalid request or document could not be loaded
+   *       401:
+   *         description: Unauthorized - Invalid or missing authentication
+   *       403:
+   *         description: Forbidden - Insufficient admin permissions
+   */
+  app.post(
+    buildServerPath('/api/admin/sources/_ifinder/metadata'),
+    requireFeature('sources'),
+    contentAdminAuth,
+    async (req, res) => {
+      try {
+        const { documentId, searchProfile } = req.body || {};
+
+        if (!documentId || typeof documentId !== 'string' || documentId.trim() === '') {
+          return sendBadRequest(res, 'documentId is required');
+        }
+        if (!IFINDER_DOCUMENT_ID_PATTERN.test(documentId.trim())) {
+          return sendBadRequest(res, 'Invalid document ID format');
+        }
+        if (searchProfile !== undefined && typeof searchProfile !== 'string') {
+          return sendBadRequest(res, 'searchProfile must be a string');
+        }
+
+        const startTime = Date.now();
+
+        try {
+          const metadata = await iFinderService.getMetadata({
+            documentId: documentId.trim(),
+            chatId: `admin-ifinder-metadata-${crypto.randomUUID()}`,
+            user: req.user,
+            searchProfile: searchProfile?.trim() || undefined
+          });
+
+          // Return a curated subset — the raw search result contains the full
+          // document record and would leak far more than the admin UI needs.
+          res.json({
+            success: true,
+            duration: Date.now() - startTime,
+            metadata: {
+              documentId: metadata.documentId,
+              title: metadata.title,
+              author: metadata.author,
+              language: metadata.language,
+              mediaType: metadata.mediaType,
+              sourceType: metadata.sourceType,
+              sourceName: metadata.sourceName,
+              application: metadata.application,
+              filename: metadata.filename,
+              size: metadata.size,
+              sizeFormatted: metadata.sizeFormatted,
+              contentLength: metadata.contentLength,
+              modificationDate: metadata.modificationDate,
+              indexingDate: metadata.indexingDate,
+              link: metadata.deepLink || metadata.url || null,
+              searchProfile: metadata.searchProfile
+            }
+          });
+        } catch (metadataError) {
+          res.status(400).json({
+            success: false,
+            error: metadataError.message,
+            duration: Date.now() - startTime
+          });
+        }
+      } catch (error) {
+        sendFailedOperationError(res, 'load iFinder document metadata', error);
+      }
+    }
+  );
+
+  /**
+   * @swagger
+   * /api/admin/sources/_ifinder/search:
+   *   post:
+   *     summary: Preview an iFinder source query
+   *     description: >
+   *       Run a search against iFinder and return the matching documents so an
+   *       admin can verify which documents a query-based source would load —
+   *       before the source is saved. Uses the central iFinder integration with
+   *       the requesting admin's identity (admin access required)
+   *     tags: [Admin - Sources]
+   *     security:
+   *       - bearerAuth: []
+   *       - sessionAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - query
+   *             properties:
+   *               query:
+   *                 type: string
+   *                 description: Search query to preview
+   *               searchProfile:
+   *                 type: string
+   *                 description: Optional search profile (defaults to the platform-wide profile)
+   *               maxResults:
+   *                 type: number
+   *                 minimum: 1
+   *                 maximum: 100
+   *                 default: 10
+   *                 description: Number of hits to return
+   *     responses:
+   *       200:
+   *         description: Search preview executed successfully
+   *       400:
+   *         description: Invalid request or search failed
+   *       401:
+   *         description: Unauthorized - Invalid or missing authentication
+   *       403:
+   *         description: Forbidden - Insufficient admin permissions
+   */
+  app.post(
+    buildServerPath('/api/admin/sources/_ifinder/search'),
+    requireFeature('sources'),
+    contentAdminAuth,
+    async (req, res) => {
+      try {
+        const { query, searchProfile, maxResults } = req.body || {};
+
+        if (!query || typeof query !== 'string' || query.trim() === '') {
+          return sendBadRequest(res, 'query is required');
+        }
+        if (query.length > 1000) {
+          return sendBadRequest(res, 'query must not exceed 1000 characters');
+        }
+        if (searchProfile !== undefined && typeof searchProfile !== 'string') {
+          return sendBadRequest(res, 'searchProfile must be a string');
+        }
+        const parsedMaxResults = maxResults === undefined ? 10 : Number(maxResults);
+        if (!Number.isInteger(parsedMaxResults) || parsedMaxResults < 1 || parsedMaxResults > 100) {
+          return sendBadRequest(res, 'maxResults must be an integer between 1 and 100');
+        }
+
+        const startTime = Date.now();
+
+        try {
+          const searchResult = await iFinderService.search({
+            query: query.trim(),
+            chatId: `admin-ifinder-search-${crypto.randomUUID()}`,
+            user: req.user,
+            maxResults: parsedMaxResults,
+            searchProfile: searchProfile?.trim() || undefined
+          });
+
+          res.json({
+            success: true,
+            duration: Date.now() - startTime,
+            totalFound: searchResult.totalFound,
+            searchProfile: searchResult.searchProfile,
+            results: (searchResult.results || []).map(hit => ({
+              documentId: hit.id,
+              title: hit.title,
+              score: hit.score,
+              language: hit.language,
+              mediaType: hit.mediaType,
+              sourceName: hit.sourceName,
+              filename: hit.filename,
+              size: hit.size,
+              sizeFormatted: hit.sizeFormatted,
+              modificationDate: hit.modificationDate,
+              link: hit.deepLink || hit.url || null
+            }))
+          });
+        } catch (searchError) {
+          res.status(400).json({
+            success: false,
+            error: searchError.message,
+            duration: Date.now() - startTime
+          });
+        }
+      } catch (error) {
+        sendFailedOperationError(res, 'preview iFinder search', error);
       }
     }
   );

--- a/server/routes/admin/sources.js
+++ b/server/routes/admin/sources.js
@@ -17,20 +17,12 @@ import {
 } from '../../utils/responseHelpers.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import { requireFeature } from '../../featureRegistry.js';
-import { validateIdForPath } from '../../utils/pathSecurity.js';
+import { validateIdForPath, isValidId } from '../../utils/pathSecurity.js';
 import logger from '../../utils/logger.js';
 import { logAudit } from '../../services/AuditLogService.js';
 import { saveSnapshot } from '../../services/ChangeHistoryService.js';
 import { getLocalizedString } from '../../utils/localize.js';
 import iFinderService from '../../services/integrations/iFinderService.js';
-
-/**
- * Character allowlist for iFinder document IDs. The ID is embedded in a quoted
- * `_id:"…"` search expression, so anything beyond word characters, dots and
- * hyphens is rejected to prevent query injection (same rule as
- * iFinderService.resolveDocumentLink).
- */
-const IFINDER_DOCUMENT_ID_PATTERN = /^[\w.\-]+$/;
 
 /**
  * Initialize source manager singleton
@@ -677,7 +669,9 @@ export default function registerAdminSourcesRoutes(app) {
         if (!documentId || typeof documentId !== 'string' || documentId.trim() === '') {
           return sendBadRequest(res, 'documentId is required');
         }
-        if (!IFINDER_DOCUMENT_ID_PATTERN.test(documentId.trim())) {
+        // Central safe-ID allowlist — the ID is embedded in a quoted _id:"…"
+        // search expression by iFinderService.getMetadata.
+        if (!isValidId(documentId.trim())) {
           return sendBadRequest(res, 'Invalid document ID format');
         }
         if (searchProfile !== undefined && typeof searchProfile !== 'string') {

--- a/server/services/integrations/iFinderService.js
+++ b/server/services/integrations/iFinderService.js
@@ -2,6 +2,7 @@ import { actionTracker } from '../../actionTracker.js';
 import config from '../../config.js';
 import { throttledFetch } from '../../requestThrottler.js';
 import { getIFinderAuthorizationHeader } from '../../utils/iFinderJwt.js';
+import { isValidId } from '../../utils/pathSecurity.js';
 import configCache from '../../configCache.js';
 import authDebugService from '../../utils/authDebugService.js';
 import fs from 'fs';
@@ -547,6 +548,13 @@ class IFinderService {
       throw new Error('Document ID parameter is required');
     }
 
+    // The ID is embedded in a quoted _id:"…" query below. Document IDs can
+    // arrive from model/tool parameters, so validate against the central safe
+    // ID allowlist to prevent query injection.
+    if (!isValidId(documentId)) {
+      throw new Error('Invalid document ID format');
+    }
+
     // Use the search method with _id:documentId query
     const searchResult = await this.search({
       query: `_id:\"${documentId}\"`,
@@ -987,9 +995,10 @@ class IFinderService {
     const baseUrl = config.baseUrl.replace(/\/+$/, '');
     const authHeader = getIFinderAuthorizationHeader(user);
 
-    // Validate documentId to prevent query injection: allow only alphanumeric, hyphens, underscores, dots
-    if (!/^[\w.\-]+$/.test(documentId)) {
-      throw new Error(`Invalid document ID format: ${documentId}`);
+    // Validate documentId against the central safe ID allowlist to prevent
+    // query injection into the sSearchTerm below.
+    if (!isValidId(documentId)) {
+      throw new Error('Invalid document ID format');
     }
 
     const searchUrl =

--- a/server/sources/IFinderHandler.js
+++ b/server/sources/IFinderHandler.js
@@ -17,11 +17,25 @@ class IFinderHandler extends SourceHandler {
 
   /**
    * Load content from iFinder
-   * @param {Object} sourceConfig - { documentId?: string, query?: string, searchProfile?: string, user: Object, chatId: string }
+   *
+   * Connection settings come from the central iFinder integration (platform
+   * config); the source config only selects documents. Two modes:
+   * - documentId: load exactly that document
+   * - query: search and load the top `maxResults` matching documents
+   *
+   * @param {Object} sourceConfig - { documentId?: string, query?: string, searchProfile?: string, maxResults?: number, maxLength?: number, user: Object, chatId: string }
    * @returns {Promise<Object>} - { content: string, metadata: Object }
    */
   async loadContent(sourceConfig) {
-    const { documentId, query, searchProfile, user, chatId, maxLength = 50000 } = sourceConfig;
+    const {
+      documentId,
+      query,
+      searchProfile,
+      user,
+      chatId,
+      maxLength = 50000,
+      maxResults = 10
+    } = sourceConfig;
 
     if (!user) {
       throw new Error('IFinderHandler requires authenticated user in sourceConfig');
@@ -36,69 +50,170 @@ class IFinderHandler extends SourceHandler {
     }
 
     try {
-      let targetDocumentId = documentId;
-      let searchResults = null;
-
-      // If only query provided, search first to get document ID
-      if (!documentId && query) {
-        searchResults = await iFinder.search({
-          query,
-          chatId,
+      if (documentId) {
+        return await this.loadSingleDocument({
+          documentId,
+          searchProfile,
           user,
-          maxResults: 1,
-          searchProfile
+          chatId,
+          maxLength
         });
-
-        if (!searchResults.results || searchResults.results.length === 0) {
-          throw new Error(`No documents found for query: ${query}`);
-        }
-
-        targetDocumentId = searchResults.results[0].id;
       }
 
-      // Get document content
-      const contentResult = await iFinder.getContent({
-        documentId: targetDocumentId,
-        chatId,
-        user,
+      return await this.loadDocumentsByQuery({
+        query,
         searchProfile,
-        maxLength
-      });
-
-      // Get additional metadata if needed
-      const metadataResult = await iFinder.getMetadata({
-        documentId: targetDocumentId,
-        chatId,
         user,
-        searchProfile
+        chatId,
+        maxLength,
+        maxResults
       });
-
-      return {
-        content: contentResult.content,
-        metadata: {
-          type: 'ifinder',
-          documentId: targetDocumentId,
-          link: metadataResult.url || `ifinder://document/${targetDocumentId}`, // Use document URL if available
-          title: metadataResult.title,
-          author: metadataResult.author,
-          documentType: metadataResult.documentType,
-          mimeType: metadataResult.mimeType,
-          size: metadataResult.size,
-          sizeFormatted: metadataResult.sizeFormatted,
-          createdDate: metadataResult.createdDate,
-          lastModified: metadataResult.lastModified,
-          contentLength: contentResult.contentLength,
-          contentLengthFormatted: contentResult.contentLengthFormatted,
-          searchProfile: contentResult.searchProfile,
-          truncated: contentResult.truncated,
-          searchQuery: query,
-          searchResults: searchResults,
-          loadedAt: new Date().toISOString()
-        }
-      };
     } catch (error) {
       throw new Error(`Error loading from iFinder: ${error.message}`);
     }
+  }
+
+  /**
+   * Load one specific document with its metadata
+   * @param {Object} params - { documentId, searchProfile, user, chatId, maxLength }
+   * @returns {Promise<Object>} - { content: string, metadata: Object }
+   */
+  async loadSingleDocument({ documentId, searchProfile, user, chatId, maxLength }) {
+    const contentResult = await iFinder.getContent({
+      documentId,
+      chatId,
+      user,
+      searchProfile,
+      maxLength
+    });
+
+    const metadataResult = await iFinder.getMetadata({
+      documentId,
+      chatId,
+      user,
+      searchProfile
+    });
+
+    return {
+      content: contentResult.content,
+      metadata: {
+        type: 'ifinder',
+        documentId,
+        link: metadataResult.url || `ifinder://document/${documentId}`, // Use document URL if available
+        title: metadataResult.title,
+        author: metadataResult.author,
+        documentType: metadataResult.documentType,
+        mimeType: metadataResult.mimeType,
+        size: metadataResult.size,
+        sizeFormatted: metadataResult.sizeFormatted,
+        createdDate: metadataResult.createdDate,
+        lastModified: metadataResult.lastModified,
+        contentLength: contentResult.contentLength,
+        contentLengthFormatted: contentResult.contentLengthFormatted,
+        searchProfile: contentResult.searchProfile,
+        truncated: contentResult.truncated,
+        loadedAt: new Date().toISOString()
+      }
+    };
+  }
+
+  /**
+   * Search for documents and load the content of the top matches
+   * @param {Object} params - { query, searchProfile, user, chatId, maxLength, maxResults }
+   * @returns {Promise<Object>} - { content: string, metadata: Object }
+   */
+  async loadDocumentsByQuery({ query, searchProfile, user, chatId, maxLength, maxResults }) {
+    const searchResults = await iFinder.search({
+      query,
+      chatId,
+      user,
+      maxResults,
+      searchProfile
+    });
+
+    const hits = searchResults.results || [];
+    if (hits.length === 0) {
+      throw new Error(`No documents found for query: ${query}`);
+    }
+
+    const loaded = [];
+    const failed = [];
+    const concurrency = 3;
+
+    // Load document contents in small batches to avoid overwhelming iFinder
+    for (let i = 0; i < hits.length; i += concurrency) {
+      const batch = hits.slice(i, i + concurrency);
+      const batchResults = await Promise.all(
+        batch.map(async hit => {
+          try {
+            const contentResult = await iFinder.getContent({
+              documentId: hit.id,
+              chatId,
+              user,
+              searchProfile,
+              maxLength
+            });
+            return { hit, contentResult };
+          } catch (error) {
+            failed.push({ documentId: hit.id, error: error.message });
+            return null;
+          }
+        })
+      );
+      loaded.push(...batchResults.filter(Boolean));
+    }
+
+    if (loaded.length === 0) {
+      throw new Error(
+        `Failed to load documents for query "${query}": ${failed.map(f => f.error).join('; ')}`
+      );
+    }
+
+    const content = loaded
+      .map(({ hit, contentResult }) => {
+        const title = hit.title || contentResult.metadata?.title || hit.id;
+        const link = hit.url || hit.deepLink || '';
+        const linkAttr = link ? ` link="${this.escapeAttribute(link)}"` : '';
+        return `<document id="${this.escapeAttribute(hit.id)}" title="${this.escapeAttribute(title)}"${linkAttr}>\n${contentResult.content}\n</document>`;
+      })
+      .join('\n\n');
+
+    return {
+      content,
+      metadata: {
+        type: 'ifinder',
+        searchQuery: query,
+        searchProfile: searchResults.searchProfile,
+        totalFound: searchResults.totalFound,
+        loadedDocuments: loaded.length,
+        failedDocuments: failed,
+        documents: loaded.map(({ hit, contentResult }) => ({
+          documentId: hit.id,
+          title: hit.title,
+          author: hit.author,
+          mimeType: hit.mimeType,
+          size: hit.size,
+          lastModified: hit.lastModified,
+          link: hit.url || hit.deepLink || `ifinder://document/${hit.id}`,
+          contentLength: contentResult.contentLength,
+          truncated: contentResult.truncated || false
+        })),
+        loadedAt: new Date().toISOString()
+      }
+    };
+  }
+
+  /**
+   * Escape a value for use inside a double-quoted XML-style attribute
+   * @param {*} value - Value to escape
+   * @returns {string} - Escaped string
+   */
+  escapeAttribute(value) {
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
   }
 
   /**
@@ -107,7 +222,7 @@ class IFinderHandler extends SourceHandler {
    * @returns {string} - Cache key
    */
   getCacheKey(sourceConfig) {
-    const { documentId, query, searchProfile, user } = sourceConfig;
+    const { documentId, query, searchProfile, maxResults, maxLength, user } = sourceConfig;
 
     // Create user-specific cache key to avoid permission issues
     const userKey = user ? user.email || user.id : 'anonymous';
@@ -116,6 +231,8 @@ class IFinderHandler extends SourceHandler {
       documentId,
       query,
       searchProfile,
+      maxResults,
+      maxLength,
       user: userKey
     });
   }
@@ -129,6 +246,11 @@ class IFinderHandler extends SourceHandler {
 
   /**
    * Validate iFinder source configuration
+   *
+   * Only static configuration is validated here — the runtime context
+   * (user, chatId) is injected later by the SourceManager and enforced in
+   * loadContent, so requiring it here would reject every stored source.
+   *
    * @param {Object} sourceConfig - Configuration to validate
    * @returns {boolean} - True if valid
    */
@@ -137,24 +259,13 @@ class IFinderHandler extends SourceHandler {
       return false;
     }
 
-    const { documentId, query, user, chatId } = sourceConfig;
+    const { documentId, query } = sourceConfig;
+
+    const hasDocumentId = typeof documentId === 'string' && documentId.trim() !== '';
+    const hasQuery = typeof query === 'string' && query.trim() !== '';
 
     // Must have either documentId or query
-    if (!documentId && !query) {
-      return false;
-    }
-
-    // Must have user and chatId
-    if (!user || !chatId) {
-      return false;
-    }
-
-    // Validate user object
-    if (typeof user !== 'object' || (user.id && user.id === 'anonymous')) {
-      return false;
-    }
-
-    return true;
+    return hasDocumentId || hasQuery;
   }
 
   /**

--- a/server/sources/IFinderHandler.js
+++ b/server/sources/IFinderHandler.js
@@ -33,7 +33,7 @@ class IFinderHandler extends SourceHandler {
       searchProfile,
       user,
       chatId,
-      maxLength = 50000,
+      maxLength = 10000, // matches the source schema default
       maxResults = 10
     } = sourceConfig;
 

--- a/server/sources/SourceManager.js
+++ b/server/sources/SourceManager.js
@@ -653,24 +653,29 @@ class SourceManager {
    * Test iFinder source
    */
   async testIFinderSource(config) {
-    const { searchProfile = 'default' } = config;
-
     try {
-      const testQuery = 'test';
       const startTime = Date.now();
 
-      // Use the existing IFinderHandler to test
+      // Use the existing IFinderHandler to test. Keep the probe light: a
+      // single document with trimmed content. When the source pins a
+      // documentId that document is loaded; otherwise the configured query
+      // (or a generic fallback) is searched.
       const handler = this.handlers.get('ifinder');
-      const testConfig = { ...config, query: testQuery, maxResults: 1 };
+      const testConfig = { ...config, maxResults: 1, maxLength: 1000 };
+      if (!testConfig.documentId && !testConfig.query) {
+        testConfig.query = 'test';
+      }
 
-      await handler.loadContent(testConfig);
+      const result = await handler.loadContent(testConfig);
       const duration = Date.now() - startTime;
 
       return {
         accessible: true,
-        searchProfile,
+        searchProfile: result.metadata?.searchProfile || config.searchProfile,
         duration,
-        testQuery
+        ...(testConfig.documentId
+          ? { documentId: testConfig.documentId, documentTitle: result.metadata?.title }
+          : { testQuery: testConfig.query, totalFound: result.metadata?.totalFound })
       };
     } catch (error) {
       throw new Error(`iFinder test failed: ${error.message}`);

--- a/server/tests/iFinderSourceHandler.test.js
+++ b/server/tests/iFinderSourceHandler.test.js
@@ -1,0 +1,235 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert';
+import iFinder from '../tools/iFinder.js';
+import IFinderHandler from '../sources/IFinderHandler.js';
+
+/**
+ * IFinderHandler tests
+ *
+ * The handler talks to iFinder through the `iFinder` tool wrapper (a plain
+ * object export), so the network layer is stubbed by swapping the wrapper's
+ * methods for the duration of each test.
+ */
+
+const user = { id: 'user-1', email: 'user@example.com' };
+const chatId = 'chat-1';
+
+const originals = {
+  search: iFinder.search,
+  getContent: iFinder.getContent,
+  getMetadata: iFinder.getMetadata
+};
+
+function restore() {
+  iFinder.search = originals.search;
+  iFinder.getContent = originals.getContent;
+  iFinder.getMetadata = originals.getMetadata;
+}
+
+describe('IFinderHandler', () => {
+  let handler;
+
+  beforeEach(() => {
+    handler = new IFinderHandler();
+  });
+
+  afterEach(() => {
+    restore();
+  });
+
+  describe('validateConfig', () => {
+    it('accepts static config with documentId only', () => {
+      assert.strictEqual(handler.validateConfig({ documentId: 'doc-1' }), true);
+    });
+
+    it('accepts static config with query only', () => {
+      assert.strictEqual(handler.validateConfig({ query: 'manual' }), true);
+    });
+
+    it('does not require runtime context (user/chatId)', () => {
+      // Stored source configs never contain user/chatId — they are injected
+      // later by the SourceManager. validateConfig must not reject them.
+      assert.strictEqual(handler.validateConfig({ query: 'manual' }), true);
+    });
+
+    it('rejects config without documentId and query', () => {
+      assert.strictEqual(handler.validateConfig({}), false);
+      assert.strictEqual(handler.validateConfig({ documentId: '  ', query: '' }), false);
+      assert.strictEqual(handler.validateConfig(null), false);
+    });
+  });
+
+  describe('loadContent - runtime requirements', () => {
+    it('requires user', async () => {
+      await assert.rejects(
+        handler.loadContent({ documentId: 'doc-1', chatId }),
+        /requires authenticated user/
+      );
+    });
+
+    it('requires chatId', async () => {
+      await assert.rejects(handler.loadContent({ documentId: 'doc-1', user }), /requires chatId/);
+    });
+
+    it('requires documentId or query', async () => {
+      await assert.rejects(
+        handler.loadContent({ user, chatId }),
+        /requires either documentId or query/
+      );
+    });
+  });
+
+  describe('loadContent - single document mode', () => {
+    it('loads content and metadata for a pinned document', async () => {
+      iFinder.getContent = async params => {
+        assert.strictEqual(params.documentId, 'doc-1');
+        assert.strictEqual(params.user, user);
+        assert.strictEqual(params.chatId, chatId);
+        return {
+          content: 'Document body',
+          contentLength: 13,
+          contentLengthFormatted: '13 characters',
+          searchProfile: 'profile-1',
+          truncated: false
+        };
+      };
+      iFinder.getMetadata = async () => ({
+        title: 'My Document',
+        author: 'Alice',
+        mimeType: 'application/pdf',
+        url: 'https://ifinder.example.com/doc-1'
+      });
+
+      const result = await handler.loadContent({ documentId: 'doc-1', user, chatId });
+
+      assert.strictEqual(result.content, 'Document body');
+      assert.strictEqual(result.metadata.type, 'ifinder');
+      assert.strictEqual(result.metadata.documentId, 'doc-1');
+      assert.strictEqual(result.metadata.title, 'My Document');
+      assert.strictEqual(result.metadata.link, 'https://ifinder.example.com/doc-1');
+    });
+  });
+
+  describe('loadContent - query mode', () => {
+    it('loads up to maxResults documents for a query', async () => {
+      const hits = [
+        { id: 'doc-1', title: 'First', url: 'https://example.com/1' },
+        { id: 'doc-2', title: 'Second', deepLink: 'https://example.com/2' },
+        { id: 'doc-3', title: 'Third' }
+      ];
+
+      let searchParams = null;
+      iFinder.search = async params => {
+        searchParams = params;
+        return { results: hits, totalFound: 42, searchProfile: 'profile-1' };
+      };
+      const loadedIds = [];
+      iFinder.getContent = async params => {
+        loadedIds.push(params.documentId);
+        return {
+          content: `Content of ${params.documentId}`,
+          contentLength: 20,
+          truncated: false
+        };
+      };
+
+      const result = await handler.loadContent({ query: 'manual', maxResults: 3, user, chatId });
+
+      assert.strictEqual(searchParams.maxResults, 3);
+      assert.strictEqual(searchParams.query, 'manual');
+      assert.deepStrictEqual(loadedIds.sort(), ['doc-1', 'doc-2', 'doc-3']);
+
+      // All three documents wrapped individually
+      assert.match(
+        result.content,
+        /<document id="doc-1" title="First" link="https:\/\/example.com\/1">/
+      );
+      assert.match(
+        result.content,
+        /<document id="doc-2" title="Second" link="https:\/\/example.com\/2">/
+      );
+      assert.match(result.content, /<document id="doc-3" title="Third">/);
+      assert.match(result.content, /Content of doc-2/);
+
+      assert.strictEqual(result.metadata.type, 'ifinder');
+      assert.strictEqual(result.metadata.searchQuery, 'manual');
+      assert.strictEqual(result.metadata.totalFound, 42);
+      assert.strictEqual(result.metadata.loadedDocuments, 3);
+      assert.strictEqual(result.metadata.documents.length, 3);
+      assert.strictEqual(result.metadata.documents[0].documentId, 'doc-1');
+    });
+
+    it('continues when individual documents fail to load', async () => {
+      iFinder.search = async () => ({
+        results: [
+          { id: 'doc-ok', title: 'Works' },
+          { id: 'doc-broken', title: 'Broken' }
+        ],
+        totalFound: 2,
+        searchProfile: 'profile-1'
+      });
+      iFinder.getContent = async ({ documentId }) => {
+        if (documentId === 'doc-broken') {
+          throw new Error('Access denied');
+        }
+        return { content: 'ok', contentLength: 2, truncated: false };
+      };
+
+      const result = await handler.loadContent({ query: 'manual', user, chatId });
+
+      assert.strictEqual(result.metadata.loadedDocuments, 1);
+      assert.strictEqual(result.metadata.failedDocuments.length, 1);
+      assert.strictEqual(result.metadata.failedDocuments[0].documentId, 'doc-broken');
+      assert.match(result.content, /<document id="doc-ok"/);
+      assert.ok(!result.content.includes('doc-broken'));
+    });
+
+    it('throws when the query matches nothing', async () => {
+      iFinder.search = async () => ({ results: [], totalFound: 0 });
+
+      await assert.rejects(
+        handler.loadContent({ query: 'nothing', user, chatId }),
+        /No documents found for query/
+      );
+    });
+
+    it('throws when every matched document fails to load', async () => {
+      iFinder.search = async () => ({
+        results: [{ id: 'doc-1', title: 'First' }],
+        totalFound: 1
+      });
+      iFinder.getContent = async () => {
+        throw new Error('Access denied');
+      };
+
+      await assert.rejects(
+        handler.loadContent({ query: 'manual', user, chatId }),
+        /Failed to load documents for query/
+      );
+    });
+
+    it('escapes attribute values in document wrappers', async () => {
+      iFinder.search = async () => ({
+        results: [{ id: 'doc-1', title: 'Says "hello" & <more>' }],
+        totalFound: 1
+      });
+      iFinder.getContent = async () => ({ content: 'body', contentLength: 4, truncated: false });
+
+      const result = await handler.loadContent({ query: 'manual', user, chatId });
+
+      assert.match(result.content, /title="Says &quot;hello&quot; &amp; &lt;more&gt;"/);
+    });
+  });
+
+  describe('getCacheKey', () => {
+    it('differs per selection and per user', () => {
+      const base = { query: 'manual', maxResults: 5, maxLength: 1000, user };
+      const keyA = handler.getCacheKey(base);
+      const keyB = handler.getCacheKey({ ...base, maxResults: 10 });
+      const keyC = handler.getCacheKey({ ...base, user: { id: 'other' } });
+
+      assert.notStrictEqual(keyA, keyB);
+      assert.notStrictEqual(keyA, keyC);
+    });
+  });
+});

--- a/server/tests/iFinderSourceHandler.test.js
+++ b/server/tests/iFinderSourceHandler.test.js
@@ -233,3 +233,20 @@ describe('IFinderHandler', () => {
     });
   });
 });
+
+describe('iFinderService.getMetadata document ID validation', () => {
+  it('rejects IDs that could inject into the _id query', async () => {
+    // documentId can arrive from model/tool parameters; getMetadata embeds it
+    // in a quoted _id:"…" search expression and must reject unsafe values
+    // before any request is built.
+    const { default: iFinderService } = await import('../services/integrations/iFinderService.js');
+
+    for (const bad of ['doc" OR *:*', 'a/b', '..', 'doc id with spaces']) {
+      await assert.rejects(
+        iFinderService.getMetadata({ documentId: bad, user, chatId }),
+        /Invalid document ID format/,
+        `expected rejection for ${JSON.stringify(bad)}`
+      );
+    }
+  });
+});

--- a/server/tests/source-validation.test.js
+++ b/server/tests/source-validation.test.js
@@ -115,14 +115,65 @@ describe('Source Validation', () => {
   });
 
   describe('iFinder Source Validation', () => {
-    it('should reject iFinder source with missing apiKey', () => {
+    it('should accept iFinder source with a document ID', () => {
       const source = {
         id: 'test-ifinder',
         name: { en: 'Test iFinder' },
         type: 'ifinder',
         config: {
-          baseUrl: 'https://ifinder.example.com',
-          apiKey: ''
+          documentId: 'doc-12345'
+        }
+      };
+
+      const result = validateSourceConfig(source);
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.data.config.documentId, 'doc-12345');
+      // Defaults applied
+      assert.strictEqual(result.data.config.maxResults, 10);
+      assert.strictEqual(result.data.config.maxLength, 10000);
+    });
+
+    it('should accept iFinder source with a search query', () => {
+      const source = {
+        id: 'test-ifinder',
+        name: { en: 'Test iFinder' },
+        type: 'ifinder',
+        config: {
+          query: 'product manual',
+          searchProfile: 'searchprofile-standard',
+          maxResults: 5
+        }
+      };
+
+      const result = validateSourceConfig(source);
+      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.data.config.query, 'product manual');
+      assert.strictEqual(result.data.config.maxResults, 5);
+    });
+
+    it('should reject prompt-exposed iFinder source without documentId or query', () => {
+      const source = {
+        id: 'test-ifinder',
+        name: { en: 'Test iFinder' },
+        type: 'ifinder',
+        exposeAs: 'prompt',
+        config: {}
+      };
+
+      const result = validateSourceConfig(source);
+      assert.strictEqual(result.success, false);
+    });
+
+    it('should treat empty strings as missing document selection', () => {
+      const source = {
+        id: 'test-ifinder',
+        name: { en: 'Test iFinder' },
+        type: 'ifinder',
+        exposeAs: 'prompt',
+        config: {
+          documentId: '',
+          query: '   ',
+          searchProfile: ''
         }
       };
 
@@ -130,19 +181,34 @@ describe('Source Validation', () => {
       assert.strictEqual(result.success, false);
     });
 
-    it('should accept iFinder source with valid config', () => {
+    it('should accept tool-exposed iFinder source without documentId or query', () => {
+      // The model provides documentId/query as tool parameters at call time
+      const source = {
+        id: 'test-ifinder-tool',
+        name: { en: 'Test iFinder Tool' },
+        type: 'ifinder',
+        exposeAs: 'tool',
+        config: {}
+      };
+
+      const result = validateSourceConfig(source);
+      assert.strictEqual(result.success, true);
+    });
+
+    it('should reject legacy connection fields (now provided by the central integration)', () => {
       const source = {
         id: 'test-ifinder',
         name: { en: 'Test iFinder' },
         type: 'ifinder',
         config: {
+          documentId: 'doc-12345',
           baseUrl: 'https://ifinder.example.com',
           apiKey: 'test-key'
         }
       };
 
       const result = validateSourceConfig(source);
-      assert.strictEqual(result.success, true);
+      assert.strictEqual(result.success, false);
     });
   });
 

--- a/server/validators/sourceConfigSchema.js
+++ b/server/validators/sourceConfigSchema.js
@@ -61,15 +61,21 @@ const urlConfigSchema = z
 /**
  * iFinder source configuration schema
  * Complete schema to match IFinderHandler expectations and client form
+ *
+ * Connection settings (base URL, JWT authentication) come from the central
+ * iFinder integration in platform.json — a source only selects which
+ * documents to load: either one pinned document ID or a search query that
+ * loads the top `maxResults` matching documents.
  */
+const emptyStringAsUndefined = value =>
+  typeof value === 'string' && value.trim() === '' ? undefined : value;
+
 const ifinderConfigSchema = z
   .object({
-    baseUrl: z.string().url('Valid base URL is required'),
-    apiKey: z.string().min(1, 'API key is required'),
-    searchProfile: z.string().default('default'),
+    documentId: z.preprocess(emptyStringAsUndefined, z.string().optional()),
+    query: z.preprocess(emptyStringAsUndefined, z.string().optional()),
+    searchProfile: z.preprocess(emptyStringAsUndefined, z.string().optional()),
     maxResults: z.number().min(1).max(100).default(10),
-    queryTemplate: z.string().default(''),
-    filters: z.record(z.any()).default({}),
     maxLength: z.number().positive().default(10000)
   })
   .strict();
@@ -151,7 +157,7 @@ export function validateSourceConfig(source) {
     }
 
     if (validated.type === 'ifinder') {
-      validateIFinderConfig(validated.config);
+      validateIFinderConfig(validated);
     }
 
     if (validated.type === 'page') {
@@ -243,18 +249,18 @@ function validateUrlConfig(config) {
 
 /**
  * Validate iFinder configuration
- * @param {Object} config - iFinder configuration to validate
+ * @param {Object} source - Full validated source (needed to inspect exposeAs)
  */
-function validateIFinderConfig(config) {
-  const { baseUrl } = config;
+function validateIFinderConfig(source) {
+  const { config, exposeAs } = source;
 
-  // Validate base URL protocol
-  const urlObj = new URL(baseUrl);
-  if (!['http:', 'https:'].includes(urlObj.protocol)) {
-    throw new Error('Invalid iFinder base URL: Only HTTP and HTTPS protocols are allowed');
+  // Tool-exposed sources receive documentId/query from the model at call time;
+  // prompt sources must know up front which documents to load.
+  if (exposeAs !== 'tool' && !config.documentId && !config.query) {
+    throw new Error(
+      'iFinder sources exposed as prompt context require either a document ID or a search query'
+    );
   }
-
-  // Additional validation is handled by the Zod schema
 }
 
 /**
@@ -321,12 +327,10 @@ export function getDefaultSourceConfig(type) {
       return {
         ...baseConfig,
         config: {
-          baseUrl: '',
-          apiKey: '',
-          searchProfile: 'default',
+          documentId: '',
+          query: '',
+          searchProfile: '',
           maxResults: 10,
-          queryTemplate: '',
-          filters: {},
           maxLength: 10000
         }
       };

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1977,6 +1977,43 @@
       "externalMappingsPlaceholder": "Gruppennamen eingeben und Enter drücken…",
       "externalMappingsEmpty": "Noch keine externen Zuordnungen",
       "externalMappingsHelp": "Geben Sie externe Gruppennamen ein, die dieser Gruppe zugeordnet werden sollen. Benutzer mit diesen externen Gruppen werden automatisch dieser internen Gruppe zugewiesen."
+    },
+    "sources": {
+      "ifinderConnectionInfo": "Die iFinder-Verbindung (URL und Authentifizierung) wird zentral in den iFinder-Integrationseinstellungen unter Admin → Provider verwaltet. Hier wählen Sie nur aus, welche Dokumente diese Quelle lädt: ein einzelnes Dokument per ID festlegen oder per Suchanfrage die am besten passenden Dokumente laden.",
+      "ifinderDocumentId": "Dokument-ID",
+      "ifinderDocumentIdPlaceholder": "z. B. 5f2c9a1b3d4e…",
+      "ifinderDocumentIdHelp": "Legt diese Quelle auf ein bestimmtes iFinder-Dokument fest. Mit „Verbinden“ laden Sie die Metadaten und prüfen, ob es das richtige Dokument ist.",
+      "ifinderConnect": "Verbinden",
+      "ifinderConnecting": "Verbinde...",
+      "ifinderMetadataFailed": "Dokument-Metadaten konnten nicht geladen werden",
+      "ifinderUntitledDocument": "Unbenanntes Dokument",
+      "ifinderMetaAuthor": "Autor",
+      "ifinderMetaMediaType": "Medientyp",
+      "ifinderMetaFilename": "Dateiname",
+      "ifinderMetaSize": "Größe",
+      "ifinderMetaLanguage": "Sprache",
+      "ifinderMetaModified": "Geändert",
+      "ifinderMetaSource": "Quelle",
+      "ifinderMetaProfile": "Suchprofil",
+      "ifinderOpenDocument": "Dokument öffnen",
+      "ifinderOr": "oder",
+      "ifinderQuery": "Suchanfrage",
+      "ifinderQueryPlaceholder": "z. B. Produkthandbuch OR title:\"Benutzerhandbuch\"",
+      "ifinderQueryHelp": "Dokumente, die dieser Anfrage entsprechen, werden bis zur konfigurierten Höchstzahl als Quelleninhalt geladen. Wird ignoriert, wenn eine Dokument-ID gesetzt ist.",
+      "ifinderTestQuery": "Anfrage testen",
+      "ifinderTestingQuery": "Suche läuft...",
+      "ifinderQueryFailed": "Suchanfrage konnte nicht ausgeführt werden",
+      "ifinderQueryMatches": "{{total}} Dokumente gefunden — die ersten {{shown}} würden geladen",
+      "searchProfile": "Suchprofil",
+      "searchProfilePlaceholder": "Plattform-Standard",
+      "searchProfileHelp": "Leer lassen, um das in der iFinder-Integration konfigurierte Profil zu verwenden.",
+      "maxResults": "Max. Ergebnisse",
+      "maxResultsHelp": "Anzahl der Dokumente, die bei einer Suchanfrage geladen werden.",
+      "maxLength": "Max. Inhaltslänge",
+      "maxLengthHelp": "Maximale Zeichenzahl pro Dokument; längerer Inhalt wird gekürzt.",
+      "validation": {
+        "ifinderContentRequired": "Geben Sie eine Dokument-ID oder eine Suchanfrage an, damit die Quelle weiß, welche Dokumente geladen werden sollen"
+      }
     }
   },
   "cloudStorage": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1724,6 +1724,43 @@
       "externalMappingsPlaceholder": "Type a group name and press Enter…",
       "externalMappingsEmpty": "No external mappings yet",
       "externalMappingsHelp": "Enter external group names that should be mapped to this group. Users with these external groups will automatically be assigned to this internal group."
+    },
+    "sources": {
+      "ifinderConnectionInfo": "The iFinder connection (URL and authentication) is managed centrally in the iFinder integration settings under Admin → Providers. Here you only choose which documents this source loads: pin a single document by ID, or use a search query to load the top matching documents.",
+      "ifinderDocumentId": "Document ID",
+      "ifinderDocumentIdPlaceholder": "e.g. 5f2c9a1b3d4e…",
+      "ifinderDocumentIdHelp": "Pin this source to one specific iFinder document. Use Connect to load its metadata and verify it is the right one.",
+      "ifinderConnect": "Connect",
+      "ifinderConnecting": "Connecting...",
+      "ifinderMetadataFailed": "Failed to load document metadata",
+      "ifinderUntitledDocument": "Untitled document",
+      "ifinderMetaAuthor": "Author",
+      "ifinderMetaMediaType": "Media type",
+      "ifinderMetaFilename": "File name",
+      "ifinderMetaSize": "Size",
+      "ifinderMetaLanguage": "Language",
+      "ifinderMetaModified": "Modified",
+      "ifinderMetaSource": "Source",
+      "ifinderMetaProfile": "Search profile",
+      "ifinderOpenDocument": "Open document",
+      "ifinderOr": "or",
+      "ifinderQuery": "Search Query",
+      "ifinderQueryPlaceholder": "e.g. product manual OR title:\"user guide\"",
+      "ifinderQueryHelp": "Documents matching this query are loaded as source content, up to the configured maximum. Ignored when a document ID is set.",
+      "ifinderTestQuery": "Test Query",
+      "ifinderTestingQuery": "Searching...",
+      "ifinderQueryFailed": "Failed to run search query",
+      "ifinderQueryMatches": "{{total}} documents found — the first {{shown}} would be loaded",
+      "searchProfile": "Search Profile",
+      "searchProfilePlaceholder": "Platform default",
+      "searchProfileHelp": "Leave empty to use the profile configured in the iFinder integration.",
+      "maxResults": "Max Results",
+      "maxResultsHelp": "Number of documents loaded when using a search query.",
+      "maxLength": "Max Content Length",
+      "maxLengthHelp": "Maximum characters loaded per document; longer content is truncated.",
+      "validation": {
+        "ifinderContentRequired": "Provide a document ID or a search query so the source knows which documents to load"
+      }
     }
   },
   "cloudStorage": {

--- a/tests/unit/server/ifinder-source-config.test.js
+++ b/tests/unit/server/ifinder-source-config.test.js
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment node
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  validateSourceConfig,
+  validateSourcesArray,
+  getDefaultSourceConfig
+} from '../../../server/validators/sourceConfigSchema.js';
+
+// The validator logs rejected configs — keep the test output clean.
+jest.mock('../../../server/utils/logger.js', () => ({
+  __esModule: true,
+  default: { debug: jest.fn(), info: jest.fn(), warn: jest.fn(), error: jest.fn() }
+}));
+
+/**
+ * iFinder source configuration schema tests
+ *
+ * iFinder sources no longer carry their own connection settings — the base
+ * URL and JWT authentication come from the central iFinder integration in
+ * platform.json. A source only selects documents: a pinned documentId or a
+ * search query loading the top maxResults matches.
+ */
+
+const baseSource = {
+  id: 'test-ifinder',
+  name: { en: 'Test iFinder' },
+  type: 'ifinder'
+};
+
+describe('iFinder source config schema', () => {
+  it('accepts a source pinned to a document ID and applies defaults', () => {
+    const result = validateSourceConfig({
+      ...baseSource,
+      config: { documentId: 'doc-12345' }
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data.config.documentId).toBe('doc-12345');
+    expect(result.data.config.maxResults).toBe(10);
+    expect(result.data.config.maxLength).toBe(10000);
+    // No injected connection or profile values
+    expect(result.data.config.searchProfile).toBeUndefined();
+  });
+
+  it('accepts a query-based source', () => {
+    const result = validateSourceConfig({
+      ...baseSource,
+      config: { query: 'product manual', maxResults: 5, searchProfile: 'searchprofile-standard' }
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data.config.query).toBe('product manual');
+    expect(result.data.config.maxResults).toBe(5);
+    expect(result.data.config.searchProfile).toBe('searchprofile-standard');
+  });
+
+  it('rejects prompt-exposed sources without a document ID or query', () => {
+    const result = validateSourceConfig({
+      ...baseSource,
+      exposeAs: 'prompt',
+      config: {}
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('treats empty strings as missing values', () => {
+    const result = validateSourceConfig({
+      ...baseSource,
+      exposeAs: 'prompt',
+      config: { documentId: '', query: '   ', searchProfile: '' }
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('allows tool-exposed sources without a document ID or query', () => {
+    // The model supplies documentId/query as tool parameters at call time
+    const result = validateSourceConfig({
+      ...baseSource,
+      exposeAs: 'tool',
+      config: {}
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects the legacy connection fields', () => {
+    const result = validateSourceConfig({
+      ...baseSource,
+      config: {
+        documentId: 'doc-12345',
+        baseUrl: 'https://ifinder.example.com',
+        apiKey: 'secret'
+      }
+    });
+
+    expect(result.success).toBe(false);
+  });
+
+  it('provides a default config without connection settings', () => {
+    const defaults = getDefaultSourceConfig('ifinder');
+
+    expect(defaults.config).toEqual({
+      documentId: '',
+      query: '',
+      searchProfile: '',
+      maxResults: 10,
+      maxLength: 10000
+    });
+  });
+});
+
+describe('shipped default sources', () => {
+  it('validate against the sources schema', () => {
+    const sourcesPath = path.join(process.cwd(), 'server/defaults/config/sources.json');
+    const sources = JSON.parse(fs.readFileSync(sourcesPath, 'utf8'));
+
+    const result = validateSourcesArray(sources);
+    expect(result.success).toBe(true);
+  });
+});


### PR DESCRIPTION
# iFinder sources: use the central integration, pick documents by ID or query

## Motivation

iFinder sources still asked admins for a `baseUrl` and `apiKey`, even though those fields were **never read** — the handler has always connected through the central iFinder integration (`platform.json` → `iFinder`, per-user JWT). Worse, the schema didn't allow the fields the handler actually reads (`documentId`/`query`), and the handler's `validateConfig` demanded runtime `user`/`chatId`, so prompt-exposed iFinder sources always failed validation in `SourceManager.loadSources`.

## What changed

### Source configuration (`server/validators/sourceConfigSchema.js`)
- `ifinder` config is now `{ documentId?, query?, searchProfile?, maxResults (1–100, default 10), maxLength (default 10000) }`.
- `baseUrl`, `apiKey`, `queryTemplate`, `filters` are removed (rejected by the strict schema).
- Prompt-exposed sources must set `documentId` or `query`; tool sources may leave both empty — the model supplies them at call time.
- Empty strings are treated as "not set".

### Handler (`server/sources/IFinderHandler.js`)
- **Query mode now loads up to `maxResults` documents** (was: always 1), fetched in small batches; each document is wrapped in a `<document id title link>` tag inside the source content. Individual failures are skipped and recorded in metadata.
- `documentId` mode keeps the existing single-document behavior (content + metadata + deep link).
- `validateConfig` only checks static config now; the runtime context requirement stays enforced in `loadContent`. This fixes prompt-exposed iFinder sources being rejected before loading.
- Cache key includes `maxResults`/`maxLength`.

### Admin API (`server/routes/admin/sources.js`)
- `POST /api/admin/sources/_ifinder/metadata` — resolves a document ID to curated metadata (title, author, media type, size, dates, deep link) with the requesting admin's identity. Document IDs are validated against the same allowlist used by `iFinderService.resolveDocumentLink` to prevent query injection.
- `POST /api/admin/sources/_ifinder/search` — previews which documents a query would load (`totalFound` + hit list).
- Both work **before the source is saved** (the existing `/:id/test` endpoint requires a saved source), and `testIFinderSource` now tests the configured document/query instead of always searching "test".

### Admin UI (`SourceConfigForm.jsx`)
- URL/API-key fields replaced by: an info banner pointing to the central integration (Admin → Providers), a **Document ID + Connect** button that shows the document metadata card, a **Search Query + Test Query** button that lists the matching documents, and search profile / max results / max content length fields.
- Search profile placeholder makes clear it falls back to the platform-wide default.

### Migration (`V083__simplify_ifinder_source_config.js`)
- Strips `baseUrl`/`apiKey`/`filters` from stored iFinder sources, carries a non-empty `queryTemplate` over to `query`, and drops the auto-injected `searchProfile: "default"` so the platform default applies. Explicit profiles are kept.

### Docs
- `docs/sources.md` updated (config reference, examples, troubleshooting, new endpoints).
- Release notes: feature entry + breaking-change entry (API payloads with the legacy fields are now rejected) in `docs/releases/5.5.0/`.

## Tests

- `tests/unit/server/ifinder-source-config.test.js` (runs in CI via `test:unit`): schema accept/reject matrix incl. legacy-field rejection, defaults, empty-string handling, tool-source exemption; validates shipped default sources.
- `server/tests/iFinderSourceHandler.test.js` (node:test): single-doc mode, multi-doc query mode (batching, wrapper tags, attribute escaping, partial failures, empty results), runtime requirements, cache key.
- `server/tests/source-validation.test.js` updated for the new schema.
- Manual E2E against a running dev server: create/reject flows via `POST /api/admin/sources`, both new endpoints (input validation + clean 400 when the integration is unconfigured), migration verified on legacy configs, client `vite build` passes, `timeout 12s node server/server.js` starts cleanly with V083 applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N2f6FRmtWzjouRh43AW8cM

---
_Generated by [Claude Code](https://claude.ai/code/session_01N2f6FRmtWzjouRh43AW8cM)_