### PR TITLE
 fix(auth): proxy users always get 403 even with allowSelfSignup: true (#2201)

### DIFF
--- a/server/utils/userManager.js
+++ b/server/utils/userManager.js
@@ -432,7 +432,7 @@ export async function validateAndPersistExternalUser(externalUser, platformConfi
       ? 'ldap'
       : externalUser.authMethod === 'ntlm' || externalUser.provider === 'ntlm'
         ? 'ntlm'
-        : externalUser.provider === 'proxy'
+        : externalUser.authMethod === 'proxy' || externalUser.provider === 'proxy'
           ? 'proxy'
           : externalUser.provider === 'teams'
             ? 'teams'


### PR DESCRIPTION
## Summary

- `proxyAuth.allowSelfSignup: true` had no effect — new proxy users always received a 403
- Root cause: `validateAndPersistExternalUser()` checked `externalUser.provider === 'proxy'`
  but `proxyAuth.js` sets `authMethod: 'proxy'` without setting `provider`, causing the
  user to be misidentified as `'oidc'`
- The code then read `oidcAuth` config instead of `proxyAuth`, so `allowSelfSignup` was
  always `undefined → false`

## Fix

Added `externalUser.authMethod === 'proxy'` check alongside the existing `provider` check,
consistent with how NTLM already handles both fields.

## Test plan
- [ ] Set `auth.mode: "proxy"` and `proxyAuth.allowSelfSignup: true` in `platform.json`
- [ ] Authenticate as a new user via reverse proxy (`X-Forwarded-User` header)
- [ ] Verify user is created and login succeeds (no 403)
- [ ] Verify `proxyAuth.allowSelfSignup: false` still blocks new users
- [ ] Verify existing OIDC/NTLM/LDAP self-signup behaviour is unchanged

Closes #2201