### PR TITLE
fix: enable ESLint no-undef and fix the ReferenceError bugs it surfaces

### DIFF
--- a/client/src/auth-gate/auth-gate.js
+++ b/client/src/auth-gate/auth-gate.js
@@ -14,6 +14,7 @@
  * before DOM insertion. Only static template strings and escaped values
  * are used with innerHTML for rendering the login UI.
  */
+/* global __authGateI18n */
 (function authGate() {
   'use strict';
 

--- a/client/src/config/marked.config.js
+++ b/client/src/config/marked.config.js
@@ -114,7 +114,7 @@ const createRenderer = t => {
   };
 
   // --- Link Renderer ---
-  renderer.link = token => {
+  renderer.link = function (token) {
     // In marked v5+, the renderer receives a token object instead of separate parameters
     // Extract href, title, and text from the token
     let actualHref = token.href;

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -53,3 +53,23 @@ a specific model instead of only the app's preferred one.
 - Apps that restrict their models advertise the allowed ids as a fixed choice list.
 - Apps configured to hide model selection do not expose the option.
 - An unknown or incompatible model falls back to the app's preferred model rather than failing.
+
+## Crashes in Error Handlers Fixed
+
+A group of error handlers referenced a variable name that did not exist in that scope, so whenever
+the original problem occurred the handler itself threw a `ReferenceError` instead of logging the
+cause. The real failure was lost, and in a few places a clean failure turned into a hard crash.
+
+- Proxy authentication now logs and recovers from JWKS fetch and JWT verification failures instead of
+  throwing inside the handler.
+- Short link redirects, admin config saves, prompt/skill/style loading, marketplace skill installs,
+  usage rollups, SharePoint drive listing, and workflow execution recovery all log the actual error
+  again.
+- Workflow registry recovery re-throws the original error instead of a `ReferenceError`, so unexpected
+  filesystem problems surface with their real message.
+- An SSE chat connection that fails during setup now reports the error against the right chat id
+  rather than crashing the handler a second time.
+- The tool-calling entry point (`createConverter`, `ToolCallPatterns.*`) threw on every call because
+  the helpers it uses were re-exported but never imported locally. They now work.
+
+Lint now enforces `no-undef`, so this class of bug fails the build rather than shipping.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -47,7 +47,8 @@ export default [
           caughtErrorsIgnorePattern: '^_'
         }
       ],
-      'no-console': 'off'
+      'no-console': 'off',
+      'no-undef': 'error'
       // Removed all formatting rules that conflict with Prettier
       // Prettier handles: indent, quotes, semi, no-multiple-empty-lines, eol-last,
       // comma-dangle, object-curly-spacing, array-bracket-spacing, space-before-function-paren,
@@ -105,6 +106,27 @@ export default [
       globals: {
         ...globals.node,
         ...globals.es2024
+      }
+    }
+  },
+  {
+    files: ['tests/**/*.js', 'tests/**/*.jsx', 'server/tests/**/*.js', '**/__tests__/**/*.js'],
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true
+        }
+      },
+      globals: {
+        ...globals.jest
+      }
+    }
+  },
+  {
+    files: ['browser-extension/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.webextensions
       }
     }
   }

--- a/server/adapters/toolCalling/OpenAIConverter.js
+++ b/server/adapters/toolCalling/OpenAIConverter.js
@@ -382,7 +382,7 @@ export async function convertOpenAIResponseToGeneric(data, streamId = 'default')
             } catch (error) {
               logger.warn('Failed to parse accumulated OpenAI tool arguments', {
                 component: 'OpenAIConverter',
-                error: e
+                error
               });
               parsedArgs = { __raw_arguments: pending.arguments };
             }

--- a/server/adapters/toolCalling/index.js
+++ b/server/adapters/toolCalling/index.js
@@ -20,6 +20,11 @@
  * // Now you have a uniform response format regardless of provider
  */
 
+// Local imports: the re-exports below do NOT bind these names in module scope,
+// and `createConverter` / `ToolCallPatterns` call them directly.
+import { createUnifiedInterface } from './ToolCallingConverter.js';
+import { normalizeToolName } from './GenericToolCalling.js';
+
 // Export main converter interface
 export {
   convertToolsToGeneric,

--- a/server/middleware/proxyAuth.js
+++ b/server/middleware/proxyAuth.js
@@ -18,7 +18,7 @@ async function getJwks(jwkUrl) {
     jwksCache.set(jwkUrl, jwks);
     return jwks;
   } catch (error) {
-    logger.error('Error fetching JWKs', { component: 'ProxyAuth', error: err });
+    logger.error('Error fetching JWKs', { component: 'ProxyAuth', error });
     return null;
   }
 }
@@ -41,7 +41,7 @@ async function verifyJwt(token, provider) {
 
     return payload;
   } catch (error) {
-    logger.error('JWT verification failed', { component: 'ProxyAuth', error: err });
+    logger.error('JWT verification failed', { component: 'ProxyAuth', error });
     return null;
   }
 }

--- a/server/routes/admin/configs.js
+++ b/server/routes/admin/configs.js
@@ -414,7 +414,7 @@ export default function registerAdminConfigRoutes(app) {
             component: 'AdminConfigs'
           });
         } catch (error) {
-          logger.warn('Could not reset iFinder caches', { component: 'AdminConfigs', error: err });
+          logger.warn('Could not reset iFinder caches', { component: 'AdminConfigs', error });
         }
       }
 

--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -348,8 +348,10 @@ export default function registerSessionRoutes(
     chatAuthRequired,
     validate(chatConnectSchema),
     async (req, res) => {
+      // Destructured outside the try so the catch below can still reference
+      // chatId when channel setup throws.
+      const { appId, chatId } = req.params;
       try {
-        const { appId, chatId } = req.params;
         const channel = createSseChannel({
           req,
           res,

--- a/server/routes/shortLinkRoutes.js
+++ b/server/routes/shortLinkRoutes.js
@@ -118,7 +118,7 @@ export default function registerShortLinkRoutes(app) {
       }
       res.redirect(link.url);
     } catch (error) {
-      logger.error('Error redirecting short link', { component: 'ShortLinkRoutes', error: e });
+      logger.error('Error redirecting short link', { component: 'ShortLinkRoutes', error });
       res.status(500).send('Error');
     }
   });

--- a/server/services/PromptService.js
+++ b/server/services/PromptService.js
@@ -375,7 +375,7 @@ class PromptService {
         } catch (error) {
           logger.error('Error loading skills for system prompt', {
             component: 'PromptService',
-            error: err
+            error
           });
         }
       }
@@ -403,7 +403,7 @@ class PromptService {
           logger.error('Error pre-activating skill', {
             component: 'PromptService',
             requestedSkill,
-            error: err
+            error
           });
         }
       }
@@ -422,7 +422,7 @@ class PromptService {
             });
           }
         } catch (error) {
-          logger.error('Error loading styles', { component: 'PromptService', error: err });
+          logger.error('Error loading styles', { component: 'PromptService', error });
         }
       }
 

--- a/server/services/UsageAggregator.js
+++ b/server/services/UsageAggregator.js
@@ -171,7 +171,7 @@ export async function generateDailyRollups() {
     logger.info('Generated daily rollups', { component: 'UsageAggregator', daysGenerated });
     return { eventsProcessed: events.length, daysGenerated };
   } catch (error) {
-    logger.error('Failed to generate daily rollups', { component: 'UsageAggregator', error: e });
+    logger.error('Failed to generate daily rollups', { component: 'UsageAggregator', error });
     return { eventsProcessed: 0, daysGenerated: 0 };
   }
 }
@@ -212,7 +212,7 @@ export async function generateMonthlyRollups() {
     logger.info('Generated monthly rollups', { component: 'UsageAggregator', monthsGenerated });
     return { monthsGenerated };
   } catch (error) {
-    logger.error('Failed to generate monthly rollups', { component: 'UsageAggregator', error: e });
+    logger.error('Failed to generate monthly rollups', { component: 'UsageAggregator', error });
     return { monthsGenerated: 0 };
   }
 }

--- a/server/services/integrations/Office365Service.js
+++ b/server/services/integrations/Office365Service.js
@@ -963,7 +963,7 @@ class Office365Service {
           logger.warn('Could not load drives for site', {
             component: 'Office365Service',
             siteName: site.displayName,
-            error: e
+            error
           });
         }
       }

--- a/server/services/marketplace/ContentInstaller.js
+++ b/server/services/marketplace/ContentInstaller.js
@@ -242,7 +242,7 @@ async function buildSkillContent(item, skillMd, authHeaders) {
     try {
       companions = await registryService.discoverCompanions(item.source.url, authHeaders);
     } catch (error) {
-      logger.warn('Companion discovery fallback failed', { component: COMPONENT, error: err });
+      logger.warn('Companion discovery fallback failed', { component: COMPONENT, error });
     }
   }
 
@@ -278,7 +278,7 @@ async function buildSkillContent(item, skillMd, authHeaders) {
         logger.warn('Failed to fetch companion file', {
           component: COMPONENT,
           relativePath,
-          error: err
+          error
         });
       }
     })

--- a/server/services/workflow/ExecutionRegistry.js
+++ b/server/services/workflow/ExecutionRegistry.js
@@ -435,7 +435,7 @@ export class ExecutionRegistry {
         if (error.code !== 'ENOENT') {
           logger.warn('Error loading registry file, will rebuild from checkpoints', {
             component: 'ExecutionRegistry',
-            error: err
+            error
           });
         }
       }
@@ -515,7 +515,7 @@ export class ExecutionRegistry {
           logger.debug('Skipping directory without valid checkpoint', {
             component: 'ExecutionRegistry',
             executionId,
-            error: err
+            error
           });
         }
       }
@@ -524,7 +524,7 @@ export class ExecutionRegistry {
         // State directory doesn't exist yet, that's fine
         logger.debug('State directory does not exist yet', { component: 'ExecutionRegistry' });
       } else {
-        throw err;
+        throw error;
       }
     }
   }

--- a/server/utils/installationCleanup.js
+++ b/server/utils/installationCleanup.js
@@ -34,7 +34,7 @@ export async function removeMarketplaceInstallation(type, itemId) {
       component: 'InstallationCleanup',
       type,
       itemId,
-      error: err
+      error
     });
   }
 }

--- a/tests/unit/client/outlook-mail-context.test.jsx
+++ b/tests/unit/client/outlook-mail-context.test.jsx
@@ -14,6 +14,7 @@
  *   - Context reads are serialized behind the module's mailbox lock so they
  *     can't interleave with a load/unload cycle.
  */
+/* global Office */
 
 import '@testing-library/jest-dom';
 


### PR DESCRIPTION
## Summary

Review of #1960, reworked onto current `main`. That branch shares **no merge base** with `main` (`git merge-base` returns nothing), so it cannot be merged or rebased — this PR re-applies the same change, corrected and re-verified against today's `main`.

Closes #1762.

`eslint.config.js` never pulled in `@eslint/js`'s recommended rules, so `no-undef` was silently off repo-wide. That let a class of `ReferenceError` bugs ship — mostly `catch (error) { … error: err }` typos where the logged name doesn't match the bound catch parameter, so the handler itself throws and the real cause is lost.

### Changes

- **`eslint.config.js`**: `'no-undef': 'error'`, plus scoped `globals` blocks so it doesn't false-positive — Jest globals (and JSX parsing) for `tests/**`, `server/tests/**`, `**/__tests__/**`; `webextensions` for `browser-extension/**` (needed for `chrome.*` in `background.js`).
- **17 catch-parameter typos** fixed across `proxyAuth.js`, `PromptService.js` (×3), `UsageAggregator.js` (×2), `ExecutionRegistry.js` (×3), `shortLinkRoutes.js`, `admin/configs.js`, `Office365Service.js`, `ContentInstaller.js` (×2), `installationCleanup.js`, `OpenAIConverter.js` — including a `throw err` that masked the real error with a `ReferenceError`.
- **`server/routes/chat/sessionRoutes.js`**: `chatId` was destructured *inside* the `try`, so the sibling `catch` couldn't see it. Moved above the `try`.
- **`server/adapters/toolCalling/index.js`**: `createUnifiedInterface` / `normalizeToolName` were only re-exported (`export { x } from './y.js'`), which does not bind them in module scope — `createConverter()` and every `ToolCallPatterns` factory threw on call. Added local imports.
- **`client/src/config/marked.config.js`**: the link renderer's legacy-argument branch read `arguments` from an arrow function. Converted to a function expression; `this` is unused, so behaviour is otherwise unchanged.
- **Genuine runtime globals annotated, not "fixed"**: `__authGateI18n` (inlined by the Vite auth-gate plugin) and `Office` in the Outlook test — matching the `/* global Office */` convention already used in the module under test.
- **`docs/releases/5.5.0/fixes.md`**: changelog entry.

### Differences from #1960

- `PromptNodeExecutor.js` (the `nativeWebSearch` threading) is **not** included — that already landed on `main`, with a `= null` default this PR's original version lacked.
- Verified that the two `.catch(e => … error: e)` call sites in `UsageAggregator.js` (lines 386/390) are **correct as-is** — `e` is a bound arrow parameter there, not a typo. A blanket rename would have broken them.

## Test plan

- [x] `npx eslint .` — **0 errors** (647 pre-existing warnings, all `no-unused-vars`/a11y, unrelated)
- [x] `npx prettier --check` on every touched file — clean
- [x] `npm run test:unit` — **34/34 suites, 330/330 tests pass**
- [x] Smoke-tested `createConverter('openai')` and `ToolCallPatterns.createTextTool()` — both threw `ReferenceError` on `main`, both work now
- [x] Differential test of the marked link renderer (relative + external links, title, `rel`) — byte-identical output before and after the arrow→function change
- [x] `node server/server.js` boots and listens; no new startup errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01AwYj48xmFXNP2mKSSoVawt)_