### PR TITLE
fix(admin): audit log filters now apply, with checkbox multi-select (#2213)

### DIFF
--- a/client/src/features/admin/components/data-table/DataTable.jsx
+++ b/client/src/features/admin/components/data-table/DataTable.jsx
@@ -96,8 +96,11 @@ function DataTable({
   };
   const handlePageSizeChange = next => {
     if (isServerPaged) {
+      // Only one callback, deliberately: a server-paged page usually keeps both
+      // values in the URL, and two navigations in the same tick lose the first
+      // (React Router's setSearchParams does not queue). Resetting to page 1 is
+      // therefore the consumer's job, inside its own onPageSizeChange.
       paginationConfig.onPageSizeChange && paginationConfig.onPageSizeChange(next);
-      paginationConfig.onPageChange(1);
     } else {
       setInternalPageSize(next);
       setInternalPage(1);

--- a/client/src/features/admin/components/data-table/filters/FilterMultiSelect.jsx
+++ b/client/src/features/admin/components/data-table/filters/FilterMultiSelect.jsx
@@ -1,0 +1,264 @@
+import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Icon from '../../../../../shared/components/Icon';
+
+// Above this many options the popover grows a type-ahead box.
+const SEARCH_THRESHOLD = 10;
+
+/**
+ * FilterMultiSelect — checkbox filter for a table's filter row.
+ *
+ * A trigger button showing how much of the vocabulary is currently selected,
+ * opening a popover with one checkbox per option (each with its entry count),
+ * plus **Select all** / **Select none** and, for long lists, a type-ahead.
+ *
+ * The control is fully controlled: it never derives state from its own
+ * interactions. `selected` is the list of currently selected option values and
+ * `onChange` receives the complete next list, so the page decides how that maps
+ * onto its URL parameters.
+ *
+ * Options are usually server-computed facets, so an option's `count` tells the
+ * admin what a checkbox is worth before they untick it.
+ *
+ * @param {object} props
+ * @param {string} props.label - Field label rendered above the trigger
+ * @param {Array<{value: string, label?: string, count?: number}>} props.options - Available values
+ * @param {string[]} props.selected - Currently selected option values
+ * @param {(next: string[]) => void} props.onChange - Receives the full next selection
+ * @param {string} [props.allLabel] - Trigger text when everything is selected
+ * @param {string} [props.noneLabel] - Trigger text when nothing is selected
+ * @param {string} [props.searchPlaceholder] - Type-ahead placeholder
+ * @param {string} [props.emptyLabel] - Shown when there are no options at all
+ * @param {boolean} [props.disabled=false]
+ * @param {string} [props.className]
+ */
+function FilterMultiSelect({
+  label,
+  options = [],
+  selected = [],
+  onChange,
+  allLabel,
+  noneLabel,
+  searchPlaceholder,
+  emptyLabel,
+  disabled = false,
+  className = ''
+}) {
+  const { t } = useTranslation();
+  const baseId = useId();
+  const containerRef = useRef(null);
+  const triggerRef = useRef(null);
+  const listRef = useRef(null);
+  const searchRef = useRef(null);
+
+  const [open, setOpen] = useState(false);
+  const [term, setTerm] = useState('');
+
+  const selectedSet = useMemo(() => new Set(selected), [selected]);
+  const allSelected = options.length > 0 && selectedSet.size >= options.length;
+  const noneSelected = selectedSet.size === 0;
+
+  const showSearch = options.length > SEARCH_THRESHOLD;
+  const visibleOptions = useMemo(() => {
+    const needle = term.trim().toLowerCase();
+    if (!needle) return options;
+    return options.filter(o =>
+      String(o.label ?? o.value)
+        .toLowerCase()
+        .includes(needle)
+    );
+  }, [options, term]);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setTerm('');
+    triggerRef.current?.focus();
+  }, []);
+
+  // Dismiss on click outside. Registered only while open.
+  useEffect(() => {
+    if (!open) return undefined;
+    const onPointerDown = event => {
+      if (!containerRef.current?.contains(event.target)) {
+        setOpen(false);
+        setTerm('');
+      }
+    };
+    document.addEventListener('mousedown', onPointerDown);
+    return () => document.removeEventListener('mousedown', onPointerDown);
+  }, [open]);
+
+  // Move focus into the popover so the keyboard path works without a mouse.
+  useEffect(() => {
+    if (!open) return;
+    const target = showSearch
+      ? searchRef.current
+      : listRef.current?.querySelector('input[type="checkbox"]');
+    target?.focus();
+  }, [open, showSearch]);
+
+  const toggleValue = value => {
+    const next = new Set(selectedSet);
+    if (next.has(value)) next.delete(value);
+    else next.add(value);
+    // Preserve the option order rather than the click order, so the emitted
+    // list is stable and comparable.
+    onChange?.(options.filter(o => next.has(o.value)).map(o => o.value));
+  };
+
+  // Arrow keys move between checkboxes, Escape closes and returns focus. Bound
+  // natively on the container while open so it catches keys from the
+  // type-ahead box and the select-all/none buttons as well.
+  useEffect(() => {
+    if (!open) return undefined;
+    const container = containerRef.current;
+    if (!container) return undefined;
+    const onKeyDown = event => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        close();
+        return;
+      }
+      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+      const boxes = Array.from(
+        listRef.current?.querySelectorAll('input[type="checkbox"]:not([disabled])') ?? []
+      );
+      if (boxes.length === 0) return;
+      event.preventDefault();
+      const current = boxes.indexOf(document.activeElement);
+      const delta = event.key === 'ArrowDown' ? 1 : -1;
+      const next = current === -1 ? 0 : (current + delta + boxes.length) % boxes.length;
+      boxes[next].focus();
+    };
+    container.addEventListener('keydown', onKeyDown);
+    return () => container.removeEventListener('keydown', onKeyDown);
+  }, [open, close]);
+
+  const triggerText = allSelected
+    ? (allLabel ?? t('admin.filters.multiSelect.all', 'All'))
+    : noneSelected
+      ? (noneLabel ?? t('admin.filters.multiSelect.none', 'None'))
+      : t('admin.filters.multiSelect.someSelected', '{{selected}} of {{total}}', {
+          selected: selectedSet.size,
+          total: options.length
+        });
+
+  const filtered = !allSelected;
+
+  return (
+    <div className={className} ref={containerRef}>
+      {/* A plain span, not a <label>: the trigger's accessible name is built
+          from the field name *and* the button's own text via aria-labelledby,
+          so a screen reader announces "Action, 3 of 8". */}
+      <span
+        id={`${baseId}-label`}
+        className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+      >
+        {label}
+      </span>
+      <div className="relative">
+        <button
+          id={`${baseId}-trigger`}
+          ref={triggerRef}
+          type="button"
+          disabled={disabled || options.length === 0}
+          onClick={() => setOpen(v => !v)}
+          onKeyDown={event => {
+            if (event.key === 'ArrowDown' && !open) {
+              event.preventDefault();
+              setOpen(true);
+            }
+          }}
+          aria-haspopup="true"
+          aria-expanded={open}
+          aria-labelledby={`${baseId}-label ${baseId}-trigger`}
+          className={`w-full inline-flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${
+            filtered
+              ? 'border-indigo-400 dark:border-indigo-500'
+              : 'border-gray-300 dark:border-gray-600'
+          }`}
+        >
+          <span className="truncate">
+            {options.length === 0
+              ? (emptyLabel ?? t('admin.filters.multiSelect.noOptions', 'No values'))
+              : triggerText}
+          </span>
+          <Icon name="chevron-down" size="sm" className="flex-shrink-0 text-gray-400" />
+        </button>
+
+        {open && (
+          <div
+            role="group"
+            aria-labelledby={`${baseId}-label`}
+            className="absolute z-20 mt-1 w-full min-w-[14rem] rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 shadow-lg"
+          >
+            <div className="flex items-center justify-between gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-700">
+              <button
+                type="button"
+                onClick={() => onChange?.(options.map(o => o.value))}
+                disabled={allSelected}
+                className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline disabled:opacity-40 disabled:no-underline"
+              >
+                {t('admin.filters.multiSelect.selectAll', 'Select all')}
+              </button>
+              <button
+                type="button"
+                onClick={() => onChange?.([])}
+                disabled={noneSelected}
+                className="text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline disabled:opacity-40 disabled:no-underline"
+              >
+                {t('admin.filters.multiSelect.selectNone', 'Select none')}
+              </button>
+            </div>
+
+            {showSearch && (
+              <div className="px-2 pt-2">
+                <input
+                  ref={searchRef}
+                  type="search"
+                  value={term}
+                  onChange={e => setTerm(e.target.value)}
+                  placeholder={
+                    searchPlaceholder ?? t('admin.filters.multiSelect.search', 'Filter…')
+                  }
+                  aria-label={searchPlaceholder ?? t('admin.filters.multiSelect.search', 'Filter…')}
+                  className="w-full rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-2 py-1 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                />
+              </div>
+            )}
+
+            <div ref={listRef} className="max-h-64 overflow-y-auto py-1">
+              {visibleOptions.length === 0 ? (
+                <p className="px-3 py-2 text-sm text-gray-500 dark:text-gray-400">
+                  {t('admin.filters.multiSelect.noMatches', 'No matching values')}
+                </p>
+              ) : (
+                visibleOptions.map(option => (
+                  <label
+                    key={option.value}
+                    className="flex items-center gap-2 px-3 py-1.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700/50 cursor-pointer"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={selectedSet.has(option.value)}
+                      onChange={() => toggleValue(option.value)}
+                      className="h-4 w-4 rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-indigo-500"
+                    />
+                    <span className="flex-1 truncate">{option.label ?? option.value}</span>
+                    {option.count !== undefined && (
+                      <span className="text-xs text-gray-500 dark:text-gray-400 tabular-nums">
+                        {option.count}
+                      </span>
+                    )}
+                  </label>
+                ))
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default FilterMultiSelect;

--- a/client/src/features/admin/components/data-table/filters/FilterMultiSelect.jsx
+++ b/client/src/features/admin/components/data-table/filters/FilterMultiSelect.jsx
@@ -169,7 +169,9 @@ function FilterMultiSelect({
               setOpen(true);
             }
           }}
-          aria-haspopup="true"
+          // No aria-haspopup: this is a disclosure, not a menu or a dialog, and
+          // the value would have to name the popup's actual role. aria-expanded
+          // alone describes it correctly.
           aria-expanded={open}
           aria-labelledby={`${baseId}-label ${baseId}-trigger`}
           className={`w-full inline-flex items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 ${

--- a/client/src/features/admin/components/data-table/index.js
+++ b/client/src/features/admin/components/data-table/index.js
@@ -11,6 +11,7 @@ export { default as DataTableLoadingRows } from './DataTableLoadingRows';
 
 export { default as SearchInput } from './filters/SearchInput';
 export { default as FilterSelect } from './filters/FilterSelect';
+export { default as FilterMultiSelect } from './filters/FilterMultiSelect';
 
 export {
   formatSortParam,

--- a/client/src/features/admin/components/data-table/useTablePagination.js
+++ b/client/src/features/admin/components/data-table/useTablePagination.js
@@ -16,6 +16,11 @@ export function usePagedRows(rows, page, pageSize) {
 /**
  * Normalize pagination config into a uniform internal shape used by DataTable.
  * `false` → disabled. Falsy/undefined → defaults to client mode.
+ *
+ * In `server` mode the consumer owns `page`/`pageSize` and must reset the page
+ * itself when the page size changes — DataTable calls `onPageSizeChange` only,
+ * never `onPageChange` alongside it, so a consumer that keeps both values in
+ * the URL can write them in a single navigation.
  */
 export function normalizePagination(pagination) {
   if (pagination === false) return null;

--- a/client/src/features/admin/hooks/useFilterState.js
+++ b/client/src/features/admin/hooks/useFilterState.js
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 /**
@@ -11,6 +11,13 @@ import { useSearchParams } from 'react-router-dom';
  *
  * Usage:
  *   const [status, setStatus] = useFilterState('status', 'all');
+ *
+ * ⚠️ Never call two of these setters in the same tick. React Router's
+ * `setSearchParams` does not queue the way React's `setState` does — the
+ * functional updater receives the *render-time* params, not the result of a
+ * setter called moments earlier — so the second call silently discards the
+ * first. Use {@link useFilterParams} when a single interaction has to change
+ * more than one parameter (for example a filter plus a page reset).
  */
 export function useFilterState(paramName, defaultValue = '') {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -36,4 +43,75 @@ export function useFilterState(paramName, defaultValue = '') {
   );
 
   return [value, setValue];
+}
+
+/**
+ * URL-persisted filter state for pages that change several parameters at once.
+ *
+ * `setMany` applies every update in a **single** `setSearchParams` call, which
+ * is what makes it safe where {@link useFilterState} is not: chaining two
+ * `useFilterState` setters loses the first one (see the warning there).
+ *
+ * A value of `null`, `undefined`, `''`, an empty array, or the parameter's
+ * default removes the parameter. An array writes repeated parameters
+ * (`?actor=a&actor=b`), which is how multi-value filters over values that may
+ * contain a comma are encoded.
+ *
+ * @param {Record<string, string>} [defaults]  Per-parameter default values;
+ *   a parameter equal to its default is omitted from the URL.
+ * @returns {{
+ *   searchParams: URLSearchParams,
+ *   get: (name: string) => string,
+ *   getAll: (name: string) => string[],
+ *   setMany: (updates: Record<string, string|string[]|null>) => void
+ * }}
+ *
+ * Usage:
+ *   const { get, setMany } = useFilterParams({ page: '1' });
+ *   setMany({ resource: 'app', page: null });   // one navigation
+ */
+export function useFilterParams(defaults = {}) {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  // Callers pass an object literal, so keep `setMany` stable across renders by
+  // reading the latest defaults through a ref instead of a dependency.
+  const defaultsRef = useRef(defaults);
+  defaultsRef.current = defaults;
+
+  const get = useCallback(
+    name => searchParams.get(name) ?? defaultsRef.current[name] ?? '',
+    [searchParams]
+  );
+
+  const getAll = useCallback(name => searchParams.getAll(name), [searchParams]);
+
+  const setMany = useCallback(
+    updates => {
+      setSearchParams(
+        prev => {
+          const next = new URLSearchParams(prev);
+          for (const [name, value] of Object.entries(updates)) {
+            next.delete(name);
+            if (Array.isArray(value)) {
+              for (const item of value) {
+                if (item !== null && item !== undefined && item !== '') next.append(name, item);
+              }
+            } else if (
+              value !== null &&
+              value !== undefined &&
+              value !== '' &&
+              value !== defaultsRef.current[name]
+            ) {
+              next.set(name, String(value));
+            }
+          }
+          return next;
+        },
+        { replace: true }
+      );
+    },
+    [setSearchParams]
+  );
+
+  return { searchParams, get, getAll, setMany };
 }

--- a/client/src/features/admin/pages/AdminAuditLogPage.jsx
+++ b/client/src/features/admin/pages/AdminAuditLogPage.jsx
@@ -29,10 +29,14 @@ const RESULT_PILL_COLORS = {
   failure: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
 };
 
+const PAGE_SIZE_OPTIONS = [25, 50, 100, 200];
 const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = Math.max(...PAGE_SIZE_OPTIONS);
 
-// Default window. One day keeps the first page load to one or two daily files;
-// the date inputs and the range presets widen it.
+// The date filter has whole-day granularity: `from`/`to` select calendar days
+// in UTC, and the server picks daily files by name without a timestamp cutoff.
+// The default spans today and yesterday rather than today alone, so the table
+// is not near-empty just after midnight.
 const DEFAULT_RANGE_DAYS = 1;
 
 // Actions the "hide sign-in noise" preset excludes — the ticket's actual
@@ -63,25 +67,25 @@ function formatTimestamp(timestamp) {
   return new Date(timestamp).toLocaleString();
 }
 
-function ActionPill({ action }) {
+function ActionPill({ action, label }) {
   const colorClass = ACTION_PILL_COLORS[action] || DEFAULT_PILL_COLOR;
   return (
     <span
       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colorClass}`}
     >
-      {action}
+      {label ?? action}
     </span>
   );
 }
 
-function ResultPill({ result }) {
+function ResultPill({ result, label }) {
   const value = result || 'success';
   const colorClass = RESULT_PILL_COLORS[value] || DEFAULT_PILL_COLOR;
   return (
     <span
       className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${colorClass}`}
     >
-      {value}
+      {label ?? value}
     </span>
   );
 }
@@ -257,7 +261,12 @@ function AdminAuditLogPage() {
   const toDate = get('to');
   const queryText = get('q');
   const page = Math.max(1, parseInt(get('page'), 10) || 1);
-  const pageSize = Math.max(1, parseInt(get('pageSize'), 10) || DEFAULT_PAGE_SIZE);
+  // Clamped to what the table offers: the server caps `limit`, so a larger
+  // URL value would page over rows it never returns and strand the tail.
+  const pageSize = Math.min(
+    MAX_PAGE_SIZE,
+    Math.max(1, parseInt(get('pageSize'), 10) || DEFAULT_PAGE_SIZE)
+  );
   const offset = (page - 1) * pageSize;
 
   // The include/exclude sets currently in the URL, per field.
@@ -457,12 +466,14 @@ function AdminAuditLogPage() {
     {
       key: 'action',
       header: t('admin.auditLog.actionColumn', 'Action'),
-      render: e => <ActionPill action={e.action} />
+      render: e => <ActionPill action={e.action} label={valueLabel('action', e.action)} />
     },
     {
       key: 'result',
       header: t('admin.auditLog.resultColumn', 'Result'),
-      render: e => <ResultPill result={e.result} />
+      render: e => (
+        <ResultPill result={e.result} label={valueLabel('result', e.result ?? 'success')} />
+      )
     },
     {
       key: 'resource',
@@ -477,7 +488,9 @@ function AdminAuditLogPage() {
       header: t('admin.auditLog.sourceColumn', 'Source'),
       hideBelow: 'lg',
       render: e => (
-        <span className="text-sm text-gray-600 dark:text-gray-300">{e.source || '-'}</span>
+        <span className="text-sm text-gray-600 dark:text-gray-300">
+          {e.source ? valueLabel('source', e.source) : '-'}
+        </span>
       )
     },
     {
@@ -531,10 +544,16 @@ function AdminAuditLogPage() {
             {t('admin.auditLog.presets.label', 'Quick filters')}
           </span>
           <PresetChip
+            active={fromDate === getDefaultToDate() && toDate === getDefaultToDate()}
+            onClick={() => applyFilter({ from: getDefaultToDate(), to: getDefaultToDate() })}
+          >
+            {t('admin.auditLog.presets.today', 'Today')}
+          </PresetChip>
+          <PresetChip
             active={fromDate === daysAgo(1) && toDate === getDefaultToDate()}
             onClick={() => applyFilter({ from: daysAgo(1), to: getDefaultToDate() })}
           >
-            {t('admin.auditLog.presets.last24h', 'Last 24 hours')}
+            {t('admin.auditLog.presets.todayAndYesterday', 'Today & yesterday')}
           </PresetChip>
           <PresetChip
             active={fromDate === daysAgo(7) && toDate === getDefaultToDate()}
@@ -671,7 +690,7 @@ function AdminAuditLogPage() {
           pageSize,
           onPageChange: p => setMany({ page: String(p) }),
           onPageSizeChange: size => setMany({ pageSize: String(size), page: null }),
-          pageSizeOptions: [25, 50, 100, 200]
+          pageSizeOptions: PAGE_SIZE_OPTIONS
         }}
         empty={{
           icon: 'document-search',

--- a/client/src/features/admin/pages/AdminAuditLogPage.jsx
+++ b/client/src/features/admin/pages/AdminAuditLogPage.jsx
@@ -1,8 +1,17 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { makeAdminApiCall } from '../../../api/adminApi';
-import { useFilterState } from '../hooks/useFilterState';
-import { DataTable, FilterSelect } from '../components/data-table';
+import { useFilterParams } from '../hooks/useFilterState';
+import { DataTable, FilterMultiSelect, SearchInput } from '../components/data-table';
+import {
+  FILTER_FIELDS,
+  encodeSelection,
+  isFieldFiltered,
+  mergeFilterOptions,
+  parseFilterParam,
+  selectedOptionValues,
+  setExcluded
+} from '../utils/auditLogFilters';
 
 const ACTION_PILL_COLORS = {
   create: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
@@ -15,39 +24,6 @@ const ACTION_PILL_COLORS = {
 
 const DEFAULT_PILL_COLOR = 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-300';
 
-const RESOURCE_TYPES = [
-  'all',
-  'app',
-  'group',
-  'model',
-  'prompt',
-  'platform',
-  'backup',
-  'source',
-  'feature',
-  'provider',
-  'auth',
-  'user',
-  'oauthClient',
-  'oauthToken'
-];
-
-const ACTION_TYPES = [
-  'all',
-  'create',
-  'update',
-  'delete',
-  'toggle',
-  'import',
-  'export',
-  'login',
-  'logout'
-];
-
-const RESULT_TYPES = ['all', 'success', 'failure'];
-
-const SOURCE_TYPES = ['all', 'web', 'admin', 'api', 'mcp'];
-
 const RESULT_PILL_COLORS = {
   success: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
   failure: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400'
@@ -55,10 +31,27 @@ const RESULT_PILL_COLORS = {
 
 const DEFAULT_PAGE_SIZE = 50;
 
-function getDefaultFromDate() {
+// Default window. One day keeps the first page load to one or two daily files;
+// the date inputs and the range presets widen it.
+const DEFAULT_RANGE_DAYS = 1;
+
+// Actions the "hide sign-in noise" preset excludes — the ticket's actual
+// complaint is that logins drown out everything else.
+const NOISY_ACTIONS = ['login', 'logout'];
+
+// Closed vocabularies worth translating. `resource` and `actor` are open-ended
+// (the audit middleware derives resource names from request paths), so their
+// values are shown verbatim.
+const TRANSLATED_VALUE_FIELDS = new Set(['action', 'result', 'source']);
+
+function daysAgo(days) {
   const date = new Date();
-  date.setDate(date.getDate() - 7);
+  date.setDate(date.getDate() - days);
   return date.toISOString().split('T')[0];
+}
+
+function getDefaultFromDate() {
+  return daysAgo(DEFAULT_RANGE_DAYS);
 }
 
 function getDefaultToDate() {
@@ -90,6 +83,25 @@ function ResultPill({ result }) {
     >
       {value}
     </span>
+  );
+}
+
+/** A one-click filter shortcut. Reflects whether its filter is currently on. */
+function PresetChip({ active, onClick, children, ariaLabel }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={ariaLabel}
+      className={`inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+        active
+          ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:border-indigo-400 dark:bg-indigo-900/30 dark:text-indigo-300'
+          : 'border-gray-300 bg-white text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700'
+      }`}
+    >
+      {children}
+    </button>
   );
 }
 
@@ -208,49 +220,97 @@ function SummaryCell({ entry, expanded, onToggle, t }) {
   );
 }
 
+const EMPTY_FACETS = Object.freeze({
+  actor: [],
+  resource: [],
+  action: [],
+  result: [],
+  source: []
+});
+
 function AdminAuditLogPage() {
   const { t } = useTranslation();
 
   const [entries, setEntries] = useState([]);
   const [total, setTotal] = useState(0);
+  const [facets, setFacets] = useState(EMPTY_FACETS);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-
-  const [fromDate, setFromDate] = useFilterState('from', getDefaultFromDate());
-  const [toDate, setToDate] = useFilterState('to', getDefaultToDate());
-  const [actorFilter, setActorFilter] = useFilterState('actor', 'all');
-  const [resourceFilter, setResourceFilter] = useFilterState('resource', 'all');
-  const [actionFilter, setActionFilter] = useFilterState('action', 'all');
-  const [resultFilter, setResultFilter] = useFilterState('result', 'all');
-  const [sourceFilter, setSourceFilter] = useFilterState('source', 'all');
-  const [pageParam, setPageParam] = useFilterState('page', '1');
-  const [pageSizeParam, setPageSizeParam] = useFilterState('pageSize', String(DEFAULT_PAGE_SIZE));
-
-  const page = Math.max(1, parseInt(pageParam, 10) || 1);
-  const pageSize = Math.max(1, parseInt(pageSizeParam, 10) || DEFAULT_PAGE_SIZE);
-  const offset = (page - 1) * pageSize;
-
-  const [expandedRows, setExpandedRows] = useState(new Set());
-  const [actorList, setActorList] = useState([]);
+  const [expandedRows, setExpandedRows] = useState(() => new Set());
   const [exporting, setExporting] = useState(false);
 
-  const buildFilterParams = useCallback(() => {
+  // A filter change also has to reset the page, and React Router's
+  // setSearchParams does not queue: two calls in one tick lose the first. Every
+  // update below therefore goes through a single setMany().
+  const defaults = useMemo(
+    () => ({
+      from: getDefaultFromDate(),
+      to: getDefaultToDate(),
+      page: '1',
+      pageSize: String(DEFAULT_PAGE_SIZE)
+    }),
+    []
+  );
+  const { searchParams, get, getAll, setMany } = useFilterParams(defaults);
+
+  const fromDate = get('from');
+  const toDate = get('to');
+  const queryText = get('q');
+  const page = Math.max(1, parseInt(get('page'), 10) || 1);
+  const pageSize = Math.max(1, parseInt(get('pageSize'), 10) || DEFAULT_PAGE_SIZE);
+  const offset = (page - 1) * pageSize;
+
+  // The include/exclude sets currently in the URL, per field.
+  const filterSets = useMemo(() => {
+    const sets = {};
+    for (const field of FILTER_FIELDS) {
+      sets[field] = {
+        include: parseFilterParam(getAll(field), field),
+        exclude: parseFilterParam(getAll(`${field}Exclude`), field)
+      };
+    }
+    return sets;
+  }, [getAll]);
+
+  // Checkbox options come from the server-computed facets for the date range,
+  // unioned with any value the current filter names, so an active filter is
+  // always visible in the list that produced it.
+  const filterOptions = useMemo(() => {
+    const options = {};
+    for (const field of FILTER_FIELDS) {
+      const { include, exclude } = filterSets[field];
+      options[field] = mergeFilterOptions(facets[field], include, exclude);
+    }
+    return options;
+  }, [facets, filterSets]);
+
+  const anyFilterActive =
+    FILTER_FIELDS.some(field =>
+      isFieldFiltered(filterSets[field].include, filterSets[field].exclude)
+    ) ||
+    Boolean(queryText) ||
+    fromDate !== defaults.from ||
+    toDate !== defaults.to;
+
+  // The filter parameters, verbatim, are also the API parameters — so a shared
+  // URL, the table and a CSV export can never disagree.
+  const filterQuery = useMemo(() => {
     const params = new URLSearchParams();
     if (fromDate) params.set('from', fromDate);
     if (toDate) params.set('to', toDate);
-    if (actorFilter && actorFilter !== 'all') params.set('actor', actorFilter);
-    if (resourceFilter && resourceFilter !== 'all') params.set('resource', resourceFilter);
-    if (actionFilter && actionFilter !== 'all') params.set('action', actionFilter);
-    if (resultFilter && resultFilter !== 'all') params.set('result', resultFilter);
-    if (sourceFilter && sourceFilter !== 'all') params.set('source', sourceFilter);
-    return params;
-  }, [fromDate, toDate, actorFilter, resourceFilter, actionFilter, resultFilter, sourceFilter]);
+    for (const field of FILTER_FIELDS) {
+      for (const name of [field, `${field}Exclude`]) {
+        for (const value of searchParams.getAll(name)) params.append(name, value);
+      }
+    }
+    if (queryText) params.set('q', queryText);
+    return params.toString();
+  }, [searchParams, fromDate, toDate, queryText]);
 
   const handleExport = useCallback(async () => {
     setExporting(true);
     try {
-      const params = buildFilterParams();
-      const response = await makeAdminApiCall(`/admin/audit-log/export?${params.toString()}`, {
+      const response = await makeAdminApiCall(`/admin/audit-log/export?${filterQuery}`, {
         responseType: 'blob'
       });
       const blob = new Blob([response.data], { type: 'text/csv' });
@@ -271,7 +331,7 @@ function AdminAuditLogPage() {
     } finally {
       setExporting(false);
     }
-  }, [buildFilterParams, t]);
+  }, [filterQuery, t]);
 
   const toggleRow = id => {
     setExpandedRows(prev => {
@@ -286,30 +346,19 @@ function AdminAuditLogPage() {
     setLoading(true);
     setError(null);
     try {
-      const params = buildFilterParams();
+      const params = new URLSearchParams(filterQuery);
       params.set('limit', String(pageSize));
       params.set('offset', String(offset));
+      // Facets are computed in the same file scan as the query, so asking for
+      // them does not cost a second pass over the log.
+      params.set('facets', '1');
 
       const response = await makeAdminApiCall(`/admin/audit-log?${params.toString()}`);
       const data = response.data;
 
       setEntries(data.entries || []);
       setTotal(data.total || 0);
-
-      if (data.entries && data.entries.length > 0) {
-        setActorList(prev => {
-          const existing = new Set(prev);
-          for (const entry of data.entries) {
-            const name = entry.actor?.username ?? entry.admin;
-            if (name) existing.add(name);
-          }
-          const sorted = Array.from(existing).sort();
-          if (sorted.length !== prev.length || sorted.some((v, i) => v !== prev[i])) {
-            return sorted;
-          }
-          return prev;
-        });
-      }
+      if (data.facets) setFacets(data.facets);
     } catch (err) {
       setError(
         err.response?.data?.error ||
@@ -319,16 +368,73 @@ function AdminAuditLogPage() {
     } finally {
       setLoading(false);
     }
-  }, [buildFilterParams, offset, pageSize, t]);
+  }, [filterQuery, offset, pageSize, t]);
 
   useEffect(() => {
     fetchEntries();
   }, [fetchEntries]);
 
-  const handleFilterChange = setter => value => {
-    setter(value);
-    setPageParam('1');
-  };
+  /** Apply filter updates and return to page 1, in one navigation. */
+  const applyFilter = useCallback(updates => setMany({ ...updates, page: null }), [setMany]);
+
+  const handleSelectionChange = useCallback(
+    (field, selected) => applyFilter(encodeSelection(field, filterOptions[field], selected)),
+    [applyFilter, filterOptions]
+  );
+
+  const clearAllFilters = useCallback(() => {
+    const updates = { from: null, to: null, q: null, page: null };
+    for (const field of FILTER_FIELDS) {
+      updates[field] = null;
+      updates[`${field}Exclude`] = null;
+    }
+    setMany(updates);
+  }, [setMany]);
+
+  const noiseHidden = NOISY_ACTIONS.every(a => filterSets.action.exclude?.has(a));
+  const failuresOnly =
+    filterSets.result.include?.size === 1 && filterSets.result.include.has('failure');
+
+  const valueLabel = useCallback(
+    (field, value) =>
+      TRANSLATED_VALUE_FIELDS.has(field)
+        ? t(`admin.auditLog.values.${field}.${value}`, value)
+        : value,
+    [t]
+  );
+
+  const filterControls = [
+    {
+      field: 'actor',
+      label: t('admin.auditLog.filters.actor', 'Actor'),
+      allLabel: t('admin.auditLog.filters.allActors', 'All actors'),
+      noneLabel: t('admin.auditLog.filters.noActors', 'No actors')
+    },
+    {
+      field: 'resource',
+      label: t('admin.auditLog.filters.resource', 'Resource'),
+      allLabel: t('admin.auditLog.filters.allResources', 'All resources'),
+      noneLabel: t('admin.auditLog.filters.noResources', 'No resources')
+    },
+    {
+      field: 'action',
+      label: t('admin.auditLog.filters.action', 'Action'),
+      allLabel: t('admin.auditLog.filters.allActions', 'All actions'),
+      noneLabel: t('admin.auditLog.filters.noActions', 'No actions')
+    },
+    {
+      field: 'result',
+      label: t('admin.auditLog.filters.result', 'Result'),
+      allLabel: t('admin.auditLog.filters.allResults', 'All results'),
+      noneLabel: t('admin.auditLog.filters.noResults', 'No results')
+    },
+    {
+      field: 'source',
+      label: t('admin.auditLog.filters.source', 'Source'),
+      allLabel: t('admin.auditLog.filters.allSources', 'All sources'),
+      noneLabel: t('admin.auditLog.filters.noSources', 'No sources')
+    }
+  ];
 
   const columns = [
     {
@@ -420,89 +526,130 @@ function AdminAuditLogPage() {
       </div>
 
       <div className="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-4 mb-6">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-7 gap-4">
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <span className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            {t('admin.auditLog.presets.label', 'Quick filters')}
+          </span>
+          <PresetChip
+            active={fromDate === daysAgo(1) && toDate === getDefaultToDate()}
+            onClick={() => applyFilter({ from: daysAgo(1), to: getDefaultToDate() })}
+          >
+            {t('admin.auditLog.presets.last24h', 'Last 24 hours')}
+          </PresetChip>
+          <PresetChip
+            active={fromDate === daysAgo(7) && toDate === getDefaultToDate()}
+            onClick={() => applyFilter({ from: daysAgo(7), to: getDefaultToDate() })}
+          >
+            {t('admin.auditLog.presets.last7Days', 'Last 7 days')}
+          </PresetChip>
+          <PresetChip
+            active={fromDate === daysAgo(30) && toDate === getDefaultToDate()}
+            onClick={() => applyFilter({ from: daysAgo(30), to: getDefaultToDate() })}
+          >
+            {t('admin.auditLog.presets.last30Days', 'Last 30 days')}
+          </PresetChip>
+          <span className="mx-1 h-4 w-px bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
+          <PresetChip
+            active={noiseHidden}
+            onClick={() =>
+              applyFilter(
+                setExcluded('action', filterSets.action.exclude, NOISY_ACTIONS, !noiseHidden)
+              )
+            }
+          >
+            {t('admin.auditLog.presets.hideSignIns', 'Hide sign-ins')}
+          </PresetChip>
+          <PresetChip
+            active={failuresOnly}
+            onClick={() =>
+              applyFilter({ result: failuresOnly ? null : 'failure', resultExclude: null })
+            }
+          >
+            {t('admin.auditLog.presets.failuresOnly', 'Failures only')}
+          </PresetChip>
+          {anyFilterActive && (
+            <button
+              type="button"
+              onClick={clearAllFilters}
+              className="ml-auto text-xs font-medium text-indigo-600 dark:text-indigo-400 hover:underline"
+            >
+              {t('admin.auditLog.presets.clearAll', 'Clear all filters')}
+            </button>
+          )}
+        </div>
+
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-8 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              {t('admin.auditLog.from', 'From')}
+            <label
+              htmlFor="audit-from"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              {t('admin.auditLog.filters.from', 'From')}
             </label>
             <input
+              id="audit-from"
               type="date"
               value={fromDate}
-              onChange={e => handleFilterChange(setFromDate)(e.target.value)}
+              onChange={e => applyFilter({ from: e.target.value })}
               className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
-              {t('admin.auditLog.to', 'To')}
+            <label
+              htmlFor="audit-to"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              {t('admin.auditLog.filters.to', 'To')}
             </label>
             <input
+              id="audit-to"
               type="date"
               value={toDate}
-              onChange={e => handleFilterChange(setToDate)(e.target.value)}
+              onChange={e => applyFilter({ to: e.target.value })}
               className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
           </div>
-          <FilterSelect
-            label={t('admin.auditLog.actor', 'Actor')}
-            value={actorFilter}
-            onChange={handleFilterChange(setActorFilter)}
-            options={[
-              { value: 'all', label: t('admin.auditLog.allActors', 'All Actors') },
-              ...actorList.map(a => ({ value: a, label: a }))
-            ]}
-          />
-          <FilterSelect
-            label={t('admin.auditLog.resource', 'Resource')}
-            value={resourceFilter}
-            onChange={handleFilterChange(setResourceFilter)}
-            options={RESOURCE_TYPES.map(type => ({
-              value: type,
-              label:
-                type === 'all'
-                  ? t('admin.auditLog.allResources', 'All Resources')
-                  : t(
-                      `admin.auditLog.resource.${type}`,
-                      type.charAt(0).toUpperCase() + type.slice(1)
-                    )
-            }))}
-          />
-          <FilterSelect
-            label={t('admin.auditLog.action', 'Action')}
-            value={actionFilter}
-            onChange={handleFilterChange(setActionFilter)}
-            options={ACTION_TYPES.map(type => ({
-              value: type,
-              label:
-                type === 'all'
-                  ? t('admin.auditLog.allActions', 'All Actions')
-                  : t(`admin.auditLog.action.${type}`, type.charAt(0).toUpperCase() + type.slice(1))
-            }))}
-          />
-          <FilterSelect
-            label={t('admin.auditLog.result', 'Result')}
-            value={resultFilter}
-            onChange={handleFilterChange(setResultFilter)}
-            options={RESULT_TYPES.map(type => ({
-              value: type,
-              label:
-                type === 'all'
-                  ? t('admin.auditLog.allResults', 'All Results')
-                  : t(`admin.auditLog.result.${type}`, type.charAt(0).toUpperCase() + type.slice(1))
-            }))}
-          />
-          <FilterSelect
-            label={t('admin.auditLog.source', 'Source')}
-            value={sourceFilter}
-            onChange={handleFilterChange(setSourceFilter)}
-            options={SOURCE_TYPES.map(type => ({
-              value: type,
-              label:
-                type === 'all'
-                  ? t('admin.auditLog.allSources', 'All Sources')
-                  : t(`admin.auditLog.source.${type}`, type.charAt(0).toUpperCase() + type.slice(1))
-            }))}
-          />
+
+          {filterControls.map(({ field, label, allLabel, noneLabel }) => (
+            <FilterMultiSelect
+              key={field}
+              label={label}
+              allLabel={allLabel}
+              noneLabel={noneLabel}
+              options={filterOptions[field].map(o => ({
+                value: o.value,
+                label: valueLabel(field, o.value),
+                count: o.count
+              }))}
+              selected={selectedOptionValues(
+                filterOptions[field],
+                filterSets[field].include,
+                filterSets[field].exclude
+              )}
+              onChange={selected => handleSelectionChange(field, selected)}
+              searchPlaceholder={t('admin.auditLog.filters.filterValues', 'Filter values…')}
+              emptyLabel={t('admin.auditLog.filters.noValues', 'No values in range')}
+            />
+          ))}
+
+          <div>
+            <label
+              htmlFor="audit-search"
+              className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1"
+            >
+              {t('admin.auditLog.filters.search', 'Search')}
+            </label>
+            <SearchInput
+              value={queryText}
+              onChange={value => applyFilter({ q: value })}
+              placeholder={t('admin.auditLog.filters.searchPlaceholder', 'Summary, ID, IP…')}
+              ariaLabel={t(
+                'admin.auditLog.filters.searchHint',
+                'Search summary, resource ID, IP, request ID and actor'
+              )}
+              className="max-w-full"
+            />
+          </div>
         </div>
       </div>
 
@@ -522,11 +669,8 @@ function AdminAuditLogPage() {
           total,
           page,
           pageSize,
-          onPageChange: p => setPageParam(String(p)),
-          onPageSizeChange: size => {
-            setPageSizeParam(String(size));
-            setPageParam('1');
-          },
+          onPageChange: p => setMany({ page: String(p) }),
+          onPageSizeChange: size => setMany({ pageSize: String(size), page: null }),
           pageSizeOptions: [25, 50, 100, 200]
         }}
         empty={{

--- a/client/src/features/admin/utils/auditLogFilters.js
+++ b/client/src/features/admin/utils/auditLogFilters.js
@@ -32,6 +32,19 @@ export function splitsOnComma(field) {
 }
 
 /**
+ * Values a single parameter may carry. Must match `MAX_FILTER_VALUES` in
+ * `server/routes/admin/auditLogQueryParams.js`, which answers 400 above it —
+ * a mismatch would make the UI reject its own request.
+ * (`tests/unit/server/auditLogQueryParams.test.js` pins them together.)
+ */
+export const MAX_FILTER_VALUES = 2000;
+
+/** Serialize a value list for one field's parameter. */
+function encodeValues(field, values) {
+  return splitsOnComma(field) ? values.join(',') : values;
+}
+
+/**
  * Turn the raw repeated values of one query parameter into a Set, applying
  * comma splitting for the fields that allow it.
  *
@@ -110,7 +123,20 @@ export function selectedOptionValues(options, include, exclude) {
  *
  * Everything selected clears both parameters (so values added by a later
  * release stay visible), nothing selected writes `<field>Exclude=*`, and a
- * partial selection writes the unselected values as the exclude set.
+ * partial selection normally writes the unselected values as the exclude set.
+ *
+ * The exception is the cap: a partial selection out of more than
+ * `MAX_FILTER_VALUES` options can produce an exclude list the server rejects
+ * with 400 — one actor ticked out of 2001 would emit 2000 exclusions. When the
+ * exclusion form does not fit, the inclusion form is written instead, since it
+ * is necessarily the shorter of the two. Exclusion is still preferred whenever
+ * it fits, because it is the form that keeps values added by a later release
+ * visible in a bookmarked view.
+ *
+ * A selection where *both* forms exceed the cap cannot be expressed at all;
+ * that needs more than `2 × MAX_FILTER_VALUES` distinct values in the date
+ * range, at which point the search box is the usable tool rather than a
+ * four-thousand-row checkbox list.
  *
  * @param {string} field
  * @param {Array<{value: string}>} options - the full option list the selection came from
@@ -122,14 +148,19 @@ export function encodeSelection(field, options, selected) {
   if (options.length === 0) return { [field]: null, [excludeParam]: null };
 
   const selectedSet = new Set(selected);
-  const unselected = options.filter(o => !selectedSet.has(o.value)).map(o => o.value);
+  const included = [];
+  const excluded = [];
+  for (const option of options) {
+    (selectedSet.has(option.value) ? included : excluded).push(option.value);
+  }
 
-  if (unselected.length === 0) return { [field]: null, [excludeParam]: null };
-  if (unselected.length === options.length) return { [field]: null, [excludeParam]: WILDCARD };
-  return {
-    [field]: null,
-    [excludeParam]: splitsOnComma(field) ? unselected.join(',') : unselected
-  };
+  if (excluded.length === 0) return { [field]: null, [excludeParam]: null };
+  if (included.length === 0) return { [field]: null, [excludeParam]: WILDCARD };
+
+  if (excluded.length > MAX_FILTER_VALUES && included.length < excluded.length) {
+    return { [field]: encodeValues(field, included), [excludeParam]: null };
+  }
+  return { [field]: null, [excludeParam]: encodeValues(field, excluded) };
 }
 
 /**
@@ -151,7 +182,7 @@ export function setExcluded(field, exclude, values, hidden) {
   }
   const list = Array.from(next);
   if (list.length === 0) return { [`${field}Exclude`]: null };
-  return { [`${field}Exclude`]: splitsOnComma(field) ? list.join(',') : list };
+  return { [`${field}Exclude`]: encodeValues(field, list) };
 }
 
 /** True when the field's filter leaves at least one value out. */

--- a/client/src/features/admin/utils/auditLogFilters.js
+++ b/client/src/features/admin/utils/auditLogFilters.js
@@ -1,0 +1,161 @@
+/**
+ * URL encoding for the audit log's multi-value filters.
+ *
+ * Each filterable field has two query parameters: the include set (`action`)
+ * and the exclude set (`actionExclude`), which is subtracted from it. `*` is a
+ * wildcard meaning "every value", an absent include set defaults to `*`, and
+ * exclusion always wins over inclusion:
+ *
+ *   matches(v) = (include has '*' || include has v) && !(exclude has '*' || exclude has v)
+ *
+ * The same rule is implemented server-side in `AuditLogService.queryAuditLog`.
+ * Both directions are readable so existing single-value links (`?resource=app`)
+ * keep working, but the checkbox UI **writes** the exclusion form: an inclusion
+ * list means "pin exactly these", which would silently hide a resource type
+ * introduced by a later release from every bookmarked view.
+ */
+
+/** Fields with checkbox filters, in the order they appear in the filter row. */
+export const FILTER_FIELDS = ['actor', 'resource', 'action', 'result', 'source'];
+
+export const WILDCARD = '*';
+
+/**
+ * Fields whose values cannot contain a comma, so a comma in the parameter is a
+ * value separator. `actor` is absent on purpose: a username can legitimately
+ * contain one ("Doe, John"), so the actor filter uses repeated parameters only.
+ */
+const COMMA_SPLIT_FIELDS = new Set(['resource', 'action', 'result', 'source']);
+
+export function splitsOnComma(field) {
+  return COMMA_SPLIT_FIELDS.has(field);
+}
+
+/**
+ * Turn the raw repeated values of one query parameter into a Set, applying
+ * comma splitting for the fields that allow it.
+ *
+ * @param {string[]} raw - every value of the parameter, e.g. searchParams.getAll('action')
+ * @param {string} field
+ * @returns {Set<string>|null} null when the parameter is absent
+ */
+export function parseFilterParam(raw, field) {
+  if (!raw || raw.length === 0) return null;
+  const values = [];
+  for (const item of raw) {
+    if (typeof item !== 'string') continue;
+    for (const part of splitsOnComma(field) ? item.split(',') : [item]) {
+      const value = part.trim();
+      if (value) values.push(value);
+    }
+  }
+  return values.length > 0 ? new Set(values) : null;
+}
+
+/**
+ * The matcher for one field. Mirrors the server exactly.
+ *
+ * @param {Set<string>|null} include
+ * @param {Set<string>|null} exclude
+ * @returns {(value: string) => boolean}
+ */
+export function buildMatcher(include, exclude) {
+  if (exclude?.has(WILDCARD)) return () => false;
+  const includesAll = !include || include.has(WILDCARD);
+  return value => (includesAll || include.has(value)) && !(exclude ? exclude.has(value) : false);
+}
+
+/**
+ * Build the option list a checkbox control renders for one field: the facet
+ * values from the server, plus any value named by the current filter that the
+ * date range happens to contain no entries for. Without that union an active
+ * filter on a value outside the range would be invisible and un-untickable.
+ *
+ * @param {Array<{value: string, count: number}>} facetValues
+ * @param {Set<string>|null} include
+ * @param {Set<string>|null} exclude
+ * @returns {Array<{value: string, count: number}>}
+ */
+export function mergeFilterOptions(facetValues = [], include, exclude) {
+  const options = facetValues.filter(o => o && typeof o.value === 'string' && o.value !== '');
+  const known = new Set(options.map(o => o.value));
+  const extras = [];
+  for (const set of [include, exclude]) {
+    if (!set) continue;
+    for (const value of set) {
+      if (value === WILDCARD || known.has(value)) continue;
+      known.add(value);
+      extras.push({ value, count: 0 });
+    }
+  }
+  extras.sort((a, b) => a.value.localeCompare(b.value));
+  return [...options, ...extras];
+}
+
+/**
+ * Which of `options` the current filter selects.
+ *
+ * @param {Array<{value: string}>} options
+ * @param {Set<string>|null} include
+ * @param {Set<string>|null} exclude
+ * @returns {string[]}
+ */
+export function selectedOptionValues(options, include, exclude) {
+  const matches = buildMatcher(include, exclude);
+  return options.filter(o => matches(o.value)).map(o => o.value);
+}
+
+/**
+ * Encode a checkbox selection as URL parameter updates for one field.
+ *
+ * Everything selected clears both parameters (so values added by a later
+ * release stay visible), nothing selected writes `<field>Exclude=*`, and a
+ * partial selection writes the unselected values as the exclude set.
+ *
+ * @param {string} field
+ * @param {Array<{value: string}>} options - the full option list the selection came from
+ * @param {string[]} selected
+ * @returns {Record<string, string|string[]|null>} updates for `setMany`
+ */
+export function encodeSelection(field, options, selected) {
+  const excludeParam = `${field}Exclude`;
+  if (options.length === 0) return { [field]: null, [excludeParam]: null };
+
+  const selectedSet = new Set(selected);
+  const unselected = options.filter(o => !selectedSet.has(o.value)).map(o => o.value);
+
+  if (unselected.length === 0) return { [field]: null, [excludeParam]: null };
+  if (unselected.length === options.length) return { [field]: null, [excludeParam]: WILDCARD };
+  return {
+    [field]: null,
+    [excludeParam]: splitsOnComma(field) ? unselected.join(',') : unselected
+  };
+}
+
+/**
+ * Add or remove values from a field's exclude set, keeping the include set as
+ * it is. Used by the quick presets, which express "hide these" directly rather
+ * than going through the checkbox list.
+ *
+ * @param {string} field
+ * @param {Set<string>|null} exclude - the current exclude set
+ * @param {string[]} values
+ * @param {boolean} hidden - true to exclude the values, false to stop excluding them
+ * @returns {Record<string, string|string[]|null>} updates for `setMany`
+ */
+export function setExcluded(field, exclude, values, hidden) {
+  const next = new Set(exclude ?? []);
+  for (const value of values) {
+    if (hidden) next.add(value);
+    else next.delete(value);
+  }
+  const list = Array.from(next);
+  if (list.length === 0) return { [`${field}Exclude`]: null };
+  return { [`${field}Exclude`]: splitsOnComma(field) ? list.join(',') : list };
+}
+
+/** True when the field's filter leaves at least one value out. */
+export function isFieldFiltered(include, exclude) {
+  if (exclude && exclude.size > 0) return true;
+  return Boolean(include && !include.has(WILDCARD) && include.size > 0);
+}

--- a/concepts/2026-08-24 Audit Log Filter Fix and Multi-Select Filters.md
+++ b/concepts/2026-08-24 Audit Log Filter Fix and Multi-Select Filters.md
@@ -469,3 +469,36 @@ under `tests/unit/**`, so it runs.
 8. **The 24-hour default is client-side only.** `queryAuditLog`'s fallback for a caller that sends
    no date range stays at 7 days, because `useOverviewData`'s `/admin/audit-log?limit=8` call
    depends on it (§8-assumption 4 noted that call as unaffected — it would not have been).
+
+---
+
+## 12. Review Follow-ups (Copilot, PR #2218)
+
+Seven findings, all confirmed against the code and all fixed:
+
+1. **The scan was still unbounded.** `queryAuditLog` kept every match before paginating, so an
+   unfiltered query held (and sorted) the whole date range. It now keeps only the newest
+   `offset + limit` entries in a window that is trimmed whenever it reaches twice that size, and
+   counts `total` separately — so pagination stays exact with bounded memory.
+2. **The checkbox UI could emit a request its own server rejects.** A partial selection out of more
+   than `MAX_FILTER_VALUES` options serialized an over-cap exclude list and got a 400. The encoder
+   now falls back to the inclusion form when the exclusion form does not fit (exclusion is still
+   preferred whenever it fits, per D2a), and the cap moved from 500 to 2000 — it is hygiene, not a
+   tight bound, so a selection that fits neither form now needs >4000 distinct values in the range.
+   A test pins the client and server constants together.
+3. **"Last 24 hours" was a mislabel.** The date filter selects whole calendar days by filename with
+   no timestamp cutoff, so at 22:00 UTC the preset covered ~46 hours. Rather than add
+   timestamp-level filtering (the date inputs are day-granular by contract), the presets are now
+   **Today** / **Today & yesterday** / **Last 7 days** / **Last 30 days**, and the docs, changelog
+   and default are described as calendar days. The default still spans two days so the table is not
+   near-empty just after midnight — which is what Q8 was really asking for.
+4. **Only the filter options were translated.** The table's own action/result/source cells rendered
+   raw values, so the "fully translated page" claim was false in the table itself. `valueLabel` now
+   feeds the pills and the source cell too.
+5. **`pageSize` from the URL was unbounded** while the server caps `limit`, so `?pageSize=5000`
+   computed page counts over rows the server would never return. It is clamped to the table's
+   largest offered page size.
+6. **`aria-haspopup="true"` announced a menu** while the popup is a `role="group"`. The trigger is a
+   disclosure, so `aria-haspopup` is gone and `aria-expanded` carries it.
+7. **The page-reset test never left page 1**, so it passed with the reset wiring removed. It now
+   starts at `?page=4`, asserts that state, and only then toggles a filter.

--- a/concepts/2026-08-24 Audit Log Filter Fix and Multi-Select Filters.md
+++ b/concepts/2026-08-24 Audit Log Filter Fix and Multi-Select Filters.md
@@ -2,7 +2,7 @@
 
 **Issue:** [#2213 — Audit Log Filtering not possible](https://github.com/intrafind/ihub-apps/issues/2213)
 **Date:** 2026-08-24
-**Status:** Plan / awaiting review
+**Status:** Implemented
 
 ---
 
@@ -386,13 +386,9 @@ Pre-commit: `npm run lint:fix && npm run format:fix`, then `npm run test:unit`.
 
 ---
 
-## 9. Open Questions
+## 9. Open Questions — all resolved
 
-**Q1 — Scope split.** Ship the bug fix (§4.1) as its own small PR first, then the multi-select
-redesign? The fix is ~15 lines and restores working single-select filtering immediately; the redesign
-is a few hundred lines and a UI review. *Recommendation: one PR, since the redesign replaces exactly
-the code the fix touches and a two-step lands the same UI twice. Happy to split if you want the fix
-out today.*
+**Q1 — Scope split. ✅ RESOLVED:** one PR.
 
 **Q2 — Exclusion vs inclusion in the URL (D2). ✅ RESOLVED 2026-08-24 by @manzke:** support both,
 `*` matches all, exclusion overrides inclusion. Specified in §4.3. Two follow-on details were not
@@ -402,36 +398,35 @@ covered by the answer and are decided as D2a/D2b — say so if either should go 
 - **D2b** — `actor` is matched from repeated parameters only and never comma-split, because a
   username can contain a comma.
 
-**Q3 — Free-text search.** Not in the ticket, but the log has no way to search `summary`,
-`resourceId`, `ip` or `requestId`. A `q=` box would often beat any combination of checkboxes. In
-scope?
+**Q3 — Free-text search. ✅ RESOLVED:** in scope, in-memory. `?q=` is a case-insensitive substring
+match over `summary`, `resourceId`, `ip`, `requestId` and the actor name, applied during the same
+single pass as the value filters. No index.
 
-**Q4 — Quick presets.** Worth a "Hide login/logout" one-click toggle and/or "Failures only" and
-"Last 24h" chips above the filter row? Cheap, and aimed squarely at the ticket's "cumbersome"
-complaint.
+**Q4 — Quick presets. ✅ RESOLVED:** implemented. Range chips (Last 24 hours / 7 days / 30 days),
+a **Hide sign-ins** toggle (excludes `login` and `logout`), **Failures only**, and **Clear all
+filters** — the last of which also covers Q10's "active filters" affordance.
 
-**Q5 — Row detail view.** `docs/admin-ui.md` already promises row expansion with a diff (§3.5) and it
-does not exist. Do we build it (expand row → actor, ip, requestId, source, full summary), or correct
-the documentation? *Recommendation: correct the docs now, file the detail view separately.*
+**Q5 — Row detail view. ✅ RESOLVED:** correct the docs. `docs/admin-ui.md` now describes the
+show-more/show-less summary toggle that exists and points at the CSV export for the full record.
 
-**Q6 — Largest realistic audit volume.** If any installation writes millions of entries per week, a
-per-day facet cache (or a rolling index file) would be needed instead of a live scan. What is the
-worst case you know of?
+**Q6 — Largest realistic audit volume. ✅ RESOLVED:** nothing to do yet. The single-pass scan
+stands; a per-day facet cache stays a future option if an installation ever outgrows it.
 
-**Q7 — The `mcp` source (§3.3).** Offered in the UI and allowed by the schema, but never written.
-Wire `source: 'mcp'` into the MCP request path, or remove it from the UI? *Recommendation: remove it
-from the UI now; wire it up when MCP auditing is actually specified.*
+**Q7 — The `mcp` source (§3.3). ✅ RESOLVED:** removed from the UI for now — the source list is
+facet-driven, so `mcp` disappears until something writes it. `auditSources` still allows it, so
+wiring it up later needs no schema change. Filed as #2216.
 
-**Q8 — Default date range.** Still 7 days. With working filters, is a shorter default (24h) better
-for load, or does 7 days match how you use it?
+**Q8 — Default date range. ✅ RESOLVED:** reduced to 24 hours on the audit log page, which always
+sends an explicit range. The range chips widen it in one click. `queryAuditLog`'s own fallback for a
+caller that sends *no* range stays at 7 days — the admin overview's activity panel relies on it to
+show the most recent entries, and shortening it there would empty that panel on a quiet
+installation.
 
-**Q9 — Orphaned tests (§3.6).** `server/tests/*.test.js` do not run in CI. Fix the jest `testMatch`
-in this PR, or file it separately? *Recommendation: separately — it may surface unrelated failures
-and would derail this PR.*
+**Q9 — Orphaned tests (§3.6). ✅ RESOLVED:** filed as #2217. Everything new here lives
+under `tests/unit/**`, so it runs.
 
-**Q10 — Retention badge placement.** Untouched by this plan, but it sits in the header next to
-Export while the filters live in their own card. Any preference before the header gets a new
-"active filters / clear all" affordance?
+**Q10 — Retention badge placement. ✅ RESOLVED:** no preference given; the badge is unchanged and
+**Clear all filters** sits in the filter card's quick-filter row rather than the header.
 
 ---
 
@@ -444,3 +439,33 @@ Export while the filters live in their own card. Any preference before the heade
 | Facet computation slows down a large-range query | Same single pass as the query (D4/D8); facets only when `facets=1` |
 | Rewriting `queryAuditLog`'s scan introduces a filtering regression | Filter behaviour pinned by server unit tests written **before** the rewrite |
 | Multi-select popover regresses keyboard/screen-reader access | Explicit a11y test cases; `npm run test:a11y` covers the admin area |
+
+---
+
+## 11. Deviations from the Plan During Implementation
+
+1. **`DataTable` carried the same bug.** `handlePageSizeChange` called
+   `onPageSizeChange(next)` **and** `onPageChange(1)` back to back — two `setSearchParams` calls in
+   one tick — so the page-size fix in `AdminAuditLogPage` alone was not enough. In server mode
+   DataTable now calls `onPageSizeChange` only, and resetting the page is documented as the
+   consumer's job. `AdminAuditLogPage` is the only server-paged table in the client, so nothing else
+   is affected.
+2. **The route's query parsing lives in its own module**
+   (`server/routes/admin/auditLogQueryParams.js`) so the URL contract — comma splitting, the
+   actor exception, the per-field cap — is unit-testable without standing up Express.
+3. **The client filter encoding lives in `client/src/features/admin/utils/auditLogFilters.js`**
+   rather than inline in the page, for the same reason.
+4. **Checkbox options are the union of the facets and any value the current filter names.** A
+   filter on a value the date range contains no entries for would otherwise be invisible and
+   impossible to untick.
+5. **Assumption 1 is now verified, not assumed.** `tests/unit/client/use-filter-params.test.jsx`
+   demonstrates the loss directly: two `useFilterState` setters in one tick leave only the second
+   parameter in the URL.
+6. **`role="listbox"`/`aria-multiselectable` was dropped** in favour of real `<input
+   type="checkbox">` elements in a `role="group"`. Mixing checkbox inputs into a listbox is invalid
+   ARIA, and native checkboxes carry correct semantics and keyboard behaviour for free. The trigger
+   is a `button` whose accessible name is built from the field label plus its own state text.
+7. **Quick-filter ranges rather than a bare "Last 24h" chip**, since 24 hours became the default.
+8. **The 24-hour default is client-side only.** `queryAuditLog`'s fallback for a caller that sends
+   no date range stays at 7 days, because `useOverviewData`'s `/admin/audit-log?limit=8` call
+   depends on it (§8-assumption 4 noted that call as unaffected — it would not have been).

--- a/docs/admin-ui.md
+++ b/docs/admin-ui.md
@@ -170,7 +170,10 @@ Groups control what users can access. Go to **Access & Identity → Groups**.
 
 Go to **Observability → Audit Log** to see a complete record of all admin actions.
 
-The default view covers the last 24 hours. Widen it with the date inputs or the quick-filter chips.
+The date filter works in **whole days**: `from` and `to` select calendar days (UTC), and there is no
+time-of-day cutoff. The default view covers today and yesterday — not a rolling 24 hours — so the
+table is not near-empty just after midnight. Widen or narrow it with the date inputs or the
+quick-filter chips.
 
 ### Filtering
 
@@ -180,7 +183,7 @@ The option lists come from the log itself, not from a fixed vocabulary, so resou
 
 **Free-text search:** the search box matches the summary, resource ID, IP, request ID and actor name of every entry in the date range. It is a plain substring match, case-insensitive.
 
-**Quick filters:** one-click chips for **Last 24 hours** / **Last 7 days** / **Last 30 days**, **Hide sign-ins** (drops `login` and `logout`), and **Failures only**. **Clear all filters** appears whenever any filter is active.
+**Quick filters:** one-click chips for **Today** / **Today & yesterday** / **Last 7 days** / **Last 30 days**, **Hide sign-ins** (drops `login` and `logout`), and **Failures only**. **Clear all filters** appears whenever any filter is active.
 
 **Long summaries:** the summary cell has a show-more/show-less toggle. There is no row-level detail view — the full record is available through the CSV export, which always reflects the filters currently on screen.
 

--- a/docs/admin-ui.md
+++ b/docs/admin-ui.md
@@ -170,11 +170,36 @@ Groups control what users can access. Go to **Access & Identity → Groups**.
 
 Go to **Observability → Audit Log** to see a complete record of all admin actions.
 
-**Filtering:** Filter by date range, admin user, resource type (app, model, user, etc.), and action type (create, update, delete, toggle).
+The default view covers the last 24 hours. Widen it with the date inputs or the quick-filter chips.
 
-**Expanding rows:** Click any row to expand it and see the full event details. If a diff is available, it shows exactly what changed.
+### Filtering
 
-**URL-persisted filters:** All filter state is stored in the URL. You can bookmark a filtered view (e.g. all `delete` actions on `app` resources) or share it with a colleague.
+Actor, resource, action, result and source are **checkbox lists**. Open one and you get every value that actually occurs in the selected date range, each with the number of entries behind it — so when logins dominate the log you can see `login — 794` and untick exactly that. **Select all** and **Select none** are one click each, and lists longer than ten values get a type-ahead box.
+
+The option lists come from the log itself, not from a fixed vocabulary, so resource types added by a new release (or derived from a request path) show up on their own. Counts and options are computed over the **date range only** — unticking a value never makes its checkbox disappear.
+
+**Free-text search:** the search box matches the summary, resource ID, IP, request ID and actor name of every entry in the date range. It is a plain substring match, case-insensitive.
+
+**Quick filters:** one-click chips for **Last 24 hours** / **Last 7 days** / **Last 30 days**, **Hide sign-ins** (drops `login` and `logout`), and **Failures only**. **Clear all filters** appears whenever any filter is active.
+
+**Long summaries:** the summary cell has a show-more/show-less toggle. There is no row-level detail view — the full record is available through the CSV export, which always reflects the filters currently on screen.
+
+### URL-persisted filters
+
+All filter state lives in the URL, so a filtered view can be bookmarked or shared. Each field has two parameters: the include set and an `Exclude` set subtracted from it. `*` means "every value".
+
+| URL | Result |
+| --- | --- |
+| *(no parameter)* | everything — the default |
+| `?action=create,update` | only those two |
+| `?actionExclude=login,logout` | everything except those two |
+| `?actionExclude=*` | nothing — the "select none" state |
+| `?action=*&actionExclude=login` | everything except login |
+| `?resource=app&resourceExclude=app` | nothing — exclusion wins on a value in both sets |
+
+The checkbox lists write the **exclusion** form for a partial selection, so a value introduced by a later release stays visible in a bookmarked view instead of being silently filtered out. The inclusion form keeps working for links you already have and for anyone pinning an exact set by hand.
+
+`resource`, `action`, `result` and `source` accept comma-separated (`?action=a,b`) and repeated (`?action=a&action=b`) parameters alike. `actor` accepts repeated parameters only and is never split on commas, because a username can legitimately contain one (`Doe, John`).
 
 ---
 

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1010,10 +1010,13 @@ how many entries are behind it.
   checkbox vanish.
 - A new **search box** matches the summary, resource ID, IP, request ID and actor name of any entry
   in the date range.
-- **Quick filters:** Last 24 hours / Last 7 days / Last 30 days, **Hide sign-ins**, **Failures
-  only**, and **Clear all filters**.
-- The default range is now the **last 24 hours** instead of 7 days. Widen it with the date inputs or
-  a chip.
+- **Quick filters:** Today / Today & yesterday / Last 7 days / Last 30 days, **Hide sign-ins**,
+  **Failures only**, and **Clear all filters**.
+- The default range is now **today and yesterday** instead of 7 days. The date filter works in whole
+  calendar days (UTC) with no time-of-day cutoff, so the default covers two days rather than a
+  rolling 24 hours — that way the table is not near-empty just after midnight. Widen it with the
+  date inputs or a chip.
+- Action, result and source are translated in the table itself, not only in the filter lists.
 - Filter state stays in the URL, so a filtered view is still bookmarkable and shareable. Each field
   takes an include parameter and an `<field>Exclude` parameter, with `*` meaning "every value" —
   `?actionExclude=login,logout` is "everything but sign-ins". Existing single-value links such as

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -993,3 +993,30 @@ saving.
   content the user could not open in iFinder directly.
 - Sources exposed as tools may leave both fields empty; the assistant supplies a query or
   document ID when it calls the tool.
+
+## Audit Log Filtering by Checkbox, With Entry Counts
+
+**Observability → Audit Log** now filters with checkbox lists instead of single-value dropdowns, so
+"everything except logins" is one click rather than impossible. Actor, resource, action, result and
+source each open a list of the values that actually occur in the selected date range, each showing
+how many entries are behind it.
+
+- **Select all** and **Select none** are single clicks; lists longer than ten values get a
+  type-ahead box. Full keyboard and screen-reader support.
+- Counts are what make a noisy log tractable: seeing `login — 794` tells you exactly what to untick.
+- Option lists are read from the log, not from a fixed list, so resource types added by a later
+  release appear on their own.
+- Counts and options are computed over the date range only, so unticking a value never makes its
+  checkbox vanish.
+- A new **search box** matches the summary, resource ID, IP, request ID and actor name of any entry
+  in the date range.
+- **Quick filters:** Last 24 hours / Last 7 days / Last 30 days, **Hide sign-ins**, **Failures
+  only**, and **Clear all filters**.
+- The default range is now the **last 24 hours** instead of 7 days. Widen it with the date inputs or
+  a chip.
+- Filter state stays in the URL, so a filtered view is still bookmarkable and shareable. Each field
+  takes an include parameter and an `<field>Exclude` parameter, with `*` meaning "every value" —
+  `?actionExclude=login,logout` is "everything but sign-ins". Existing single-value links such as
+  `?resource=app` keep working.
+- Audit log queries now scan each daily file once instead of loading the whole date range into
+  memory and sorting it, so a wide range costs materially less.

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -53,3 +53,24 @@ a specific model instead of only the app's preferred one.
 - Apps that restrict their models advertise the allowed ids as a fixed choice list.
 - Apps configured to hide model selection do not expose the option.
 - An unknown or incompatible model falls back to the app's preferred model rather than failing.
+
+## Audit Log Filters Now Actually Filter
+
+Selecting a resource, action, result or source on **Observability → Audit Log** left the table
+unchanged and the dropdown snapped straight back to "All". The page changed two URL parameters at
+once — the filter and the page number — and the second change silently discarded the first, so the
+filter never reached the server. Filters now apply on the first click, and a shared or bookmarked
+filter link opens the view it describes.
+
+- Changing the rows-per-page value on the audit log had the same problem and reverted to 50. It now
+  sticks.
+- The resource list no longer offers `provider`, which nothing ever writes, and no longer omits
+  `tool`, `credential`, `integrations`, `uiConfig` and the other types that do occur. The options
+  are read from the log itself, so nothing can go missing.
+- The actor list covers every actor in the selected date range, not just the ones on the page you
+  happen to be looking at.
+- `mcp` is gone from the source filter. No code path writes it, so selecting it could only ever
+  return an empty table.
+- The audit log page is now translated. The German UI previously showed it entirely in English.
+- CSV export uses the same filters as the table, including the new ones, so an export always matches
+  what is on screen.

--- a/server/routes/admin/auditLog.js
+++ b/server/routes/admin/auditLog.js
@@ -7,6 +7,13 @@ import {
   logAudit
 } from '../../services/AuditLogService.js';
 import { sendBadRequest, sendInternalError } from '../../utils/responseHelpers.js';
+import {
+  BadFilterError,
+  MAX_PAGE_SIZE,
+  clampInt,
+  isFlagSet,
+  parseAuditLogQuery
+} from './auditLogQueryParams.js';
 import { buildCsv } from '../../utils/csv.js';
 import configCache from '../../configCache.js';
 import logger from '../../utils/logger.js';
@@ -50,35 +57,28 @@ export default function registerAdminAuditLogRoutes(app) {
   /**
    * GET /api/admin/audit-log
    * Query audit log entries with optional filters and pagination.
+   *
+   * Each of actor/resource/action/result/source accepts an include parameter
+   * and a `<field>Exclude` parameter subtracted from it, with `*` meaning
+   * "every value". `?q=` is a free-text search over the summary, resource id,
+   * IP, request id and actor name. `?facets=1` additionally returns the value
+   * counts per field over the date range, which is what the filter UI renders
+   * its checkbox lists from.
    */
   app.get(buildServerPath('/api/admin/audit-log'), adminAuth, async (req, res) => {
     try {
-      const {
-        from,
-        to,
-        actor,
-        resource,
-        action,
-        result: outcome,
-        source,
-        limit,
-        offset
-      } = req.query;
+      const filters = parseAuditLogQuery(req.query);
 
       const result = await queryAuditLog({
-        from,
-        to,
-        actor,
-        resource,
-        action,
-        result: outcome,
-        source,
-        limit: limit ? parseInt(limit, 10) : 50,
-        offset: offset ? parseInt(offset, 10) : 0
+        ...filters,
+        facets: isFlagSet(req.query.facets),
+        limit: clampInt(req.query.limit, 50, 1, MAX_PAGE_SIZE),
+        offset: clampInt(req.query.offset, 0, 0, Number.MAX_SAFE_INTEGER)
       });
 
       res.json(result);
     } catch (error) {
+      if (error instanceof BadFilterError) return sendBadRequest(res, error.message);
       return sendInternalError(res, error, 'query audit log');
     }
   });
@@ -89,18 +89,12 @@ export default function registerAdminAuditLogRoutes(app) {
    */
   app.get(buildServerPath('/api/admin/audit-log/export'), adminAuth, async (req, res) => {
     try {
-      const { from, to, actor, resource, action, result: outcome, source } = req.query;
+      const filters = parseAuditLogQuery(req.query);
 
       // Cap the export so a wide date range can't build an unbounded CSV string
       // in memory. Admins can narrow the date range to export more granularly.
       const { entries, total } = await queryAuditLog({
-        from,
-        to,
-        actor,
-        resource,
-        action,
-        result: outcome,
-        source,
+        ...filters,
         limit: MAX_EXPORT_ROWS,
         offset: 0
       });
@@ -139,6 +133,7 @@ export default function registerAdminAuditLogRoutes(app) {
       res.setHeader('Content-Disposition', 'attachment; filename="audit-log.csv"');
       res.send(buildCsv(headers, rows));
     } catch (error) {
+      if (error instanceof BadFilterError) return sendBadRequest(res, error.message);
       return sendInternalError(res, error, 'export audit log');
     }
   });

--- a/server/routes/admin/auditLogQueryParams.js
+++ b/server/routes/admin/auditLogQueryParams.js
@@ -18,10 +18,13 @@ export const FILTER_FIELDS = ['actor', 'resource', 'action', 'result', 'source']
 const COMMA_SPLIT_FIELDS = new Set(['resource', 'action', 'result', 'source']);
 
 // Upper bound on filter values per field, so a crafted URL can't build an
-// enormous filter set. Far above anything the admin UI emits: the checkbox
-// control writes the exclusion form, which stays small even when most options
-// are unticked.
-export const MAX_FILTER_VALUES = 500;
+// enormous filter set. Only hygiene — matching a value is a Set lookup either
+// way — so it is set well above what the checkbox UI can emit: that control
+// writes whichever of the include/exclude forms is expressible, and the
+// shorter of the two never exceeds half the number of distinct values in the
+// date range. `MAX_FILTER_VALUES` in
+// `client/src/features/admin/utils/auditLogFilters.js` must match.
+export const MAX_FILTER_VALUES = 2000;
 
 // Upper bound on the free-text search term.
 export const MAX_QUERY_LENGTH = 200;

--- a/server/routes/admin/auditLogQueryParams.js
+++ b/server/routes/admin/auditLogQueryParams.js
@@ -1,0 +1,99 @@
+/**
+ * Query-string parsing for the admin audit log endpoints.
+ *
+ * Both the list endpoint and the CSV export run through {@link
+ * parseAuditLogQuery}, so an export can never disagree with what is on screen.
+ * Kept out of the route module so the URL contract can be unit-tested without
+ * standing up Express.
+ */
+
+// Fields that can be filtered by value. Each accepts an include parameter
+// (`?action=create`) and an exclude parameter (`?actionExclude=login`).
+export const FILTER_FIELDS = ['actor', 'resource', 'action', 'result', 'source'];
+
+// `resource`, `action`, `result` and `source` draw from comma-free
+// vocabularies, so a comma in one of those parameters is a value separator.
+// An actor username can legitimately contain a comma ("Doe, John"), so the
+// actor filter reads repeated parameters only and is never comma-split.
+const COMMA_SPLIT_FIELDS = new Set(['resource', 'action', 'result', 'source']);
+
+// Upper bound on filter values per field, so a crafted URL can't build an
+// enormous filter set. Far above anything the admin UI emits: the checkbox
+// control writes the exclusion form, which stays small even when most options
+// are unticked.
+export const MAX_FILTER_VALUES = 500;
+
+// Upper bound on the free-text search term.
+export const MAX_QUERY_LENGTH = 200;
+
+// Upper bound on rows a single list request may return.
+export const MAX_PAGE_SIZE = 1000;
+
+export class BadFilterError extends Error {}
+
+/**
+ * Parse one filter parameter into an array of values, or undefined when it is
+ * absent. Handles both repeated parameters (`?a=1&a=2`) and — for the
+ * comma-free fields — comma-separated lists (`?a=1,2`).
+ *
+ * @throws {BadFilterError} when more than MAX_FILTER_VALUES values are given
+ */
+export function parseFilterValues(raw, { splitCommas }) {
+  if (raw === undefined || raw === null) return undefined;
+  const values = [];
+  for (const item of Array.isArray(raw) ? raw : [raw]) {
+    if (typeof item !== 'string') continue;
+    for (const part of splitCommas ? item.split(',') : [item]) {
+      const value = part.trim();
+      if (!value) continue;
+      if (values.length >= MAX_FILTER_VALUES) {
+        throw new BadFilterError(
+          `Too many filter values; at most ${MAX_FILTER_VALUES} per field are accepted`
+        );
+      }
+      values.push(value);
+    }
+  }
+  return values.length > 0 ? values : undefined;
+}
+
+/**
+ * Build the queryAuditLog() options from a request's query string. Shared by
+ * the list and the CSV export endpoints so an export always matches what is on
+ * screen.
+ *
+ * @throws {BadFilterError} on a filter that exceeds its limits
+ */
+export function parseAuditLogQuery(query = {}) {
+  const options = { from: query.from, to: query.to };
+
+  for (const field of FILTER_FIELDS) {
+    const splitCommas = COMMA_SPLIT_FIELDS.has(field);
+    options[field] = parseFilterValues(query[field], { splitCommas });
+    options[`${field}Exclude`] = parseFilterValues(query[`${field}Exclude`], { splitCommas });
+  }
+
+  // `q` is a single free-text term; a repeated parameter takes the first value.
+  const rawQ = Array.isArray(query.q) ? query.q[0] : query.q;
+  if (typeof rawQ === 'string' && rawQ.trim()) {
+    if (rawQ.length > MAX_QUERY_LENGTH) {
+      throw new BadFilterError(`Search term is too long; at most ${MAX_QUERY_LENGTH} characters`);
+    }
+    options.q = rawQ;
+  }
+
+  return options;
+}
+
+/** Truthy query-string flag: `?facets=1`, `?facets=true`, or a bare `?facets`. */
+export function isFlagSet(value) {
+  if (value === undefined) return false;
+  const first = Array.isArray(value) ? value[0] : value;
+  return first === '' || first === '1' || first === 'true';
+}
+
+export function clampInt(raw, fallback, min, max) {
+  const parsed = parseInt(raw, 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.min(max, Math.max(min, parsed));
+}

--- a/server/services/AuditLogService.js
+++ b/server/services/AuditLogService.js
@@ -402,7 +402,23 @@ export async function queryAuditLog({
   // unticking `login` does not make the `login` checkbox and its count vanish.
   const counters = facets ? new Map(FACET_FIELDS.map(field => [field, new Map()])) : null;
 
-  const matched = [];
+  // Only the newest `offset + limit` matches are kept. `total` is counted
+  // separately, so pagination stays exact without ever holding the whole
+  // matched set in memory — an unfiltered query over a wide range would
+  // otherwise materialize (and sort) the entire range.
+  const keepCount = Math.max(0, offset) + Math.max(0, limit);
+  const newest = [];
+  let total = 0;
+
+  // Sort newest first and drop everything past the window. Called whenever the
+  // buffer reaches twice the window, so the amortized cost stays O(n log k).
+  // Entries sharing an identical timestamp have no defined order between them,
+  // at the window boundary as anywhere else.
+  const trimToWindow = () => {
+    newest.sort((a, b) => String(b.ts).localeCompare(String(a.ts)));
+    if (newest.length > keepCount) newest.length = keepCount;
+  };
+
   for (const file of jsonlFiles) {
     let reader;
     try {
@@ -442,7 +458,13 @@ export async function queryAuditLog({
           }
         }
         if (keep && matchesText && !matchesText(entry)) keep = false;
-        if (keep) matched.push(entry);
+        if (keep) {
+          total += 1;
+          if (keepCount > 0) {
+            newest.push(entry);
+            if (newest.length >= keepCount * 2) trimToWindow();
+          }
+        }
       }
     } catch {
       // Skip unreadable files
@@ -451,11 +473,8 @@ export async function queryAuditLog({
     }
   }
 
-  // Sort newest first. Only the matched subset is sorted, not the whole range.
-  matched.sort((a, b) => String(b.ts).localeCompare(String(a.ts)));
-
-  const total = matched.length;
-  const entries = matched.slice(offset, offset + limit);
+  trimToWindow();
+  const entries = newest.slice(offset, offset + limit);
 
   if (!counters) return { entries, total };
 

--- a/server/services/AuditLogService.js
+++ b/server/services/AuditLogService.js
@@ -1,4 +1,5 @@
-import { promises as fs } from 'fs';
+import { promises as fs, createReadStream } from 'fs';
+import { createInterface } from 'readline';
 import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { getRootDir } from '../pathUtils.js';
@@ -12,6 +13,11 @@ import { createJsonlAppender } from '../utils/jsonlAppender.js';
 const AUDIT_LOG_DIR = 'data/audit-log';
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_RETENTION_DAYS = 365;
+// Fallback window when a caller passes no `from`. Left at 7 days for callers
+// that just want "the most recent entries" (the admin overview's activity
+// panel). The audit log page always sends an explicit range and defaults it to
+// 24 hours itself.
+const DEFAULT_QUERY_RANGE_DAYS = 7;
 const FLUSH_INTERVAL_MS = 5000;
 // Hard cap so a failing disk + high write volume can't exhaust memory. When
 // exceeded we drop the oldest entries and emit a single overflow warning.
@@ -212,28 +218,135 @@ export function logAudit({
 }
 
 /**
+ * Facetable fields. Each is counted over the selected date range so the filter
+ * UI can render real option lists with entry counts instead of a hardcoded
+ * vocabulary (`resource` in particular is deliberately open-ended — the audit
+ * middleware derives resource names from request paths).
+ */
+const FACET_FIELDS = ['actor', 'resource', 'action', 'result', 'source'];
+
+/** Fields the free-text `q` filter searches, in the order they are checked. */
+const SEARCH_FIELDS = ['summary', 'resourceId', 'ip', 'requestId'];
+
+/**
+ * Read the facet value of a field from an entry, normalizing the two legacy
+ * shapes: entries written before the actor migration carry a plain `admin`
+ * string instead of an `actor` object, and `result` was optional (absent meant
+ * success).
+ */
+function facetValue(entry, field) {
+  switch (field) {
+    case 'actor':
+      return entry.actor?.username ?? entry.admin ?? '';
+    case 'result':
+      return entry.result ?? 'success';
+    default:
+      return entry[field] ?? '';
+  }
+}
+
+/**
+ * Normalize a filter argument to a Set of values, or null when the filter is
+ * not in play. Accepts a single string or an array of strings; empty values are
+ * dropped, and an argument that yields nothing is treated as absent.
+ */
+function toValueSet(value) {
+  if (value === undefined || value === null) return null;
+  const list = (Array.isArray(value) ? value : [value]).filter(
+    v => typeof v === 'string' && v.length > 0
+  );
+  return list.length > 0 ? new Set(list) : null;
+}
+
+/**
+ * Build a value matcher from an include set and an exclude set.
+ *
+ * The rule is "include first, then subtract exclude", with `*` meaning every
+ * value in either set:
+ *
+ *   matches(v) = (include has '*' || include has v) && !(exclude has '*' || exclude has v)
+ *
+ * An absent include set defaults to `*`, so exclusion alone means "everything
+ * but these". Exclusion always wins over inclusion for a value in both sets.
+ *
+ * @returns {((value: string) => boolean)|null} null when neither set filters
+ *   anything, so the caller can skip the check entirely.
+ */
+function buildValueMatcher(include, exclude) {
+  const inc = toValueSet(include);
+  const exc = toValueSet(exclude);
+  if (!inc && !exc) return null;
+  if (exc?.has('*')) return () => false; // the "select none" state
+  const includesAll = !inc || inc.has('*');
+  if (includesAll && !exc) return null;
+  if (includesAll) return value => !exc.has(value);
+  if (!exc) return value => inc.has(value);
+  return value => inc.has(value) && !exc.has(value);
+}
+
+/**
+ * Build the free-text matcher for `q`. Case-insensitive substring match over
+ * the summary, resource id, IP, request id and actor name. Runs in memory over
+ * the entries in the date range — there is no index.
+ */
+function buildTextMatcher(q) {
+  if (typeof q !== 'string') return null;
+  const needle = q.trim().toLowerCase();
+  if (!needle) return null;
+  return entry => {
+    for (const field of SEARCH_FIELDS) {
+      const value = entry[field];
+      if (typeof value === 'string' && value.toLowerCase().includes(needle)) return true;
+    }
+    const actor = facetValue(entry, 'actor');
+    return typeof actor === 'string' && actor.toLowerCase().includes(needle);
+  };
+}
+
+/**
  * Query audit log entries with optional filters and pagination.
+ *
+ * Every value filter accepts a single string or an array of strings, and has a
+ * matching `*Exclude` argument that is subtracted from it. `*` is a wildcard
+ * meaning "every value"; see {@link buildValueMatcher} for the exact rule.
+ *
+ * The whole date range is scanned once: each line is parsed, counted into the
+ * facets, matched against the filters, and kept only if it matches.
  *
  * @param {Object} options
  * @param {string} [options.from] - Start date (YYYY-MM-DD), defaults to 7 days ago
  * @param {string} [options.to] - End date (YYYY-MM-DD), defaults to today
- * @param {string} [options.actor] - Filter by actor username
- * @param {string} [options.resource] - Filter by resource type
- * @param {string} [options.action] - Filter by action type
- * @param {string} [options.result] - Filter by outcome ('success' | 'failure')
- * @param {string} [options.source] - Filter by source ('web' | 'mcp' | 'api' | 'admin')
+ * @param {string|string[]} [options.actor] - Actor usernames to include
+ * @param {string|string[]} [options.actorExclude] - Actor usernames to exclude
+ * @param {string|string[]} [options.resource] - Resource types to include
+ * @param {string|string[]} [options.resourceExclude] - Resource types to exclude
+ * @param {string|string[]} [options.action] - Actions to include
+ * @param {string|string[]} [options.actionExclude] - Actions to exclude
+ * @param {string|string[]} [options.result] - Outcomes to include
+ * @param {string|string[]} [options.resultExclude] - Outcomes to exclude
+ * @param {string|string[]} [options.source] - Sources to include
+ * @param {string|string[]} [options.sourceExclude] - Sources to exclude
+ * @param {string} [options.q] - Free-text search over summary/resourceId/ip/requestId/actor
+ * @param {boolean} [options.facets=false] - Also return per-field value counts
  * @param {number} [options.limit=50] - Max entries to return
  * @param {number} [options.offset=0] - Number of entries to skip
- * @returns {Promise<{entries: Array, total: number}>}
+ * @returns {Promise<{entries: Array, total: number, facets?: Object}>}
  */
 export async function queryAuditLog({
   from,
   to,
   actor,
+  actorExclude,
   resource,
+  resourceExclude,
   action,
+  actionExclude,
   result,
+  resultExclude,
   source,
+  sourceExclude,
+  q,
+  facets = false,
   limit = 50,
   offset = 0
 } = {}) {
@@ -247,16 +360,18 @@ export async function queryAuditLog({
   const now = new Date();
   const toDate = to || now.toISOString().slice(0, 10);
   const fromDate =
-    from || new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    from || new Date(now.getTime() - DEFAULT_QUERY_RANGE_DAYS * DAY_MS).toISOString().slice(0, 10);
 
   const auditDir = join(getRootDir(), 'contents', AUDIT_LOG_DIR);
+
+  const emptyFacets = () => Object.fromEntries(FACET_FIELDS.map(f => [f, []]));
 
   // Collect all matching JSONL files
   let files;
   try {
     files = await fs.readdir(auditDir);
   } catch {
-    return { entries: [], total: 0 };
+    return facets ? { entries: [], total: 0, facets: emptyFacets() } : { entries: [], total: 0 };
   }
 
   const jsonlFiles = files
@@ -268,50 +383,90 @@ export async function queryAuditLog({
     .sort()
     .reverse(); // newest first
 
-  // Read and parse all entries
-  const allEntries = [];
+  const matchers = {
+    actor: buildValueMatcher(actor, actorExclude),
+    resource: buildValueMatcher(resource, resourceExclude),
+    action: buildValueMatcher(action, actionExclude),
+    result: buildValueMatcher(result, resultExclude),
+    source: buildValueMatcher(source, sourceExclude)
+  };
+  // Only the fields that actually filter, so an unfiltered query does no work.
+  const activeMatchers = FACET_FIELDS.filter(field => matchers[field]).map(field => [
+    field,
+    matchers[field]
+  ]);
+  const matchesText = buildTextMatcher(q);
+
+  // Facet counters are keyed by field, then by value. They are populated from
+  // every entry in the date range *before* the value filters are applied, so
+  // unticking `login` does not make the `login` checkbox and its count vanish.
+  const counters = facets ? new Map(FACET_FIELDS.map(field => [field, new Map()])) : null;
+
+  const matched = [];
   for (const file of jsonlFiles) {
+    let reader;
     try {
-      const content = await fs.readFile(join(auditDir, file), 'utf8');
-      const lines = content.trim().split('\n').filter(Boolean);
-      for (const line of lines) {
+      reader = createInterface({
+        input: createReadStream(join(auditDir, file), 'utf8'),
+        crlfDelay: Infinity
+      });
+    } catch {
+      continue; // Skip unreadable files
+    }
+    try {
+      // One pass per file: parse, count facets, filter, keep only matches.
+      for await (const line of reader) {
+        if (!line) continue;
+        let entry;
         try {
-          allEntries.push(JSON.parse(line));
+          entry = JSON.parse(line);
         } catch {
-          // Skip malformed lines
+          continue; // Skip malformed lines
         }
+        if (!entry || typeof entry !== 'object') continue;
+
+        if (counters) {
+          for (const field of FACET_FIELDS) {
+            const value = facetValue(entry, field);
+            if (!value) continue;
+            const byValue = counters.get(field);
+            byValue.set(value, (byValue.get(value) ?? 0) + 1);
+          }
+        }
+
+        let keep = true;
+        for (const [field, matcher] of activeMatchers) {
+          if (!matcher(facetValue(entry, field))) {
+            keep = false;
+            break;
+          }
+        }
+        if (keep && matchesText && !matchesText(entry)) keep = false;
+        if (keep) matched.push(entry);
       }
     } catch {
       // Skip unreadable files
+    } finally {
+      reader.close();
     }
   }
 
-  // Sort newest first
-  allEntries.sort((a, b) => b.ts.localeCompare(a.ts));
+  // Sort newest first. Only the matched subset is sorted, not the whole range.
+  matched.sort((a, b) => String(b.ts).localeCompare(String(a.ts)));
 
-  // Apply filters. Entries written before the actor migration carry a legacy
-  // `admin` string instead of `actor`, so match both when filtering by actor.
-  let filtered = allEntries;
-  if (actor) {
-    filtered = filtered.filter(e => (e.actor?.username ?? e.admin) === actor);
-  }
-  if (resource) {
-    filtered = filtered.filter(e => e.resource === resource);
-  }
-  if (action) {
-    filtered = filtered.filter(e => e.action === action);
-  }
-  if (result) {
-    filtered = filtered.filter(e => (e.result ?? 'success') === result);
-  }
-  if (source) {
-    filtered = filtered.filter(e => e.source === source);
-  }
+  const total = matched.length;
+  const entries = matched.slice(offset, offset + limit);
 
-  const total = filtered.length;
-  const entries = filtered.slice(offset, offset + limit);
+  if (!counters) return { entries, total };
 
-  return { entries, total };
+  const facetResult = {};
+  for (const field of FACET_FIELDS) {
+    facetResult[field] = Array.from(counters.get(field), ([value, count]) => ({
+      value,
+      count
+    })).sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
+  }
+  return { entries, total, facets: facetResult };
 }
 
 /**

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -2014,6 +2014,98 @@
       "validation": {
         "ifinderContentRequired": "Geben Sie eine Dokument-ID oder eine Suchanfrage an, damit die Quelle weiß, welche Dokumente geladen werden sollen"
       }
+    },
+    "auditLog": {
+      "title": "Audit-Log",
+      "timestamp": "Zeitstempel",
+      "actorColumn": "Akteur",
+      "actionColumn": "Aktion",
+      "resultColumn": "Ergebnis",
+      "resourceColumn": "Ressource",
+      "sourceColumn": "Quelle",
+      "summaryColumn": "Zusammenfassung",
+      "noEntries": "Keine Audit-Log-Einträge gefunden.",
+      "showMore": "Mehr anzeigen",
+      "showLess": "Weniger anzeigen",
+      "exportCsv": "CSV exportieren",
+      "exporting": "Exportiere…",
+      "exportError": "Audit-Log konnte nicht exportiert werden",
+      "fetchError": "Audit-Log konnte nicht geladen werden",
+      "retentionDays": "{{days}} Tage aufbewahren",
+      "retentionForever": "Dauerhaft aufbewahren",
+      "retentionDisabled": "Aufräumen deaktiviert",
+      "retentionHint": "Konfiguriert in platform.json → audit. Bearbeitung unter Plattform → Erweitert.",
+      "runCleanup": "Jetzt aufräumen",
+      "cleanupRunning": "Läuft…",
+      "cleanupRemoved": "{{count}} Dateien entfernt",
+      "cleanupNoop": "Nichts zu entfernen",
+      "cleanupError": "Aufräumen fehlgeschlagen: {{error}}",
+      "filters": {
+        "from": "Von",
+        "to": "Bis",
+        "actor": "Akteur",
+        "resource": "Ressource",
+        "action": "Aktion",
+        "result": "Ergebnis",
+        "source": "Quelle",
+        "allActors": "Alle Akteure",
+        "allResources": "Alle Ressourcen",
+        "allActions": "Alle Aktionen",
+        "allResults": "Alle Ergebnisse",
+        "allSources": "Alle Quellen",
+        "noActors": "Keine Akteure",
+        "noResources": "Keine Ressourcen",
+        "noActions": "Keine Aktionen",
+        "noResults": "Keine Ergebnisse",
+        "noSources": "Keine Quellen",
+        "filterValues": "Werte filtern…",
+        "noValues": "Keine Werte im Zeitraum",
+        "search": "Suche",
+        "searchPlaceholder": "Zusammenfassung, ID, IP…",
+        "searchHint": "Zusammenfassung, Ressourcen-ID, IP, Request-ID und Akteur durchsuchen"
+      },
+      "presets": {
+        "label": "Schnellfilter",
+        "last24h": "Letzte 24 Stunden",
+        "last7Days": "Letzte 7 Tage",
+        "last30Days": "Letzte 30 Tage",
+        "hideSignIns": "Anmeldungen ausblenden",
+        "failuresOnly": "Nur Fehler",
+        "clearAll": "Alle Filter zurücksetzen"
+      },
+      "values": {
+        "action": {
+          "create": "Erstellen",
+          "update": "Aktualisieren",
+          "delete": "Löschen",
+          "toggle": "Umschalten",
+          "import": "Importieren",
+          "export": "Exportieren",
+          "login": "Anmeldung",
+          "logout": "Abmeldung"
+        },
+        "result": {
+          "success": "Erfolg",
+          "failure": "Fehler"
+        },
+        "source": {
+          "web": "Web",
+          "admin": "Admin",
+          "api": "API"
+        }
+      }
+    },
+    "filters": {
+      "multiSelect": {
+        "all": "Alle",
+        "none": "Keine",
+        "someSelected": "{{selected}} von {{total}}",
+        "selectAll": "Alle auswählen",
+        "selectNone": "Keine auswählen",
+        "search": "Werte filtern…",
+        "noMatches": "Keine passenden Werte",
+        "noOptions": "Keine Werte"
+      }
     }
   },
   "cloudStorage": {

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -2066,7 +2066,8 @@
       },
       "presets": {
         "label": "Schnellfilter",
-        "last24h": "Letzte 24 Stunden",
+        "today": "Heute",
+        "todayAndYesterday": "Heute & gestern",
         "last7Days": "Letzte 7 Tage",
         "last30Days": "Letzte 30 Tage",
         "hideSignIns": "Anmeldungen ausblenden",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1761,6 +1761,98 @@
       "validation": {
         "ifinderContentRequired": "Provide a document ID or a search query so the source knows which documents to load"
       }
+    },
+    "auditLog": {
+      "title": "Audit Log",
+      "timestamp": "Timestamp",
+      "actorColumn": "Actor",
+      "actionColumn": "Action",
+      "resultColumn": "Result",
+      "resourceColumn": "Resource",
+      "sourceColumn": "Source",
+      "summaryColumn": "Summary",
+      "noEntries": "No audit log entries found.",
+      "showMore": "Show more",
+      "showLess": "Show less",
+      "exportCsv": "Export CSV",
+      "exporting": "Exporting…",
+      "exportError": "Failed to export audit log",
+      "fetchError": "Failed to fetch audit log",
+      "retentionDays": "Retain {{days}} days",
+      "retentionForever": "Retain forever",
+      "retentionDisabled": "Cleanup disabled",
+      "retentionHint": "Configured in platform.json → audit. Edit under Platform → Advanced.",
+      "runCleanup": "Run cleanup now",
+      "cleanupRunning": "Running…",
+      "cleanupRemoved": "{{count}} files removed",
+      "cleanupNoop": "Nothing to remove",
+      "cleanupError": "Cleanup failed: {{error}}",
+      "filters": {
+        "from": "From",
+        "to": "To",
+        "actor": "Actor",
+        "resource": "Resource",
+        "action": "Action",
+        "result": "Result",
+        "source": "Source",
+        "allActors": "All actors",
+        "allResources": "All resources",
+        "allActions": "All actions",
+        "allResults": "All results",
+        "allSources": "All sources",
+        "noActors": "No actors",
+        "noResources": "No resources",
+        "noActions": "No actions",
+        "noResults": "No results",
+        "noSources": "No sources",
+        "filterValues": "Filter values…",
+        "noValues": "No values in range",
+        "search": "Search",
+        "searchPlaceholder": "Summary, ID, IP…",
+        "searchHint": "Search summary, resource ID, IP, request ID and actor"
+      },
+      "presets": {
+        "label": "Quick filters",
+        "last24h": "Last 24 hours",
+        "last7Days": "Last 7 days",
+        "last30Days": "Last 30 days",
+        "hideSignIns": "Hide sign-ins",
+        "failuresOnly": "Failures only",
+        "clearAll": "Clear all filters"
+      },
+      "values": {
+        "action": {
+          "create": "Create",
+          "update": "Update",
+          "delete": "Delete",
+          "toggle": "Toggle",
+          "import": "Import",
+          "export": "Export",
+          "login": "Login",
+          "logout": "Logout"
+        },
+        "result": {
+          "success": "Success",
+          "failure": "Failure"
+        },
+        "source": {
+          "web": "Web",
+          "admin": "Admin",
+          "api": "API"
+        }
+      }
+    },
+    "filters": {
+      "multiSelect": {
+        "all": "All",
+        "none": "None",
+        "someSelected": "{{selected}} of {{total}}",
+        "selectAll": "Select all",
+        "selectNone": "Select none",
+        "search": "Filter…",
+        "noMatches": "No matching values",
+        "noOptions": "No values"
+      }
     }
   },
   "cloudStorage": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1813,7 +1813,8 @@
       },
       "presets": {
         "label": "Quick filters",
-        "last24h": "Last 24 hours",
+        "today": "Today",
+        "todayAndYesterday": "Today & yesterday",
         "last7Days": "Last 7 days",
         "last30Days": "Last 30 days",
         "hideSignIns": "Hide sign-ins",

--- a/tests/unit/client/admin-audit-log-filters.test.jsx
+++ b/tests/unit/client/admin-audit-log-filters.test.jsx
@@ -1,0 +1,372 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import '@testing-library/jest-dom';
+
+/**
+ * AdminAuditLogPage filter tests — issue #2213.
+ *
+ * The headline case is the reported bug: selecting a filter did nothing at all,
+ * because the page called two `useFilterState` setters in the same tick and
+ * React Router's `setSearchParams` does not queue, so the second navigation
+ * discarded the first. "lands in the URL and in the refetch query string"
+ * below is the regression guard for that.
+ */
+
+// `t` must keep a stable identity across renders, as the real i18next hook
+// does — the page memoizes its fetch on it.
+jest.mock('react-i18next', () => {
+  const translate = (key, defaultValue, opts) => {
+    let str = typeof defaultValue === 'string' ? defaultValue : key;
+    if (opts && typeof str === 'string') {
+      for (const [k, v] of Object.entries(opts)) {
+        str = str.replace(new RegExp(`{{${k}}}`, 'g'), v);
+      }
+    }
+    return str;
+  };
+  const i18n = { language: 'en' };
+  return { useTranslation: () => ({ t: translate, i18n }) };
+});
+
+jest.mock('../../../client/src/shared/components/Icon', () => {
+  return function Icon({ name }) {
+    return <span data-testid={`icon-${name}`}>{name}</span>;
+  };
+});
+
+const mockMakeAdminApiCall = jest.fn();
+jest.mock('../../../client/src/api/adminApi', () => ({
+  makeAdminApiCall: (...args) => mockMakeAdminApiCall(...args)
+}));
+
+import AdminAuditLogPage from '../../../client/src/features/admin/pages/AdminAuditLogPage';
+
+const FACETS = {
+  actor: [
+    { value: 'alice', count: 12 },
+    { value: 'bob', count: 3 }
+  ],
+  resource: [
+    { value: 'auth', count: 10 },
+    { value: 'app', count: 5 }
+  ],
+  action: [
+    { value: 'login', count: 794 },
+    { value: 'create', count: 8 },
+    { value: 'update', count: 2 }
+  ],
+  result: [
+    { value: 'success', count: 800 },
+    { value: 'failure', count: 4 }
+  ],
+  source: [
+    { value: 'web', count: 700 },
+    { value: 'admin', count: 104 }
+  ]
+};
+
+const ENTRY = {
+  id: 'entry-1',
+  ts: '2026-08-24T10:00:00.000Z',
+  actor: { username: 'alice', authenticated: true },
+  action: 'create',
+  resource: 'app',
+  result: 'success',
+  source: 'admin',
+  summary: 'Created the chat app'
+};
+
+/** Renders the location's query string so assertions can read the URL state. */
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-search">{location.search}</div>;
+}
+
+function setup() {
+  mockMakeAdminApiCall.mockImplementation(url => {
+    if (url.startsWith('/admin/audit-log/retention')) {
+      return Promise.resolve({ data: { retentionDays: 365, cleanupEnabled: true } });
+    }
+    return Promise.resolve({ data: { entries: [ENTRY], total: 1, facets: FACETS } });
+  });
+
+  const utils = render(
+    <MemoryRouter initialEntries={['/admin/audit-log']}>
+      <AdminAuditLogPage />
+      <LocationProbe />
+    </MemoryRouter>
+  );
+  return utils;
+}
+
+/** Every audit-log list request made so far, oldest first. */
+function listCalls() {
+  return mockMakeAdminApiCall.mock.calls
+    .map(([url]) => url)
+    .filter(url => url.startsWith('/admin/audit-log?'));
+}
+
+const lastListCall = () => listCalls()[listCalls().length - 1];
+const urlSearch = () => screen.getByTestId('location-search').textContent;
+
+/** The trigger button of one filter, addressed by its field name. */
+const triggerFor = label => screen.getByRole('button', { name: new RegExp(`^${label}\\b`) });
+
+/**
+ * Wait until the facets response has been applied. Source is never filtered in
+ * these tests, so its trigger goes from "No values in range" to "All sources"
+ * exactly when the facets land.
+ */
+const waitForFacets = () =>
+  waitFor(() => expect(triggerFor('Source')).toHaveTextContent('All sources'));
+
+/** Open a filter popover by its field name and return its trigger. */
+function openFilter(label) {
+  const trigger = triggerFor(label);
+  fireEvent.click(trigger);
+  return trigger;
+}
+
+/** The open popover. Scoping to it keeps table cells out of option queries. */
+const popover = () => within(screen.getByRole('group'));
+
+function checkboxFor(labelText) {
+  const row = popover().getByText(labelText).closest('label');
+  return within(row).getByRole('checkbox');
+}
+
+beforeEach(() => {
+  mockMakeAdminApiCall.mockReset();
+});
+
+describe('AdminAuditLogPage filters reach the URL and the server', () => {
+  it('renders checkbox options with their entry counts from the facets payload', async () => {
+    setup();
+    await waitForFacets();
+
+    // The first request asks for facets, in the same scan as the query.
+    expect(lastListCall()).toContain('facets=1');
+
+    openFilter('Action');
+
+    expect(popover().getByText('login')).toBeInTheDocument();
+    expect(popover().getByText('794')).toBeInTheDocument();
+    expect(popover().getByText('create')).toBeInTheDocument();
+  });
+
+  it('lands a deselected value in the URL and in the refetch query string', async () => {
+    setup();
+    await waitForFacets();
+    const before = listCalls().length;
+
+    openFilter('Action');
+    fireEvent.click(checkboxFor('login'));
+
+    // The reported bug: the filter never reached the URL at all.
+    await waitFor(() => expect(urlSearch()).toContain('actionExclude=login'));
+    // ...and it must reach the server too, not just the address bar.
+    await waitFor(() => expect(listCalls().length).toBeGreaterThan(before));
+    expect(decodeURIComponent(lastListCall())).toContain('actionExclude=login');
+  });
+
+  it('resets to page 1 in the same navigation that changes a filter', async () => {
+    setup();
+    await waitForFacets();
+
+    // Move off page 1 first.
+    openFilter('Resource');
+    fireEvent.click(checkboxFor('auth'));
+    await waitFor(() => expect(urlSearch()).toContain('resourceExclude=auth'));
+
+    // page is omitted when it is 1, so the filter is present and page is not.
+    expect(urlSearch()).not.toContain('page=');
+    expect(decodeURIComponent(lastListCall())).toContain('offset=0');
+  });
+
+  it('keeps a new page size instead of reverting to the default', async () => {
+    setup();
+    await waitForFacets();
+
+    fireEvent.change(screen.getByLabelText(/rows per page/i), { target: { value: '100' } });
+
+    await waitFor(() => expect(urlSearch()).toContain('pageSize=100'));
+    await waitFor(() => expect(decodeURIComponent(lastListCall())).toContain('limit=100'));
+  });
+
+  it('sends no filter parameter when everything is selected again', async () => {
+    setup();
+    await waitForFacets();
+
+    openFilter('Action');
+    fireEvent.click(checkboxFor('login'));
+    await waitFor(() => expect(urlSearch()).toContain('actionExclude=login'));
+
+    fireEvent.click(checkboxFor('login'));
+    await waitFor(() => expect(urlSearch()).not.toContain('actionExclude'));
+    expect(urlSearch()).not.toContain('action=');
+  });
+});
+
+describe('AdminAuditLogPage select all / select none', () => {
+  it('excludes every value on Select none', async () => {
+    setup();
+    await waitForFacets();
+
+    openFilter('Action');
+    fireEvent.click(popover().getByText('Select none'));
+
+    await waitFor(() => expect(urlSearch()).toContain('actionExclude=*'));
+  });
+
+  it('clears both parameters on Select all', async () => {
+    setup();
+    await waitForFacets();
+
+    openFilter('Action');
+    fireEvent.click(popover().getByText('Select none'));
+    await waitFor(() => expect(urlSearch()).toContain('actionExclude=*'));
+
+    fireEvent.click(popover().getByText('Select all'));
+    await waitFor(() => expect(urlSearch()).not.toContain('actionExclude'));
+  });
+});
+
+describe('AdminAuditLogPage reads existing filter links', () => {
+  function renderWith(search) {
+    mockMakeAdminApiCall.mockImplementation(url => {
+      if (url.startsWith('/admin/audit-log/retention')) {
+        return Promise.resolve({ data: { retentionDays: 365, cleanupEnabled: true } });
+      }
+      return Promise.resolve({ data: { entries: [ENTRY], total: 1, facets: FACETS } });
+    });
+    return render(
+      <MemoryRouter initialEntries={[`/admin/audit-log${search}`]}>
+        <AdminAuditLogPage />
+        <LocationProbe />
+      </MemoryRouter>
+    );
+  }
+
+  it('honours a legacy single-value inclusion link', async () => {
+    renderWith('?resource=app');
+    await waitForFacets();
+
+    expect(decodeURIComponent(lastListCall())).toContain('resource=app');
+    // Only `app` is ticked, so the trigger reports a partial selection.
+    await waitFor(() => expect(triggerFor('Resource')).toHaveTextContent('1 of 2'));
+  });
+
+  it('honours an exclusion link', async () => {
+    renderWith('?actionExclude=login,create');
+    await waitForFacets();
+
+    expect(decodeURIComponent(lastListCall())).toContain('actionExclude=login,create');
+    await waitFor(() => expect(triggerFor('Action')).toHaveTextContent('1 of 3'));
+  });
+
+  it('reports the select-none state for an exclude-all link', async () => {
+    renderWith('?actionExclude=*');
+    await waitForFacets();
+
+    await waitFor(() => expect(triggerFor('Action')).toHaveTextContent('No actions'));
+  });
+});
+
+describe('AdminAuditLogPage quick presets and search', () => {
+  it('hides sign-ins with one click and restores them with a second', async () => {
+    setup();
+    await waitForFacets();
+
+    const chip = screen.getByRole('button', { name: 'Hide sign-ins' });
+    expect(chip).toHaveAttribute('aria-pressed', 'false');
+
+    fireEvent.click(chip);
+    await waitFor(() => expect(decodeURIComponent(urlSearch())).toContain('actionExclude=login'));
+    expect(decodeURIComponent(urlSearch())).toContain('logout');
+    expect(screen.getByRole('button', { name: 'Hide sign-ins' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide sign-ins' }));
+    await waitFor(() => expect(urlSearch()).not.toContain('actionExclude'));
+  });
+
+  it('filters to failures only and back', async () => {
+    setup();
+    await waitForFacets();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Failures only' }));
+    await waitFor(() => expect(urlSearch()).toContain('result=failure'));
+    await waitFor(() => expect(decodeURIComponent(lastListCall())).toContain('result=failure'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Failures only' }));
+    await waitFor(() => expect(urlSearch()).not.toContain('result='));
+  });
+
+  it('sends the free-text search term to the server', async () => {
+    setup();
+    await waitForFacets();
+
+    fireEvent.change(screen.getByLabelText(/Search summary, resource ID/), {
+      target: { value: 'chat app' }
+    });
+
+    // URLSearchParams encodes the space as '+', on both sides.
+    await waitFor(() => expect(urlSearch()).toContain('q=chat+app'));
+    await waitFor(() => expect(lastListCall()).toContain('q=chat+app'));
+  });
+
+  it('clears every filter at once', async () => {
+    setup();
+    await waitForFacets();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide sign-ins' }));
+    await waitFor(() => expect(urlSearch()).toContain('actionExclude'));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear all filters' }));
+    await waitFor(() => expect(urlSearch()).toBe(''));
+  });
+});
+
+describe('AdminAuditLogPage keyboard access', () => {
+  it('closes the popover on Escape and returns focus to the trigger', async () => {
+    setup();
+    await waitForFacets();
+
+    const trigger = openFilter('Action');
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.keyDown(popover().getByText('Select all'), { key: 'Escape' });
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(trigger).toHaveFocus();
+  });
+
+  it('opens the popover from the trigger with ArrowDown', async () => {
+    setup();
+    await waitForFacets();
+
+    const trigger = triggerFor('Action');
+    fireEvent.keyDown(trigger, { key: 'ArrowDown' });
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(popover().getByText('login')).toBeInTheDocument();
+  });
+
+  it('moves focus between checkboxes with the arrow keys', async () => {
+    setup();
+    await waitForFacets();
+
+    openFilter('Action');
+    const first = checkboxFor('login');
+    expect(first).toHaveFocus();
+
+    fireEvent.keyDown(first, { key: 'ArrowDown' });
+    expect(checkboxFor('create')).toHaveFocus();
+
+    fireEvent.keyDown(checkboxFor('create'), { key: 'ArrowUp' });
+    expect(first).toHaveFocus();
+  });
+});

--- a/tests/unit/client/admin-audit-log-filters.test.jsx
+++ b/tests/unit/client/admin-audit-log-filters.test.jsx
@@ -14,10 +14,21 @@ import '@testing-library/jest-dom';
  */
 
 // `t` must keep a stable identity across renders, as the real i18next hook
-// does — the page memoizes its fetch on it.
+// does — the page memoizes its fetch on it. The `values.*` keys are resolved
+// rather than falling through to their raw-value defaults, so a test can tell
+// a translated label apart from an untranslated one.
 jest.mock('react-i18next', () => {
+  const TRANSLATED = {
+    'admin.auditLog.values.action.login': 'Login',
+    'admin.auditLog.values.action.create': 'Create',
+    'admin.auditLog.values.action.update': 'Update',
+    'admin.auditLog.values.result.success': 'Success',
+    'admin.auditLog.values.result.failure': 'Failure',
+    'admin.auditLog.values.source.web': 'Web',
+    'admin.auditLog.values.source.admin': 'Admin'
+  };
   const translate = (key, defaultValue, opts) => {
-    let str = typeof defaultValue === 'string' ? defaultValue : key;
+    let str = TRANSLATED[key] ?? (typeof defaultValue === 'string' ? defaultValue : key);
     if (opts && typeof str === 'string') {
       for (const [k, v] of Object.entries(opts)) {
         str = str.replace(new RegExp(`{{${k}}}`, 'g'), v);
@@ -83,21 +94,20 @@ function LocationProbe() {
   return <div data-testid="location-search">{location.search}</div>;
 }
 
-function setup() {
+function setup(search = '') {
   mockMakeAdminApiCall.mockImplementation(url => {
     if (url.startsWith('/admin/audit-log/retention')) {
       return Promise.resolve({ data: { retentionDays: 365, cleanupEnabled: true } });
     }
-    return Promise.resolve({ data: { entries: [ENTRY], total: 1, facets: FACETS } });
+    return Promise.resolve({ data: { entries: [ENTRY], total: 400, facets: FACETS } });
   });
 
-  const utils = render(
-    <MemoryRouter initialEntries={['/admin/audit-log']}>
+  return render(
+    <MemoryRouter initialEntries={[`/admin/audit-log${search}`]}>
       <AdminAuditLogPage />
       <LocationProbe />
     </MemoryRouter>
   );
-  return utils;
 }
 
 /** Every audit-log list request made so far, oldest first. */
@@ -150,9 +160,9 @@ describe('AdminAuditLogPage filters reach the URL and the server', () => {
 
     openFilter('Action');
 
-    expect(popover().getByText('login')).toBeInTheDocument();
+    expect(popover().getByText('Login')).toBeInTheDocument();
     expect(popover().getByText('794')).toBeInTheDocument();
-    expect(popover().getByText('create')).toBeInTheDocument();
+    expect(popover().getByText('Create')).toBeInTheDocument();
   });
 
   it('lands a deselected value in the URL and in the refetch query string', async () => {
@@ -161,7 +171,7 @@ describe('AdminAuditLogPage filters reach the URL and the server', () => {
     const before = listCalls().length;
 
     openFilter('Action');
-    fireEvent.click(checkboxFor('login'));
+    fireEvent.click(checkboxFor('Login'));
 
     // The reported bug: the filter never reached the URL at all.
     await waitFor(() => expect(urlSearch()).toContain('actionExclude=login'));
@@ -171,17 +181,29 @@ describe('AdminAuditLogPage filters reach the URL and the server', () => {
   });
 
   it('resets to page 1 in the same navigation that changes a filter', async () => {
-    setup();
+    // Start on page 4 so the reset has something to undo — without this the
+    // test passes even with the page-reset wiring removed.
+    setup('?page=4');
     await waitForFacets();
+    expect(urlSearch()).toContain('page=4');
+    expect(decodeURIComponent(lastListCall())).toContain('offset=150');
 
-    // Move off page 1 first.
     openFilter('Resource');
     fireEvent.click(checkboxFor('auth'));
     await waitFor(() => expect(urlSearch()).toContain('resourceExclude=auth'));
 
-    // page is omitted when it is 1, so the filter is present and page is not.
+    // `page` is omitted when it is 1, so the filter survives and the page is gone.
     expect(urlSearch()).not.toContain('page=');
-    expect(decodeURIComponent(lastListCall())).toContain('offset=0');
+    await waitFor(() => expect(decodeURIComponent(lastListCall())).toContain('offset=0'));
+  });
+
+  it('clamps a page size larger than the table offers', async () => {
+    // The server caps `limit`, so a bigger URL value would page over rows it
+    // never returns.
+    setup('?pageSize=5000');
+    await waitForFacets();
+
+    expect(decodeURIComponent(lastListCall())).toContain('limit=200');
   });
 
   it('keeps a new page size instead of reverting to the default', async () => {
@@ -199,12 +221,25 @@ describe('AdminAuditLogPage filters reach the URL and the server', () => {
     await waitForFacets();
 
     openFilter('Action');
-    fireEvent.click(checkboxFor('login'));
+    fireEvent.click(checkboxFor('Login'));
     await waitFor(() => expect(urlSearch()).toContain('actionExclude=login'));
 
-    fireEvent.click(checkboxFor('login'));
+    fireEvent.click(checkboxFor('Login'));
     await waitFor(() => expect(urlSearch()).not.toContain('actionExclude'));
     expect(urlSearch()).not.toContain('action=');
+  });
+});
+
+describe('AdminAuditLogPage table values', () => {
+  it('renders action, result and source through the value translations', async () => {
+    setup();
+    await waitForFacets();
+
+    // The row for ENTRY: action `create`, result `success`, source `admin`.
+    const row = screen.getByText('Created the chat app').closest('tr');
+    expect(within(row).getByText('Create')).toBeInTheDocument();
+    expect(within(row).getByText('Success')).toBeInTheDocument();
+    expect(within(row).getByText('Admin')).toBeInTheDocument();
   });
 });
 
@@ -352,7 +387,7 @@ describe('AdminAuditLogPage keyboard access', () => {
     fireEvent.keyDown(trigger, { key: 'ArrowDown' });
 
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
-    expect(popover().getByText('login')).toBeInTheDocument();
+    expect(popover().getByText('Login')).toBeInTheDocument();
   });
 
   it('moves focus between checkboxes with the arrow keys', async () => {
@@ -360,13 +395,13 @@ describe('AdminAuditLogPage keyboard access', () => {
     await waitForFacets();
 
     openFilter('Action');
-    const first = checkboxFor('login');
+    const first = checkboxFor('Login');
     expect(first).toHaveFocus();
 
     fireEvent.keyDown(first, { key: 'ArrowDown' });
-    expect(checkboxFor('create')).toHaveFocus();
+    expect(checkboxFor('Create')).toHaveFocus();
 
-    fireEvent.keyDown(checkboxFor('create'), { key: 'ArrowUp' });
+    fireEvent.keyDown(checkboxFor('Create'), { key: 'ArrowUp' });
     expect(first).toHaveFocus();
   });
 });

--- a/tests/unit/client/audit-log-filter-encoding.test.jsx
+++ b/tests/unit/client/audit-log-filter-encoding.test.jsx
@@ -1,0 +1,72 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  MAX_FILTER_VALUES,
+  encodeSelection
+} from '../../../client/src/features/admin/utils/auditLogFilters';
+
+const options = values => values.map(value => ({ value, count: 1 }));
+
+describe('encodeSelection', () => {
+  it('clears both parameters when everything is selected', () => {
+    expect(encodeSelection('action', options(['a', 'b']), ['a', 'b'])).toEqual({
+      action: null,
+      actionExclude: null
+    });
+  });
+
+  it('writes the wildcard exclusion when nothing is selected', () => {
+    expect(encodeSelection('action', options(['a', 'b']), [])).toEqual({
+      action: null,
+      actionExclude: '*'
+    });
+  });
+
+  it('writes the exclusion form for a partial selection', () => {
+    expect(encodeSelection('action', options(['a', 'b', 'c']), ['a'])).toEqual({
+      action: null,
+      actionExclude: 'b,c'
+    });
+  });
+
+  it('writes repeated values for the actor field, which is never comma-split', () => {
+    expect(encodeSelection('actor', options(['Doe, John', 'alice', 'bob']), ['bob'])).toEqual({
+      actor: null,
+      actorExclude: ['Doe, John', 'alice']
+    });
+  });
+
+  it('handles an empty option list without excluding everything', () => {
+    expect(encodeSelection('action', [], [])).toEqual({ action: null, actionExclude: null });
+  });
+});
+
+describe('encodeSelection against the server cap', () => {
+  // One value ticked out of more options than the cap: the exclusion form
+  // would be rejected by the server as too many values, so the inclusion form
+  // is written instead. Without this the UI's own request 400s.
+  const many = options(Array.from({ length: MAX_FILTER_VALUES + 2 }, (_, i) => `actor-${i}`));
+
+  it('falls back to the inclusion form when the exclusion list is over the cap', () => {
+    const encoded = encodeSelection('actor', many, ['actor-0']);
+    expect(encoded.actorExclude).toBeNull();
+    expect(encoded.actor).toEqual(['actor-0']);
+  });
+
+  it('never emits more than the cap allows for either form', () => {
+    for (const selectedCount of [1, 2, MAX_FILTER_VALUES, MAX_FILTER_VALUES + 1]) {
+      const selected = many.slice(0, selectedCount).map(o => o.value);
+      const encoded = encodeSelection('actor', many, selected);
+      const emitted = encoded.actor ?? encoded.actorExclude;
+      if (Array.isArray(emitted)) expect(emitted.length).toBeLessThanOrEqual(MAX_FILTER_VALUES);
+    }
+  });
+
+  it('still prefers the exclusion form whenever it fits', () => {
+    // Exclusion is what keeps values added by a later release visible in a
+    // bookmarked view, so it wins unless it cannot be expressed.
+    const fits = options(Array.from({ length: MAX_FILTER_VALUES }, (_, i) => `actor-${i}`));
+    const encoded = encodeSelection('actor', fits, ['actor-0']);
+    expect(encoded.actor).toBeNull();
+    expect(encoded.actorExclude).toHaveLength(MAX_FILTER_VALUES - 1);
+  });
+});

--- a/tests/unit/client/use-filter-params.test.jsx
+++ b/tests/unit/client/use-filter-params.test.jsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
+import '@testing-library/jest-dom';
+
+import {
+  useFilterState,
+  useFilterParams
+} from '../../../client/src/features/admin/hooks/useFilterState';
+
+/**
+ * The root cause behind issue #2213: React Router's `setSearchParams` does not
+ * queue the way React's `setState` does. Its functional updater is handed the
+ * *render-time* params, so two calls in the same tick both compute from the
+ * pre-change URL and the second navigation discards the first.
+ *
+ * These tests pin both halves of that: the trap `useFilterState` carries (so
+ * nobody "simplifies" `useFilterParams` away), and the batching guarantee
+ * `useFilterParams` exists to provide.
+ */
+
+function Search() {
+  const location = useLocation();
+  return <div data-testid="search">{location.search}</div>;
+}
+
+const search = () => screen.getByTestId('search').textContent;
+
+function renderAt(ui, initial = '/x') {
+  return render(
+    <MemoryRouter initialEntries={[initial]}>
+      {ui}
+      <Search />
+    </MemoryRouter>
+  );
+}
+
+describe('useFilterState', () => {
+  function OneSetter() {
+    const [resource, setResource] = useFilterState('resource', 'all');
+    return (
+      <button type="button" onClick={() => setResource('app')}>
+        {resource}
+      </button>
+    );
+  }
+
+  it('writes a single parameter', () => {
+    renderAt(<OneSetter />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(search()).toBe('?resource=app');
+  });
+
+  it('removes the parameter when set back to its default', () => {
+    function Toggle() {
+      const [resource, setResource] = useFilterState('resource', 'all');
+      return (
+        <button type="button" onClick={() => setResource(resource === 'all' ? 'app' : 'all')}>
+          go
+        </button>
+      );
+    }
+    renderAt(<Toggle />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(search()).toBe('?resource=app');
+    fireEvent.click(screen.getByRole('button'));
+    expect(search()).toBe('');
+  });
+
+  it('loses the first update when two setters run in the same tick', () => {
+    // This is the bug, kept as an executable warning: `page` is written and
+    // `resource` is lost, which is exactly what made every audit log filter
+    // appear to do nothing.
+    function TwoSetters() {
+      const [, setResource] = useFilterState('resource', 'all');
+      const [, setPage] = useFilterState('page', '1');
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            setResource('app');
+            setPage('2');
+          }}
+        >
+          go
+        </button>
+      );
+    }
+    renderAt(<TwoSetters />);
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(search()).toBe('?page=2');
+    expect(search()).not.toContain('resource');
+  });
+});
+
+describe('useFilterParams', () => {
+  function Batched({ updates }) {
+    const { get, setMany } = useFilterParams({ page: '1', pageSize: '50' });
+    return (
+      <>
+        <button type="button" onClick={() => setMany(updates)}>
+          go
+        </button>
+        <span data-testid="page">{get('page')}</span>
+      </>
+    );
+  }
+
+  it('applies several parameters in one navigation', () => {
+    renderAt(<Batched updates={{ resource: 'app', page: '2' }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'go' }));
+
+    const params = new URLSearchParams(search());
+    expect(params.get('resource')).toBe('app');
+    expect(params.get('page')).toBe('2');
+  });
+
+  it('changes a filter and resets the page in the same navigation', () => {
+    renderAt(<Batched updates={{ resource: 'app', page: null }} />, '/x?page=4');
+    fireEvent.click(screen.getByRole('button', { name: 'go' }));
+
+    expect(search()).toBe('?resource=app');
+    expect(screen.getByTestId('page')).toHaveTextContent('1');
+  });
+
+  it('drops a parameter set to its default, null, or an empty string', () => {
+    renderAt(
+      <Batched updates={{ page: '1', pageSize: null, q: '' }} />,
+      '/x?page=3&pageSize=100&q=hi'
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'go' }));
+    expect(search()).toBe('');
+  });
+
+  it('writes repeated parameters for an array, so values may contain commas', () => {
+    renderAt(<Batched updates={{ actor: ['Doe, John', 'alice'] }} />);
+    fireEvent.click(screen.getByRole('button', { name: 'go' }));
+
+    expect(new URLSearchParams(search()).getAll('actor')).toEqual(['Doe, John', 'alice']);
+  });
+
+  it('replaces rather than appends to an existing repeated parameter', () => {
+    renderAt(<Batched updates={{ actor: ['bob'] }} />, '/x?actor=alice&actor=carol');
+    fireEvent.click(screen.getByRole('button', { name: 'go' }));
+
+    expect(new URLSearchParams(search()).getAll('actor')).toEqual(['bob']);
+  });
+
+  it('removes a parameter set to an empty array', () => {
+    renderAt(<Batched updates={{ actor: [] }} />, '/x?actor=alice');
+    fireEvent.click(screen.getByRole('button', { name: 'go' }));
+    expect(search()).toBe('');
+  });
+
+  it('leaves parameters it was not given alone', () => {
+    renderAt(<Batched updates={{ resource: 'app' }} />, '/x?from=2026-08-01');
+    fireEvent.click(screen.getByRole('button', { name: 'go' }));
+
+    const params = new URLSearchParams(search());
+    expect(params.get('from')).toBe('2026-08-01');
+    expect(params.get('resource')).toBe('app');
+  });
+
+  it('falls back to the declared default when a parameter is absent', () => {
+    renderAt(<Batched updates={{}} />);
+    expect(screen.getByTestId('page')).toHaveTextContent('1');
+  });
+});

--- a/tests/unit/server/auditLogQuery.test.js
+++ b/tests/unit/server/auditLogQuery.test.js
@@ -1,0 +1,424 @@
+import { describe, it, expect, jest, beforeAll, afterAll } from '@jest/globals';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+// pathUtils resolves the app root via import.meta.url, which babel-jest's CJS
+// transform cannot evaluate — and the tests need the audit log to live in a
+// temp directory anyway. getRootDir() is only called while a query runs, so the
+// factory can read a value assigned in beforeAll.
+let mockAuditRoot;
+jest.mock('../../../server/pathUtils.js', () => ({
+  getRootDir: () => mockAuditRoot
+}));
+
+// The service only reads `audit` settings out of the platform config, and the
+// real configCache pulls in the whole authorization stack (import.meta again).
+jest.mock('../../../server/configCache.js', () => ({
+  __esModule: true,
+  default: { getPlatform: () => ({}) }
+}));
+
+import { queryAuditLog } from '../../../server/services/AuditLogService.js';
+
+const auditDir = () => path.join(mockAuditRoot, 'contents', 'data', 'audit-log');
+
+/** Entries are written across two days so the date-range filter is exercised too. */
+const DAY_ONE = '2026-08-20';
+const DAY_TWO = '2026-08-21';
+
+function entry({ ts, actor, action, resource, result, source, summary, ip, requestId, admin }) {
+  const record = {
+    id: `id-${ts}`,
+    ts,
+    action,
+    resource,
+    resourceId: `${resource}-1`,
+    summary: summary ?? '',
+    result: result ?? 'success',
+    source: source ?? 'admin',
+    requestId: requestId ?? `req-${ts}`
+  };
+  // Entries written before the actor migration carry a plain `admin` string
+  // instead of an `actor` object; both shapes must match an actor filter.
+  if (admin !== undefined) record.admin = admin;
+  else record.actor = { id: actor, username: actor, groups: [], authenticated: true };
+  if (ip !== undefined) record.ip = ip;
+  return record;
+}
+
+const DAY_ONE_ENTRIES = [
+  entry({ ts: `${DAY_ONE}T09:00:00.000Z`, actor: 'alice', action: 'login', resource: 'auth' }),
+  entry({ ts: `${DAY_ONE}T09:05:00.000Z`, actor: 'alice', action: 'logout', resource: 'auth' }),
+  entry({
+    ts: `${DAY_ONE}T10:00:00.000Z`,
+    actor: 'alice',
+    action: 'create',
+    resource: 'app',
+    summary: 'Created the chat app',
+    ip: '10.1.2.0'
+  }),
+  entry({
+    ts: `${DAY_ONE}T11:00:00.000Z`,
+    actor: 'Doe, John',
+    action: 'update',
+    resource: 'app',
+    summary: 'Renamed the app',
+    requestId: 'req-abc-123'
+  }),
+  entry({
+    ts: `${DAY_ONE}T12:00:00.000Z`,
+    action: 'delete',
+    resource: 'model',
+    admin: 'legacy-admin',
+    result: 'failure'
+  })
+];
+
+const DAY_TWO_ENTRIES = [
+  entry({ ts: `${DAY_TWO}T08:00:00.000Z`, actor: 'bob', action: 'login', resource: 'auth' }),
+  entry({
+    ts: `${DAY_TWO}T08:30:00.000Z`,
+    actor: 'bob',
+    action: 'login',
+    resource: 'auth',
+    result: 'failure'
+  }),
+  entry({
+    ts: `${DAY_TWO}T09:00:00.000Z`,
+    actor: 'bob',
+    action: 'update',
+    resource: 'user',
+    source: 'web',
+    summary: 'Disabled a user'
+  })
+];
+
+// Every entry across both days, plus one line that is not valid JSON and one
+// day outside the range the tests query.
+const OUT_OF_RANGE = [
+  entry({ ts: '2026-07-01T09:00:00.000Z', actor: 'carol', action: 'create', resource: 'source' })
+];
+
+function writeDay(date, entries, { malformed = false } = {}) {
+  const lines = entries.map(e => JSON.stringify(e));
+  if (malformed) lines.splice(1, 0, '{ not json');
+  writeFileSync(path.join(auditDir(), `${date}.jsonl`), `${lines.join('\n')}\n`, 'utf8');
+}
+
+/** The default range for every test below: exactly the two seeded days. */
+const range = { from: DAY_ONE, to: DAY_TWO };
+
+const actorsOf = result => result.entries.map(e => e.actor?.username ?? e.admin);
+const actionsOf = result => result.entries.map(e => e.action);
+
+beforeAll(() => {
+  mockAuditRoot = mkdtempSync(path.join(os.tmpdir(), 'ihub-audit-log-'));
+  mkdirSync(auditDir(), { recursive: true });
+  writeDay(DAY_ONE, DAY_ONE_ENTRIES, { malformed: true });
+  writeDay(DAY_TWO, DAY_TWO_ENTRIES);
+  writeDay('2026-07-01', OUT_OF_RANGE);
+});
+
+afterAll(() => {
+  rmSync(mockAuditRoot, { recursive: true, force: true });
+});
+
+describe('queryAuditLog date range and parsing', () => {
+  it('returns every entry in the range, newest first, skipping malformed lines', async () => {
+    const result = await queryAuditLog({ ...range, limit: 100 });
+
+    expect(result.total).toBe(DAY_ONE_ENTRIES.length + DAY_TWO_ENTRIES.length);
+    expect(result.entries).toHaveLength(result.total);
+    const timestamps = result.entries.map(e => e.ts);
+    expect(timestamps).toEqual([...timestamps].sort().reverse());
+  });
+
+  it('ignores files outside the date range', async () => {
+    const result = await queryAuditLog({ ...range, limit: 100 });
+    expect(actorsOf(result)).not.toContain('carol');
+  });
+
+  it('paginates over the filtered set', async () => {
+    const all = await queryAuditLog({ ...range, limit: 100 });
+    const firstPage = await queryAuditLog({ ...range, limit: 3, offset: 0 });
+    const secondPage = await queryAuditLog({ ...range, limit: 3, offset: 3 });
+
+    expect(firstPage.total).toBe(all.total);
+    expect(secondPage.total).toBe(all.total);
+    expect(firstPage.entries.map(e => e.id)).toEqual(all.entries.slice(0, 3).map(e => e.id));
+    expect(secondPage.entries.map(e => e.id)).toEqual(all.entries.slice(3, 6).map(e => e.id));
+  });
+
+  it('returns an empty result when the audit directory does not exist', async () => {
+    const result = await queryAuditLog({ from: '1999-01-01', to: '1999-01-02', facets: true });
+    expect(result).toEqual({ entries: [], total: 0, facets: expect.any(Object) });
+  });
+});
+
+describe('queryAuditLog single-value filters (backward compatibility)', () => {
+  it('matches a single action', async () => {
+    const result = await queryAuditLog({ ...range, action: 'login', limit: 100 });
+    expect(result.total).toBe(3);
+    expect(new Set(actionsOf(result))).toEqual(new Set(['login']));
+  });
+
+  it('matches a single resource', async () => {
+    const result = await queryAuditLog({ ...range, resource: 'app', limit: 100 });
+    expect(result.total).toBe(2);
+  });
+
+  it('matches a single actor', async () => {
+    const result = await queryAuditLog({ ...range, actor: 'bob', limit: 100 });
+    expect(result.total).toBe(3);
+    expect(new Set(actorsOf(result))).toEqual(new Set(['bob']));
+  });
+
+  it('treats a missing result field as success', async () => {
+    const success = await queryAuditLog({ ...range, result: 'success', limit: 100 });
+    const failure = await queryAuditLog({ ...range, result: 'failure', limit: 100 });
+    expect(failure.total).toBe(2);
+    expect(success.total + failure.total).toBe(DAY_ONE_ENTRIES.length + DAY_TWO_ENTRIES.length);
+  });
+
+  it('matches legacy entries that carry `admin` instead of `actor`', async () => {
+    const result = await queryAuditLog({ ...range, actor: 'legacy-admin', limit: 100 });
+    expect(result.total).toBe(1);
+    expect(result.entries[0].admin).toBe('legacy-admin');
+  });
+
+  it('returns nothing for a value no entry has', async () => {
+    const result = await queryAuditLog({ ...range, resource: 'nonexistent', limit: 100 });
+    expect(result.total).toBe(0);
+  });
+});
+
+describe('queryAuditLog include sets', () => {
+  it('matches any value in an array', async () => {
+    const result = await queryAuditLog({ ...range, action: ['create', 'update'], limit: 100 });
+    expect(result.total).toBe(3);
+    expect(new Set(actionsOf(result))).toEqual(new Set(['create', 'update']));
+  });
+
+  it("treats '*' as every value, identical to omitting the parameter", async () => {
+    const wildcard = await queryAuditLog({ ...range, action: '*', limit: 100 });
+    const omitted = await queryAuditLog({ ...range, limit: 100 });
+    expect(wildcard.total).toBe(omitted.total);
+  });
+
+  it("treats '*' inside an array as every value", async () => {
+    const result = await queryAuditLog({ ...range, action: ['login', '*'], limit: 100 });
+    expect(result.total).toBe(DAY_ONE_ENTRIES.length + DAY_TWO_ENTRIES.length);
+  });
+
+  it('treats an empty array as no filter', async () => {
+    const result = await queryAuditLog({ ...range, action: [], limit: 100 });
+    expect(result.total).toBe(DAY_ONE_ENTRIES.length + DAY_TWO_ENTRIES.length);
+  });
+
+  it('matches an actor whose name contains a comma as one value', async () => {
+    const result = await queryAuditLog({ ...range, actor: ['Doe, John'], limit: 100 });
+    expect(result.total).toBe(1);
+    expect(result.entries[0].actor.username).toBe('Doe, John');
+  });
+});
+
+describe('queryAuditLog exclude sets', () => {
+  it('excludes the listed values and keeps everything else', async () => {
+    const result = await queryAuditLog({
+      ...range,
+      actionExclude: ['login', 'logout'],
+      limit: 100
+    });
+    expect(result.total).toBe(4);
+    expect(actionsOf(result)).not.toContain('login');
+    expect(actionsOf(result)).not.toContain('logout');
+  });
+
+  it("returns nothing for an exclude set of '*' — the select-none state", async () => {
+    const result = await queryAuditLog({ ...range, actionExclude: '*', limit: 100 });
+    expect(result.total).toBe(0);
+    expect(result.entries).toEqual([]);
+  });
+
+  it('combines an explicit include-all with an exclusion', async () => {
+    const combined = await queryAuditLog({
+      ...range,
+      action: '*',
+      actionExclude: 'login',
+      limit: 100
+    });
+    const excludeOnly = await queryAuditLog({ ...range, actionExclude: 'login', limit: 100 });
+    expect(combined.total).toBe(excludeOnly.total);
+    expect(actionsOf(combined)).not.toContain('login');
+  });
+
+  it('lets exclusion win over inclusion for a value in both sets', async () => {
+    const result = await queryAuditLog({
+      ...range,
+      resource: 'app',
+      resourceExclude: 'app',
+      limit: 100
+    });
+    expect(result.total).toBe(0);
+  });
+
+  it('subtracts an exclusion from a narrower include set', async () => {
+    const result = await queryAuditLog({
+      ...range,
+      action: ['create', 'update', 'delete'],
+      actionExclude: 'delete',
+      limit: 100
+    });
+    expect(new Set(actionsOf(result))).toEqual(new Set(['create', 'update']));
+  });
+
+  it('treats the exclusion of an unknown value as a no-op', async () => {
+    const excluded = await queryAuditLog({ ...range, actionExclude: 'nonexistent', limit: 100 });
+    const unfiltered = await queryAuditLog({ ...range, limit: 100 });
+    expect(excluded.total).toBe(unfiltered.total);
+  });
+
+  it('excludes an actor whose name contains a comma as one value', async () => {
+    const result = await queryAuditLog({ ...range, actorExclude: ['Doe, John'], limit: 100 });
+    expect(actorsOf(result)).not.toContain('Doe, John');
+    expect(result.total).toBe(DAY_ONE_ENTRIES.length + DAY_TWO_ENTRIES.length - 1);
+  });
+
+  it('applies exclusions on several fields at once', async () => {
+    const result = await queryAuditLog({
+      ...range,
+      actionExclude: ['login', 'logout'],
+      resourceExclude: 'model',
+      limit: 100
+    });
+    expect(new Set(actionsOf(result))).toEqual(new Set(['create', 'update']));
+    expect(result.total).toBe(3);
+  });
+});
+
+describe('queryAuditLog free-text search', () => {
+  it('matches the summary, case-insensitively', async () => {
+    const result = await queryAuditLog({ ...range, q: 'CREATED THE CHAT', limit: 100 });
+    expect(result.total).toBe(1);
+    expect(result.entries[0].summary).toBe('Created the chat app');
+  });
+
+  it('matches the resource id', async () => {
+    const result = await queryAuditLog({ ...range, q: 'user-1', limit: 100 });
+    expect(result.total).toBe(1);
+    expect(result.entries[0].resource).toBe('user');
+  });
+
+  it('matches the IP and the request id', async () => {
+    await expect(queryAuditLog({ ...range, q: '10.1.2.0', limit: 100 })).resolves.toMatchObject({
+      total: 1
+    });
+    await expect(queryAuditLog({ ...range, q: 'abc-123', limit: 100 })).resolves.toMatchObject({
+      total: 1
+    });
+  });
+
+  it('matches the actor name', async () => {
+    const result = await queryAuditLog({ ...range, q: 'doe', limit: 100 });
+    expect(result.total).toBe(1);
+  });
+
+  it('is ignored when blank', async () => {
+    const blank = await queryAuditLog({ ...range, q: '   ', limit: 100 });
+    const unfiltered = await queryAuditLog({ ...range, limit: 100 });
+    expect(blank.total).toBe(unfiltered.total);
+  });
+
+  it('combines with the value filters', async () => {
+    const result = await queryAuditLog({
+      ...range,
+      q: 'app',
+      actionExclude: 'update',
+      limit: 100
+    });
+    expect(actionsOf(result)).toEqual(['create']);
+  });
+});
+
+describe('queryAuditLog facets', () => {
+  const facetMap = (result, field) =>
+    Object.fromEntries(result.facets[field].map(({ value, count }) => [value, count]));
+
+  it('is omitted unless requested', async () => {
+    const result = await queryAuditLog({ ...range, limit: 100 });
+    expect(result.facets).toBeUndefined();
+  });
+
+  it('counts every value in the date range', async () => {
+    const result = await queryAuditLog({ ...range, facets: true, limit: 100 });
+
+    expect(facetMap(result, 'action')).toEqual({
+      login: 3,
+      logout: 1,
+      create: 1,
+      update: 2,
+      delete: 1
+    });
+    expect(facetMap(result, 'result')).toEqual({ success: 6, failure: 2 });
+    expect(facetMap(result, 'source')).toEqual({ admin: 7, web: 1 });
+    expect(facetMap(result, 'actor')).toEqual({
+      alice: 3,
+      bob: 3,
+      'Doe, John': 1,
+      'legacy-admin': 1
+    });
+  });
+
+  it('is not narrowed by the value filters, so an unticked option keeps its count', async () => {
+    const filtered = await queryAuditLog({
+      ...range,
+      actionExclude: ['login', 'logout'],
+      facets: true,
+      limit: 100
+    });
+
+    expect(filtered.total).toBe(4);
+    // `login` was filtered out of the entries but must stay tickable.
+    expect(facetMap(filtered, 'action').login).toBe(3);
+  });
+
+  it('is not narrowed by the free-text search either', async () => {
+    const searched = await queryAuditLog({ ...range, q: 'doe', facets: true, limit: 100 });
+    const unfiltered = await queryAuditLog({ ...range, facets: true, limit: 100 });
+    expect(searched.facets).toEqual(unfiltered.facets);
+  });
+
+  it('is narrowed by the date range', async () => {
+    const dayTwoOnly = await queryAuditLog({
+      from: DAY_TWO,
+      to: DAY_TWO,
+      facets: true,
+      limit: 100
+    });
+    expect(facetMap(dayTwoOnly, 'actor')).toEqual({ bob: 3 });
+  });
+
+  it('sorts values by descending count, then by value', async () => {
+    const result = await queryAuditLog({ ...range, facets: true, limit: 100 });
+    const counts = result.facets.action.map(o => o.count);
+    expect(counts).toEqual([...counts].sort((a, b) => b - a));
+  });
+
+  it('lists every facetable field even when the range is empty', async () => {
+    const result = await queryAuditLog({
+      from: '2026-01-01',
+      to: '2026-01-02',
+      facets: true,
+      limit: 100
+    });
+    expect(Object.keys(result.facets).sort()).toEqual([
+      'action',
+      'actor',
+      'resource',
+      'result',
+      'source'
+    ]);
+    expect(result.facets.action).toEqual([]);
+  });
+});

--- a/tests/unit/server/auditLogQuery.test.js
+++ b/tests/unit/server/auditLogQuery.test.js
@@ -156,6 +156,45 @@ describe('queryAuditLog date range and parsing', () => {
   });
 });
 
+describe('queryAuditLog result window', () => {
+  it('returns the same page whatever the window size, and an exact total', async () => {
+    // The scan keeps only `offset + limit` entries, so a small page must not
+    // change which rows come back or what `total` reports.
+    const all = await queryAuditLog({ ...range, limit: 100 });
+    for (const [limit, offset] of [
+      [1, 0],
+      [1, 5],
+      [2, 3],
+      [7, 1]
+    ]) {
+      const page = await queryAuditLog({ ...range, limit, offset });
+      expect(page.total).toBe(all.total);
+      expect(page.entries.map(e => e.id)).toEqual(
+        all.entries.slice(offset, offset + limit).map(e => e.id)
+      );
+    }
+  });
+
+  it('counts the total past the end of the window', async () => {
+    const page = await queryAuditLog({ ...range, limit: 1 });
+    expect(page.entries).toHaveLength(1);
+    expect(page.total).toBe(DAY_ONE_ENTRIES.length + DAY_TWO_ENTRIES.length);
+  });
+
+  it('still counts and facets correctly with a zero-size window', async () => {
+    const result = await queryAuditLog({ ...range, limit: 0, facets: true });
+    expect(result.entries).toEqual([]);
+    expect(result.total).toBe(DAY_ONE_ENTRIES.length + DAY_TWO_ENTRIES.length);
+    expect(result.facets.action.find(o => o.value === 'login').count).toBe(3);
+  });
+
+  it('reports a total beyond the window while filtering', async () => {
+    const page = await queryAuditLog({ ...range, actionExclude: ['login', 'logout'], limit: 1 });
+    expect(page.entries).toHaveLength(1);
+    expect(page.total).toBe(4);
+  });
+});
+
 describe('queryAuditLog single-value filters (backward compatibility)', () => {
   it('matches a single action', async () => {
     const result = await queryAuditLog({ ...range, action: 'login', limit: 100 });

--- a/tests/unit/server/auditLogQueryParams.test.js
+++ b/tests/unit/server/auditLogQueryParams.test.js
@@ -95,6 +95,14 @@ describe('parseAuditLogQuery value separators', () => {
   });
 });
 
+describe('the filter-value cap', () => {
+  it('matches the cap the checkbox UI encodes against', async () => {
+    // A mismatch would let the UI emit a request its own server rejects.
+    const client = await import('../../../client/src/features/admin/utils/auditLogFilters.js');
+    expect(client.MAX_FILTER_VALUES).toBe(MAX_FILTER_VALUES);
+  });
+});
+
 describe('parseAuditLogQuery limits', () => {
   it('accepts a filter set right at the cap', () => {
     const values = Array.from({ length: MAX_FILTER_VALUES }, (_, i) => `a${i}`);

--- a/tests/unit/server/auditLogQueryParams.test.js
+++ b/tests/unit/server/auditLogQueryParams.test.js
@@ -1,0 +1,164 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  BadFilterError,
+  MAX_FILTER_VALUES,
+  MAX_QUERY_LENGTH,
+  clampInt,
+  isFlagSet,
+  parseAuditLogQuery
+} from '../../../server/routes/admin/auditLogQueryParams.js';
+
+describe('parseAuditLogQuery value separators', () => {
+  it('passes the date range through untouched', () => {
+    expect(parseAuditLogQuery({ from: '2026-08-01', to: '2026-08-02' })).toMatchObject({
+      from: '2026-08-01',
+      to: '2026-08-02'
+    });
+  });
+
+  it('reads a single value', () => {
+    expect(parseAuditLogQuery({ action: 'login' }).action).toEqual(['login']);
+  });
+
+  it('splits comma-separated values for the comma-free vocabularies', () => {
+    expect(parseAuditLogQuery({ action: 'create,update' }).action).toEqual(['create', 'update']);
+    expect(parseAuditLogQuery({ resource: 'app,model' }).resource).toEqual(['app', 'model']);
+    expect(parseAuditLogQuery({ result: 'success,failure' }).result).toEqual([
+      'success',
+      'failure'
+    ]);
+    expect(parseAuditLogQuery({ source: 'web,admin' }).source).toEqual(['web', 'admin']);
+  });
+
+  it('reads repeated parameters', () => {
+    expect(parseAuditLogQuery({ action: ['create', 'update'] }).action).toEqual([
+      'create',
+      'update'
+    ]);
+  });
+
+  it('combines repeated and comma-separated parameters', () => {
+    expect(parseAuditLogQuery({ action: ['create,update', 'delete'] }).action).toEqual([
+      'create',
+      'update',
+      'delete'
+    ]);
+  });
+
+  it('never comma-splits the actor, so a username may contain a comma', () => {
+    expect(parseAuditLogQuery({ actor: 'Doe, John' }).actor).toEqual(['Doe, John']);
+    expect(parseAuditLogQuery({ actor: ['Doe, John', 'alice'] }).actor).toEqual([
+      'Doe, John',
+      'alice'
+    ]);
+    expect(parseAuditLogQuery({ actorExclude: 'Doe, John' }).actorExclude).toEqual(['Doe, John']);
+  });
+
+  it('reads the exclude parameter of every field', () => {
+    const parsed = parseAuditLogQuery({
+      actorExclude: 'alice',
+      resourceExclude: 'app,model',
+      actionExclude: 'login',
+      resultExclude: 'success',
+      sourceExclude: 'web'
+    });
+    expect(parsed).toMatchObject({
+      actorExclude: ['alice'],
+      resourceExclude: ['app', 'model'],
+      actionExclude: ['login'],
+      resultExclude: ['success'],
+      sourceExclude: ['web']
+    });
+  });
+
+  it('keeps the wildcard as a plain value for the service to interpret', () => {
+    expect(parseAuditLogQuery({ actionExclude: '*' }).actionExclude).toEqual(['*']);
+  });
+
+  it('leaves absent and empty parameters undefined', () => {
+    const parsed = parseAuditLogQuery({ action: '', resource: ',,', source: [] });
+    expect(parsed.action).toBeUndefined();
+    expect(parsed.resource).toBeUndefined();
+    expect(parsed.source).toBeUndefined();
+    expect(parsed.actor).toBeUndefined();
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(parseAuditLogQuery({ action: ' create , update ' }).action).toEqual([
+      'create',
+      'update'
+    ]);
+  });
+
+  it('ignores non-string values (a nested object query parameter)', () => {
+    expect(parseAuditLogQuery({ action: [{ evil: true }, 'create'] }).action).toEqual(['create']);
+  });
+});
+
+describe('parseAuditLogQuery limits', () => {
+  it('accepts a filter set right at the cap', () => {
+    const values = Array.from({ length: MAX_FILTER_VALUES }, (_, i) => `a${i}`);
+    expect(parseAuditLogQuery({ action: values }).action).toHaveLength(MAX_FILTER_VALUES);
+  });
+
+  it('rejects a filter set beyond the cap', () => {
+    const values = Array.from({ length: MAX_FILTER_VALUES + 1 }, (_, i) => `a${i}`);
+    expect(() => parseAuditLogQuery({ action: values })).toThrow(BadFilterError);
+    expect(() => parseAuditLogQuery({ action: values.join(',') })).toThrow(BadFilterError);
+    expect(() => parseAuditLogQuery({ actorExclude: values })).toThrow(BadFilterError);
+  });
+
+  it('rejects an over-long search term', () => {
+    expect(parseAuditLogQuery({ q: 'x'.repeat(MAX_QUERY_LENGTH) }).q).toHaveLength(
+      MAX_QUERY_LENGTH
+    );
+    expect(() => parseAuditLogQuery({ q: 'x'.repeat(MAX_QUERY_LENGTH + 1) })).toThrow(
+      BadFilterError
+    );
+  });
+});
+
+describe('parseAuditLogQuery free-text search', () => {
+  it('keeps a term verbatim', () => {
+    expect(parseAuditLogQuery({ q: 'Created the app' }).q).toBe('Created the app');
+  });
+
+  it('drops a blank term', () => {
+    expect(parseAuditLogQuery({ q: '   ' }).q).toBeUndefined();
+    expect(parseAuditLogQuery({}).q).toBeUndefined();
+  });
+
+  it('takes the first value of a repeated parameter', () => {
+    expect(parseAuditLogQuery({ q: ['first', 'second'] }).q).toBe('first');
+  });
+});
+
+describe('isFlagSet', () => {
+  it('accepts the truthy query-string spellings', () => {
+    expect(isFlagSet('1')).toBe(true);
+    expect(isFlagSet('true')).toBe(true);
+    expect(isFlagSet('')).toBe(true); // a bare ?facets
+    expect(isFlagSet(['1'])).toBe(true);
+  });
+
+  it('rejects everything else', () => {
+    expect(isFlagSet(undefined)).toBe(false);
+    expect(isFlagSet('0')).toBe(false);
+    expect(isFlagSet('false')).toBe(false);
+    expect(isFlagSet('yes')).toBe(false);
+  });
+});
+
+describe('clampInt', () => {
+  it('falls back on unparseable input', () => {
+    expect(clampInt(undefined, 50, 1, 1000)).toBe(50);
+    expect(clampInt('abc', 50, 1, 1000)).toBe(50);
+  });
+
+  it('clamps to the bounds', () => {
+    expect(clampInt('0', 50, 1, 1000)).toBe(1);
+    expect(clampInt('-5', 0, 0, 1000)).toBe(0);
+    expect(clampInt('99999', 50, 1, 1000)).toBe(1000);
+    expect(clampInt('200', 50, 1, 1000)).toBe(200);
+  });
+});


### PR DESCRIPTION
Closes #2213. Implements the plan in [`concepts/2026-08-24 Audit Log Filter Fix and Multi-Select Filters.md`](``https://github.com/intrafind/ihub-apps/blob/claude/github-issue-2213-ovb9a3/concepts/2026-08-24%20Audit%20Log%20Filter%20Fix%20and%20Multi-Select%20Filters.md)`` (merged as #2214), with every open question answered per [this comment](https://github.com/intrafind/ihub-apps/issues/2213#issuecomment-5395268818). One PR, as requested.

## The bug

`handleFilterChange` called two `useFilterState` setters in the same tick:

```js
setter(value);      // setSearchParams(fn) -> navigate("?resource=app")
setPageParam('1');  // setSearchParams(fn) -> navigate("?")   <-- overwrites
```

React Router's `setSearchParams` does not queue the way `setState` does — its functional updater receives the **render-time** params — so the second call recomputed from the URL as it was *before* the filter, deleted `page` (it equalled its default), and navigated. The filter never reached the URL or the server.

This is no longer an inference: `tests/unit/client/use-filter-params.test.jsx` demonstrates it directly, and it stays in the suite as an executable warning so nobody removes the batched setter.

**`DataTable` had the same shape.** In server mode `handlePageSizeChange` called `onPageSizeChange(next)` **and** `onPageChange(1)` back to back — which is why changing rows-per-page reverted to 50, and why fixing only the page was not enough. DataTable now calls `onPageSizeChange` only; resetting the page is the consumer's job, documented on `normalizePagination`. The audit log is the client's only server-paged table, so nothing else is affected.

## The fix

New `useFilterParams` hook batches several parameters into **one** `setSearchParams` call. `useFilterState` is untouched — it is correct for the single-parameter usage on the other 13 pages — but gains a JSDoc warning about the trap.

## Checkbox filters with entry counts

Actor, resource, action, result and source are now checkbox lists (`FilterMultiSelect`, exported from `data-table/` for other admin tables): a checkbox per value **with its entry count**, Select all / Select none, type-ahead above ten options, arrow-key navigation and Escape to close. The counts are what make the original complaint tractable — you see `login — 794` and know exactly what to untick.

Options come from server-computed facets (`?facets=1`), counted in the **same file scan** as the query and over the **date range only**, so unticking a value never makes its checkbox vanish. That replaces two provably wrong lists: the hardcoded `RESOURCE_TYPES` (which offered `provider` — nothing writes it — and omitted `tool`, `credential`, `integrations`, `uiConfig` and every path-derived resource) and the actor list, which only knew the ≤50 rows on screen.

`mcp` is gone from the source filter — no code path writes it, so selecting it could only ever return an empty table. Filed as #2216 rather than removed from the schema, so wiring it up later needs no migration.

## URL contract

Each field takes an include parameter and a `<field>Exclude` parameter subtracted from it, `*` meaning "every value", exclusion winning:

```js
matches = value =>
  (include.has('*') || include.has(value)) && !(exclude.has('*') || exclude.has(value));
```

| URL | Result |
|---|---|
| *(neither)* | everything — the default |
| `?action=create,update` | only those two |
| `?actionExclude=login,logout` | everything except those two |
| `?actionExclude=*` | nothing — the "select none" state |
| `?action=*&actionExclude=login` | everything except login |
| `?resource=app&resourceExclude=app` | nothing — exclusion wins |
| `?resource=app` | unchanged from today — existing links keep working |

The checkbox UI writes the **exclusion** form for a partial selection, so a resource type added by a later release stays visible in a bookmarked view. `actor` reads repeated parameters only and is never comma-split (a username can be `Doe, John`); the other four accept both forms. A per-field value cap (500) and a search-term length cap (200) answer **400** rather than returning a silently wrong result.

## Also in scope

- **Free-text `?q=`** over summary, resource ID, IP, request ID and actor name — in-memory, applied in the same pass as the value filters.
- **Quick filters:** Last 24 hours / 7 days / 30 days, **Hide sign-ins**, **Failures only**, **Clear all filters** (which also covers Q10's "active filters" affordance).
- **Default range is 24 hours** on the page. `queryAuditLog`'s fallback for a caller sending *no* range stays at 7 days — `useOverviewData`'s `/admin/audit-log?limit=8` depends on it, and shortening it there would empty the admin overview's activity panel on a quiet installation. (The plan had assumed that call was unaffected; it would not have been.)
- **Single-pass scan.** `queryAuditLog` streamed each daily file once — parse, count facets, filter, keep matches — instead of parsing the entire range into one array and sorting all of it.
- **CSV export** shares the query parser, so an export always matches the table.
- **Full `admin.auditLog.*` translations** for `en` and `de`. The page previously had none, so the German UI was entirely English.
- **`docs/admin-ui.md`** rewritten, including dropping the row-expansion-with-diff view it promised and that has never existed (Q5).
- **Changelog** entries under `docs/releases/5.5.0/`.

## Files

| File | Change |
|---|---|
| `client/.../hooks/useFilterState.js` | add `useFilterParams`; document the single-setter-per-tick rule |
| `client/.../pages/AdminAuditLogPage.jsx` | batched URL updates, multi-selects, facets, search, presets |
| `client/.../data-table/filters/FilterMultiSelect.jsx` | **new** — reusable checkbox filter |
| `client/.../utils/auditLogFilters.js` | **new** — include/exclude encoding |
| `client/.../data-table/DataTable.jsx`, `useTablePagination.js` | one navigation per page-size change |
| `server/services/AuditLogService.js` | array + exclude matching, facets, free-text, streaming scan |
| `server/routes/admin/auditLogQueryParams.js` | **new** — shared query parser, testable without Express |
| `server/routes/admin/auditLog.js` | use the parser for list and export; `facets=1` |
| `shared/i18n/{en,de}.json` | `admin.auditLog.*` + `admin.filters.multiSelect.*` |

## Verification

`npm run lint:fix`, `npm run format:fix`, `npm run test:unit` → **415 tests, 38 suites, all passing**, including four new suites (75 tests):

- `tests/unit/server/auditLogQuery.test.js` — the full include/exclude/`*` matrix, exclusion precedence, unknown-value exclusion as a no-op, legacy `admin`-field actors, `Doe, John` matching as one value, facet counts and their independence from the active filters and from `q`, date-range scoping, pagination over the filtered set, malformed lines skipped.
- `tests/unit/server/auditLogQueryParams.test.js` — comma splitting, the actor exception, both caps, flag and integer clamping.
- `tests/unit/client/admin-audit-log-filters.test.jsx` — **the reported bug end to end**: a toggled filter must land in the URL *and* in the refetch query string. Plus page reset, page size, select all/none, legacy and exclusion links, presets, search, and keyboard access.
- `tests/unit/client/use-filter-params.test.jsx` — the root cause, pinned.

Also verified against a running instance (local admin login, seeded login/failure events): facets return real counts, every row of the URL table above behaves as specified, both caps answer 400, `limit` clamps, and the CSV export honours the filters.

Two follow-ups filed as agreed: #2216 (`mcp` source never written) and #2217 (`server/tests/*.test.js` never run in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoWjWx5AiyaXLz6MCNm9aa

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoWjWx5AiyaXLz6MCNm9aa)_