### PR TITLE
refactor(sources): single implementation of the contents/sources boundary

### DIFF
--- a/server/routes/admin/sources.js
+++ b/server/routes/admin/sources.js
@@ -1851,7 +1851,9 @@ export default function registerAdminSourcesRoutes(app) {
         if (!validateIdForPath(id, 'source', res)) {
           return;
         }
-        const { path = 'sources' } = req.query;
+        // Default to the sources root; an explicitly empty ?path= must fall
+        // back too, since '' is now outside the allowed directory.
+        const path = req.query.path || 'sources';
         const { data: sources } = configCache.getSources(true);
         const source = sources.find(s => s.id === id);
 

--- a/server/sources/FileSystemHandler.js
+++ b/server/sources/FileSystemHandler.js
@@ -35,13 +35,19 @@ class FileSystemHandler extends SourceHandler {
   }
 
   /**
-   * Resolve a relative path safely within the base directory.
-   * Strips leading slashes and validates the resolved path stays within bounds.
-   * @param {string} relativePath - Relative file path
-   * @returns {string} - Resolved absolute path
-   * @throws {Error} - If the path escapes the base directory
+   * Resolve a source-relative path within the contents/sources boundary.
+   *
+   * This is the single implementation of that boundary for filesystem
+   * sources: every read/write/list/delete call in this handler funnels
+   * through it, and SourceManager.testFilesystemSource() calls it too, so the
+   * two can never drift apart.
+   *
+   * @param {string} relativePath - Path relative to the contents directory,
+   *   e.g. "sources/faq.md" (a leading slash is tolerated and stripped)
+   * @returns {Promise<string>} - Resolved absolute path
+   * @throws {Error} - If the path escapes contents/sources
    */
-  async _resolveSafePath(relativePath) {
+  async resolveSourcePath(relativePath) {
     const cleaned = sanitizeRelativePath(relativePath);
 
     // Filesystem sources must live under contents/sources — reject anything
@@ -57,30 +63,15 @@ class FileSystemHandler extends SourceHandler {
       throw new Error(`Access denied: path ${relativePath} is outside allowed directory`);
     }
 
-    const sourcesDir = await this._getSourcesDir();
+    // resolveAndValidatePath() canonicalizes the base itself, so passing the
+    // lexical sources path is enough — no need to pre-resolve or cache it.
+    const sourcesDir = path.resolve(this.basePath, 'sources');
     const resolved = await resolveAndValidatePath(remainder, sourcesDir);
     if (!resolved) {
       throw new Error(`Access denied: path ${relativePath} is outside allowed directory`);
     }
 
     return resolved;
-  }
-
-  /**
-   * Resolve and cache the canonical contents/sources directory used as the
-   * containment boundary for all filesystem-source operations.
-   * @returns {Promise<string>} - Canonical sources directory path
-   */
-  async _getSourcesDir() {
-    if (!this._sourcesDirCache) {
-      const sourcesPath = path.resolve(this.basePath, 'sources');
-      try {
-        this._sourcesDirCache = await fs.realpath(sourcesPath);
-      } catch {
-        this._sourcesDirCache = sourcesPath;
-      }
-    }
-    return this._sourcesDirCache;
   }
 
   /**
@@ -95,7 +86,7 @@ class FileSystemHandler extends SourceHandler {
       throw new Error('FileSystemHandler requires a path in sourceConfig');
     }
 
-    const fullPath = await this._resolveSafePath(filePath);
+    const fullPath = await this.resolveSourcePath(filePath);
 
     try {
       // Get file stats
@@ -142,7 +133,7 @@ class FileSystemHandler extends SourceHandler {
   async getEnhancedCacheKey(sourceConfig) {
     try {
       const { path: filePath, url, encoding } = sourceConfig;
-      const fullPath = await this._resolveSafePath(filePath);
+      const fullPath = await this.resolveSourcePath(filePath);
       const stats = await fs.stat(fullPath);
 
       // Include relevant config in cache key for consistency
@@ -220,7 +211,7 @@ class FileSystemHandler extends SourceHandler {
    * @returns {Promise<Array>} - List of files with metadata
    */
   async listFiles(dirPath = '') {
-    const fullPath = await this._resolveSafePath(dirPath);
+    const fullPath = await this.resolveSourcePath(dirPath);
 
     try {
       const entries = await fs.readdir(fullPath, { withFileTypes: true });
@@ -254,7 +245,7 @@ class FileSystemHandler extends SourceHandler {
    */
   async fileExists(filePath) {
     try {
-      const fullPath = await this._resolveSafePath(filePath);
+      const fullPath = await this.resolveSourcePath(filePath);
       const stats = await fs.stat(fullPath);
       return stats.isFile();
     } catch {
@@ -277,7 +268,7 @@ class FileSystemHandler extends SourceHandler {
       throw new Error('Content must be a string');
     }
 
-    const fullPath = await this._resolveSafePath(filePath);
+    const fullPath = await this.resolveSourcePath(filePath);
 
     try {
       // Ensure directory exists
@@ -316,7 +307,7 @@ class FileSystemHandler extends SourceHandler {
       throw new Error('File path is required');
     }
 
-    const fullPath = await this._resolveSafePath(filePath);
+    const fullPath = await this.resolveSourcePath(filePath);
 
     try {
       await fs.unlink(fullPath);
@@ -347,7 +338,7 @@ class FileSystemHandler extends SourceHandler {
       throw new Error('Directory path is required');
     }
 
-    const fullPath = await this._resolveSafePath(dirPath);
+    const fullPath = await this.resolveSourcePath(dirPath);
 
     try {
       await fs.mkdir(fullPath, { recursive: true });
@@ -369,7 +360,7 @@ class FileSystemHandler extends SourceHandler {
    * @returns {Promise<Array>} - List of directories
    */
   async listDirectories(dirPath = '') {
-    const fullPath = await this._resolveSafePath(dirPath);
+    const fullPath = await this.resolveSourcePath(dirPath);
 
     try {
       const entries = await fs.readdir(fullPath, { withFileTypes: true });
@@ -415,7 +406,7 @@ class FileSystemHandler extends SourceHandler {
       return { files: [], directories: [] };
     }
 
-    const fullPath = await this._resolveSafePath(dirPath);
+    const fullPath = await this.resolveSourcePath(dirPath);
 
     try {
       const entries = await fs.readdir(fullPath, { withFileTypes: true });

--- a/server/sources/SourceManager.js
+++ b/server/sources/SourceManager.js
@@ -4,7 +4,6 @@ import IFinderHandler from './IFinderHandler.js';
 import PageHandler from './PageHandler.js';
 import logger from '../utils/logger.js';
 import { httpFetch } from '../utils/httpConfig.js';
-import { resolveAndValidatePath } from '../utils/pathSecurity.js';
 import { recordSourceLoad } from '../telemetry/metrics.js';
 import { getLocalizedString } from '../utils/localize.js';
 
@@ -560,31 +559,21 @@ class SourceManager {
   async testFilesystemSource(config) {
     const { path: filePath, encoding = 'utf-8' } = config;
     const fs = await import('fs');
-    const path = await import('path');
-    const { getRootDir } = await import('../pathUtils.js');
 
     try {
       if (!filePath) {
         throw new Error('File path is required');
       }
 
-      // config.path is stored with a "sources/" prefix (e.g. "sources/faq.md").
-      // Reject anything else up front, then delegate the actual boundary and
-      // symlink validation to resolveAndValidatePath() against the sources
-      // directory itself (the same centralized check FileSystemHandler uses),
-      // rather than re-checking containment by hand against contents/.
-      let remainder;
-      if (filePath === 'sources') {
-        remainder = '.';
-      } else if (filePath.startsWith('sources/')) {
-        remainder = filePath.slice('sources/'.length) || '.';
-      } else {
-        throw new Error('Invalid file path: Path must be within the sources directory');
-      }
-
-      const sourcesDir = path.join(getRootDir(), 'contents', 'sources');
-      const fullPath = await resolveAndValidatePath(remainder, sourcesDir);
-      if (!fullPath) {
+      // Resolve through the filesystem handler itself rather than repeating
+      // the contents/sources boundary here. That handler owns the single
+      // implementation of the check (and honours CONTENTS_DIR), so the test
+      // endpoint can never accept a path the real read/write path rejects.
+      const handler = this.getHandler('filesystem');
+      let fullPath;
+      try {
+        fullPath = await handler.resolveSourcePath(filePath);
+      } catch {
         throw new Error('Invalid file path: Path must be within the sources directory');
       }
 

--- a/server/tests/fileSystemHandler-sources-scope.test.js
+++ b/server/tests/fileSystemHandler-sources-scope.test.js
@@ -13,6 +13,7 @@ import { promises as fs } from 'fs';
 import os from 'os';
 import path from 'path';
 import FileSystemHandler from '../sources/FileSystemHandler.js';
+import SourceManager from '../sources/SourceManager.js';
 
 describe('FileSystemHandler sources/ containment', () => {
   let tempDir;
@@ -83,8 +84,74 @@ describe('FileSystemHandler sources/ containment', () => {
     assert.strictEqual(written, 'hello');
   });
 
+  it('tolerates a leading slash on a path under sources/', async () => {
+    // SourceManager.testFilesystemSource() delegates to this same method, so
+    // both entry points agree on what a valid path looks like.
+    const resolved = await handler.resolveSourcePath('/sources/faq.md');
+    assert.strictEqual(resolved, path.join(await fs.realpath(tempDir), 'sources', 'faq.md'));
+  });
+
+  it('rejects a leading-slash path outside sources/', async () => {
+    await assert.rejects(
+      () => handler.resolveSourcePath('/config/groups.json'),
+      /outside allowed directory/
+    );
+  });
+
+  it('rejects traversal that escapes sources/ via ..', async () => {
+    await assert.rejects(
+      () => handler.resolveSourcePath('sources/../config/groups.json'),
+      /outside allowed directory/
+    );
+  });
+
   it('validateConfig rejects a path outside sources/', () => {
     assert.strictEqual(handler.validateConfig({ path: 'config/groups.json' }), false);
     assert.strictEqual(handler.validateConfig({ path: 'sources/faq.md' }), true);
+  });
+});
+
+describe('SourceManager.testFilesystemSource sources/ containment', () => {
+  let tempDir;
+  let manager;
+
+  before(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ihub-source-manager-'));
+    await fs.mkdir(path.join(tempDir, 'config'), { recursive: true });
+    await fs.writeFile(path.join(tempDir, 'config', 'groups.json'), '{"secret":true}');
+
+    manager = new SourceManager({ filesystem: { basePath: tempDir } });
+    await manager.getHandler('filesystem').ensureSourcesDirectory();
+    await fs.writeFile(path.join(tempDir, 'sources', 'faq.md'), '# FAQ');
+  });
+
+  after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('accepts a file under sources/', async () => {
+    const result = await manager.testFilesystemSource({ path: 'sources/faq.md' });
+    assert.strictEqual(result.accessible, true);
+  });
+
+  it('rejects a path outside sources/', async () => {
+    await assert.rejects(
+      () => manager.testFilesystemSource({ path: 'config/groups.json' }),
+      /within the sources directory/
+    );
+  });
+
+  it('agrees with the handler on leading-slash paths', async () => {
+    // Regression: the test endpoint used to skip sanitizeRelativePath(), so it
+    // rejected a leading-slash path the read/write path happily accepted.
+    const result = await manager.testFilesystemSource({ path: '/sources/faq.md' });
+    assert.strictEqual(result.accessible, true);
+  });
+
+  it('honours a custom contents basePath instead of hardcoding contents/', async () => {
+    // Regression: testFilesystemSource() used to resolve against
+    // <root>/contents/sources regardless of the handler's configured basePath.
+    const result = await manager.testFilesystemSource({ path: 'sources/faq.md' });
+    assert.strictEqual(result.fileSize, 5);
   });
 });


### PR DESCRIPTION
## Summary

Follow-up to the Copilot review on #2030, targeting that PR's branch so it folds into #2030.

The previous round centralized the *containment check* (both call sites now delegate to `resolveAndValidatePath`), but left the "strip the `sources/` prefix, then resolve" logic duplicated in `FileSystemHandler._resolveSafePath()` and `SourceManager.testFilesystemSource()`. That is exactly the drift the reviewer warned about — and the two copies had **already** diverged:

1. `testFilesystemSource()` never called `sanitizeRelativePath()`, so it rejected a leading-slash path (`/sources/faq.md`) that the read/write path accepts. "Test connection" failed on a source that loads fine.
2. `testFilesystemSource()` resolved against a hardcoded `<root>/contents/sources`, ignoring `CONTENTS_DIR`. On an installation with a custom contents directory, "Test connection" probed the wrong directory entirely — a pre-existing bug the old code carried too.

## Changes

- **`server/sources/FileSystemHandler.js`**: `_resolveSafePath()` becomes the public `resolveSourcePath()` — the one place the `contents/sources` boundary is implemented. Also drops the `_getSourcesDir()` cache: `resolveAndValidatePath()` canonicalizes the base directory itself, so pre-resolving added nothing but a stale-value risk if the sources directory only appeared after first use.
- **`server/sources/SourceManager.js`**: `testFilesystemSource()` calls `handler.resolveSourcePath()` instead of repeating the logic, fixing both divergences above. Removes the now-unused `resolveAndValidatePath`/`getRootDir`/`path` imports.
- **`server/routes/admin/sources.js`**: the browse route falls back to `sources` for an explicitly empty `?path=` too, not just a missing one. Destructuring defaults only apply to `undefined`, so `?path=` previously produced a confusing `outside allowed directory` 400 instead of the sources listing.

No behavior change to the security boundary itself — this is the same scope, expressed once.

## Test plan

- [x] `server/tests/fileSystemHandler-sources-scope.test.js`: added leading-slash accept/reject and a `..` traversal-escape case; new `SourceManager.testFilesystemSource` suite covering containment, leading-slash parity with the handler, and a custom `basePath`. The parity and custom-basePath cases both fail on the pre-change code.
- [x] `npm run test:unit` — 430/430 pass (39 suites).
- [x] `npm run test:quick` — pass.
- [x] `npx eslint` and `npx prettier --check` clean on all changed files.
- [x] `tests/integration/workflows/workflow-execution.test.js` has 2 failures; confirmed identical on `main`, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3WbggFhm9GRnRH92GtKMX

---
_Generated by [Claude Code](https://claude.ai/code/session_01L3WbggFhm9GRnRH92GtKMX)_