### PR TITLE
fix(auth): expire the proxy-auth JWKS cache and log crashes outside a request

### DIFF
--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -94,3 +94,28 @@ cause. The real failure was lost, and in a few places a clean failure turned int
   the helpers it uses were re-exported but never imported locally. They now work.
 
 Lint now enforces `no-undef`, so this class of bug fails the build rather than shipping.
+
+## Rotated Identity Provider Signing Keys Are Picked Up Without a Restart
+
+Proxy authentication cached each provider's JWKS document forever. When an identity provider rotated
+its signing keys, every token signed with a new key failed verification — users were locked out until
+the iHub process was restarted. The cache now expires.
+
+- A JWKS document is re-fetched after 10 hours, or immediately when a token arrives with a key id the
+  cached document does not contain (at most once every 5 minutes per provider, so unknown key ids
+  cannot be used to hammer the provider).
+- If a refresh fails, the previously cached keys keep working instead of rejecting every request while
+  the provider's JWKS endpoint is briefly unreachable.
+- The JWKS request still goes through the platform's configured HTTP proxy and TLS settings.
+- No configuration change is needed.
+
+## Crashes Outside a Request Are Logged Instead of Disappearing
+
+An exception or rejected promise raised outside Express's request handling — in a background job, a
+timer, or a streaming callback — terminated the process with nothing written to the application log,
+leaving no trace of what failed.
+
+- Unhandled promise rejections are logged with their message and stack, and the server keeps running.
+- Uncaught exceptions are logged and the process then exits deliberately. With `WORKERS` above 1 the
+  affected worker is respawned automatically, as it already was for any other worker exit.
+- The standalone binary already behaved this way; the regular server now matches it.

--- a/server/middleware/proxyAuth.js
+++ b/server/middleware/proxyAuth.js
@@ -19,10 +19,12 @@ const JWKS_CACHE_TTL_MS = 10 * 60 * 60 * 1000; // 10 hours
 const JWKS_REFRESH_MIN_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
 const jwksCache = new Map();
+// One in-flight request per URL. The throttle below is checked before the fetch
+// is awaited, so without this a burst of concurrent requests arriving after the
+// TTL expires would each start their own outbound call.
+const inFlightFetches = new Map();
 
-async function fetchJwks(jwkUrl, previous) {
-  // Record the attempt regardless of outcome so a persistently unreachable
-  // endpoint is retried on a fixed interval instead of on every request.
+async function requestJwks(jwkUrl, previous) {
   const attemptedAt = Date.now();
   try {
     const res = await httpFetch(jwkUrl);
@@ -32,16 +34,35 @@ async function fetchJwks(jwkUrl, previous) {
     return jwks;
   } catch (error) {
     logger.error('Error fetching JWKs', { component: 'ProxyAuth', error });
-    if (previous) jwksCache.set(jwkUrl, { ...previous, lastAttemptAt: attemptedAt });
+    // Record the attempt whatever the outcome, so an unreachable endpoint is
+    // retried on a fixed interval instead of on every request. This has to
+    // happen on a cold start too, where there is no stale document to carry
+    // over — otherwise an outage at startup turns into one outbound call per
+    // login attempt.
+    jwksCache.set(jwkUrl, {
+      jwks: previous?.jwks ?? null,
+      fetchedAt: previous?.fetchedAt ?? 0,
+      lastAttemptAt: attemptedAt
+    });
     return null;
   }
+}
+
+function fetchJwks(jwkUrl, previous) {
+  const inFlight = inFlightFetches.get(jwkUrl);
+  if (inFlight) return inFlight;
+
+  const pending = requestJwks(jwkUrl, previous).finally(() => inFlightFetches.delete(jwkUrl));
+  inFlightFetches.set(jwkUrl, pending);
+  return pending;
 }
 
 async function getJwks(jwkUrl, { forceRefresh = false } = {}) {
   const entry = jwksCache.get(jwkUrl);
   if (entry) {
-    const fresh = Date.now() - entry.fetchedAt < JWKS_CACHE_TTL_MS;
-    const throttled = Date.now() - entry.lastAttemptAt < JWKS_REFRESH_MIN_INTERVAL_MS;
+    const now = Date.now();
+    const fresh = now - entry.fetchedAt < JWKS_CACHE_TTL_MS;
+    const throttled = now - entry.lastAttemptAt < JWKS_REFRESH_MIN_INTERVAL_MS;
     if ((fresh && !forceRefresh) || throttled) return entry.jwks;
   }
 

--- a/server/middleware/proxyAuth.js
+++ b/server/middleware/proxyAuth.js
@@ -7,29 +7,69 @@ import { enhanceUserGroups } from '../utils/authorization.js';
 import { validateAndPersistExternalUser } from '../utils/userManager.js';
 import logger from '../utils/logger.js';
 
+// JWKS documents are cached per provider URL, but only for a bounded TTL. The
+// previous cache never expired, so once an IdP rotated its signing keys every
+// token signed with the new key failed verification until the process was
+// restarted. `httpFetch` is deliberately kept instead of a library with its own
+// HTTP stack (e.g. `jwks-rsa`) so the platform's proxy and TLS settings still
+// apply to the JWKS request.
+const JWKS_CACHE_TTL_MS = 10 * 60 * 60 * 1000; // 10 hours
+// Floor between forced refreshes, so a stream of tokens carrying unknown `kid`
+// values cannot turn into a stream of outbound requests to the IdP.
+const JWKS_REFRESH_MIN_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
 const jwksCache = new Map();
 
-async function getJwks(jwkUrl) {
-  if (jwksCache.has(jwkUrl)) return jwksCache.get(jwkUrl);
+async function fetchJwks(jwkUrl, previous) {
+  // Record the attempt regardless of outcome so a persistently unreachable
+  // endpoint is retried on a fixed interval instead of on every request.
+  const attemptedAt = Date.now();
   try {
     const res = await httpFetch(jwkUrl);
     if (!res.ok) throw new Error(`Failed to load JWKs: ${res.status}`);
     const jwks = await res.json();
-    jwksCache.set(jwkUrl, jwks);
+    jwksCache.set(jwkUrl, { jwks, fetchedAt: attemptedAt, lastAttemptAt: attemptedAt });
     return jwks;
   } catch (error) {
     logger.error('Error fetching JWKs', { component: 'ProxyAuth', error });
+    if (previous) jwksCache.set(jwkUrl, { ...previous, lastAttemptAt: attemptedAt });
     return null;
   }
 }
 
+async function getJwks(jwkUrl, { forceRefresh = false } = {}) {
+  const entry = jwksCache.get(jwkUrl);
+  if (entry) {
+    const fresh = Date.now() - entry.fetchedAt < JWKS_CACHE_TTL_MS;
+    const throttled = Date.now() - entry.lastAttemptAt < JWKS_REFRESH_MIN_INTERVAL_MS;
+    if ((fresh && !forceRefresh) || throttled) return entry.jwks;
+  }
+
+  // Fall back to the stale copy if the refresh fails, rather than locking every
+  // user out while the IdP's JWKS endpoint is briefly unreachable.
+  const jwks = await fetchJwks(jwkUrl, entry);
+  return jwks || entry?.jwks || null;
+}
+
+function findSigningKey(jwks, kid) {
+  if (!jwks?.keys?.length) return null;
+  return (kid ? jwks.keys.find(k => k.kid === kid) : jwks.keys[0]) || null;
+}
+
 async function verifyJwt(token, provider) {
   try {
-    const jwks = await getJwks(provider.jwkUrl);
-    if (!jwks || !jwks.keys?.length) throw new Error('No keys');
     const decoded = jwt.decode(token, { complete: true });
     const kid = decoded?.header?.kid;
-    const jwk = kid ? jwks.keys.find(k => k.kid === kid) : jwks.keys[0];
+
+    let jwks = await getJwks(provider.jwkUrl);
+    let jwk = findSigningKey(jwks, kid);
+
+    // An unknown `kid` normally means the IdP rotated keys since the last fetch;
+    // refresh once before giving up instead of waiting out the full TTL.
+    if (!jwk && kid) {
+      jwks = await getJwks(provider.jwkUrl, { forceRefresh: true });
+      jwk = findSigningKey(jwks, kid);
+    }
     if (!jwk) throw new Error('Key not found');
 
     // Use jose to import the JWK and verify the JWT

--- a/server/server.js
+++ b/server/server.js
@@ -80,6 +80,38 @@ dotenv.config();
 
 import config from './config.js';
 
+// Process-level safety net. Without these, a rejected promise with no local
+// `.catch` (or an exception thrown outside Express's synchronous error
+// handling) tears the process down with nothing written to the application log,
+// leaving no trace of what actually failed.
+process.on('unhandledRejection', reason => {
+  logger.error({
+    component: 'Server',
+    message: 'Unhandled promise rejection',
+    error: reason instanceof Error ? reason.message : String(reason),
+    stack: reason instanceof Error ? reason.stack : undefined,
+    pid: process.pid
+  });
+});
+
+process.on('uncaughtException', error => {
+  logger.error({
+    component: 'Server',
+    message: 'Uncaught exception, exiting',
+    error: error?.message ?? String(error),
+    stack: error?.stack,
+    pid: process.pid
+  });
+  // The process is in an undefined state now; exit rather than keep serving
+  // requests from a possibly corrupted worker. Under clustering the primary's
+  // `exit` handler respawns it (see the `cluster.on('exit', ...)` below).
+  //
+  // The short delay gives winston's file transport a chance to flush; whether a
+  // same-tick exit truncates the entry depends on the write stream's state, and
+  // losing the one line that explains the crash is the worst possible outcome.
+  setTimeout(() => process.exit(1), 100);
+});
+
 // ----- Cluster setup -----
 const workerCount = config.WORKERS;
 

--- a/server/tests/proxyAuth-jwks-rotation.test.js
+++ b/server/tests/proxyAuth-jwks-rotation.test.js
@@ -1,0 +1,169 @@
+/**
+ * Proxy Auth JWKS Cache Tests
+ *
+ * The JWKS document fetched for a `proxyAuth.jwtProviders` entry used to be cached
+ * for the lifetime of the process, so an identity provider that rotated its signing
+ * keys locked every user out until iHub was restarted. These tests pin down the
+ * refresh behaviour: TTL expiry, refresh on an unknown `kid`, the throttle that keeps
+ * unknown key ids from hammering the provider, and the stale-copy fallback.
+ */
+
+import { jest } from '@jest/globals';
+import * as jose from 'jose';
+
+const JWK_URL = 'https://idp.example.com/.well-known/jwks.json';
+const ISSUER = 'https://idp.example.com';
+const AUDIENCE = 'ihub';
+
+const mockPlatformConfig = {
+  auth: { mode: 'proxy', authenticatedGroup: 'authenticated' },
+  proxyAuth: {
+    enabled: true,
+    userHeader: 'x-forwarded-user',
+    jwtProviders: [{ header: 'authorization', jwkUrl: JWK_URL, issuer: ISSUER, audience: AUDIENCE }]
+  }
+};
+
+const httpFetch = jest.fn();
+jest.unstable_mockModule('../utils/httpConfig.js', () => ({ httpFetch }));
+
+jest.unstable_mockModule('../configCache.js', () => ({
+  default: { getPlatform: jest.fn(() => mockPlatformConfig), getLocalizations: jest.fn() }
+}));
+
+// Groups configuration lives under contents/, which isn't present in this checkout.
+jest.unstable_mockModule('../utils/authorization.js', () => ({
+  enhanceUserGroups: jest.fn(user => user)
+}));
+jest.unstable_mockModule('../utils/userManager.js', () => ({
+  validateAndPersistExternalUser: jest.fn(async user => user)
+}));
+
+/** Generate a signing key plus the JWK the provider would publish for it. */
+async function makeKey(kid) {
+  const { publicKey, privateKey } = await jose.generateKeyPair('RS256', { extractable: true });
+  const jwk = { ...(await jose.exportJWK(publicKey)), kid, use: 'sig', alg: 'RS256' };
+  return { jwk, privateKey, kid };
+}
+
+async function signWith(key) {
+  return new jose.SignJWT({ email: 'user@example.com', groups: ['users'] })
+    .setProtectedHeader({ alg: 'RS256', kid: key.kid })
+    .setSubject('user-1')
+    .setIssuer(ISSUER)
+    .setAudience(AUDIENCE)
+    .setIssuedAt()
+    .setExpirationTime('1h')
+    .sign(key.privateKey);
+}
+
+/** Queue the JWKS document the next httpFetch call should answer with. */
+function serveJwks(...keys) {
+  httpFetch.mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ keys: keys.map(k => k.jwk) })
+  });
+}
+
+async function callProxyAuth(proxyAuth, token) {
+  const req = { headers: { authorization: `Bearer ${token}` }, path: '/api/apps' };
+  const res = { status: jest.fn(() => res), json: jest.fn() };
+  const next = jest.fn();
+  await proxyAuth(req, res, next);
+  return { req, res, next };
+}
+
+describe('proxyAuth JWKS cache', () => {
+  let proxyAuth;
+  let now;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    httpFetch.mockReset();
+    now = 1_700_000_000_000;
+    jest.spyOn(Date, 'now').mockImplementation(() => now);
+    // Re-import so each test starts with an empty module-level JWKS cache.
+    ({ proxyAuth } = await import('../middleware/proxyAuth.js'));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('caches the JWKS document across requests', async () => {
+    const key = await makeKey('key-1');
+    serveJwks(key);
+    const token = await signWith(key);
+
+    const first = await callProxyAuth(proxyAuth, token);
+    expect(first.req.user?.id).toBe('user@example.com');
+
+    now += 60_000;
+    const second = await callProxyAuth(proxyAuth, token);
+    expect(second.req.user?.id).toBe('user@example.com');
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches the JWKS document once the TTL has passed', async () => {
+    const key = await makeKey('key-1');
+    serveJwks(key);
+    const token = await signWith(key);
+
+    await callProxyAuth(proxyAuth, token);
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+
+    now += 10 * 60 * 60 * 1000 + 1; // just past the 10h TTL
+    serveJwks(key);
+    const after = await callProxyAuth(proxyAuth, token);
+    expect(after.req.user?.id).toBe('user@example.com');
+    expect(httpFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('picks up a rotated signing key without waiting for the TTL', async () => {
+    const oldKey = await makeKey('key-1');
+    const newKey = await makeKey('key-2');
+    serveJwks(oldKey);
+
+    await callProxyAuth(proxyAuth, await signWith(oldKey));
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+
+    // Provider rotates; the new token's kid is absent from the cached document.
+    now += 6 * 60 * 1000; // past the refresh throttle
+    serveJwks(oldKey, newKey);
+    const rotated = await callProxyAuth(proxyAuth, await signWith(newKey));
+
+    expect(httpFetch).toHaveBeenCalledTimes(2);
+    expect(rotated.req.user?.id).toBe('user@example.com');
+  });
+
+  it('throttles refreshes so unknown key ids cannot hammer the provider', async () => {
+    const key = await makeKey('key-1');
+    const unknown = await makeKey('attacker-kid');
+    serveJwks(key);
+
+    await callProxyAuth(proxyAuth, await signWith(key));
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+
+    now += 1000; // well inside the 5 minute refresh floor
+    for (let i = 0; i < 5; i++) {
+      const rejected = await callProxyAuth(proxyAuth, await signWith(unknown));
+      expect(rejected.req.user).toBeNull();
+    }
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps serving the cached keys when a refresh fails', async () => {
+    const key = await makeKey('key-1');
+    serveJwks(key);
+    const token = await signWith(key);
+
+    await callProxyAuth(proxyAuth, token);
+
+    now += 10 * 60 * 60 * 1000 + 1; // TTL expired, forcing a refresh
+    httpFetch.mockRejectedValueOnce(new Error('JWKS endpoint unreachable'));
+
+    const during = await callProxyAuth(proxyAuth, token);
+    expect(httpFetch).toHaveBeenCalledTimes(2);
+    expect(during.req.user?.id).toBe('user@example.com');
+  });
+});

--- a/server/tests/proxyAuth-jwks-rotation.test.js
+++ b/server/tests/proxyAuth-jwks-rotation.test.js
@@ -12,6 +12,7 @@ import { jest } from '@jest/globals';
 import * as jose from 'jose';
 
 const JWK_URL = 'https://idp.example.com/.well-known/jwks.json';
+const JWKS_REFRESH_MIN_INTERVAL_MS = 5 * 60 * 1000; // mirrors proxyAuth.js
 const ISSUER = 'https://idp.example.com';
 const AUDIENCE = 'ihub';
 
@@ -150,6 +151,56 @@ describe('proxyAuth JWKS cache', () => {
       expect(rejected.req.user).toBeNull();
     }
     expect(httpFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('throttles retries when the very first fetch fails', async () => {
+    const key = await makeKey('key-1');
+    const token = await signWith(key);
+
+    // Cold start during an outage: nothing cached to fall back on.
+    httpFetch.mockRejectedValueOnce(new Error('JWKS endpoint unreachable'));
+    const first = await callProxyAuth(proxyAuth, token);
+    expect(first.req.user).toBeNull();
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+
+    // Further logins inside the retry interval must not each hit the IdP.
+    now += 1000;
+    for (let i = 0; i < 3; i++) {
+      const rejected = await callProxyAuth(proxyAuth, token);
+      expect(rejected.req.user).toBeNull();
+    }
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+
+    // Once the interval passes it tries again and recovers.
+    now += JWKS_REFRESH_MIN_INTERVAL_MS + 1;
+    serveJwks(key);
+    const recovered = await callProxyAuth(proxyAuth, token);
+    expect(httpFetch).toHaveBeenCalledTimes(2);
+    expect(recovered.req.user?.id).toBe('user@example.com');
+  });
+
+  it('collapses a concurrent burst into a single JWKS request', async () => {
+    const key = await makeKey('key-1');
+    const token = await signWith(key);
+
+    // Hold the response open so all five requests are in flight at once.
+    let release;
+    const gate = new Promise(resolve => {
+      release = resolve;
+    });
+    httpFetch.mockImplementation(async () => {
+      await gate;
+      return { ok: true, json: async () => ({ keys: [key.jwk] }) };
+    });
+
+    const inFlight = Array.from({ length: 5 }, () => callProxyAuth(proxyAuth, token));
+    release();
+    const results = await Promise.all(inFlight);
+
+    expect(httpFetch).toHaveBeenCalledTimes(1);
+    for (const result of results) {
+      expect(result.req.user?.id).toBe('user@example.com');
+    }
   });
 
   it('keeps serving the cached keys when a refresh fails', async () => {


### PR DESCRIPTION
## Summary

Picks up the two changes from #2034 that never landed on `main`.

**#2034 cannot be merged or rebased.** Its branch (`claude/charming-fermat-aas5b3`) shares *no merge base* with `main` — `git merge-base origin/main origin/claude/charming-fermat-aas5b3` returns nothing, and `git diff main...branch` fails with `no merge base`. GitHub reports it as `dirty`, but this is not a conflict that resolving fixes; the two histories have different root commits. This is the same situation #2215 described for #1960.

Most of #2034's content is **already on `main`** via #2215 (which re-applied the same work onto current `main`). Comparing every file #2034 touches against `main`:

| Already on `main` | Not on `main` |
| --- | --- |
| `eslint.config.js` `no-undef` rule | `server/middleware/proxyAuth.js` — JWKS cache TTL |
| `adapters/toolCalling/index.js` local imports | `server/server.js` — process-level handlers |
| `adapters/toolCalling/OpenAIConverter.js` | |
| `routes/admin/configs.js`, `routes/shortLinkRoutes.js` | |
| `routes/chat/sessionRoutes.js` (`chatId` scope) | |
| `services/PromptService.js`, `UsageAggregator.js` | |
| `services/integrations/Office365Service.js` | |
| `services/marketplace/ContentInstaller.js` | |
| `services/workflow/ExecutionRegistry.js` | |
| `services/workflow/executors/PromptNodeExecutor.js` (`nativeWebSearch`) | |
| `utils/installationCleanup.js` | |

One further change in #2034 — `server/shortLinkManager.js`'s `scheduleSave` catch block — is obsolete: that function no longer exists on `main` after the store refactor.

This PR carries the two remaining items forward. **#2034 can be closed once this merges.**

## Changes

### JWKS cache expiry (`server/middleware/proxyAuth.js`)

The JWKS document fetched for each `proxyAuth.jwtProviders` entry was cached for the lifetime of the process. Once an IdP rotated its signing keys, every token signed with a new key failed verification until iHub was restarted.

- The cache now expires after **10 hours**.
- A token whose `kid` is absent from the cached document triggers an **immediate refresh**, so rotation is picked up without waiting out the TTL.
- That refresh is **throttled to once per 5 minutes per provider**, so a stream of tokens carrying unknown key ids cannot be turned into a stream of outbound requests to the IdP.
- A **failed refresh falls back to the previously cached keys** rather than rejecting every request while the JWKS endpoint is briefly unreachable, and the failed attempt is recorded so an unreachable endpoint is retried on a fixed interval instead of on every request.

#### Deviation from #2034

#2034 replaced the hand-rolled cache with a `jwks-rsa` client. That would have routed the JWKS request through the library's own HTTP stack, **bypassing the platform's proxy and TLS configuration** — `server/utils/httpConfig.js` states plainly that "All outbound HTTP calls should use `httpFetch()` to ensure proxy/SSL configuration is applied", and that module carries a deliberate `TlsForwardingHttpsProxyAgent` workaround for self-signed certificates behind a proxy. For an on-premise product where the IdP commonly sits behind a corporate proxy or presents an internal CA certificate, that swap is a regression.

This PR keeps `httpFetch` + `jose` and puts the TTL on the existing cache instead. (`teamsAuth.js` does use `jwks-rsa`, but it targets Microsoft's public endpoint — a different situation.)

### Process-level handlers (`server/server.js`)

An exception or rejected promise raised outside Express's request handling — in a background job, a timer, a streaming callback — terminated the process with nothing written to the application log.

- `unhandledRejection` is logged with message and stack; the server keeps running.
- `uncaughtException` is logged and the process then exits deliberately, so a clustered worker is respawned by the existing `cluster.on('exit', …)` handler.
- The exit is deferred by 100 ms to give winston's file transport a chance to flush the entry that explains the crash.
- This matches what `server/sea-server.cjs` already does for the standalone binary.

## Test plan

- [x] **New test** — `server/tests/proxyAuth-jwks-rotation.test.js`, 5 cases driving the `proxyAuth` middleware with real `jose`-signed tokens and a mocked `httpFetch`: cache hit within TTL, re-fetch after TTL expiry, rotated-key pickup on unknown `kid`, refresh throttling, and stale-copy fallback on a failed refresh. **3 of the 5 fail against the previous implementation** (verified by running the suite against `origin/main`'s `proxyAuth.js`).
- [x] **No regressions** — full `server` Jest suite run before and after; the failure set is byte-identical (49 pre-existing failures, mostly standalone scripts under `server/tests/` that Jest picks up but which contain no `it()` blocks).
- [x] **Process handlers** — smoke-tested both handler bodies against the real logger: an `Error` and a plain-string rejection both log correctly and the process survives; `uncaughtException` logs to a winston file transport and exits with code 1.
- [x] `npx eslint` and `npx prettier --check` clean on all touched files.
- [x] `node server/server.js` boots and listens.
- [x] Changelog entries added to `docs/releases/5.5.0/fixes.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RnbNsA2o1T1BDWoSNmoETc)_