### PR TITLE
fix(http): stop sending hop-by-hop Connection headers

### DIFF
--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -119,3 +119,18 @@ leaving no trace of what failed.
 - Uncaught exceptions are logged and the process then exits deliberately. With `WORKERS` above 1 the
   affected worker is respawned automatically, as it already was for any other worker exit.
 - The standalone binary already behaved this way; the regular server now matches it.
+
+## Streaming Works Behind HTTP/2 Reverse Proxies
+
+Chat responses and long-running tool jobs stopped mid-stream — or never started — for users behind a
+reverse proxy that serves iHub over HTTP/2, typically shown in the browser as
+`ERR_HTTP2_PROTOCOL_ERROR`. iHub sent a `Connection: keep-alive` header on its event-stream
+responses; that header is forbidden in HTTP/2, so a proxy that forwards it instead of removing it
+produces a stream strict clients reject outright.
+
+- The header is no longer sent on chat streaming or job progress responses. HTTP/1.1 keeps
+  connections alive on its own, so nothing changes for deployments served over HTTP/1.1.
+- The same header is no longer sent on outbound calls either — to the iAssistant conversation API and
+  when fetching web pages for URL sources and the web content extractor — so those requests survive
+  an intermediary that converts them to HTTP/2.
+- No configuration change is needed.

--- a/server/adapters/iassistant-conversation.js
+++ b/server/adapters/iassistant-conversation.js
@@ -164,8 +164,7 @@ class IAssistantConversationAdapterClass extends BaseAdapter {
       'Content-Type': 'application/json',
       Accept: 'text/event-stream',
       Authorization: authHeader,
-      'Cache-Control': 'no-cache',
-      Connection: 'keep-alive'
+      'Cache-Control': 'no-cache'
     };
 
     return {

--- a/server/routes/toolsService/jobRoutes.js
+++ b/server/routes/toolsService/jobRoutes.js
@@ -37,10 +37,11 @@ router.get('/jobs/:jobId/progress', authRequired, (req, res) => {
     return sendNotFound(res, 'Job');
   }
 
+  // `Connection: keep-alive` is intentionally absent — hop-by-hop headers are
+  // forbidden in HTTP/2 (RFC 9113 §8.2.2) and break proxies that forward them.
   res.writeHead(200, {
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
-    Connection: 'keep-alive',
     'X-Accel-Buffering': 'no'
   });
 

--- a/server/sources/URLHandler.js
+++ b/server/sources/URLHandler.js
@@ -126,8 +126,7 @@ class URLHandler extends SourceHandler {
               'User-Agent': 'ihub-Apps/1.0 (+https://github.com/intrafind/ihub-apps)',
               Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
               'Accept-Language': 'en-US,en;q=0.5',
-              'Accept-Encoding': 'gzip, deflate',
-              Connection: 'keep-alive'
+              'Accept-Encoding': 'gzip, deflate'
             },
             signal: controller.signal,
             redirect: followRedirects ? 'follow' : 'manual'

--- a/server/tests/sseChannel.test.js
+++ b/server/tests/sseChannel.test.js
@@ -44,7 +44,9 @@ function fakeReqRes() {
   createSseChannel({ req: helper.req, res: helper.res, id: 'a', map, component: 'Test' });
   assert.strictEqual(helper.headers['Content-Type'], 'text/event-stream');
   assert.strictEqual(helper.headers['Cache-Control'], 'no-cache');
-  assert.strictEqual(helper.headers['Connection'], 'keep-alive');
+  // Hop-by-hop headers are forbidden in HTTP/2 and must not be sent on SSE
+  // responses, or h2-translating proxies produce a malformed stream.
+  assert.strictEqual(helper.headers['Connection'], undefined);
   assert.strictEqual(helper.headers['X-Accel-Buffering'], 'no');
   assert.ok(map.has('a'), 'registers itself in the map');
   helper.triggerClose();

--- a/server/tools/webContentExtractor.js
+++ b/server/tools/webContentExtractor.js
@@ -126,7 +126,6 @@ export default async function webContentExtractor({
           Accept: 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
           'Accept-Language': 'en-US,en;q=0.5',
           'Accept-Encoding': 'gzip, deflate',
-          Connection: 'keep-alive',
           'Upgrade-Insecure-Requests': '1'
         },
         signal: controller.signal,

--- a/server/utils/sseChannel.js
+++ b/server/utils/sseChannel.js
@@ -23,9 +23,13 @@ import logger from './logger.js';
  * checking whether this connection is still the current one for `id`.
  */
 export function createSseChannel({ req, res, id, map, component, heartbeatMs = 30000, onClose }) {
+  // No `Connection: keep-alive` here on purpose: it is a hop-by-hop header that
+  // HTTP/1.1 already implies, and RFC 9113 §8.2.2 forbids it in HTTP/2. Proxies
+  // that translate this response to HTTP/2 without stripping it make the stream
+  // malformed, and strict clients (curl/nghttp2, Chromium) kill it with
+  // PROTOCOL_ERROR instead of streaming.
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Connection', 'keep-alive');
   res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
 
   const myEntry = { response: res, lastActivity: new Date() };


### PR DESCRIPTION
## Why

`Connection: keep-alive` is a hop-by-hop header. HTTP/1.1 implies it already, and [RFC 9113 §8.2.2](https://www.rfc-editor.org/rfc/rfc9113#section-8.2.2) forbids it in HTTP/2 — a receiver **MUST** treat a message carrying it as malformed. A proxy that translates HTTP/1.1 ↔ HTTP/2 without stripping hop-by-hop headers therefore produces a stream that strict clients (curl/nghttp2, Chromium, Java `HttpClient`) reject with `PROTOCOL_ERROR` rather than processing.

This came out of investigating an iFinder connectivity failure in a deployment fronted by exactly such a proxy: reachable over `--http1.1`, dead over HTTP/2. The proxy misconfiguration itself is outside this repo, but iHub was emitting the offending header in five places, so it was exposed to the same class of failure.

## What changed

**Responses** — removed from both event-stream endpoints, so iHub survives being fronted by a reverse proxy that serves HTTP/2 and forwards the header verbatim. Without this, chat streaming and job progress surface as `ERR_HTTP2_PROTOCOL_ERROR` in the browser.

- `server/utils/sseChannel.js` — the shared SSE channel (chat streaming)
- `server/routes/toolsService/jobRoutes.js` — tool job progress stream

**Requests** — removed from three outbound call sites. `node-fetch` never negotiates HTTP/2 (verified: `httpVersion 1.1`, no `h2` in ALPN), so the header was already a no-op for us and only mattered to an intermediary that converts these requests upstream — where it breaks them.

- `server/adapters/iassistant-conversation.js` — iAssistant conversation API
- `server/sources/URLHandler.js` — URL source fetch
- `server/tools/webContentExtractor.js` — web content extractor

Node's default agent keeps HTTP/1.1 connections alive on its own, so connection reuse is unchanged in both directions. Both response sites carry a short comment explaining the deliberate omission, so the header doesn't get "restored" later as an oversight.

## Verification

- `server/tests/sseChannel.test.js` updated to assert the header is absent; suite passes.
- `npm run test:quick` (the PR gate): **350/350 tests pass**. The 9 suites that fail to load are `tests/unit/client/*.jsx` needing `client/node_modules`, which isn't installed in this environment — pre-existing, and no client files are touched here.
- `eslint` and `prettier --check` clean on all changed files.
- Server boots and `/api/health` returns 200.

Changelog entry added under `docs/releases/5.5.0/fixes.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UbesyVZFDaF9QxQTKxV2oM)_