### PR TITLE
docs: document core concepts (providers, models, apps, skills, sources, tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,35 @@ All apps are **fully configurable** via the admin interface — customize prompt
 
 ---
 
+## 🧩 Core Concepts — Apps, Skills, Sources & Tools
+
+iHub is built from a handful of building blocks. Knowing which one to reach for is the fastest way to turn an idea into a working use case:
+
+| Building block     | Answers the question                                  |
+| ------------------ | ----------------------------------------------------- |
+| **Provider**       | How does iHub reach a model or external service?      |
+| **Model**          | Which model answers, with which limits and abilities? |
+| **App**            | What is the concrete use case and its frame?          |
+| **Skill**          | Which reusable procedure, rules, or know-how apply?   |
+| **Source**         | What domain knowledge does the model need?            |
+| **Tool**           | What can the model _do_ beyond producing text?        |
+| **Prompt library** | Which reusable text can a user drop into a chat?      |
+| **Group**          | Who sees all of the above?                            |
+
+**Providers and models.** Providers hold the technical connection — endpoint and credentials — to an external or local service; API keys are administered centrally and stored encrypted at rest. Models (GPT, Claude, Gemini, Mistral, or a local model) are what apps and users select. It pays to split models by use case: internal or sensitive scenarios on a local or dedicated model, public ones on a cloud model. Model choice can be narrowed per app (`allowedModels`) or fully predetermined (`disallowModelSelection`).
+
+**Apps vs. prompt library vs. skills.** Apps are standardized use cases with a fixed frame — prompt, variables, tools, sources, model — and are rolled out per user group, including groups mapped from LDAP or OIDC. The prompt library is the flexible counterpart inside general chat, but a flat list of many prompts becomes hard to navigate. Skills package complex, multi-step procedures and reusable rules modularly: rather than growing one giant app prompt, split a workflow such as a story generator into separate skills for interviewing, structuring, and drafting.
+
+**Sources.** Sources give the model its knowledge: local files (Markdown, PDF, text, JSON), URLs, iFinder documents, and internal pages. URLs suit content that changes regularly, at the risk that page boilerplate adds noise to the context; local files give a more controlled context but must be updated by hand. Each source is either loaded into the prompt up front or fetched on demand as a tool.
+
+**Tools.** Tools extend iHub beyond text generation — web search, API calls, screenshots, people search, Jira, iFinder, and further systems via MCP.
+
+In short: **apps** frame the use case, **skills** define reusable procedures, **sources** deliver the knowledge, and **tools** let the model act. Groups decide who gets what.
+
+📖 **[Full Core Concepts Guide](docs/concepts.md)**
+
+---
+
 ## 🎆 Why Teams Choose iHub Apps
 
 ### 🔒 Full Data Control
@@ -275,10 +304,12 @@ Best for: customization, contributing, building new apps.
 
 | What                         | Where                                                   |
 | ---------------------------- | ------------------------------------------------------- |
+| 🧩 Understand the concepts   | [Core Concepts](docs/concepts.md)                       |
 | 📱 Create custom AI apps     | [App Creation Guide](docs/apps.md)                      |
 | 🤖 Add LLM providers         | [Model Configuration](docs/models.md)                   |
 | 📚 Connect knowledge sources | [Sources System](docs/sources.md)                       |
 | 🔍 Enable web search tools   | [Web Tools](docs/web-tools.md)                          |
+| 🛠️ Add tools & MCP servers   | [Tool Calling](docs/tool-calling.md)                    |
 | 🔐 Configure SSO / OIDC      | [Authentication Guide](docs/external-authentication.md) |
 | 🖥️ Local LLMs (privacy mode) | [Local LLM Providers](docs/local-llm-providers.md)      |
 | 🔧 Full documentation        | [docs/README.md](docs/README.md)                        |
@@ -290,19 +321,35 @@ Best for: customization, contributing, building new apps.
 ### 🤖 AI & LLM Integration
 
 - **Multi-provider**: OpenAI, Anthropic Claude, Google Gemini, Mistral — unified API
+- **Central provider management**: Endpoints and API keys administered in one place, encrypted at rest
 - **Local LLMs**: LM Studio, Jan.ai, vLLM — complete privacy, zero API costs
+- **Per-app model control**: Restrict the selectable models or fix the model entirely
 - **Streaming responses**: Real-time token streaming via Server-Sent Events
 - **Structured output**: JSON schema validation for AI responses
 - **Tool calling**: Function calling and agentic workflows
+- **Vision**: Image understanding on models that support it
 - **Thinking models**: Extended reasoning support (Claude, o1-series)
+- **Compare Mode**: Send one input to two models and compare the answers side by side
 
 ### 📚 Knowledge & Sources
 
 - **Filesystem**: Local markdown, text, and JSON files as AI context
 - **Web pages**: Intelligent content extraction from any URL
 - **Enterprise docs**: iFinder document management integration
+- **Internal pages**: Reuse FAQ and help pages as AI context
 - **Multi-source**: Combine multiple knowledge sources per app
+- **On-demand or up front**: Load a source into the prompt or let the model fetch it as a tool
 - **Admin interface**: Create, test, and preview sources without coding
+
+### 🧠 Apps, Skills & Prompts
+
+- **Apps**: Standardized use cases with a fixed prompt, variables, tools, sources, and model
+- **Skills**: Reusable, modular instruction packages (`SKILL.md` + references) for multi-step procedures
+- **Prompt library**: Searchable, reusable prompts users insert into the general chat
+- **Magic Prompt**: Turns short or incomplete input into a well-formed prompt, with undo
+- **Group-based rollout**: Deliver apps, skills, models, and prompts to specific departments or roles
+- **Portable configuration**: Export an app as JSON and re-create it on another installation
+- **No-code authoring**: Create and edit everything through the admin UI or a raw JSON editor
 
 ### 🛠️ Tools & Integrations
 
@@ -313,6 +360,9 @@ Best for: customization, contributing, building new apps.
 - **File processing**: Upload and analyze PDFs, text, images, audio
 - **Microsoft Entra**: Corporate directory and people search
 - **Jira integration**: Issue tracking and project management
+- **MCP**: Connect further systems via the Model Context Protocol
+- **Self-hosted speech-to-text**: Realtime transcription on your own GPU host — audio never reaches a third party
+- **Outlook add-in & browser extension**: Centrally distributable, group-based rollout
 
 ### 🔐 Security & Authentication
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ This book contains configuration details and user instructions for the iHub Apps
 - [Getting Started Guide](GETTING_STARTED.md) - Quick setup and first steps
 - [Installation Guide](INSTALLATION.md) - Detailed installation instructions
 - [User Guide](user-guide.md) - End-user documentation
+- [Core Concepts](concepts.md) - Providers, models, apps, skills, sources, and tools — and when to use which
 - [Architecture Overview](architecture.md) - System architecture and components
 
 ## Configuration

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -3,6 +3,7 @@
   - [Installation Guide](INSTALLATION.md)
   - [User Guide](user-guide.md)
   - [Admin UI Guide](admin-ui.md)
+  - [Core Concepts](concepts.md)
   - [Architecture Overview](architecture.md)
   - [Configuration]()
     - [Customizing iHub Apps](customization.md)

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -1,0 +1,155 @@
+# Core Concepts: Providers, Models, Apps, Skills, Sources & Tools
+
+This guide explains the building blocks of iHub Apps and, more importantly, **when to use which**. It is the write-up we use when introducing iHub to a new team: once these boundaries are clear, designing use cases for a department and rolling them out to the right people becomes straightforward.
+
+## The mental model
+
+| Building block     | Answers the question                                  | Configured in                    |
+| ------------------ | ----------------------------------------------------- | -------------------------------- |
+| **Provider**       | How does iHub reach a model or external service?      | Admin → Providers                |
+| **Model**          | Which model answers, with which limits and abilities? | Admin → Models                   |
+| **App**            | What is the concrete use case and its frame?          | Admin → Apps                     |
+| **Skill**          | Which reusable procedure, rules, or know-how apply?   | Admin → Skills                   |
+| **Source**         | What domain knowledge does the model need?            | Admin → Sources                  |
+| **Tool**           | What can the model *do* beyond producing text?        | Admin → Tools / MCP servers      |
+| **Prompt library** | Which reusable text can a user drop into a chat?      | Admin → Prompts                  |
+| **Group**          | Who sees all of the above?                            | Admin → Groups                   |
+
+The short version:
+
+- **Apps** model the concrete use case and its frame.
+- **Skills** define reusable procedures, rules, and behaviour.
+- **Sources** supply the factual context and knowledge.
+- **Tools** give the model the ability to act and to fetch live data.
+
+---
+
+## Providers and models
+
+**Providers** are the technical connection to an external or local service. A provider holds the endpoint and the credentials — API keys are administered centrally and [stored encrypted at rest](encryption-key-management.md). Out of the box iHub ships providers for OpenAI, Anthropic, Google, Mistral, and local/OpenAI-compatible servers, plus service providers such as iFinder.
+
+**Models** are the entries users and apps actually select — GPT, Claude, Gemini, Mistral, or a locally hosted model. Each model carries its own configuration: context window, maximum output tokens, and capability flags such as tool calling and image support. See [Models](models.md).
+
+### Separate models by use case
+
+It pays to deliberately split models across use cases instead of routing everything through one:
+
+- Internal or sensitive use cases run on a local model ([LM Studio, Jan.ai, vLLM](local-llm-providers.md)) or a dedicated, contractually covered endpoint.
+- Public or low-risk scenarios can use a cloud model where quality or speed matters more.
+
+### Control what users may choose
+
+Model selection can be narrowed or fully predetermined:
+
+| Setting                   | Effect                                                     |
+| ------------------------- | ---------------------------------------------------------- |
+| `preferredModel`          | The model an app starts with                               |
+| `allowedModels`           | Restricts the selectable models for that app               |
+| `disallowModelSelection`  | Hides the model selector entirely — the app decides        |
+| Group `models` permission | Restricts which models a user group may use at all         |
+
+---
+
+## Apps, prompt library, and skills — when to use which
+
+These three overlap in what they can achieve, and the difference is mostly about **how much of the use case is fixed**.
+
+### Apps
+
+An [app](apps.md) is a standardized use case with a fixed frame: system prompt, input variables, output format, preferred/allowed models, plus the tools and sources it may use. Use apps when the result should be reproducible and the user should not have to know anything about prompting.
+
+Apps are the unit of rollout: via group permissions — including groups mapped from [LDAP](ldap-ntlm-authentication.md) or [OIDC](oidc-authentication.md) — an app can be made available to exactly one department or role.
+
+An existing app is portable. Download it as JSON from the app editor and re-create it on another installation by pasting the JSON into the editor's raw JSON view.
+
+### Prompt library
+
+The [prompt library](prompts.md) offers the opposite trade-off: maximum flexibility inside the general chat. A prompt is a reusable piece of text the user inserts into the input field and then edits freely.
+
+The trade-off is discoverability — beyond a few dozen entries, a flat prompt library becomes hard to navigate. Mitigate that with categories and by scoping prompts to a single app (`appId`), or promote a frequently used prompt into a proper app.
+
+### Skills
+
+A [skill](architecture.md#skills-system) is a modular, reusable instruction package: a `SKILL.md` with metadata and instructions, plus optional reference documents, scripts, and assets. Skills are assigned to apps, permission-controlled per group, and can declare which tools they are allowed to use.
+
+Skills are the right tool for **complex, multi-step procedures and rules that are reused in more than one place**. Instead of growing a single app prompt until nobody dares to touch it, cut the workflow into skills.
+
+Example — a story or article generator: model the interview, the structuring, and the actual drafting as separate skills, and let the app compose them. Each step stays readable, testable, and reusable in other apps.
+
+### Decision guide
+
+| Situation                                                          | Use                |
+| ------------------------------------------------------------------ | ------------------ |
+| Recurring use case, fixed frame, should just work for everyone     | **App**            |
+| Ad-hoc support in general chat, user wants to edit before sending  | **Prompt library** |
+| Multi-step procedure, or rules reused across several apps          | **Skill**          |
+| Needs to be visible only to one department                         | **App** + group    |
+
+---
+
+## Sources: giving the model knowledge
+
+[Sources](sources.md) supply the domain context. Supported types include local files, URLs, iFinder documents, and internal iHub pages.
+
+### Local files vs. URLs
+
+| Source type    | Best for                                          | Trade-off                                                       |
+| -------------- | ------------------------------------------------- | --------------------------------------------------------------- |
+| **Local file** | Curated content — Markdown, text, PDF, JSON       | Controlled, predictable context, but must be updated by hand    |
+| **URL**        | Content that changes regularly                    | Always current, but page boilerplate can add noise to the context |
+
+For URL sources, enable content cleaning and set a `maxContentLength` so navigation, footers, and cookie banners do not consume context that should hold the actual answer.
+
+### iFinder as a source
+
+Documents from [iFinder](iFinder-Integration.md) can be used directly as a source — pinned to a specific document ID or driven by a search query that loads the top matching documents. The connection is configured once centrally; documents are always fetched with the identity of the current user, so users only ever see what they are allowed to see.
+
+### Loaded up front or fetched on demand
+
+Each source is exposed either as a **prompt source** (its content is interpolated into the system prompt for every request) or as a **tool source** (the model fetches it only when it needs to). Prompt sources guarantee the content is present; tool sources keep the context small and scale to many sources.
+
+### A note on wikis and linked content
+
+When wiring up an internal wiki, point at concrete pages or at prepared, condensed content. Do not assume the model will navigate deep chains of links on its own — the more specific the source, the better the answer.
+
+---
+
+## Tools: letting the model act
+
+[Tools](tool-calling.md) extend iHub beyond text generation: [web search and content extraction](web-tools.md), API calls, screenshots, people search, [Jira](JIRA_INTEGRATION.md), iFinder, and further systems connected via [MCP](mcp-integration.md). Tools are enabled per app, and the model calls them when the task requires it.
+
+Note that tool calling requires a model that supports it — check the model's `supportsTools` flag.
+
+---
+
+## Integrations and data flow
+
+- **Authentication**: [LDAP](ldap-ntlm-authentication.md), [OIDC/SSO](oidc-authentication.md), local accounts, proxy headers, or anonymous access — combinable. External groups are mapped onto iHub groups, which is what makes group-based app rollout work. See [Authentication Architecture](authentication-architecture.md).
+- **Outlook add-in**: can be distributed centrally by IT and made available group-based. See [Outlook Add-in Rollout](outlook-add-in.md).
+- **Speech-to-text**: which service transcribes matters. Browser-based speech recognition can send audio to the browser vendor's cloud. For sensitive environments, use the [self-hosted realtime transcription stack](voice-transcription.md), where audio is relayed by the iHub server to your own GPU host and nothing is persisted.
+- **MCP servers and cloud models**: as with any external endpoint, check whether data leaves your own infrastructure before enabling them.
+
+---
+
+## Further capabilities
+
+| Capability                                   | Notes                                                                                                              |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **Vision / image understanding**             | Depends on the model. It must support images (`supportsImages`) and be configured accordingly. See [Image Upload](image-upload-feature.md). |
+| **[Magic Prompt](magic-prompt-feature.md)**  | Rewrites a short or incomplete user input into a better prompt, with an undo option.                               |
+| **[Compare Mode](compare-mode.md)**          | Sends one input to two models and shows the answers side by side — useful for evaluating models against each other. |
+| **Chat history**                             | Users can keep a conversation across reloads. There is no persistent memory spanning different conversations in chat apps — keeping chat history and long-term memory are separate things. Long-term memory exists only for agents in the [Agent Factory](agents.md). |
+| **[Structured output](structured-output.md)**| JSON-schema-validated responses for apps whose output feeds another system.                                        |
+
+---
+
+## Related documentation
+
+- [App Configuration](apps.md)
+- [Models](models.md)
+- [Sources System](sources.md)
+- [Tool Calling](tool-calling.md)
+- [Prompts Library](prompts.md)
+- [Architecture Overview](architecture.md)
+- [Admin UI Guide](admin-ui.md)
+- [User Guide](user-guide.md)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -40,6 +40,8 @@ Use the **Model** dropdown in the settings panel to choose among the models conf
 
 Toggle **Keep Chat History** to preserve conversations in your browser. When disabled, the chat resets whenever you reload or close the page.
 
+Keeping chat history applies to the current conversation only — iHub does not carry a persistent memory from one conversation into the next. If a new chat needs earlier context, provide it again in the input or use an app with the relevant sources attached.
+
 ## Using the Prompt Database
 
 Click the book icon above the input field to open the prompts library. You can search by name or description and sort the results. Selecting **Insert** copies the prompt text into your current message so you can edit or send it immediately.


### PR DESCRIPTION
## What

Writes up the way we explain iHub in customer sessions, so it stops living only in meeting notes.

**New: `docs/concepts.md`** — a conceptual guide to the building blocks and, above all, when to use which:

- **Providers vs. models** — providers hold the endpoint and credentials, models are what apps and users select; separating models by use case (internal/sensitive vs. public) and how to narrow or fix model selection (`preferredModel`, `allowedModels`, `disallowModelSelection`, group `models` permission).
- **Apps vs. prompt library vs. skills** — including a decision table. Apps frame a use case and are the unit of group-based rollout; the prompt library is the flexible counterpart in general chat but gets hard to navigate at scale; skills package multi-step procedures modularly (story generator split into interview / structuring / drafting instead of one giant app prompt). Also notes app portability via JSON export + the raw JSON editor.
- **Sources** — local files vs. URLs vs. iFinder vs. internal pages, with the trade-offs (URL freshness vs. boilerplate noise; local files controlled but manually maintained), prompt sources vs. tool sources, and the note that concrete/prepared content beats expecting the model to navigate linked wiki pages.
- **Tools** — what they add, and that tool calling needs a model with `supportsTools`.
- **Integrations and data flow** — LDAP/OIDC group mapping as what makes group-based rollout work, Outlook add-in distribution, browser vs. self-hosted speech-to-text, and MCP/cloud endpoints as data-leaves-the-house questions.
- **Further capabilities** — vision (model-dependent), Magic Prompt, Compare Mode, chat history vs. no cross-conversation memory (long-term memory exists only for Agent Factory agents), structured output.

**README** — new "Core Concepts" section with the same model in short form, plus key-feature entries that were missing: skills, central provider management, per-app model control, vision, Compare Mode, Magic Prompt, MCP, self-hosted transcription, and Outlook add-in / browser extension rollout. Adds Core Concepts and Tool Calling to the "Extend & Customize" table.

**`docs/user-guide.md`** — clarifies that keeping chat history applies to the current conversation only; there is no memory carried into the next chat.

Linked from `docs/README.md` and `docs/SUMMARY.md`.

## Notes

- Documentation only — no code changes, so no changelog entry under `docs/releases/`.
- Every claim was checked against the code (`skillLoader.js`, `appConfigSchema.js`, `providers.json`, `features.json`, source handlers, voice pipeline) rather than taken from the meeting notes; open items and follow-up actions from those notes are deliberately not included.
- Prettier clean; all relative links in the new file resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJ3NZz9KPKuXSnTHsD7fFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ3NZz9KPKuXSnTHsD7fFv)_