### PR TITLE
fix(mermaid): keep diagrams alive when a message re-renders on hover

### DIFF
--- a/client/src/features/chat/components/StreamingMarkdown.jsx
+++ b/client/src/features/chat/components/StreamingMarkdown.jsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState, useRef, useEffect, useCallback } from 'react';
+import { memo, useLayoutEffect, useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { renderMarkdown } from '../../../config/marked.config';
 import {
   transformCitations,
@@ -19,6 +19,13 @@ import './StreamingMarkdown.css';
  *   While true the container is GPU-promoted (will-change/translateZ) for smooth
  *   incremental updates; once streaming ends the promotion is dropped so finished
  *   messages don't each hold a permanent compositor layer.
+ *
+ * Exported wrapped in `memo`: the component owns its DOM through
+ * `dangerouslySetInnerHTML`, and React re-applies that prop whenever the object
+ * it is given is not reference-identical to the previous one — it never compares
+ * the HTML string. A parent re-render for an unrelated reason (hovering a chat
+ * message toggles its action row, for example) would therefore wipe and rebuild
+ * the whole markdown subtree, throwing away every rendered Mermaid diagram in it.
  */
 function StreamingMarkdown({ content, hasCitations, streaming = false }) {
   const containerRef = useRef(null);
@@ -71,15 +78,21 @@ function StreamingMarkdown({ content, hasCitations, streaming = false }) {
     }
   }, [htmlContent, hasCitations, handleCitationClick]);
 
+  // Reference-stable as long as the markup is unchanged. React compares the
+  // `dangerouslySetInnerHTML` prop by object identity, so a fresh literal on
+  // every render would re-assign `innerHTML` — destroying and recreating every
+  // child node — even when the HTML is byte-identical.
+  const innerHtml = useMemo(() => ({ __html: htmlContent }), [htmlContent]);
+
   return (
     <div
       ref={containerRef}
       className={`markdown-content break-words whitespace-normal streaming-markdown${
         streaming ? ' is-streaming' : ''
       }`}
-      dangerouslySetInnerHTML={{ __html: htmlContent }} // sanitized with DOMPurify before setState
+      dangerouslySetInnerHTML={innerHtml} // sanitized with DOMPurify before setState
     />
   );
 }
 
-export default StreamingMarkdown;
+export default memo(StreamingMarkdown);

--- a/client/src/pages/UnifiedPage.jsx
+++ b/client/src/pages/UnifiedPage.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import LoadingSpinner from '../shared/components/LoadingSpinner';
@@ -16,6 +16,15 @@ export default function UnifiedPage() {
   const [contentType, setContentType] = useState('markdown'); // 'markdown' or 'react'
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  // Parsed once per content change, and handed to React as a reference-stable
+  // object: React re-applies `dangerouslySetInnerHTML` whenever that object is
+  // new, so a fresh literal on every render would rebuild the whole subtree and
+  // discard rendered Mermaid diagrams even though the markup never changed.
+  const parsedContent = useMemo(
+    () => ({ __html: contentType === 'react' ? '' : renderMarkdown(pageContent || '') }),
+    [contentType, pageContent]
+  );
 
   useEffect(() => {
     const loadPageContent = async () => {
@@ -106,13 +115,9 @@ export default function UnifiedPage() {
       );
     } else {
       // Default to markdown rendering
-      const parsedContent = renderMarkdown(pageContent || '');
       return (
         <div className="prose prose-sm sm:prose lg:prose-lg mx-auto dark:prose-invert">
-          <div
-            className="markdown-content"
-            dangerouslySetInnerHTML={{ __html: parsedContent }}
-          ></div>
+          <div className="markdown-content" dangerouslySetInnerHTML={parsedContent}></div>
         </div>
       );
     }

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -362,6 +362,10 @@ it for a moment before the view went blank.
   previously landed outside the visible area, which looked like an empty viewer.
 - Long chat sessions stay responsive: each re-render used to leave behind a keyboard listener and a
   pan/zoom instance that were never released.
+- Moving the mouse onto a finished answer, or off it again, no longer redraws its diagrams. The
+  rendered answer is now left alone when a message re-renders for an unrelated reason — such as its
+  action row fading in on hover — instead of being rebuilt from the markdown each time.
+
 ## Web Search Reads Pages Again Instead of Answering From Snippets
 
 A web search app answered from the short descriptions in the search result list

--- a/tests/unit/client/streaming-markdown-stability.test.jsx
+++ b/tests/unit/client/streaming-markdown-stability.test.jsx
@@ -1,0 +1,78 @@
+/**
+ * StreamingMarkdown owns its DOM through `dangerouslySetInnerHTML`. React
+ * re-applies that prop whenever the object it is given is not reference-identical
+ * to the previous one — it never compares the HTML string — so an unrelated
+ * parent re-render (hovering a chat message toggles its action row) used to wipe
+ * and rebuild the whole markdown subtree, discarding every rendered Mermaid
+ * diagram inside it.
+ */
+import { useState } from 'react';
+import { render, screen, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import StreamingMarkdown from '../../../client/src/features/chat/components/StreamingMarkdown';
+
+const DIAGRAM = '```mermaid\nflowchart TD\n  A[Start] --> B[End]\n```';
+const CONTENT = `Some text\n\n${DIAGRAM}\n\nMore text`;
+
+const diagramNode = () => document.querySelector('.mermaid-diagram-container');
+
+/**
+ * Mimics ChatMessage: local state that changes on hover (the action row's
+ * opacity) while the markdown props stay exactly the same.
+ */
+function HoverableMessage({ content, streaming = false }) {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <div data-testid="message" onMouseEnter={() => setHovered(true)}>
+      <span data-testid="actions">{hovered ? 'shown' : 'hidden'}</span>
+      <StreamingMarkdown content={content} streaming={streaming} />
+    </div>
+  );
+}
+
+describe('StreamingMarkdown DOM stability', () => {
+  test('keeps the rendered diagram node across an unrelated parent re-render', () => {
+    render(<HoverableMessage content={CONTENT} />);
+
+    const before = diagramNode();
+    expect(before).not.toBeNull();
+    // Something the Mermaid hook would have put into the container.
+    before.dataset.processed = 'true';
+
+    act(() => {
+      screen.getByTestId('message').dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      screen.getByTestId('message').dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    });
+
+    expect(screen.getByTestId('actions')).toHaveTextContent('shown');
+    // Same node, still marked processed: React left the subtree alone.
+    expect(diagramNode()).toBe(before);
+    expect(diagramNode().dataset.processed).toBe('true');
+  });
+
+  test('keeps the rendered diagram node when re-rendered with identical content', () => {
+    const { rerender } = render(<StreamingMarkdown content={CONTENT} />);
+
+    const before = diagramNode();
+    before.dataset.processed = 'true';
+
+    rerender(<StreamingMarkdown content={CONTENT} />);
+
+    expect(diagramNode()).toBe(before);
+    expect(diagramNode().dataset.processed).toBe('true');
+  });
+
+  test('still replaces the markup when the content actually changes', () => {
+    const { rerender } = render(<StreamingMarkdown content={CONTENT} />);
+
+    const before = diagramNode();
+    expect(screen.getByText('Some text')).toBeInTheDocument();
+
+    rerender(<StreamingMarkdown content={`${CONTENT}\n\nA new paragraph`} />);
+
+    expect(screen.getByText('A new paragraph')).toBeInTheDocument();
+    expect(diagramNode()).not.toBe(before);
+  });
+});


### PR DESCRIPTION
Follow-up to #2264 — the one re-render path that fix missed.

## Problem

Scrolling and fullscreen behave, but moving the mouse onto a finished answer that contains a Mermaid diagram (and moving it back off) re-renders the diagram.

## Root cause

Hover toggles `showActions` in `ChatMessage`, which re-renders `StreamingMarkdown` with unchanged props.

React 19 re-applies `dangerouslySetInnerHTML` whenever the object it is handed is not reference-identical to the previous one — it never compares the HTML string. `react-dom` 19's `updateProperties` skips a prop only on `nextProp === lastProp`, and `setProp` then does a bare `domElement.innerHTML = value.__html`.

`dangerouslySetInnerHTML={{ __html: htmlContent }}` is a fresh literal on every render, so every hover re-assigned `innerHTML`: all child nodes recreated, the `data-processed` markers on the Mermaid containers lost, and the hook's mutation observer picked them up as unprocessed and re-rendered them. The previous fix's "only push new HTML when it differs" guard covers state changes inside the component, but not a re-render driven from the parent.

## Changes

- `client/src/features/chat/components/StreamingMarkdown.jsx` — memoize the `dangerouslySetInnerHTML` object on the parsed markup, and export the component wrapped in `memo` (its props are all primitives). An unrelated parent re-render now leaves the rendered subtree, diagrams included, untouched.
- `client/src/pages/UnifiedPage.jsx` — same class of bug: the page markdown was parsed inline on every render and passed as a new object, so any state change rebuilt the whole page body. Parse is now memoized on the content and passed as a stable object.
- `docs/releases/5.5.0/fixes.md` — bullet added to the existing Mermaid entry (and the missing blank line before the next heading fixed).

## Testing

- `tests/unit/client/streaming-markdown-stability.test.jsx` — new: the diagram container node survives a parent re-render triggered by hover state, survives an identical re-render, and is still replaced when the content actually changes. 2 of the 3 fail without the fix.
- `npx jest --config tests/config/jest.config.js tests/unit/client` — 350 passed, 35 suites. One suite (`workflow-edge-condition.test.jsx`) still fails to resolve `winston` because server dependencies are not installed in this environment; unrelated and pre-existing.
- `npx vite build` in `client/` — succeeds.
- ESLint: 0 errors on the touched files (only the repo's pre-existing `dangerouslySetInnerHTML` / `set-state-in-effect` warnings). Prettier clean.

Not changed: `MarkdownViewer.jsx` and `ArtifactViewer.jsx` pass the same kind of fresh literal, but they are modals whose props do not change while open, so nothing re-renders them in place. Happy to include them if you'd rather have the pattern applied uniformly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EVRD35zCBnfZkhaHtmaVd7

---
_Generated by [Claude Code](https://claude.ai/code/session_01EVRD35zCBnfZkhaHtmaVd7)_