### PR TITLE
fix(auth): terminate OIDC provider session on logout (RP-Initiated Logout)

### DIFF
--- a/client/src/features/admin/components/platform-form/OidcProvidersSection.jsx
+++ b/client/src/features/admin/components/platform-form/OidcProvidersSection.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import Icon from '../../../../shared/components/Icon';
 import { CredentialRefSelect } from '../OpenApiToolEditor';
 import GroupMultiSelect from '../GroupMultiSelect';
+import { getBasePath } from '../../../../utils/runtimeBasePath';
 
 // OIDC Provider Templates
 const OIDC_PROVIDER_TEMPLATES = {
@@ -11,6 +12,9 @@ const OIDC_PROVIDER_TEMPLATES = {
     authorizationURL: 'https://${AUTH0_DOMAIN}/authorize',
     tokenURL: 'https://${AUTH0_DOMAIN}/oauth/token',
     userInfoURL: 'https://${AUTH0_DOMAIN}/userinfo',
+    // The OIDC-compliant endpoint - not the legacy /v2/logout, which uses
+    // different (non-standard) query parameters.
+    endSessionURL: 'https://${AUTH0_DOMAIN}/oidc/logout',
     scope: ['openid', 'profile', 'email'],
     groupsAttribute: 'groups',
     pkce: true,
@@ -22,6 +26,8 @@ const OIDC_PROVIDER_TEMPLATES = {
     authorizationURL: 'https://accounts.google.com/o/oauth2/v2/auth',
     tokenURL: 'https://www.googleapis.com/oauth2/v4/token',
     userInfoURL: 'https://www.googleapis.com/oauth2/v2/userinfo',
+    // No endSessionURL: Google has no end_session_endpoint, so RP-Initiated
+    // Logout isn't possible here - left unset deliberately.
     scope: ['openid', 'profile', 'email'],
     groupsAttribute: 'groups',
     pkce: true,
@@ -33,6 +39,7 @@ const OIDC_PROVIDER_TEMPLATES = {
     authorizationURL: 'https://login.microsoftonline.com/common/oauth2/v2.0/authorize',
     tokenURL: 'https://login.microsoftonline.com/common/oauth2/v2.0/token',
     userInfoURL: 'https://graph.microsoft.com/v1.0/me',
+    endSessionURL: 'https://login.microsoftonline.com/common/oauth2/v2.0/logout',
     scope: ['openid', 'profile', 'email', 'User.Read'],
     groupsAttribute: 'groups',
     pkce: true,
@@ -46,6 +53,8 @@ const OIDC_PROVIDER_TEMPLATES = {
     tokenURL: 'https://${KEYCLOAK_SERVER}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token',
     userInfoURL:
       'https://${KEYCLOAK_SERVER}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/userinfo',
+    endSessionURL:
+      'https://${KEYCLOAK_SERVER}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/logout',
     scope: ['openid', 'profile', 'email'],
     groupsAttribute: 'groups',
     pkce: true,
@@ -315,6 +324,42 @@ function OidcProvidersSection({ config, onChange, t, availableGroups = [] }) {
                     <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">
                       <Icon name="information-circle" className="h-3 w-3 inline mr-1" />
                       Auto-generated: /api/auth/oidc/{provider.name}/callback
+                    </p>
+                  )}
+                </div>
+                <div className="md:col-span-2">
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                    {t('admin.auth.endSessionURL', 'End Session URL')}{' '}
+                    <span className="text-xs text-gray-500 dark:text-gray-400 font-normal">
+                      {t(
+                        'admin.auth.endSessionURLOptional',
+                        '(Optional - enables full logout at the provider)'
+                      )}
+                    </span>
+                  </label>
+                  <input
+                    type="url"
+                    placeholder={t(
+                      'admin.auth.endSessionURLPlaceholder',
+                      'https://your-provider/.../logout'
+                    )}
+                    value={provider.endSessionURL || ''}
+                    onChange={e => updateOidcProvider(index, 'endSessionURL', e.target.value)}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                  />
+                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    {t(
+                      'admin.auth.endSessionURLHelp',
+                      'When set, logging out of iHub also ends the session at the provider (RP-Initiated Logout), so the next login always shows a real login prompt instead of silently reusing an active provider session. Leave empty to log out of iHub only.'
+                    )}
+                  </p>
+                  {provider.endSessionURL && (
+                    <p className="text-xs text-blue-600 dark:text-blue-400 mt-1">
+                      <Icon name="information-circle" className="h-3 w-3 inline mr-1" />
+                      {t(
+                        'admin.auth.endSessionURLRegisterHint',
+                        'Register {{url}} as a valid post-logout redirect URI at your provider, or logout will fail with an error there.'
+                      ).replace('{{url}}', `${window.location.origin}${getBasePath()}/*`)}
                     </p>
                   )}
                 </div>

--- a/client/src/shared/contexts/AuthContext.jsx
+++ b/client/src/shared/contexts/AuthContext.jsx
@@ -495,18 +495,20 @@ export function AuthProvider({ children }) {
 
   // Logout with comprehensive cleanup
   const logout = async () => {
+    let oidcLogoutRequired = false;
     try {
       console.log('🔒 LOGOUT: Redirecting to logout page to prevent auto-redirect');
 
       // Call logout API if authenticated
       if (state.isAuthenticated) {
-        await apiClient.post(
+        const response = await apiClient.post(
           '/auth/logout',
           {},
           {
             headers: getAuthHeaders()
           }
         );
+        oidcLogoutRequired = response?.data?.oidcLogoutRequired === true;
       }
     } catch (error) {
       console.error('Logout API error:', error);
@@ -515,9 +517,15 @@ export function AuthProvider({ children }) {
       await performLogoutCleanup();
       dispatch({ type: AUTH_ACTIONS.LOGOUT });
 
+      // If authenticated via OIDC, first end the session at the provider too
+      // (RP-Initiated Logout) before landing back home - otherwise the IdP's
+      // SSO session stays active and the next login silently re-authenticates
+      // without a login prompt. See GET /api/auth/oidc-logout.
       // Redirect to apps home page with logout parameter to prevent auto redirect
       // This ensures users don't remain on admin or other protected pages after logout
-      window.location.href = buildPath('/?logout=true');
+      window.location.href = oidcLogoutRequired
+        ? buildApiUrl('auth/oidc-logout')
+        : buildPath('/?logout=true');
     }
   };
 

--- a/concepts/2026-09-07 OIDC RP-Initiated Logout Fix.md
+++ b/concepts/2026-09-07 OIDC RP-Initiated Logout Fix.md
@@ -1,0 +1,313 @@
+# OIDC RP-Initiated Logout Fix
+
+Status: Implemented (branch `fix/oidc-rp-initiated-logout`)
+Date: 2026-09-07
+
+## Summary
+
+Logging out of iHub while authenticated via an OIDC provider (Keycloak,
+tested end-to-end; Entra ID / Auth0 / ADFS by design, untested live) only
+cleared iHub's own auth cookie. The provider's own SSO session stayed
+active in the browser, so the next login attempt - by the same user, or by
+a different person on a shared/kiosk device - was silently re-authenticated
+by the provider without ever showing a login form.
+
+## Bug
+
+### Current behavior (before this fix)
+
+- `server/middleware/oidcAuth.js`: the ID token returned by the provider is
+  decoded once (to read a `groups` claim some IdPs only put there), then
+  discarded. It is never persisted anywhere - not in the JWT, not in a
+  session, not in a cookie.
+- `POST /api/auth/logout` (`server/routes/auth.js`) only clears the local
+  `authToken` cookie. No call to the provider's `end_session_endpoint`, no
+  `id_token_hint`, no redirect to the IdP.
+- `client/src/shared/contexts/AuthContext.jsx` (`logout()`) redirects the
+  browser straight back to iHub's own home page, never to the provider.
+- `oidcProviderSchema` (`server/validators/platformConfigSchema.js`) has no
+  field for a logout/`end_session_endpoint` URL at all.
+
+### Root cause classification
+
+Investigated whether this was a deliberate design choice (e.g. "local
+logout only" to preserve a shared SSO session across other apps on
+purpose) versus an oversight. Evidence points to oversight:
+
+- `docs/ADFS-AUTHENTICATION-GUIDE.md` already documented a `logoutURL`
+  provider field for exactly this purpose - it was never wired up in any
+  code path (confirmed via full-repo grep). Doc/code drift, not a
+  documented trade-off.
+- iHub's own OIDC **Identity Provider** side (`server/routes/oauth.js`,
+  `/api/oauth/logout`) already implements RP-Initiated Logout correctly to
+  spec (`id_token_hint`, `post_logout_redirect_uri`, `state`,
+  `postLogoutRedirectUris` allowlist) - the team clearly knows the pattern
+  and applies it correctly elsewhere; it was simply never mirrored on
+  iHub's own relying-party (client-of-an-external-IdP) side.
+- No code comment, config toggle, or doc anywhere discusses a deliberate
+  choice to keep OIDC logout local-only.
+
+### Impact
+
+- Deviates from [OIDC RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
+  and from session-termination expectations in NIST SP 800-63B ("Session
+  tokens SHALL be erased or invalidated by the session subject when the
+  subscriber logs out").
+- Shared/kiosk devices: a user clicking "Log out" so a colleague can log in
+  can result in the colleague being silently authenticated as the first
+  user - no credential prompt, full account access (chat history, any
+  admin rights) transferred without anyone entering credentials. Confirmed
+  as the concrete, reproducible failure mode driving this fix.
+- Users are shown a "logged out" state that is misleading with respect to
+  the IdP session.
+
+## Solution
+
+### Mechanism
+
+Opt-in [OIDC RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
+per provider, via a new optional `endSessionURL` field. No behavior change
+for any provider that leaves it unset - fully backward compatible, no
+config migration needed.
+
+1. **Login** (`server/middleware/oidcAuth.js`): when the provider has
+   `endSessionURL` configured, the ID token is passed out of the Passport
+   verify callback via `done(null, user, { idToken })` - Passport's
+   existing `info` argument, not the user object (which flows into
+   `validateAndPersistExternalUser()` and can be persisted to
+   `contents/config/users.json`; the ID token must never end up there). The
+   callback handler stores it in a new httpOnly `oidcLogoutHint` cookie
+   (`{ provider, idToken }`, same cookie options as the existing
+   `authToken`).
+2. **Logout, step 1** (`POST /api/auth/logout`): clears `authToken` as
+   before, unconditionally. Additionally checks whether the *current*
+   session is OIDC-authenticated and `oidcLogoutHint` is present (never
+   reads/parses its content here), and returns that as
+   `oidcLogoutRequired: true|false`. Only clears `oidcLogoutHint` itself
+   when that's `false` - when it's `true`, step 3 below is the one that
+   reads and clears it (see Bug 4 for why clearing it here too would break
+   step 3).
+3. **Logout, step 2** (new `GET /api/auth/oidc-logout`): if the client
+   received `oidcLogoutRequired: true`, it navigates the whole page here
+   (not a fetch/XHR call). This endpoint reads and parses the
+   `oidcLogoutHint` cookie, looks up the provider, and - if it has
+   `endSessionURL` - 302-redirects the browser to
+   `{endSessionURL}?id_token_hint=...&post_logout_redirect_uri=...&client_id=...`.
+   Any missing/malformed/stale hint falls back safely to the plain
+   `/?logout=true` landing page. The `oidcLogoutHint` cookie is cleared
+   either way.
+4. **Client** (`AuthContext.jsx`): `logout()` now branches on
+   `oidcLogoutRequired` to decide between the two landing targets above.
+
+### Security review finding (addressed)
+
+First draft had `/api/auth/logout` return the fully-built provider logout
+URL - including the raw `id_token` as `id_token_hint` - as a JSON field,
+read by the client via `fetch`/axios. That puts a sensitive token into a
+JS-readable API response body: exposed to CORS misconfiguration
+(`cors.credentials: true` + an overly broad `ALLOWED_ORIGINS`), browser
+extensions with network access, or client-side error/analytics tooling
+that logs responses.
+
+Fixed by keeping the token server-side end to end: `/api/auth/logout`
+returns only a boolean, never the token or URL. The actual provider
+redirect happens through the dedicated `GET /api/auth/oidc-logout`
+endpoint, reached via a real top-level browser navigation. The raw ID
+token now only ever exists in the httpOnly cookie and the `Location`
+header of a 302 - never in a JS-readable response body. Mirrors how OIDC
+reference implementations (e.g. Spring's
+`OidcClientInitiatedLogoutSuccessHandler`) do it, and the existing
+`createOidcAuthHandler` pattern already in this codebase (a GET route
+whose whole job is redirecting the browser into an external OIDC flow).
+
+### Dev-environment regression found and fixed during manual testing
+
+`post_logout_redirect_uri` was built from `req.get('host')` directly. In
+this project's dev setup, Vite proxies `/api/*` to the backend with
+`changeOrigin: true` (`client/vite.config.js`), which rewrites `Host` to
+the backend's own port - not the SPA's port the browser actually needs to
+land back on. Vite already compensates by setting `X-Forwarded-Host` to
+the real browser host for exactly this reason. Fixed by reusing the
+already-existing, already-tested `buildPublicBaseUrl()` helper
+(`server/utils/publicBaseUrl.js`, also used by the Office 365 callback URL
+builder and the browser-extension download endpoint) instead of reading
+`req.get('host')` directly. Works unchanged in production, where there is
+no separate Vite process.
+
+### Provider coverage
+
+The redirect-building code has no provider-specific branching - it is a
+generic `id_token_hint` / `post_logout_redirect_uri` / `client_id` query
+builder against whatever `endSessionURL` is configured.
+
+| Provider | End-session endpoint | Status |
+| --- | --- | --- |
+| Keycloak | `{issuer}/protocol/openid-connect/logout` | Verified end-to-end (real login + logout + re-login round trip) |
+| Microsoft Entra ID | `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/logout` | Spec-compliant, code path exercised by tests, not verified against a live tenant |
+| Auth0 | `https://{domain}/oidc/logout` (the OIDC-compliant endpoint - not the legacy `/v2/logout`) | Same as above |
+| ADFS | `https://{adfs-server}/adfs/oauth2/logout` | Same as above; no practical way to run ADFS locally (needs a full Windows Server + AD domain controller) |
+| Custom/generic OIDC | Admin-supplied | Covered by the same generic path as Keycloak |
+| Google | No `end_session_endpoint` exists at all | Explicitly out of scope - `endSessionURL` simply stays unset; would need a different, login-side mitigation (forcing `prompt=select_account`), not a logout-time fix |
+
+### Admin UI
+
+Added an **End Session URL** field to Admin → Authentication (next to
+Callback URL), including a live-computed hint showing the exact
+`{origin}/*` value to register at the provider as a "valid post logout
+redirect URI" - the single operational step most likely to be missed
+otherwise (it was, during our own manual testing of this fix). Not
+strictly required for the feature to work - the field was already
+settable via Admin → Authentication → JSON mode or by editing
+`platform.json` directly, since `platformConfigSchema` is not enforced as
+a save-time validation gate - but added for discoverability and to reduce
+the exact setup mistake found during testing.
+
+### Operational requirement (not code)
+
+The provider's client must allow-list iHub's own URL as a valid
+post-logout redirect target (in Keycloak: client → **Valid post logout
+redirect URIs**). Without it, the provider will refuse the redirect back
+to iHub after logout - iHub's own local session is still cleared either
+way; only the bounce-back fails, and the failure is visible (an error page
+at the provider), not a silent hang. A startup-time warning log
+(`server/middleware/oidcAuth.js`) now flags any provider with
+`endSessionURL` set, naming the requirement, so this is caught during
+setup rather than by an end user.
+
+## Testing performed
+
+- `server/tests/oidc-logout.test.js` (15 tests, Jest + Supertest):
+  `oidcLogoutRequired` signaling tied to the current session's `authMode`,
+  never touching the token; the cookie is cleared in `POST /api/auth/logout`
+  only when it won't be consumed downstream, and left alone otherwise (the
+  bug 4 regression test); safe fallback on missing/malformed/unknown
+  -provider/no-endSessionURL/malformed-URL hints; correct
+  `id_token_hint`/`post_logout_redirect_uri`/`client_id` construction;
+  explicit regression test for the `X-Forwarded-Host` dev-proxy fix.
+- Manual end-to-end against a real local Keycloak (Docker), repeated after
+  each fix: login, logout, re-login. First two attempts still reproduced the
+  bug (bug 4, above) despite the code review's earlier sign-off - only the
+  third attempt, after the premature-clear fix, actually showed Keycloak's
+  own login form on re-login instead of silently re-authenticating.
+- Verified via DevTools Network tab that the raw `id_token` never appears
+  in any XHR/fetch response body - only in the `Location` header of the
+  302 from `/api/auth/oidc-logout`.
+- Regression check: providers without `endSessionURL` behave identically
+  to before (`oidcLogoutRequired: false`, direct redirect, no
+  `oidcLogoutHint` cookie ever set).
+- Full repo test suite run for comparison: pre-existing, environment-level
+  failures (worker process crashes, likely missing services such as Redis
+  in this sandbox) exist identically with and without this change (129/189
+  suites failing on a clean baseline vs. 130/190 with this change, the
+  only difference being this change's own new, passing suite) - not caused
+  by this fix, but should be confirmed against real CI before merge.
+
+## Pre-PR review findings (fixed)
+
+A full security review (dedicated agent) and an 8-angle code review (correctness,
+removed-behavior, cross-file, reuse, simplification, efficiency, altitude,
+CLAUDE.md conventions - each independently verified) were run against this
+diff before opening the PR.
+
+**Security review**: no CONFIRMED/PLAUSIBLE findings at HIGH/MEDIUM severity.
+Candidates considered and ruled out with concrete reasoning: the
+`post_logout_redirect_uri` built from `buildPublicBaseUrl()` (trusts
+`X-Forwarded-Host`) is not an open redirect within iHub's trust boundary -
+it's only ever consumed by the external, admin-configured IdP, which is
+expected to validate it against its own allowlist; the unsigned
+`oidcLogoutHint` cookie is httpOnly (no direct JS read/write) and host-only
+scoped (no `domain` attribute), so forging it requires an existing XSS or
+network MITM - preconditions that already grant far more powerful primitives
+than this cookie; the unauthenticated, CSRF-unprotected `GET
+/api/auth/oidc-logout` matches the existing pattern of every other OIDC GET
+route and its worst case is a self-targeting forced logout, not unauthorized
+access.
+
+**Code review found and fixed 3 real bugs**:
+
+1. **Stale `oidcLogoutHint` cookie could redirect a non-OIDC logout through an
+   unrelated provider.** `oidcLogoutRequired` was computed from cookie
+   presence alone; nothing cleared it on a subsequent local/LDAP/NTLM/Teams
+   login (a supported dual-auth configuration). Fixed by additionally
+   requiring `req.user?.authMode === 'oidc'` (from the current session's
+   verified JWT, not a separately-lived cookie), and by clearing
+   `oidcLogoutHint` in `POST /api/auth/logout` **only when it won't be used**
+   (`oidcLogoutRequired === false`) - see finding 4 below for why clearing it
+   unconditionally there is itself a bug, not the fix.
+2. **Unguarded `new URL(provider.endSessionURL)`** could throw an uncaught
+   exception (500) if an admin saved a malformed URL - `oidcProviderSchema`'s
+   `endSessionURL: z.string().url()` is only used for schema export, not
+   actually enforced by the admin config save route. Fixed: wrapped in
+   try/catch as another graceful-fallback branch, consistent with the other
+   invalid-state checks in the same handler.
+3. **Admin UI's "register this URL" hint ignored subpath deployments** -
+   built from `window.location.origin` alone, while the server's actual
+   `post_logout_redirect_uri` (via `buildPublicBaseUrl()`) includes the
+   `X-Forwarded-Prefix`-derived base path too. Fixed: hint now also uses
+   `getBasePath()` from `client/src/utils/runtimeBasePath.js`.
+
+Regression tests added for all three (`server/tests/oidc-logout.test.js`,
+now 15 tests). Two lower-severity suggestions (collapsing five near-identical
+guard-clause branches into a table/helper; reusing `safeParseJsonAsync` for
+the cookie's JSON parsing) were considered and deliberately not applied - see
+inline reasoning in the corresponding code-review findings.
+
+## Bug 4: fix #1 above regressed the happy path (found via live testing, not by review)
+
+The unconditional `res.clearCookie('oidcLogoutHint', ...)` that fix #1's own
+first draft added to `POST /api/auth/logout` (to close the stale-cookie gap)
+deleted the cookie in *that* response - before the client's follow-up
+navigation to `GET /api/auth/oidc-logout` ever got a chance to read it. Every
+OIDC logout was silently downgraded to local-only: iHub's own session ended,
+but the provider's SSO session never did, so the very next login
+re-authenticated without a credential prompt - reproducing the original bug
+this whole feature exists to fix, immediately after "fixing" it.
+
+Neither the security review nor the 8-angle code review (including its own
+cross-file/removed-behavior angles) caught this - it only surfaced through
+manual end-to-end testing against a real Keycloak instance, diagnosed via:
+`platform.json`'s `auth.debug.enabled` flag turned on temporarily to trace
+the token exchange (confirmed Keycloak really does return `id_token` and the
+cookie-set condition was true), the audit log (`GET /api/admin/audit-log`,
+confirmed real OIDC logins were completing each cycle), and finally the
+browser's own Network tab request headers (confirmed the cookie *was* being
+sent correctly on `POST /api/auth/logout` - proving the bug was server-side,
+in the unconditional clear, not a browser/cookie-transport issue).
+
+**Fix:** `POST /api/auth/logout` now only clears `oidcLogoutHint` when
+`oidcLogoutRequired` is `false` (i.e. when `GET /api/auth/oidc-logout` will
+never be called) - see `server/routes/auth.js:565-574`. Regression test:
+"does NOT clear the oidcLogoutHint cookie here when it WILL be used (OIDC
+session)" (`server/tests/oidc-logout.test.js`).
+
+**Lesson for next time:** a static/agent-based review, however thorough,
+does not substitute for one real end-to-end run of a multi-request flow
+against real infrastructure before calling a fix like this done - test
+coverage for this exact regression now exists, but didn't at review time
+because the review (correctly, given what it was shown) reasoned about the
+two endpoints' cookie-clearing calls in isolation rather than tracing the
+cookie's full lifecycle across both requests in sequence.
+
+**Follow-up items noted but not addressed (low severity, not blockers):**
+- If the client's `POST /api/auth/logout` succeeds with
+  `oidcLogoutRequired: true` but the follow-up navigation to
+  `GET /api/auth/oidc-logout` never happens (network failure, closed tab, JS
+  error), the hint cookie is left un-consumed until it naturally expires.
+  Not a security issue (httpOnly, single consumer), but silently reproduces
+  the user-visible symptom (provider session stays alive) via a client-side
+  gap rather than a server-side one. Not currently tested.
+- A narrow two-tab race exists: logging out from two tabs in quick
+  succession could have the second (non-OIDC-flagged, since `authToken` was
+  already cleared by the first) request's conditional clear win before the
+  first tab's `GET /api/auth/oidc-logout` reads the cookie. Requires
+  deliberate concurrent logout attempts to trigger; not currently tested.
+
+## Out of scope / follow-ups
+
+- Google-specific mitigation (`prompt=select_account` on the login
+  request) - no `end_session_endpoint` exists for Google, so this needs a
+  different, login-side mechanism.
+- Live verification against a real Entra ID / Auth0 / ADFS tenant.
+- The unrelated, pre-existing `logoutURL` doc/code mismatch in
+  `docs/ADFS-AUTHENTICATION-GUIDE.md` has been corrected to reference the
+  real `endSessionURL` field as part of this change.

--- a/docs/ADFS-AUTHENTICATION-GUIDE.md
+++ b/docs/ADFS-AUTHENTICATION-GUIDE.md
@@ -596,7 +596,13 @@ Use ADFS conditional access policies:
 
 ### Single Logout
 
-Configure logout URL in ADFS:
+By default, logging out of iHub only ends iHub's own session - the ADFS
+session stays active in the browser. Set `endSessionURL` (also available as
+the **End Session URL** field in Admin → Authentication) to also end the
+session at ADFS on logout (RP-Initiated Logout). See
+[OIDC Authentication - Logout / RP-Initiated Logout](./oidc-authentication.md#logout--rp-initiated-logout)
+for details, including the required "Valid post logout redirect URIs" entry
+on the ADFS client.
 
 ```json
 {
@@ -604,7 +610,7 @@ Configure logout URL in ADFS:
     "providers": [
       {
         "name": "adfs",
-        "logoutURL": "https://adfs.yourdomain.com/adfs/oauth2/logout"
+        "endSessionURL": "https://adfs.yourdomain.com/adfs/oauth2/logout"
       }
     ]
   }

--- a/docs/oidc-authentication.md
+++ b/docs/oidc-authentication.md
@@ -419,6 +419,64 @@ GET /api/auth/status
 
 Returns current authentication configuration and user status.
 
+### Logout
+
+```http
+POST /api/auth/logout
+GET  /api/auth/oidc-logout
+```
+
+`POST /api/auth/logout` always clears iHub's own auth cookie. If the
+provider that authenticated the current session has `endSessionURL`
+configured (see [Logout / RP-Initiated Logout](#logout--rp-initiated-logout)
+below), the response includes `"oidcLogoutRequired": true` and the client
+follows up with a top-level navigation to `GET /api/auth/oidc-logout`, which
+redirects the browser to the provider's own logout endpoint before landing
+back on iHub.
+
+## Logout / RP-Initiated Logout
+
+By default, logging out of iHub only ends iHub's own session - if the OIDC
+provider keeps a browser SSO session active (which is the normal case for
+Keycloak, Entra ID, Auth0, ADFS, etc.), the next login can silently
+re-authenticate the same browser without showing a login form. This matters
+in particular on shared/kiosk devices, where a different person could end up
+signed in as the previous user.
+
+To also end the session at the provider on logout
+([OIDC RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)),
+set the **End Session URL** field on the provider in Admin → Authentication
+(right below Callback URL). It's optional and off by default - not every
+OIDC/OAuth2 provider exposes a standard logout endpoint (Google, for
+example, does not), so this is opt-in per provider rather than assumed.
+Once set, the admin page shows the exact URL to register at the provider
+(see the required step below).
+
+Equivalent `oidcAuth.providers[]` entry (same field, editable directly via
+Admin → Authentication → JSON mode, or in `contents/config/platform.json`):
+
+```json
+{
+  "name": "keycloak",
+  "endSessionURL": "https://your-keycloak-server/realms/your-realm/protocol/openid-connect/logout"
+}
+```
+
+Provider-specific endpoints:
+
+- **Keycloak**: `{issuer}/protocol/openid-connect/logout`
+- **Microsoft Entra ID**: `https://login.microsoftonline.com/{tenant}/oauth2/v2.0/logout`
+- **Auth0**: `https://{domain}/oidc/logout` (the OIDC-compliant endpoint - not
+  the legacy `/v2/logout`)
+- **ADFS**: `https://{adfs-server}/adfs/oauth2/logout`
+- **Google**: not supported - Google has no `end_session_endpoint`
+
+**Required IdP-side step**: the provider must allow-list iHub's redirect
+target. In Keycloak, add your iHub URL (e.g. `https://your-ihub-domain.com/*`)
+to the client's **Valid post logout redirect URIs**. Without this, the
+provider will refuse the redirect back to iHub after logout (iHub's own
+session is still cleared either way - only the redirect back fails).
+
 ## Client Integration
 
 ### Login Form

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -346,6 +346,24 @@ under the same sequence number in an append-only log.
 - A worker taking over a run now re-reads the stored log first, so entry numbering always continues
   after the last recorded event.
 
+## Logging Out Now Also Ends the Session at the OIDC Provider
+
+Logging out of iHub only cleared iHub's own cookie. If the OIDC provider (Keycloak, for example)
+kept its own SSO session active in the browser, the next login silently re-authenticated the same
+browser without showing a login prompt. On a shared or kiosk device, the next person to click
+"Log in" could end up signed in as whoever logged out before them.
+
+- Set the new **End Session URL** field on a provider in Admin → Authentication to enable it
+  (RP-Initiated Logout, per the OIDC spec). It's optional and off by default — not every provider
+  exposes a logout endpoint (Google, for example, does not), so nothing changes unless an admin
+  opts in.
+- For Keycloak: `{issuer}/protocol/openid-connect/logout`. See the OIDC Authentication guide for
+  Entra ID, Auth0 and ADFS endpoints.
+- The admin page shows exactly which URL to register at the provider once the field is set.
+- The provider's client must allow-list iHub's URL as a "post logout redirect URI" — in Keycloak,
+  under the client's **Valid post logout redirect URIs** — otherwise the browser isn't sent back
+  to iHub after logging out. iHub's own session is still cleared either way.
+
 ## Mermaid Diagrams Stop Re-Rendering on Every UI Change
 
 Diagrams in a chat answer flickered and rebuilt themselves whenever anything on the page changed —

--- a/server/middleware/oidcAuth.js
+++ b/server/middleware/oidcAuth.js
@@ -229,7 +229,13 @@ export function configureOidcProviders() {
               sessionId
             );
 
-            return done(null, validatedUser);
+            // Pass the raw ID token out via Passport's `info` argument rather than
+            // attaching it to validatedUser: that object flows into
+            // validateAndPersistExternalUser() above, which can persist user fields
+            // to contents/config/users.json, and the ID token must never end up
+            // there. `info` is only used transiently by createOidcCallbackHandler
+            // to set the (also transient, httpOnly) oidcLogoutHint cookie.
+            return done(null, validatedUser, { idToken: params?.id_token });
           } catch (error) {
             authDebugService.log(
               'oidc',
@@ -266,6 +272,24 @@ export function configureOidcProviders() {
         component: 'OidcAuth',
         providerName: provider.name
       });
+
+      // endSessionURL enables RP-Initiated Logout (GET /api/auth/oidc-logout), but the
+      // provider must separately allow-list iHub's own URL as a post-logout redirect
+      // target - a setup step iHub cannot verify from here. Surface it now so it's
+      // caught during setup, not by a user hitting the IdP's error page at logout.
+      if (provider.endSessionURL) {
+        logger.warn(
+          'OIDC provider has endSessionURL configured - your iHub URL must be allow-listed ' +
+            'at the provider as a valid post-logout redirect target (e.g. Keycloak: client ' +
+            '"Valid post logout redirect URIs"), otherwise logout will fail with an IdP-side ' +
+            'error. See docs/oidc-authentication.md.',
+          {
+            component: 'OidcAuth',
+            providerName: provider.name,
+            endSessionURL: provider.endSessionURL
+          }
+        );
+      }
     } catch (error) {
       logger.error('Failed to configure OIDC provider', {
         component: 'OidcAuth',
@@ -735,6 +759,20 @@ export function createOidcCallbackHandler(providerName) {
             persistedUser: user.persistedUser || false
           }
         });
+
+        // Carry the ID token for a possible later RP-Initiated Logout
+        // (https://openid.net/specs/openid-connect-rpinitiated-1_0.html) in a
+        // dedicated httpOnly cookie. Only set when the provider actually supports
+        // it (endSessionURL configured) - no cookie, no behavior change otherwise.
+        // Consumed exclusively by GET /api/auth/oidc-logout; never exposed to
+        // client JS or included in any JSON API response.
+        if (provider.endSessionURL && info?.idToken) {
+          res.cookie(
+            'oidcLogoutHint',
+            JSON.stringify({ provider: providerName, idToken: info.idToken }),
+            getAuthCookieOptions(expiresIn * 1000, req)
+          );
+        }
 
         authDebugService.log(
           'oidc',

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -3,7 +3,8 @@ import { createAuthorizationMiddleware } from '../utils/authorization.js';
 import {
   getConfiguredProviders,
   createOidcAuthHandler,
-  createOidcCallbackHandler
+  createOidcCallbackHandler,
+  configuredProviders
 } from '../middleware/oidcAuth.js';
 import { loginLdapUser, getConfiguredLdapProviders } from '../middleware/ldapAuth.js';
 import { processNtlmLogin, getNtlmConfig } from '../middleware/ntlmAuth.js';
@@ -19,6 +20,7 @@ import { sendBadRequest, sendAuthRequired, sendErrorResponse } from '../utils/re
 import { recordAuthEvent } from '../telemetry/metrics.js';
 import { logAudit } from '../services/AuditLogService.js';
 import { getAuthCookieOptions, getClearAuthCookieOptions } from '../utils/cookieSettings.js';
+import { buildPublicBaseUrl } from '../utils/publicBaseUrl.js';
 
 /**
  * Sanitize and validate authentication input
@@ -542,8 +544,34 @@ export default function registerAuthRoutes(app) {
    * Logout (clear cookies and track logout)
    */
   app.post(buildServerPath('/api/auth/logout'), (req, res) => {
+    // Presence-only check: whether an OIDC RP-Initiated Logout redirect is
+    // needed. Deliberately does not read/parse the cookie's content here - the
+    // ID token it carries is only ever touched by GET /api/auth/oidc-logout,
+    // never by this JSON-responding endpoint.
+    //
+    // Also requires the *current* session to actually be OIDC-authenticated
+    // (req.user.authMode, decoded from the current authToken JWT - see
+    // jwtAuth.js). The cookie alone isn't enough: on a dual-auth deployment, a
+    // user could log in via OIDC (setting oidcLogoutHint), then log in again
+    // via local/LDAP/NTLM/Teams without an intervening logout - authToken gets
+    // overwritten but nothing else clears oidcLogoutHint, so without this
+    // check a later logout from that non-OIDC session would still redirect
+    // through the stale, unrelated OIDC provider's end_session_endpoint.
+    const oidcLogoutRequired =
+      req.user?.authMode === 'oidc' && req.cookies?.oidcLogoutHint !== undefined;
+
     // Clear the authentication cookie
     res.clearCookie('authToken', getClearAuthCookieOptions(req));
+    // Only clear the hint here when it WON'T be used - i.e. when this session
+    // isn't OIDC, so the client will redirect straight to /?logout=true and
+    // never call GET /api/auth/oidc-logout at all. When oidcLogoutRequired is
+    // true, that route is the one responsible for reading *and* clearing this
+    // cookie (see below) - clearing it here too would delete it before the
+    // client's follow-up navigation ever gets to read it, silently downgrading
+    // every OIDC logout to a local-only one.
+    if (!oidcLogoutRequired) {
+      res.clearCookie('oidcLogoutHint', getClearAuthCookieOptions(req));
+    }
     recordAuthEvent(req.user?.authMode || 'unknown', 'logout');
     if (req.user && req.user.id !== 'anonymous') {
       logAudit({
@@ -579,7 +607,8 @@ export default function registerAuthRoutes(app) {
 
     res.json({
       success: true,
-      message: 'Logged out successfully'
+      message: 'Logged out successfully',
+      oidcLogoutRequired
     });
   });
 
@@ -811,6 +840,121 @@ export default function registerAuthRoutes(app) {
     const providerName = req.params.provider;
     const handler = createOidcCallbackHandler(providerName);
     handler(req, res, next);
+  });
+
+  /**
+   * OIDC RP-Initiated Logout redirect (https://openid.net/specs/openid-connect-rpinitiated-1_0.html)
+   * GET /api/auth/oidc-logout
+   *
+   * Reads the ID token stashed in the httpOnly oidcLogoutHint cookie (set on
+   * OIDC login, see createOidcCallbackHandler) and redirects the browser to the
+   * provider's end_session_endpoint so it also terminates its own SSO session,
+   * not just iHub's local one. Always safe to hit directly: with no usable hint
+   * it just falls back to the normal post-logout landing page. Not gated behind
+   * auth - it's an exit point of the auth flow, like the OIDC routes above, not
+   * a protected resource.
+   *
+   * Note: this is a plain top-level navigation target (the client redirects the
+   * whole page here via window.location.href), never called via fetch/XHR - the
+   * ID token must never travel through a JS-readable response body, only
+   * through this httpOnly cookie and the Location header of the 302 below.
+   */
+  app.get(buildServerPath('/api/auth/oidc-logout'), (req, res) => {
+    const fallbackUrl = `${buildServerPath('/')}?logout=true`;
+
+    let hint;
+    let parseError = false;
+    try {
+      hint = req.cookies?.oidcLogoutHint ? JSON.parse(req.cookies.oidcLogoutHint) : null;
+    } catch {
+      hint = null;
+      parseError = true;
+    }
+
+    res.clearCookie('oidcLogoutHint', getClearAuthCookieOptions(req));
+
+    if (!req.cookies?.oidcLogoutHint) {
+      // Expected whenever this URL is opened without going through
+      // POST /api/auth/logout first (e.g. a stale bookmark, or a browser
+      // that dropped the cookie between the two requests) - not an error.
+      logger.info('OIDC logout redirect requested with no hint cookie - local logout only', {
+        component: 'Auth'
+      });
+      return res.redirect(fallbackUrl);
+    }
+
+    if (parseError) {
+      logger.warn('OIDC logout hint cookie was present but not valid JSON - falling back', {
+        component: 'Auth'
+      });
+      return res.redirect(fallbackUrl);
+    }
+
+    const provider = hint?.provider ? configuredProviders.get(hint.provider) : null;
+    if (!hint?.idToken) {
+      logger.warn('OIDC logout hint cookie had no idToken - falling back', {
+        component: 'Auth',
+        providerName: hint?.provider
+      });
+      return res.redirect(fallbackUrl);
+    }
+    if (!provider) {
+      // The provider referenced by the cookie is no longer configured - most
+      // likely removed or renamed since the user logged in.
+      logger.warn('OIDC logout hint referenced an unknown provider - falling back', {
+        component: 'Auth',
+        providerName: hint.provider
+      });
+      return res.redirect(fallbackUrl);
+    }
+    if (!provider.endSessionURL) {
+      // Most likely endSessionURL was unset on this provider after the user
+      // logged in (the hint cookie is only ever set while it was configured).
+      logger.warn('OIDC logout hint referenced a provider without endSessionURL - falling back', {
+        component: 'Auth',
+        providerName: provider.name
+      });
+      return res.redirect(fallbackUrl);
+    }
+
+    // Use the shared X-Forwarded-Host-aware helper, not req.get('host') directly:
+    // in dev, Vite proxies /api/* to this server with changeOrigin (see
+    // vite.config.js), which rewrites Host to localhost:3000 - the backend port,
+    // not the SPA the browser actually needs to land back on (localhost:5173).
+    // Vite compensates by setting X-Forwarded-Host to the real browser host,
+    // which buildPublicBaseUrl() already knows to prefer.
+    const baseUrl = buildPublicBaseUrl(req);
+
+    // endSessionURL isn't validated at save time (platformConfigSchema is only
+    // used for schema export, not enforced by the admin config save route), so
+    // a malformed value can reach here - guard the same way as every other
+    // invalid-state branch above rather than letting new URL() throw.
+    let logoutUrl;
+    try {
+      logoutUrl = new URL(provider.endSessionURL);
+    } catch {
+      logger.warn('OIDC provider endSessionURL is not a valid URL - falling back', {
+        component: 'Auth',
+        providerName: provider.name
+      });
+      return res.redirect(fallbackUrl);
+    }
+    logoutUrl.searchParams.set('id_token_hint', hint.idToken);
+    logoutUrl.searchParams.set('post_logout_redirect_uri', `${baseUrl}/?logout=true`);
+    if (provider.clientId) {
+      logoutUrl.searchParams.set('client_id', provider.clientId);
+    }
+
+    // Log the target host/path only - never the query string, which carries
+    // id_token_hint.
+    logger.info('OIDC RP-Initiated Logout redirect issued', {
+      component: 'Auth',
+      providerName: provider.name,
+      endSessionHost: logoutUrl.host,
+      postLogoutRedirectUri: `${baseUrl}/?logout=true`
+    });
+
+    res.redirect(logoutUrl.toString());
   });
 
   /**

--- a/server/tests/oidc-logout.test.js
+++ b/server/tests/oidc-logout.test.js
@@ -1,0 +1,238 @@
+/**
+ * OIDC RP-Initiated Logout — unit tests.
+ *
+ * Locks in:
+ * - POST /api/auth/logout signals oidcLogoutRequired only when the *current*
+ *   session's authMode is 'oidc' AND the hint cookie is present - not from
+ *   cookie presence alone (regression: a stale hint cookie surviving a later
+ *   non-OIDC login must not redirect that session's logout through an
+ *   unrelated provider).
+ * - It never reads/uses the ID token the cookie carries.
+ * - It always clears both authToken and oidcLogoutHint, regardless of mode.
+ * - GET /api/auth/oidc-logout safely falls back to the local post-logout
+ *   page on any missing/malformed/unknown-provider/malformed-URL hint, and
+ *   otherwise builds the provider's end_session_endpoint URL with
+ *   id_token_hint, post_logout_redirect_uri and client_id.
+ * - The X-Forwarded-Host regression found during manual testing: Vite's dev
+ *   proxy rewrites Host to the backend port, so post_logout_redirect_uri
+ *   must prefer X-Forwarded-Host (via buildPublicBaseUrl) or the browser
+ *   gets sent back to a URL that 404s.
+ */
+import request from 'supertest';
+import express from 'express';
+import cookieParser from 'cookie-parser';
+import registerAuthRoutes from '../routes/auth.js';
+import { configuredProviders } from '../middleware/oidcAuth.js';
+
+// authMode is undefined by default (no session) - pass e.g. 'oidc' or 'local'
+// to simulate a request carrying a decoded, valid authToken JWT of that mode
+// (in production this is set by jwtAuth.js's global optional-auth middleware,
+// which isn't mounted in this focused route test).
+function buildApp(authMode) {
+  const app = express();
+  app.use(cookieParser());
+  if (authMode) {
+    app.use((req, _res, next) => {
+      req.user = { id: 'user-1', authMode };
+      next();
+    });
+  }
+  registerAuthRoutes(app);
+  return app;
+}
+
+function hintCookie(value) {
+  return 'oidcLogoutHint=' + encodeURIComponent(JSON.stringify(value));
+}
+
+describe('POST /api/auth/logout - OIDC signal', () => {
+  test('reports oidcLogoutRequired: false with no oidcLogoutHint cookie', async () => {
+    const res = await request(buildApp('oidc')).post('/api/auth/logout');
+    expect(res.status).toBe(200);
+    expect(res.body.oidcLogoutRequired).toBe(false);
+  });
+
+  test('reports oidcLogoutRequired: true when the session is OIDC and the hint cookie is present', async () => {
+    const res = await request(buildApp('oidc'))
+      .post('/api/auth/logout')
+      .set('Cookie', [hintCookie({ provider: 'keycloak', idToken: 'x' })]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.oidcLogoutRequired).toBe(true);
+  });
+
+  test('reports oidcLogoutRequired: false when a stale hint cookie survives a non-OIDC login', async () => {
+    // Regression: user logged in via OIDC earlier (hint cookie set), then
+    // logged in again via local/LDAP/NTLM/Teams without an intervening
+    // logout - authToken now decodes to authMode 'local', but the old
+    // oidcLogoutHint cookie is still sitting there unless the current
+    // session is actually checked, not just cookie presence.
+    const res = await request(buildApp('local'))
+      .post('/api/auth/logout')
+      .set('Cookie', [hintCookie({ provider: 'keycloak', idToken: 'stale' })]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.oidcLogoutRequired).toBe(false);
+  });
+
+  test('reports oidcLogoutRequired: false when there is no session at all, even with the hint cookie present', async () => {
+    const res = await request(buildApp())
+      .post('/api/auth/logout')
+      .set('Cookie', [hintCookie({ provider: 'keycloak', idToken: 'x' })]);
+
+    expect(res.status).toBe(200);
+    expect(res.body.oidcLogoutRequired).toBe(false);
+  });
+
+  test('always clears the authToken cookie', async () => {
+    const res = await request(buildApp('oidc')).post('/api/auth/logout');
+    const setCookie = res.headers['set-cookie'] || [];
+    expect(setCookie.some(c => c.startsWith('authToken=;'))).toBe(true);
+  });
+
+  test('clears the oidcLogoutHint cookie here when it will NOT be used (non-OIDC session)', async () => {
+    const res = await request(buildApp('local'))
+      .post('/api/auth/logout')
+      .set('Cookie', [hintCookie({ provider: 'keycloak', idToken: 'stale' })]);
+
+    const setCookie = res.headers['set-cookie'] || [];
+    expect(setCookie.some(c => c.startsWith('oidcLogoutHint=;'))).toBe(true);
+  });
+
+  test('does NOT clear the oidcLogoutHint cookie here when it WILL be used (OIDC session)', async () => {
+    // Regression: this endpoint must leave the hint cookie alone whenever
+    // oidcLogoutRequired is true, since GET /api/auth/oidc-logout is the one
+    // responsible for reading *and* clearing it next. Clearing it here too
+    // deletes it before that follow-up request ever sees it, silently
+    // downgrading every OIDC logout to a local-only one - exactly the bug
+    // found via manual testing (Network tab showed the cookie correctly sent
+    // on this request, but "no hint cookie" was logged on the next one).
+    const res = await request(buildApp('oidc'))
+      .post('/api/auth/logout')
+      .set('Cookie', [hintCookie({ provider: 'keycloak', idToken: 'x' })]);
+
+    expect(res.body.oidcLogoutRequired).toBe(true);
+    const setCookie = res.headers['set-cookie'] || [];
+    expect(setCookie.some(c => c.startsWith('oidcLogoutHint=;'))).toBe(false);
+  });
+});
+
+describe('GET /api/auth/oidc-logout', () => {
+  let app;
+
+  beforeEach(() => {
+    app = buildApp();
+    configuredProviders.clear();
+  });
+
+  afterEach(() => {
+    configuredProviders.clear();
+  });
+
+  test('falls back to the local logout page with no hint cookie', async () => {
+    const res = await request(app).get('/api/auth/oidc-logout');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/?logout=true');
+  });
+
+  test('falls back safely on a malformed hint cookie instead of erroring', async () => {
+    const res = await request(app)
+      .get('/api/auth/oidc-logout')
+      .set('Cookie', ['oidcLogoutHint=not-json']);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/?logout=true');
+  });
+
+  test('falls back when the referenced provider has no endSessionURL configured', async () => {
+    configuredProviders.set('keycloak', { name: 'keycloak', clientId: 'ihub-client' });
+
+    const res = await request(app)
+      .get('/api/auth/oidc-logout')
+      .set('Cookie', [hintCookie({ provider: 'keycloak', idToken: 'x' })]);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/?logout=true');
+  });
+
+  test('falls back when the referenced provider is unknown', async () => {
+    const res = await request(app)
+      .get('/api/auth/oidc-logout')
+      .set('Cookie', [hintCookie({ provider: 'does-not-exist', idToken: 'x' })]);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/?logout=true');
+  });
+
+  test('redirects to the provider end_session_endpoint with id_token_hint, post_logout_redirect_uri and client_id', async () => {
+    configuredProviders.set('keycloak', {
+      name: 'keycloak',
+      clientId: 'ihub-client',
+      endSessionURL: 'https://kc.example.com/realms/test/protocol/openid-connect/logout'
+    });
+
+    const res = await request(app)
+      .get('/api/auth/oidc-logout')
+      .set('Host', 'ihub.example.com')
+      .set('Cookie', [hintCookie({ provider: 'keycloak', idToken: 'the-id-token' })]);
+
+    expect(res.status).toBe(302);
+    const location = new URL(res.headers.location);
+    expect(location.origin + location.pathname).toBe(
+      'https://kc.example.com/realms/test/protocol/openid-connect/logout'
+    );
+    expect(location.searchParams.get('id_token_hint')).toBe('the-id-token');
+    expect(location.searchParams.get('client_id')).toBe('ihub-client');
+    expect(location.searchParams.get('post_logout_redirect_uri')).toBe(
+      'http://ihub.example.com/?logout=true'
+    );
+  });
+
+  test('prefers X-Forwarded-Host over Host for post_logout_redirect_uri (dev Vite-proxy regression)', async () => {
+    configuredProviders.set('keycloak', {
+      name: 'keycloak',
+      clientId: 'ihub-client',
+      endSessionURL: 'https://kc.example.com/realms/test/protocol/openid-connect/logout'
+    });
+
+    const res = await request(app)
+      .get('/api/auth/oidc-logout')
+      .set('Host', 'localhost:3000')
+      .set('X-Forwarded-Host', 'localhost:5173')
+      .set('Cookie', [hintCookie({ provider: 'keycloak', idToken: 'x' })]);
+
+    const location = new URL(res.headers.location);
+    expect(location.searchParams.get('post_logout_redirect_uri')).toBe(
+      'http://localhost:5173/?logout=true'
+    );
+  });
+
+  test('falls back safely when endSessionURL is not a valid URL instead of throwing', async () => {
+    configuredProviders.set('keycloak', {
+      name: 'keycloak',
+      clientId: 'ihub-client',
+      endSessionURL: 'not a url'
+    });
+
+    const res = await request(app)
+      .get('/api/auth/oidc-logout')
+      .set('Cookie', [hintCookie({ provider: 'keycloak', idToken: 'x' })]);
+
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/?logout=true');
+  });
+
+  test('clears the oidcLogoutHint cookie on every outcome', async () => {
+    configuredProviders.set('keycloak', {
+      name: 'keycloak',
+      endSessionURL: 'https://kc.example.com/realms/test/protocol/openid-connect/logout'
+    });
+
+    const res = await request(app)
+      .get('/api/auth/oidc-logout')
+      .set('Cookie', [hintCookie({ provider: 'keycloak', idToken: 'x' })]);
+
+    const setCookie = res.headers['set-cookie'] || [];
+    expect(setCookie.some(c => c.startsWith('oidcLogoutHint=;'))).toBe(true);
+  });
+});

--- a/server/validators/platformConfigSchema.js
+++ b/server/validators/platformConfigSchema.js
@@ -17,6 +17,10 @@ const oidcProviderSchema = z.object({
   authorizationURL: z.string().url(),
   tokenURL: z.string().url(),
   userInfoURL: z.string().url(),
+  // RP-Initiated Logout (https://openid.net/specs/openid-connect-rpinitiated-1_0.html).
+  // Optional: when set, /api/auth/logout also ends the session at the provider
+  // instead of only clearing iHub's own auth cookie.
+  endSessionURL: z.string().url().optional(),
   scope: z.array(z.string()).default(['openid', 'profile', 'email']),
   callbackURL: z.string().url().optional(),
   groupsAttribute: z.string().default('groups'),

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -935,6 +935,11 @@
       "callbackURLOptional": "(Optional - Wird automatisch generiert, wenn leer)",
       "callbackURLPlaceholder": "/api/auth/oidc/{{providerName}}/callback",
       "callbackURLHelp": "Leer lassen für automatische Generierung. Überschreiben für benutzerdefinierte Domains oder Subpfad-Deployments.",
+      "endSessionURL": "End-Session-URL",
+      "endSessionURLOptional": "(Optional - aktiviert vollständiges Logout beim Anbieter)",
+      "endSessionURLPlaceholder": "https://auth.example.com/oidc/logout",
+      "endSessionURLHelp": "Beendet beim Logout zusätzlich die Sitzung beim Anbieter, damit die nächste Anmeldung sie nicht still weiterverwendet. Leer lassen für rein lokales Logout.",
+      "endSessionURLRegisterHint": "Tragen Sie {{url}} beim Anbieter als gültige Post-Logout-Redirect-URI ein, sonst schlägt das Logout dort fehl.",
       "oauth": {
         "title": "OAuth-Clients",
         "subtitle": "OAuth 2.0-Clients für externen API-Zugriff verwalten",

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -682,6 +682,11 @@
       "callbackURLOptional": "(Optional - Auto-generated if empty)",
       "callbackURLPlaceholder": "/api/auth/oidc/{{providerName}}/callback",
       "callbackURLHelp": "Leave empty to auto-generate. Override for custom domains or subpath deployments.",
+      "endSessionURL": "End Session URL",
+      "endSessionURLOptional": "(Optional - enables full logout at the provider)",
+      "endSessionURLPlaceholder": "https://auth.example.com/oidc/logout",
+      "endSessionURLHelp": "Also ends the session at the provider on logout, so the next login can't silently reuse it. Leave empty for local logout only.",
+      "endSessionURLRegisterHint": "Register {{url}} at the provider as a valid post-logout redirect URI, or logout will fail there.",
       "oauth": {
         "title": "OAuth Clients",
         "subtitle": "Manage OAuth 2.0 clients for external API access",


### PR DESCRIPTION
## Summary

Logging out of iHub while authenticated via an OIDC provider (Keycloak,
verified end-to-end; Entra ID / Auth0 / ADFS by design, not yet verified
against a live tenant) only cleared iHub's own auth cookie. The provider's
own SSO session stayed active in the browser, so the next login attempt -
by the same user, or by a different person on a shared/kiosk device - was
silently re-authenticated without ever showing a login form.

Implements opt-in OIDC RP-Initiated Logout per provider via a new
`endSessionURL` field. Fully backward compatible - no behavior change for
any provider that leaves it unset, no config migration needed.

Fixes #2279 

## What changed

- `server/validators/platformConfigSchema.js`: new optional `endSessionURL`
  field on `oidcProviderSchema`
- `server/middleware/oidcAuth.js`: the ID token is passed out of the OIDC
  verify callback via Passport's `info` argument (never persisted to the
  user object, JWT, or `users.json`) and stashed in a new httpOnly
  `oidcLogoutHint` cookie, only when the provider supports it
- `server/routes/auth.js`:
  - `POST /api/auth/logout` now signals `oidcLogoutRequired`, tied to the
    *current* session's `authMode` (not just cookie presence)
  - new `GET /api/auth/oidc-logout` builds the provider's
    `end_session_endpoint` redirect from the hint cookie, with a safe
    fallback to local-only logout on any missing/malformed state
- `client/src/shared/contexts/AuthContext.jsx`: `logout()` follows up with
  a top-level navigation to the new redirect route when required
- `client/.../OidcProvidersSection.jsx`: new **End Session URL** admin
  field with a live registration hint, prefilled defaults for
  Keycloak/Auth0/Microsoft templates
- `server/tests/oidc-logout.test.js`: 15 new tests
- Docs: `docs/oidc-authentication.md`, `docs/ADFS-AUTHENTICATION-GUIDE.md`,
  `docs/releases/5.5.0/fixes.md`
- Full root-cause analysis and design rationale:
  `concepts/2026-09-07 OIDC RP-Initiated Logout Fix.md`

## Security-conscious design

The raw ID token only ever exists in the httpOnly cookie and the
`Location` header of the final redirect - never in a JS-readable API
response body (an earlier draft returned it via JSON; reworked into a
two-step redirect specifically to close that exposure path).

## Review process

Both a dedicated security review and an 8-angle code review were run
against this diff before opening this PR. No HIGH/MEDIUM security
findings survived. The code review found and fixed 3 real bugs; live
end-to-end testing against a real Keycloak instance then caught a 4th,
more serious regression that neither review had caught (an earlier fix
for bug 1 cleared the hint cookie one request too early, silently
downgrading every OIDC logout back to local-only). All four are detailed,
with root cause and fix, in the concept doc linked above.

A CodeQL "missing CSRF middleware" alert on `server/tests/oidc-logout.test.js`
has been reviewed and dismissed as "Used in tests" - the test file
instantiates the real production route handlers directly but is never
deployed or reachable; the underlying (pre-existing, unrelated to this PR)
lack of CSRF protection on `/api/auth/logout` was already assessed during
the security review as low-impact (self-targeting forced logout only, no
data/account exposure), consistent with every other auth route in this
app.

## Testing

- `server/tests/oidc-logout.test.js`: 15/15 passing
- Manual end-to-end against a local Keycloak (Docker): login, logout,
  re-login now requires a real credential prompt instead of silently
  reusing the provider's SSO session
- `npm run lint:fix && npm run format:fix`: clean

## Out of scope / follow-ups

- Google-specific mitigation (no `end_session_endpoint` exists there)
- Live verification against real Entra ID / Auth0 / ADFS tenants
- Two low-severity edge cases noted in the concept doc (client never
  following through to the redirect step; a narrow two-tab logout race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)