### PR TITLE
fix(chat): keep thinking toggle pinned above the streamed answer

### DIFF
--- a/client/src/features/chat/components/ChatMessage.jsx
+++ b/client/src/features/chat/components/ChatMessage.jsx
@@ -756,6 +756,28 @@ function ChatMessage({
             <p className="text-slate-800 dark:text-slate-200">{message.clarification.question}</p>
           </div>
         )}
+        {/* Thinking/thoughts toggle: kept above the answer so it stays put while the
+            answer streams in below it, instead of being pushed down as content grows. */}
+        {!isUser && message.thoughts && message.thoughts.length > 0 && (
+          <div className="mb-2 text-xs text-gray-600 dark:text-gray-400">
+            <button onClick={() => setShowThoughts(!showThoughts)} className="underline">
+              {showThoughts ? t('pages.appChat.hideThoughts') : t('pages.appChat.showThoughts')}
+            </button>
+            {showThoughts && (
+              <ul className="list-disc pl-4 mt-1 space-y-1">
+                {message.thoughts.map((th, idx) => (
+                  <li key={idx}>
+                    {typeof th === 'string'
+                      ? th
+                      : t(`thoughts.${th.name}`, {
+                          defaultValue: th.content || JSON.stringify(th)
+                        })}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
         {renderContent()}
         {isUser && hasVariables && <MessageVariables variables={message.variables} />}
 
@@ -874,27 +896,6 @@ function ChatMessage({
                 )}
               </div>
             ))}
-          </div>
-        )}
-
-        {!isUser && message.thoughts && message.thoughts.length > 0 && (
-          <div className="mt-1 text-xs text-gray-600">
-            <button onClick={() => setShowThoughts(!showThoughts)} className="underline">
-              {showThoughts ? t('pages.appChat.hideThoughts') : t('pages.appChat.showThoughts')}
-            </button>
-            {showThoughts && (
-              <ul className="list-disc pl-4 mt-1 space-y-1">
-                {message.thoughts.map((th, idx) => (
-                  <li key={idx}>
-                    {typeof th === 'string'
-                      ? th
-                      : t(`thoughts.${th.name}`, {
-                          defaultValue: th.content || JSON.stringify(th)
-                        })}
-                  </li>
-                ))}
-              </ul>
-            )}
           </div>
         )}
 

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -398,6 +398,13 @@ are applied to, and every assignment was silently dropped.
 - Web search extracts page content again (5 results, 3000 characters each by
   default), so answers are built from the pages rather than the result list.
 
+## Thinking Steps No Longer Drift Down While an Answer Streams
+
+The "Show thinking"/"Hide thinking" toggle for models with extended thinking was rendered below
+the answer text, so each streamed chunk of the answer pushed it further down the message —
+readers watching a long response come in had to keep scrolling to find it. The toggle is now
+anchored above the answer and stays in the same place for the whole response.
+
 ## Dates in Prompts Are Spelled Out
 
 The current date reached the model as `9/3/2026`, which reads as 3 September in


### PR DESCRIPTION
## Summary

- The "Show thinking"/"Hide thinking" toggle for `message.thoughts` was rendered in the chat bubble **after** the main answer content (`renderContent()`), images, and audio.
- While a model's extended-thinking content streams in before its answer, this meant the toggle briefly sat at the top of the bubble (nothing else there yet) — but as soon as the answer text started streaming in above it, the toggle kept getting pushed further down the bubble as the answer grew.
- Moved the thinking toggle block in `client/src/features/chat/components/ChatMessage.jsx` to render immediately before `renderContent()`, so it stays anchored near the top of the assistant message for the whole response, regardless of how much answer text streams in below it.
- Added a changelog entry under `docs/releases/5.5.0/fixes.md` per the project's release documentation convention.

Fixes https://github.com/intrafind/ihub-apps/issues/2284

## Test plan

- [x] Verified the moved JSX block compiles (syntax-checked with esbuild; no local `node_modules` available in this sandboxed environment to run the full `npm run lint:fix` / dev server).
- [ ] Manually verify in a running dev environment: start a chat with a thinking-enabled model, confirm the "Show thinking" toggle stays in place above the answer as it streams, rather than drifting downward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RcK7ubMvupeGp7tJgVtHvS

---
_Generated by [Claude Code](https://claude.ai/code/session_01RcK7ubMvupeGp7tJgVtHvS)_