### PR TITLE
fix(chat): make the model selector fit narrow screens

### DIFF
--- a/client/src/features/chat/components/ModelSelector.jsx
+++ b/client/src/features/chat/components/ModelSelector.jsx
@@ -131,67 +131,89 @@ function ModelSelector({
       </button>
 
       {isOpen && !disabled && (
-        <div
-          ref={menuRef}
-          role="menu"
-          tabIndex={-1}
-          aria-label={t('appConfig.selectModel', 'Select Model')}
-          className={`absolute ${
-            dropdownDirection === 'down' ? 'top-full mt-2' : 'bottom-full mb-2'
-          } left-0 w-80 max-w-[calc(100vw-2rem)] max-h-96 overflow-y-auto bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50`}
-        >
-          <div className="p-2">
-            <div className="text-xs font-semibold text-gray-500 dark:text-gray-400 px-3 py-2">
-              {t('appConfig.selectModel', 'Select Model')}
-            </div>
-            {filteredModels.map((model, index) => {
-              const name = getLocalizedContent(model.name, currentLanguage);
-              const desc = getLocalizedContent(model.description, currentLanguage);
-              const isSelected = model.id === selectedModel;
+        <>
+          {/* Scrim behind the mobile sheet. It needs its own onClick because it
+              lives inside dropdownRef, so the document mousedown handler above
+              never treats a tap on it as "outside". */}
+          <div
+            className="fixed inset-0 z-40 bg-black/40 sm:hidden"
+            onClick={handleClose}
+            aria-hidden="true"
+          />
+          <div
+            ref={menuRef}
+            role="menu"
+            tabIndex={-1}
+            aria-label={t('appConfig.selectModel', 'Select Model')}
+            /* Below `sm` this is a full-width bottom sheet: anchoring a 20rem
+               dropdown to a trigger that sits at the right end of the toolbar
+               pushed it off the viewport, clipping every model name and
+               description. Only side-specific radius/border utilities are used
+               here — `sm:rounded-lg` / `sm:border` would sort before the mobile
+               `rounded-t-2xl` / `border-t` and lose the override. */
+            className={`fixed inset-x-0 bottom-0 z-50 max-h-[70vh] overflow-y-auto rounded-t-2xl border-t border-gray-200 bg-white shadow-lg dark:border-gray-700 dark:bg-gray-800 sm:absolute sm:inset-x-auto sm:left-0 sm:max-h-96 sm:w-80 sm:rounded-t-lg sm:rounded-b-lg sm:border-x sm:border-b ${
+              dropdownDirection === 'down'
+                ? 'sm:top-full sm:bottom-auto sm:mt-2'
+                : 'sm:bottom-full sm:mb-2'
+            }`}
+          >
+            <div className="p-2 pb-3 sm:pb-2">
+              <div className="px-3 py-2 text-xs font-semibold text-gray-500 dark:text-gray-400">
+                {t('appConfig.selectModel', 'Select Model')}
+              </div>
+              {filteredModels.map((model, index) => {
+                const name = getLocalizedContent(model.name, currentLanguage);
+                const desc = getLocalizedContent(model.description, currentLanguage);
+                const isSelected = model.id === selectedModel;
 
-              return (
-                <button
-                  key={model.id}
-                  type="button"
-                  role="menuitem"
-                  tabIndex={index === activeIndex ? 0 : -1}
-                  onClick={() => handleModelSelect(model.id)}
-                  className={`w-full text-left px-3 py-2.5 rounded-lg transition-colors ${
-                    isSelected
-                      ? 'bg-indigo-50 dark:bg-indigo-900/20'
-                      : 'hover:bg-gray-50 dark:hover:bg-gray-700 focus:bg-gray-50 dark:focus:bg-gray-700 focus:ring-2 focus:ring-indigo-500 focus:ring-inset'
-                  }`}
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="flex-1 min-w-0">
-                      <div
-                        className={`text-sm font-medium ${
-                          isSelected
-                            ? 'text-indigo-600 dark:text-indigo-400'
-                            : 'text-gray-900 dark:text-gray-100'
-                        }`}
-                      >
-                        {name}
-                      </div>
-                      {desc && (
-                        <div className="text-xs text-gray-500 dark:text-gray-400 mt-0.5 line-clamp-2">
-                          {desc}
+                return (
+                  <button
+                    key={model.id}
+                    type="button"
+                    role="menuitem"
+                    tabIndex={index === activeIndex ? 0 : -1}
+                    onClick={() => handleModelSelect(model.id)}
+                    className={`w-full rounded-lg px-3 py-2.5 text-left transition-colors ${
+                      isSelected
+                        ? 'bg-indigo-50 dark:bg-indigo-900/20'
+                        : 'hover:bg-gray-50 dark:hover:bg-gray-700 focus:bg-gray-50 dark:focus:bg-gray-700 focus:ring-2 focus:ring-indigo-500 focus:ring-inset'
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="flex-1 min-w-0">
+                        {/* Name on a single line and, on mobile, a single
+                            description line: mixing one- and two-line
+                            descriptions made row heights alternate between
+                            58px and 74px, which read as random gaps. */}
+                        <div
+                          className={`truncate text-sm font-medium ${
+                            isSelected
+                              ? 'text-indigo-600 dark:text-indigo-400'
+                              : 'text-gray-900 dark:text-gray-100'
+                          }`}
+                        >
+                          {name}
                         </div>
+                        {desc && (
+                          <div className="mt-0.5 line-clamp-1 text-xs text-gray-500 dark:text-gray-400 sm:line-clamp-2">
+                            {desc}
+                          </div>
+                        )}
+                      </div>
+                      {isSelected && (
+                        <Icon
+                          name="check"
+                          size="sm"
+                          className="text-indigo-600 dark:text-indigo-400 shrink-0"
+                        />
                       )}
                     </div>
-                    {isSelected && (
-                      <Icon
-                        name="check"
-                        size="sm"
-                        className="text-indigo-600 dark:text-indigo-400 shrink-0"
-                      />
-                    )}
-                  </div>
-                </button>
-              );
-            })}
+                  </button>
+                );
+              })}
+            </div>
           </div>
-        </div>
+        </>
       )}
     </div>
   );

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -426,3 +426,22 @@ could be six months out while looking entirely confident.
   "Thursday, September 3, 2026" / "Donnerstag, 3. September 2026".
 - A new `{{date_iso}}` variable gives the unambiguous calendar date
   (`2026-09-03`) in the user's timezone for prompts that compare dates.
+
+## The Model Selector Fits the Screen on Phones
+
+Opening the model list on a phone showed a panel that ran off the right edge of
+the screen, so model names and descriptions were cut off mid-word, and the rows
+sat at visibly uneven distances from one another.
+
+The list was a fixed 20 rem panel pinned to the left edge of its button, which
+sits at the right end of the chat toolbar — on a narrow screen there was no room
+left for it. Row heights came out uneven because a description that fitted on one
+line made a shorter row than one that wrapped onto two.
+
+- On phones the model list now opens as a full-width sheet from the bottom of the
+  screen, with the rest of the page dimmed behind it. Tapping outside the sheet
+  closes it.
+- Every row is the same height, so the list reads as an even column instead of
+  randomly spaced blocks.
+- On tablets and desktops the list is unchanged: it still opens as a panel next
+  to the model button, with the fuller two-line descriptions.

--- a/tests/unit/client/model-selector-mobile-layout.test.jsx
+++ b/tests/unit/client/model-selector-mobile-layout.test.jsx
@@ -1,0 +1,134 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * ModelSelector mobile layout regression tests.
+ *
+ * The open menu used to be a fixed 20rem panel anchored with `left-0` to a
+ * trigger that sits at the right end of the chat toolbar. On a phone that
+ * pushed most of the panel past the right edge of the viewport, so model names
+ * and descriptions were cut off mid-word; the mix of one- and two-line
+ * descriptions also made row heights alternate, which read as random gaps
+ * between models (intrafind/ihub-apps#2287).
+ *
+ * jsdom does not evaluate media queries, so these tests assert the responsive
+ * class contract that produces the layout rather than the computed geometry.
+ */
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, defaultValue) => defaultValue,
+    i18n: { language: 'en' }
+  })
+}));
+
+jest.mock('../../../client/src/shared/components/Icon', () => {
+  return function Icon({ name }) {
+    return <span data-testid={`icon-${name}`}>{name}</span>;
+  };
+});
+
+const ModelSelector = require('../../../client/src/features/chat/components/ModelSelector').default;
+
+const models = [
+  {
+    id: 'model-short-desc',
+    name: { en: 'Mistral Large' },
+    description: { en: "Mistral's fast model for general tasks" }
+  },
+  {
+    id: 'model-long-desc',
+    name: { en: 'Gemini 3.1 Flash Image Preview' },
+    description: {
+      en: "Google's state-of-the-art image generation and editing model optimized for professional asset production"
+    }
+  },
+  {
+    id: 'model-no-desc',
+    name: { en: 'Local vLLM' }
+  }
+];
+
+function renderSelector(props = {}) {
+  const onModelChange = jest.fn();
+  const utils = render(
+    <ModelSelector
+      models={models}
+      selectedModel="model-short-desc"
+      onModelChange={onModelChange}
+      currentLanguage="en"
+      {...props}
+    />
+  );
+  return { ...utils, onModelChange };
+}
+
+function openMenu() {
+  fireEvent.click(screen.getByTitle('Select Model'));
+  return screen.getByRole('menu');
+}
+
+describe('ModelSelector menu layout', () => {
+  test('is a full-width bottom sheet below `sm` and an anchored dropdown from `sm` up', () => {
+    renderSelector();
+    const menu = openMenu();
+
+    // Mobile: pinned to both viewport edges so nothing can be clipped.
+    expect(menu).toHaveClass('fixed', 'inset-x-0', 'bottom-0');
+    // Desktop: back to the panel anchored next to the trigger.
+    expect(menu).toHaveClass('sm:absolute', 'sm:inset-x-auto', 'sm:left-0', 'sm:w-80');
+    // A width that ignores the viewport must not leak into the mobile sheet.
+    expect(menu.className).not.toMatch(/(^|\s)w-80(\s|$)/);
+  });
+
+  test('keeps every row one name line and, on mobile, one description line', () => {
+    renderSelector();
+    openMenu();
+
+    for (const model of models) {
+      const row = screen.getByRole('menuitem', { name: new RegExp(model.name.en, 'i') });
+      const [name, desc] = row.querySelectorAll('div.flex-1 > div');
+
+      expect(name).toHaveTextContent(model.name.en);
+      expect(name).toHaveClass('truncate');
+
+      if (model.description) {
+        expect(desc).toHaveClass('line-clamp-1', 'sm:line-clamp-2');
+      } else {
+        expect(desc).toBeUndefined();
+      }
+    }
+  });
+
+  test('tapping the scrim closes the sheet', () => {
+    const { container } = renderSelector();
+    openMenu();
+
+    const scrim = container.querySelector('div[aria-hidden="true"].fixed.inset-0');
+    expect(scrim).toBeTruthy();
+    // The scrim is hidden once the anchored dropdown takes over.
+    expect(scrim).toHaveClass('sm:hidden');
+
+    fireEvent.click(scrim);
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+
+  test('opens downward from `sm` up when asked, without moving the mobile sheet', () => {
+    renderSelector({ dropdownDirection: 'down' });
+    const menu = openMenu();
+
+    expect(menu).toHaveClass('sm:top-full', 'sm:bottom-auto');
+    // Unprefixed positioning would fight the sheet's `bottom-0` on mobile.
+    expect(menu.className).not.toMatch(/(^|\s)top-full(\s|$)/);
+  });
+
+  test('selects a model and closes', () => {
+    const { onModelChange } = renderSelector();
+    openMenu();
+
+    fireEvent.click(screen.getByRole('menuitem', { name: /Local vLLM/i }));
+
+    expect(onModelChange).toHaveBeenCalledWith('model-no-desc');
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Fixes #2287

## The bug

Reproduced in Chromium against a local dev server (local admin login, all 10 enabled default models), measuring the open menu at several viewport widths.

The menu was a fixed `w-80` (320px) panel anchored with `left-0` to a trigger that sits at the **right** end of the chat toolbar:

| Viewport | Trigger left edge | Menu spans | Result |
| --- | --- | --- | --- |
| 390px | x=118 | 118 → 438 | 48px off the right edge |
| 330px | x=97 | 97 → 385 | 55px off the right edge |

`max-w-[calc(100vw-2rem)]` did not save it — that caps the width without moving the anchor, and at 390px the cap (358px) is wider than `w-80` anyway, so it never applied. Every model name and description was clipped mid-word.

Row heights also alternated, which is the "strange spacing between several models" the issue reports:

```
before, 390px: [74, 74, 74, 74, 74, 58, 74, 58, 58, 58]
```

`line-clamp-2` means a description that fits on one line produces a 58px row and one that wraps produces 74px, so the list read as randomly spaced blocks.

## The fix

Below `sm` the menu becomes a full-width bottom sheet — `fixed inset-x-0 bottom-0`, `max-h-[70vh]`, behind a scrim that dims the page and closes the menu when tapped. It cannot be clipped regardless of where the trigger sits. Names truncate to one line and descriptions clamp to one line on mobile:

```
after, 390px: menu 0 → 390 (full width), rows [58 × 10]
after, 330px: menu 0 → 330 (full width), rows [58 × 10]
```

From `sm` up the anchored dropdown is unchanged — same `w-80` panel, same position, same two-line descriptions:

```
after, 1280px: position absolute, w 320, left 848, rows [74, 74, 74, 74, 74, 58, 74, 58, 58, 58]
```

The scrim needs its own `onClick`: it lives inside `dropdownRef`, so the existing document `mousedown` handler never treats a tap on it as "outside".

One non-obvious detail, called out in a comment in the code: the responsive classes use **side-specific** radius and border utilities (`sm:rounded-t-lg sm:rounded-b-lg sm:border-x sm:border-b`). Tailwind sorts the shorthand groups before the longhand ones, so `sm:rounded-lg` / `sm:border` would be emitted *before* the mobile `rounded-t-2xl` / `border-t` and silently lose the override — the desktop dropdown would keep 2xl top corners and no side borders.

## Verification

In a real browser at 330px, 390px and 1280px, light and dark, and for both dropdown directions (`up` from `ChatInput`, `down` from `ComparePanel`):

- Menu is fully inside the viewport at every width, in both directions.
- Mobile rows are uniformly 58px; desktop geometry is byte-for-byte the same as before.
- Tapping a model applies the selection and closes the sheet.
- Tapping the scrim closes the sheet.
- Arrow-key navigation still lands on menu items; Escape still closes.
- `position` resolves to `fixed` on mobile and `absolute` on desktop, confirming no transformed ancestor breaks the sheet.

## Tests

`tests/unit/client/model-selector-mobile-layout.test.jsx` (5 tests) renders the real component and locks in the responsive contract. jsdom does not evaluate media queries, so these assert the class contract rather than computed geometry — the behavioural parts (scrim dismissal, select-and-close) are asserted directly.

4 of the 5 fail against the pre-fix component; the 5th guards existing select-and-close behaviour.

- `npx jest tests/unit/client` → **38 suites, 370 tests, all passing**
- `npx eslint` on both changed files → clean
- `npx prettier --check` → clean

## Notes

- Desktop row heights are intentionally left uneven. The issue is scoped to mobile, and the wider panel keeps the fuller two-line descriptions; unifying desktop would change a view nobody reported a problem with. Happy to follow up if you want it consistent everywhere.
- Changelog entry added to `docs/releases/5.5.0/fixes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014K6GzYLrMWd5zfKX6CY7Dy

---
_Generated by [Claude Code](https://claude.ai/code/session_014K6GzYLrMWd5zfKX6CY7Dy)_