### PR TITLE
feat(ui): configurable app shortcuts on the start page and sidebar, plus drag-and-drop app ordering

### DIFF
--- a/client/src/api/adminApi.js
+++ b/client/src/api/adminApi.js
@@ -198,6 +198,18 @@ export const toggleApps = async (ids, enabled) => {
   return response.data;
 };
 
+/**
+ * Save the display order of apps: the first id becomes `order: 1`, the second
+ * `order: 2`, and so on. Apps left out of `ids` keep the order they have.
+ */
+export const reorderApps = async ids => {
+  const response = await makeAdminApiCall('/admin/apps/_reorder', {
+    method: 'POST',
+    body: { ids }
+  });
+  return response.data;
+};
+
 export const fetchAdminPages = async () => {
   const response = await makeAdminApiCall('/admin/pages');
   return response.data;
@@ -945,6 +957,7 @@ export const adminApi = {
   updatePrompt,
   translateText,
   toggleApps,
+  reorderApps,
   fetchAdminPages,
   fetchAdminPage,
   createPage,

--- a/client/src/features/admin/components/ReorderableList.jsx
+++ b/client/src/features/admin/components/ReorderableList.jsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import Icon from '../../../shared/components/Icon';
+
+/**
+ * A list whose order the admin controls: drag a row with the mouse, or use the
+ * up/down buttons. The buttons are the accessible path — pointer drag has no
+ * keyboard equivalent — so every row keeps both.
+ *
+ * `onReorder` receives the whole reordered array; the component holds no copy
+ * of the list, so the parent stays the single source of truth.
+ *
+ * @param {object} props
+ * @param {Array} props.items - The items to show, in their current order.
+ * @param {(items: Array) => void} props.onReorder - Called with the new order.
+ * @param {(item: any) => string} props.getKey - Stable key/id for an item.
+ * @param {(item: any, index: number) => React.ReactNode} props.renderItem - Row content.
+ * @param {(item: any, index: number) => React.ReactNode} [props.renderActions] - Trailing controls.
+ * @param {(item: any) => string} props.getLabel - Accessible name of a row, used in button labels.
+ * @param {boolean} [props.disabled] - Render the rows without any reordering affordance.
+ */
+function ReorderableList({
+  items,
+  onReorder,
+  getKey,
+  renderItem,
+  renderActions,
+  getLabel,
+  disabled = false
+}) {
+  const { t } = useTranslation();
+  const [dragIndex, setDragIndex] = useState(null);
+  const [overIndex, setOverIndex] = useState(null);
+
+  const move = (from, to) => {
+    if (from === to || to < 0 || to >= items.length) return;
+    const next = [...items];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    onReorder(next);
+  };
+
+  const endDrag = () => {
+    setDragIndex(null);
+    setOverIndex(null);
+  };
+
+  return (
+    <ul className="space-y-1">
+      {items.map((item, index) => {
+        const label = getLabel(item);
+        const isDragging = dragIndex === index;
+        const isDropTarget = overIndex === index && dragIndex !== null && dragIndex !== index;
+        return (
+          <li
+            key={getKey(item)}
+            draggable={!disabled}
+            onDragStart={e => {
+              if (disabled) return;
+              setDragIndex(index);
+              e.dataTransfer.effectAllowed = 'move';
+              // Firefox only starts a drag when some data is set.
+              e.dataTransfer.setData('text/plain', String(index));
+            }}
+            onDragOver={e => {
+              if (disabled || dragIndex === null) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = 'move';
+              setOverIndex(index);
+            }}
+            onDrop={e => {
+              if (disabled || dragIndex === null) return;
+              e.preventDefault();
+              move(dragIndex, index);
+              endDrag();
+            }}
+            onDragEnd={endDrag}
+            className={`flex items-center gap-2 rounded-md border bg-white dark:bg-gray-700 px-2 py-2 ${
+              isDropTarget
+                ? 'border-indigo-500 ring-1 ring-indigo-500'
+                : 'border-gray-200 dark:border-gray-600'
+            } ${isDragging ? 'opacity-50' : ''}`}
+          >
+            {!disabled && (
+              <span
+                className="shrink-0 cursor-grab text-gray-400 dark:text-gray-500"
+                title={t('admin.reorder.dragHandle', 'Drag to reorder')}
+                aria-hidden="true"
+              >
+                <Icon name="menu" size="sm" />
+              </span>
+            )}
+
+            <div className="min-w-0 flex-1">{renderItem(item, index)}</div>
+
+            {!disabled && (
+              <div className="flex shrink-0 items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => move(index, index - 1)}
+                  disabled={index === 0}
+                  aria-label={t('admin.reorder.moveUp', 'Move {{name}} up', { name: label })}
+                  title={t('admin.reorder.moveUp', 'Move {{name}} up', { name: label })}
+                  className="rounded-md p-1 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-600 disabled:cursor-not-allowed disabled:opacity-30"
+                >
+                  <Icon name="chevron-up" size="sm" />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => move(index, index + 1)}
+                  disabled={index === items.length - 1}
+                  aria-label={t('admin.reorder.moveDown', 'Move {{name}} down', { name: label })}
+                  title={t('admin.reorder.moveDown', 'Move {{name}} down', { name: label })}
+                  className="rounded-md p-1 text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-600 disabled:cursor-not-allowed disabled:opacity-30"
+                >
+                  <Icon name="chevron-down" size="sm" />
+                </button>
+              </div>
+            )}
+
+            {renderActions && (
+              <div className="flex shrink-0 items-center gap-1">{renderActions(item, index)}</div>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+export default ReorderableList;

--- a/client/src/features/admin/components/StartPageCustomization.jsx
+++ b/client/src/features/admin/components/StartPageCustomization.jsx
@@ -3,11 +3,21 @@ import { fetchAdminApps } from '../../../api';
 import { getLocalizedContent } from '../../../utils/localizeContent';
 import { useTranslation } from 'react-i18next';
 import DynamicLanguageEditor from '../../../shared/components/DynamicLanguageEditor';
+import Icon from '../../../shared/components/Icon';
+import ReorderableList from './ReorderableList';
+import {
+  APP_SHORTCUT_MODES,
+  DEFAULT_APP_SHORTCUT_MODE,
+  DEFAULT_SIDEBAR_APPS_COUNT,
+  DEFAULT_START_PAGE_APPS_COUNT,
+  MAX_APP_SHORTCUTS
+} from '../../../utils/appShortcuts';
 
 /**
  * Start page configuration (uiConfig.startPage): which view the "/" route
  * shows, whether the default app's chat input is on the start page, which app
- * that is, and the subtitle under the greeting.
+ * that is, the subtitle under the greeting, and the app shortcuts the start
+ * page and the sidebar show (which apps, how they rank, how many).
  */
 function StartPageCustomization({ config, pages, onUpdate, t }) {
   const { i18n } = useTranslation();
@@ -64,6 +74,46 @@ function StartPageCustomization({ config, pages, onUpdate, t }) {
     `${getLocalizedContent(app.name, currentLanguage) || app.id}${
       app.enabled === false ? ' (disabled)' : ''
     }`;
+
+  // ---- App shortcuts: the short app lists on /start and in the sidebar ----
+  const appsMode = APP_SHORTCUT_MODES.includes(config?.appsMode)
+    ? config.appsMode
+    : DEFAULT_APP_SHORTCUT_MODE;
+  const featuredAppIds = Array.isArray(config?.featuredAppIds) ? config.featuredAppIds : [];
+
+  // An unset count means "use the built-in default", so show that number
+  // rather than an empty box the admin has to guess at.
+  const countValue = (value, fallback) =>
+    value === undefined || value === null || value === '' ? fallback : value;
+
+  const handleCountChange = (field, raw) => {
+    if (raw === '') {
+      // Clearing the box goes back to the built-in default.
+      onUpdate({ [field]: undefined });
+      return;
+    }
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isNaN(parsed)) return;
+    onUpdate({ [field]: Math.min(Math.max(parsed, 0), MAX_APP_SHORTCUTS) });
+  };
+
+  // Keep ids that no longer resolve to an app in the list so they stay
+  // removable instead of silently occupying a slot.
+  const featuredItems = featuredAppIds.map(id => ({
+    id,
+    app: apps.find(app => app.id === id) || null
+  }));
+  const addableApps = apps.filter(app => !featuredAppIds.includes(app.id));
+
+  const addFeaturedApp = id => {
+    if (!id || featuredAppIds.includes(id)) return;
+    onUpdate({ featuredAppIds: [...featuredAppIds, id] });
+  };
+  const removeFeaturedApp = id => {
+    onUpdate({ featuredAppIds: featuredAppIds.filter(entry => entry !== id) });
+  };
+  const featuredLabel = item =>
+    item.app ? getLocalizedContent(item.app.name, currentLanguage) || item.id : item.id;
 
   return (
     <div className="p-6">
@@ -283,6 +333,172 @@ function StartPageCustomization({ config, pages, onUpdate, t }) {
             {t(
               'admin.ui.startPage.defaultAppHelp',
               'The app whose chat input is shown on the start page. When unset, the first app the user can access is used.'
+            )}
+          </p>
+        </div>
+
+        <hr className="border-gray-200 dark:border-gray-700" />
+
+        {/* App shortcuts — shared by the start page grid and the sidebar */}
+        <div>
+          <h4 className="text-base font-medium text-gray-900 dark:text-gray-100">
+            {t('admin.ui.startPage.shortcuts', 'App shortcuts')}
+          </h4>
+          <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            {t(
+              'admin.ui.startPage.shortcutsHelp',
+              'The short app lists on the start page and in the sidebar. A user’s favorites always come first, then the default apps below, then everything else in the order you pick.'
+            )}
+          </p>
+        </div>
+
+        {/* How the apps that are not favorites or default apps rank */}
+        <div>
+          <label htmlFor="startPage-appsMode" className={labelClass}>
+            {t('admin.ui.startPage.appsMode', 'Order of the remaining apps')}
+          </label>
+          <select
+            id="startPage-appsMode"
+            value={appsMode}
+            onChange={e => onUpdate({ appsMode: e.target.value })}
+            className={selectClass}
+          >
+            <option value="order">
+              {t('admin.ui.startPage.appsModeOrder', 'Configured order (the app’s order field)')}
+            </option>
+            <option value="recent">
+              {t('admin.ui.startPage.appsModeRecent', 'Recently used first')}
+            </option>
+          </select>
+          <p className={helpClass}>
+            {t(
+              'admin.ui.startPage.appsModeHelp',
+              'Applies to both lists. "Recently used" ranks the apps each user opened most recently, the same way the apps browser does; the default apps below still lead the list.'
+            )}
+          </p>
+        </div>
+
+        {/* Separate counts: the grid and the sidebar have very different room */}
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label htmlFor="startPage-appsCount" className={labelClass}>
+              {t('admin.ui.startPage.appsCount', 'Apps on the start page')}
+            </label>
+            <input
+              id="startPage-appsCount"
+              type="number"
+              min="0"
+              max={MAX_APP_SHORTCUTS}
+              value={countValue(config?.appsCount, DEFAULT_START_PAGE_APPS_COUNT)}
+              onChange={e => handleCountChange('appsCount', e.target.value)}
+              className={selectClass}
+            />
+          </div>
+          <div>
+            <label htmlFor="startPage-sidebarAppsCount" className={labelClass}>
+              {t('admin.ui.startPage.sidebarAppsCount', 'Apps in the sidebar')}
+            </label>
+            <input
+              id="startPage-sidebarAppsCount"
+              type="number"
+              min="0"
+              max={MAX_APP_SHORTCUTS}
+              value={countValue(config?.sidebarAppsCount, DEFAULT_SIDEBAR_APPS_COUNT)}
+              onChange={e => handleCountChange('sidebarAppsCount', e.target.value)}
+              className={selectClass}
+            />
+          </div>
+        </div>
+        <p className="-mt-4 text-xs text-gray-500 dark:text-gray-400">
+          {t(
+            'admin.ui.startPage.appsCountHelp',
+            'Between 0 and {{max}} each. Set 0 to hide a list.',
+            {
+              max: MAX_APP_SHORTCUTS
+            }
+          )}
+        </p>
+
+        {/* The curated default apps, in the order they should appear */}
+        <div>
+          <span className={labelClass}>{t('admin.ui.startPage.featuredApps', 'Default apps')}</span>
+          {featuredItems.length === 0 ? (
+            <p className="rounded-md border border-dashed border-gray-300 dark:border-gray-600 px-3 py-4 text-xs text-gray-500 dark:text-gray-400">
+              {t(
+                'admin.ui.startPage.featuredAppsEmpty',
+                'No default apps yet — both lists follow the order above.'
+              )}
+            </p>
+          ) : (
+            <ReorderableList
+              items={featuredItems}
+              onReorder={items => onUpdate({ featuredAppIds: items.map(item => item.id) })}
+              getKey={item => item.id}
+              getLabel={featuredLabel}
+              renderItem={(item, index) => (
+                <span className="flex min-w-0 items-center gap-2">
+                  <span className="w-5 shrink-0 text-xs font-semibold text-gray-400 dark:text-gray-500">
+                    {index + 1}.
+                  </span>
+                  {item.app && (
+                    <span
+                      className="flex h-6 w-6 shrink-0 items-center justify-center rounded-md text-white"
+                      style={{ backgroundColor: item.app.color || '#4f46e5' }}
+                    >
+                      <Icon name={item.app.icon} size="sm" className="h-3.5 w-3.5" />
+                    </span>
+                  )}
+                  <span className="min-w-0 flex-1 truncate text-sm text-gray-900 dark:text-gray-100">
+                    {featuredLabel(item)}
+                    {!item.app && !loading && (
+                      <span className="ml-1 text-xs text-amber-600 dark:text-amber-400">
+                        ({t('admin.ui.startPage.unknownApp', 'not found')})
+                      </span>
+                    )}
+                    {item.app?.enabled === false && (
+                      <span className="ml-1 text-xs text-gray-500 dark:text-gray-400">
+                        ({t('admin.apps.status.disabled', 'Disabled')})
+                      </span>
+                    )}
+                  </span>
+                </span>
+              )}
+              renderActions={item => (
+                <button
+                  type="button"
+                  onClick={() => removeFeaturedApp(item.id)}
+                  aria-label={t('admin.ui.startPage.removeFeaturedApp', 'Remove {{name}}', {
+                    name: featuredLabel(item)
+                  })}
+                  title={t('admin.ui.startPage.removeFeaturedApp', 'Remove {{name}}', {
+                    name: featuredLabel(item)
+                  })}
+                  className="rounded-md p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/30"
+                >
+                  <Icon name="trash" size="sm" />
+                </button>
+              )}
+            />
+          )}
+          <select
+            id="startPage-addFeaturedApp"
+            value=""
+            disabled={loading || addableApps.length === 0}
+            onChange={e => addFeaturedApp(e.target.value)}
+            aria-label={t('admin.ui.startPage.addFeaturedApp', 'Add a default app')}
+            className={`${selectClass} mt-2`}
+          >
+            <option value="">{t('admin.ui.startPage.addFeaturedApp', 'Add a default app')}</option>
+            {addableApps.map(app => (
+              <option key={app.id} value={app.id}>
+                {appOptionLabel(app)}
+              </option>
+            ))}
+          </select>
+          <p className={helpClass}>
+            {t(
+              'admin.ui.startPage.featuredAppsHelp',
+              'Shown in this order, right after each user’s favorites. Users who cannot access an app never see it. Drag a row or use the arrows to reorder.'
             )}
           </p>
         </div>

--- a/client/src/features/admin/pages/AdminAppsPage.jsx
+++ b/client/src/features/admin/pages/AdminAppsPage.jsx
@@ -11,10 +11,12 @@ import {
   fetchAdminApps,
   getAdminApiErrorMessage,
   makeAdminApiCall,
+  reorderApps,
   toggleApps
 } from '../../../api/adminApi';
 import { fetchUIConfig } from '../../../api';
 import ConfirmDialog from '../../../shared/components/ConfirmDialog';
+import ReorderableList from '../components/ReorderableList';
 import { DataTable, SearchInput, FilterSelect } from '../components/data-table';
 
 function AppNameCell({ app, currentLanguage }) {
@@ -56,6 +58,10 @@ function AdminAppsPage() {
   const [uiConfig, setUiConfig] = useState(null);
   const [uploading, setUploading] = useState(false);
   const [confirmDialog, setConfirmDialog] = useState(null);
+  // Reorder mode replaces the table with a draggable list; `orderDraft` holds
+  // the pending order until it is saved, so cancelling changes nothing.
+  const [orderDraft, setOrderDraft] = useState(null);
+  const [savingOrder, setSavingOrder] = useState(false);
 
   useEffect(() => {
     loadApps();
@@ -80,6 +86,39 @@ function AdminAppsPage() {
       setError(getAdminApiErrorMessage(err));
     } finally {
       setLoading(false);
+    }
+  };
+
+  // The order the apps browser, the start page and the sidebar rank by:
+  // `order` ascending, unset last, then by name so the list never jitters.
+  const byDisplayOrder = (a, b) => {
+    const orderA = a.order ?? Infinity;
+    const orderB = b.order ?? Infinity;
+    if (orderA !== orderB) return orderA - orderB;
+    return getLocalizedContent(a.name, currentLanguage).localeCompare(
+      getLocalizedContent(b.name, currentLanguage)
+    );
+  };
+
+  // Reordering renumbers every app, so it deliberately ignores the filters —
+  // saving a filtered subset would leave the apps outside it with stale numbers.
+  const startReordering = () => {
+    setError(null);
+    setOrderDraft([...apps].sort(byDisplayOrder));
+  };
+
+  const saveOrder = async () => {
+    if (!orderDraft || orderDraft.length === 0) return;
+    try {
+      setSavingOrder(true);
+      setError(null);
+      await reorderApps(orderDraft.map(app => app.id));
+      setOrderDraft(null);
+      await loadApps();
+    } catch (err) {
+      setError(getAdminApiErrorMessage(err));
+    } finally {
+      setSavingOrder(false);
     }
   };
 
@@ -335,51 +374,85 @@ function AdminAppsPage() {
         </div>
         <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
           <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              className="inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-indigo-700 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto"
-              onClick={handleCreateApp}
-            >
-              <Icon name="plus" className="h-4 w-4 mr-2" />
-              {t('admin.apps.createApp', 'Create App')}
-            </button>
-            <div className="relative">
-              <input
-                type="file"
-                accept=".json"
-                onChange={handleUploadConfig}
-                className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
-                disabled={uploading}
-              />
-              <button
-                type="button"
-                className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-xs hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                disabled={uploading}
-                title={t('admin.apps.uploadConfig', 'Upload App Config')}
-              >
-                <Icon
-                  name={uploading ? 'refresh' : 'upload'}
-                  className={`h-4 w-4 mr-2 ${uploading ? 'animate-spin' : ''}`}
-                />
-                {uploading
-                  ? t('admin.apps.uploading', 'Uploading...')
-                  : t('admin.apps.uploadConfig', 'Upload Config')}
-              </button>
-            </div>
-            <button
-              type="button"
-              className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-xs hover:bg-gray-50 dark:hover:bg-gray-600"
-              onClick={enableAllApps}
-            >
-              {t('admin.common.enableAll', 'Enable All')}
-            </button>
-            <button
-              type="button"
-              className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-xs hover:bg-gray-50 dark:hover:bg-gray-600"
-              onClick={disableAllApps}
-            >
-              {t('admin.common.disableAll', 'Disable All')}
-            </button>
+            {orderDraft ? (
+              <>
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-indigo-700 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={saveOrder}
+                  disabled={savingOrder}
+                >
+                  {savingOrder
+                    ? t('admin.apps.savingOrder', 'Saving order...')
+                    : t('admin.apps.saveOrder', 'Save order')}
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-xs hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={() => setOrderDraft(null)}
+                  disabled={savingOrder}
+                >
+                  {t('common.cancel', 'Cancel')}
+                </button>
+              </>
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-xs hover:bg-indigo-700 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto"
+                  onClick={handleCreateApp}
+                >
+                  <Icon name="plus" className="h-4 w-4 mr-2" />
+                  {t('admin.apps.createApp', 'Create App')}
+                </button>
+                <div className="relative">
+                  <input
+                    type="file"
+                    accept=".json"
+                    onChange={handleUploadConfig}
+                    className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                    disabled={uploading}
+                  />
+                  <button
+                    type="button"
+                    className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-xs hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-hidden focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+                    disabled={uploading}
+                    title={t('admin.apps.uploadConfig', 'Upload App Config')}
+                  >
+                    <Icon
+                      name={uploading ? 'refresh' : 'upload'}
+                      className={`h-4 w-4 mr-2 ${uploading ? 'animate-spin' : ''}`}
+                    />
+                    {uploading
+                      ? t('admin.apps.uploading', 'Uploading...')
+                      : t('admin.apps.uploadConfig', 'Upload Config')}
+                  </button>
+                </div>
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-xs hover:bg-gray-50 dark:hover:bg-gray-600"
+                  onClick={enableAllApps}
+                >
+                  {t('admin.common.enableAll', 'Enable All')}
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-xs hover:bg-gray-50 dark:hover:bg-gray-600"
+                  onClick={disableAllApps}
+                >
+                  {t('admin.common.disableAll', 'Disable All')}
+                </button>
+                <button
+                  type="button"
+                  className="inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-200 shadow-xs hover:bg-gray-50 dark:hover:bg-gray-600 disabled:opacity-50 disabled:cursor-not-allowed"
+                  onClick={startReordering}
+                  disabled={loading || apps.length === 0}
+                >
+                  <Icon name="menu" className="h-4 w-4 mr-2" />
+                  {t('admin.apps.reorder', 'Reorder')}
+                </button>
+              </>
+            )}
           </div>
         </div>
       </div>
@@ -390,85 +463,132 @@ function AdminAppsPage() {
         </div>
       )}
 
-      <div className="mt-6 flex flex-wrap items-center gap-3">
-        <SearchInput
-          value={searchTerm}
-          onChange={setSearchTerm}
-          placeholder={t('admin.apps.searchPlaceholder', 'Search apps...')}
-        />
-        <FilterSelect
-          label={t('admin.apps.statusLabel', 'Status')}
-          value={filterEnabled}
-          onChange={setFilterEnabled}
-          options={[
-            { value: 'all', label: t('admin.apps.filterAll', 'All Apps') },
-            { value: 'enabled', label: t('admin.apps.filterEnabled', 'Enabled Only') },
-            { value: 'disabled', label: t('admin.apps.filterDisabled', 'Disabled Only') }
-          ]}
-        />
-      </div>
-
-      {uiConfig?.appsList?.categories?.enabled && (
-        <div className="mt-4 flex flex-wrap gap-2">
-          <button
-            onClick={() => setSelectedCategory('all')}
-            className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
-              selectedCategory === 'all'
-                ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900'
-                : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
-            }`}
-          >
-            {t('admin.apps.allCategories', 'All Categories')}
-          </button>
-          {uiConfig.appsList.categories.list.map(category => (
-            <button
-              key={category.id}
-              onClick={() => setSelectedCategory(category.id)}
-              className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
-                selectedCategory === category.id
-                  ? 'text-white shadow-sm'
-                  : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
-              }`}
-              style={{
-                backgroundColor: selectedCategory === category.id ? category.color : undefined
-              }}
-            >
-              {getLocalizedContent(category.name, currentLanguage)}
-            </button>
-          ))}
+      {orderDraft ? (
+        <div className="mt-6">
+          <p className="mb-3 text-sm text-gray-600 dark:text-gray-300">
+            {t(
+              'admin.apps.reorderHelp',
+              'Drag a row or use the arrows to set the order apps appear in for users — in the apps browser, on the start page and in the sidebar. Every app is listed, so search and filters do not apply here. Nothing is saved until you choose "Save order".'
+            )}
+          </p>
+          <ReorderableList
+            items={orderDraft}
+            onReorder={setOrderDraft}
+            getKey={app => app.id}
+            getLabel={app => getLocalizedContent(app.name, currentLanguage) || app.id}
+            renderItem={(app, index) => (
+              <div className="flex min-w-0 items-center gap-3">
+                <span className="w-8 shrink-0 text-right text-xs font-semibold text-gray-400 dark:text-gray-500">
+                  {index + 1}
+                </span>
+                <span
+                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-sm font-bold text-white"
+                  style={{ backgroundColor: app.color || '#6B7280' }}
+                >
+                  {(getLocalizedContent(app.name, currentLanguage) || app.id)
+                    .charAt(0)
+                    .toUpperCase()}
+                </span>
+                <span className="min-w-0">
+                  <span className="block truncate text-sm font-medium text-gray-900 dark:text-gray-100">
+                    {getLocalizedContent(app.name, currentLanguage) || app.id}
+                    {app.enabled === false && (
+                      <span className="ml-2 text-xs font-normal text-gray-500 dark:text-gray-400">
+                        ({t('admin.apps.status.disabled', 'Disabled')})
+                      </span>
+                    )}
+                  </span>
+                  <span className="block truncate text-xs text-gray-500 dark:text-gray-400">
+                    {app.id}
+                  </span>
+                </span>
+              </div>
+            )}
+          />
         </div>
-      )}
+      ) : (
+        <>
+          <div className="mt-6 flex flex-wrap items-center gap-3">
+            <SearchInput
+              value={searchTerm}
+              onChange={setSearchTerm}
+              placeholder={t('admin.apps.searchPlaceholder', 'Search apps...')}
+            />
+            <FilterSelect
+              label={t('admin.apps.statusLabel', 'Status')}
+              value={filterEnabled}
+              onChange={setFilterEnabled}
+              options={[
+                { value: 'all', label: t('admin.apps.filterAll', 'All Apps') },
+                { value: 'enabled', label: t('admin.apps.filterEnabled', 'Enabled Only') },
+                { value: 'disabled', label: t('admin.apps.filterDisabled', 'Disabled Only') }
+              ]}
+            />
+          </div>
 
-      <div className="mt-6">
-        <DataTable
-          columns={columns}
-          data={filteredApps}
-          getRowId={app => app.id}
-          actions={actions}
-          loading={loading}
-          onRowClick={app => {
-            setSelectedApp(app);
-            setShowAppDetails(true);
-          }}
-          empty={{
-            icon: 'sparkles',
-            title: t('admin.apps.noApps', 'No apps found'),
-            description: t(
-              'admin.apps.noAppsDescription',
-              'Try adjusting your search or filter criteria.'
-            ),
-            action: (
+          {uiConfig?.appsList?.categories?.enabled && (
+            <div className="mt-4 flex flex-wrap gap-2">
               <button
-                onClick={handleCreateApp}
-                className="inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                onClick={() => setSelectedCategory('all')}
+                className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
+                  selectedCategory === 'all'
+                    ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900'
+                    : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
+                }`}
               >
-                <Icon name="plus" className="h-4 w-4 mr-2" />
-                {t('admin.apps.createApp', 'Create App')}
+                {t('admin.apps.allCategories', 'All Categories')}
               </button>
-            )
-          }}
-        />
-      </div>
+              {uiConfig.appsList.categories.list.map(category => (
+                <button
+                  key={category.id}
+                  onClick={() => setSelectedCategory(category.id)}
+                  className={`px-3 py-1.5 rounded-full text-sm font-medium transition-all ${
+                    selectedCategory === category.id
+                      ? 'text-white shadow-sm'
+                      : 'text-gray-600 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600'
+                  }`}
+                  style={{
+                    backgroundColor: selectedCategory === category.id ? category.color : undefined
+                  }}
+                >
+                  {getLocalizedContent(category.name, currentLanguage)}
+                </button>
+              ))}
+            </div>
+          )}
+
+          <div className="mt-6">
+            <DataTable
+              columns={columns}
+              data={filteredApps}
+              getRowId={app => app.id}
+              actions={actions}
+              loading={loading}
+              onRowClick={app => {
+                setSelectedApp(app);
+                setShowAppDetails(true);
+              }}
+              empty={{
+                icon: 'sparkles',
+                title: t('admin.apps.noApps', 'No apps found'),
+                description: t(
+                  'admin.apps.noAppsDescription',
+                  'Try adjusting your search or filter criteria.'
+                ),
+                action: (
+                  <button
+                    onClick={handleCreateApp}
+                    className="inline-flex items-center px-4 py-2 border border-transparent shadow-xs text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-hidden focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+                  >
+                    <Icon name="plus" className="h-4 w-4 mr-2" />
+                    {t('admin.apps.createApp', 'Create App')}
+                  </button>
+                )
+              }}
+            />
+          </div>
+        </>
+      )}
 
       <AppDetailsPopup
         app={selectedApp}

--- a/client/src/features/apps/pages/StartPage.jsx
+++ b/client/src/features/apps/pages/StartPage.jsx
@@ -10,7 +10,8 @@ import useAuthKey from '../../../shared/hooks/useAuthKey';
 import useFavorites from '../../../shared/hooks/useFavorites';
 import IHubLogo from '../../../shared/components/IHubLogo';
 import { getLocalizedContent } from '../../../utils/localizeContent';
-import { sortFavoritesFirst } from '../../../utils/favoriteItems';
+import { rankAppShortcuts, readAppShortcutConfig } from '../../../utils/appShortcuts';
+import { getRecentAppIds } from '../../../utils/recentApps';
 import { pickDefaultChatApp } from '../../../utils/homePage';
 import { filterModelsForApp, pickInitialModelForApp } from '../../../utils/modelFiltering';
 import { useTranslation } from 'react-i18next';
@@ -84,16 +85,28 @@ export default function StartPage() {
     getLocalizedContent(uiConfig?.startPage?.subtitle, currentLanguage) ||
     t('startPage.subtitle', 'How can I help you today?');
 
-  // Favorites first, then the admin-defined `order` — the ranking behind the
-  // featured grid (and, in pickDefaultChatApp, the default-app fallback).
+  // How many apps the grid shows, which ones lead it and how the rest rank —
+  // all admin-configured under UI Customization → Start Page.
+  const { mode, featuredAppIds, startPageCount } = useMemo(
+    () => readAppShortcutConfig(uiConfig),
+    [uiConfig]
+  );
+
+  // Read once per visit: re-reading on every render would reshuffle the grid
+  // under the user's cursor. Only the `recent` mode needs the list at all.
+  const recentAppIds = useMemo(() => (mode === 'recent' ? getRecentAppIds() : []), [mode]);
+
+  // Favorites first, then the admin's default apps, then the rest by mode.
   const rankedApps = useMemo(
     () =>
-      sortFavoritesFirst(
-        apps,
+      rankAppShortcuts(apps, {
         favoriteAppIds,
-        (a, b) => (a.order ?? Infinity) - (b.order ?? Infinity)
-      ),
-    [apps, favoriteAppIds]
+        featuredAppIds,
+        mode,
+        recentAppIds,
+        currentLanguage
+      }),
+    [apps, favoriteAppIds, featuredAppIds, mode, recentAppIds, currentLanguage]
   );
 
   // Default app: admin-configured via uiConfig.startPage.defaultAppId; when it
@@ -181,8 +194,11 @@ export default function StartPage() {
     (defaultAppDetails?.inputMode?.microphone?.enabled ??
       defaultAppDetails?.microphone?.enabled) !== false;
 
-  // Featured apps: the top four of the shared ranking
-  const featuredApps = useMemo(() => rankedApps.slice(0, 4), [rankedApps]);
+  // Featured apps: the top of the shared ranking, capped by the admin's count.
+  const featuredApps = useMemo(
+    () => rankedApps.slice(0, startPageCount),
+    [rankedApps, startPageCount]
+  );
 
   const recentChats = chatHistoryEnabled ? MOCK_CHATS.slice(0, 3) : [];
 

--- a/client/src/shared/components/AppSidebar.jsx
+++ b/client/src/shared/components/AppSidebar.jsx
@@ -8,7 +8,8 @@ import useFavorites from '../hooks/useFavorites';
 import Icon from './Icon';
 import IHubLogo from './IHubLogo';
 import { getLocalizedContent } from '../../utils/localizeContent';
-import { sortFavoritesFirst } from '../../utils/favoriteItems';
+import { rankAppShortcuts, readAppShortcutConfig } from '../../utils/appShortcuts';
+import { getRecentAppIds } from '../../utils/recentApps';
 import { START_PAGE_PATH } from '../../utils/homePage';
 import useMediaQuery from '../hooks/useMediaQuery';
 import BrandTitle from './BrandTitle';
@@ -221,9 +222,33 @@ export default function AppSidebar({ mobileOpen = false, onMobileClose = () => {
     [toggleFavorite]
   );
 
+  // Which apps the Apps section shows, in which order and how many — shared
+  // with the start page and configured under UI Customization → Start Page.
+  const { mode, featuredAppIds, sidebarCount } = useMemo(
+    () => readAppShortcutConfig(uiConfig),
+    [uiConfig]
+  );
+
+  // Read once per mount: re-reading on every render would reorder the list
+  // while the user is aiming at it. Only the `recent` mode needs it.
+  const recentAppIds = useMemo(() => (mode === 'recent' ? getRecentAppIds() : []), [mode]);
+
+  // Favorites first, then the admin's default apps, then the rest by mode.
+  const rankedApps = useMemo(
+    () =>
+      rankAppShortcuts(apps, {
+        favoriteAppIds,
+        featuredAppIds,
+        mode,
+        recentAppIds,
+        currentLanguage
+      }),
+    [apps, favoriteAppIds, featuredAppIds, mode, recentAppIds, currentLanguage]
+  );
+
   const sidebarApps = useMemo(() => {
     const q = search.trim().toLowerCase();
-    let list = sortFavoritesFirst(apps, favoriteAppIds);
+    let list = rankedApps;
     if (q) {
       list = list.filter(a => {
         const name = getLocalizedContent(a.name, currentLanguage) || '';
@@ -231,8 +256,15 @@ export default function AppSidebar({ mobileOpen = false, onMobileClose = () => {
         return name.toLowerCase().includes(q) || desc.toLowerCase().includes(q);
       });
     }
-    return list.slice(0, 5);
-  }, [apps, favoriteAppIds, search, currentLanguage]);
+    return list.slice(0, sidebarCount);
+  }, [rankedApps, search, currentLanguage, sidebarCount]);
+
+  // The collapsed rail has room for icons only, so it shows the same ranking
+  // trimmed to what fits next to the navigation buttons.
+  const railApps = useMemo(
+    () => rankedApps.slice(0, Math.min(sidebarCount, 4)),
+    [rankedApps, sidebarCount]
+  );
 
   const recentChats = useMemo(() => {
     if (!chatHistoryEnabled) return [];
@@ -401,24 +433,21 @@ export default function AppSidebar({ mobileOpen = false, onMobileClose = () => {
 
         <div className="w-8 h-px bg-gray-200 dark:bg-gray-700 my-1" aria-hidden="true" />
 
-        {apps
-          .filter(a => favoriteAppIds.includes(a.id))
-          .slice(0, 4)
-          .map(app => {
-            const name = getLocalizedContent(app.name, currentLanguage) || app.id;
-            return (
-              <Link
-                key={app.id}
-                to={`/apps/${app.id}`}
-                title={name}
-                aria-label={name}
-                className="w-10 h-10 flex items-center justify-center rounded-xl text-white transition hover:brightness-110"
-                style={{ backgroundColor: app.color || '#4f46e5' }}
-              >
-                <Icon name={app.icon} size="md" />
-              </Link>
-            );
-          })}
+        {railApps.map(app => {
+          const name = getLocalizedContent(app.name, currentLanguage) || app.id;
+          return (
+            <Link
+              key={app.id}
+              to={`/apps/${app.id}`}
+              title={name}
+              aria-label={name}
+              className="w-10 h-10 flex items-center justify-center rounded-xl text-white transition hover:brightness-110"
+              style={{ backgroundColor: app.color || '#4f46e5' }}
+            >
+              <Icon name={app.icon} size="md" />
+            </Link>
+          );
+        })}
       </nav>
 
       <div className="flex-1" />

--- a/client/src/utils/appShortcuts.js
+++ b/client/src/utils/appShortcuts.js
@@ -1,0 +1,125 @@
+/**
+ * App shortcuts — the short app lists the start page and the sidebar show.
+ *
+ * Both places answer the same question ("which handful of apps do we put in
+ * front of this user?"), so they share one ranking and one piece of config
+ * (`ui.json → startPage`, edited under Admin → UI Customization → Start Page):
+ *
+ * - `featuredAppIds`    — the admin's default apps, in the order they set.
+ * - `appsMode`          — how everything else ranks: `order` (the app's
+ *                         `order` field) or `recent` (most recently used).
+ * - `appsCount`         — how many the start page grid shows.
+ * - `sidebarAppsCount`  — how many the sidebar's Apps section shows.
+ *
+ * The ranking is always: the user's favorites, then the admin's default apps,
+ * then the rest by mode. Favorites stay on top so a user's own picks are never
+ * pushed off the list by configuration.
+ */
+
+import { getLocalizedContent } from './localizeContent';
+
+/** The values `startPage.appsMode` accepts. Mirrored server-side in routes/admin/ui.js. */
+export const APP_SHORTCUT_MODES = ['order', 'recent'];
+
+export const DEFAULT_APP_SHORTCUT_MODE = 'order';
+
+/** Four fills the start page's two-column grid exactly. */
+export const DEFAULT_START_PAGE_APPS_COUNT = 4;
+
+/** Five keeps the sidebar's Apps section short enough to scan. */
+export const DEFAULT_SIDEBAR_APPS_COUNT = 5;
+
+/** Upper bound for both counts — beyond this neither surface stays scannable. */
+export const MAX_APP_SHORTCUTS = 12;
+
+const clampCount = (value, fallback) => {
+  // Unset means "use the built-in default" — and `Number(null)` is 0, which
+  // would silently hide the list instead. 0 only counts when it is written.
+  if (value === undefined || value === null || value === '') return fallback;
+  const count = Number(value);
+  if (!Number.isFinite(count)) return fallback;
+  return Math.min(Math.max(Math.trunc(count), 0), MAX_APP_SHORTCUTS);
+};
+
+/**
+ * Read the app-shortcut settings out of the UI config, with every field
+ * normalized so callers never have to defend against hand-edited values.
+ *
+ * @param {object} uiConfig - The UI configuration (`useUIConfig().uiConfig`).
+ * @returns {{mode: string, featuredAppIds: string[], startPageCount: number, sidebarCount: number}}
+ */
+export const readAppShortcutConfig = uiConfig => {
+  const startPage = uiConfig?.startPage || {};
+  const featured = Array.isArray(startPage.featuredAppIds) ? startPage.featuredAppIds : [];
+  return {
+    mode: APP_SHORTCUT_MODES.includes(startPage.appsMode)
+      ? startPage.appsMode
+      : DEFAULT_APP_SHORTCUT_MODE,
+    // Drop blanks and duplicates so a stray entry cannot claim a slot twice.
+    featuredAppIds: [...new Set(featured.filter(id => typeof id === 'string' && id.length > 0))],
+    startPageCount: clampCount(startPage.appsCount, DEFAULT_START_PAGE_APPS_COUNT),
+    sidebarCount: clampCount(startPage.sidebarAppsCount, DEFAULT_SIDEBAR_APPS_COUNT)
+  };
+};
+
+/**
+ * Rank apps for the start page and the sidebar: favorites first, then the
+ * admin's default apps in their configured order, then everything else by
+ * `mode` — recently used first for `recent`, otherwise the app's `order`.
+ * Ties fall back to the localized name so the list never reshuffles between
+ * renders.
+ *
+ * Returns a new array; the input is left alone.
+ *
+ * @param {Array<{id: string, order?: number, name?: object}>} apps - Apps the user may access.
+ * @param {object} [options]
+ * @param {string[]} [options.favoriteAppIds] - Locally favorited app ids.
+ * @param {string[]} [options.featuredAppIds] - Admin-configured default apps, in order.
+ * @param {string} [options.mode] - `order` (default) or `recent`.
+ * @param {string[]} [options.recentAppIds] - Recently used app ids, most recent first.
+ * @param {string} [options.currentLanguage] - Language for the name tie-breaker.
+ * @returns {Array} The ranked apps.
+ */
+export const rankAppShortcuts = (apps, options = {}) => {
+  const {
+    favoriteAppIds = [],
+    featuredAppIds = [],
+    mode = DEFAULT_APP_SHORTCUT_MODE,
+    recentAppIds = [],
+    currentLanguage
+  } = options;
+
+  const list = Array.isArray(apps) ? apps : [];
+  const favorites = new Set(favoriteAppIds || []);
+  const featuredRank = new Map((featuredAppIds || []).map((id, index) => [id, index]));
+  const recentRank = new Map((recentAppIds || []).map((id, index) => [id, index]));
+  const rankRecent = mode === 'recent';
+
+  // 0 = the user's own favorites, 1 = the admin's default apps, 2 = the rest.
+  const tier = app => (favorites.has(app.id) ? 0 : featuredRank.has(app.id) ? 1 : 2);
+  const rankIn = (map, app) => (map.has(app.id) ? map.get(app.id) : Infinity);
+  const nameOf = app => getLocalizedContent(app.name, currentLanguage) || app.id || '';
+
+  return [...list].sort((a, b) => {
+    const byTier = tier(a) - tier(b);
+    if (byTier !== 0) return byTier;
+
+    // Inside a tier the admin's curated order comes first (it also orders
+    // favorites that happen to be default apps), then the chosen mode.
+    const featuredA = rankIn(featuredRank, a);
+    const featuredB = rankIn(featuredRank, b);
+    if (featuredA !== featuredB) return featuredA - featuredB;
+
+    if (rankRecent) {
+      const recentA = rankIn(recentRank, a);
+      const recentB = rankIn(recentRank, b);
+      if (recentA !== recentB) return recentA - recentB;
+    }
+
+    const orderA = a.order ?? Infinity;
+    const orderB = b.order ?? Infinity;
+    if (orderA !== orderB) return orderA - orderB;
+
+    return nameOf(a).localeCompare(nameOf(b));
+  });
+};

--- a/client/src/utils/favoriteItems.js
+++ b/client/src/utils/favoriteItems.js
@@ -74,21 +74,3 @@ export const createFavoriteItemHelpers = storageKey => {
     toggleFavorite
   };
 };
-
-/**
- * Stable sort: favorites first, then `tieBreaker` (if given), else input order.
- * Shared by the start page, the sidebar and the apps browser so "favorites
- * first" means the same thing everywhere.
- * @param {Array<{id: string}>} items
- * @param {string[]} favoriteIds
- * @param {(a: object, b: object) => number} [tieBreaker]
- */
-export const sortFavoritesFirst = (items, favoriteIds, tieBreaker = null) => {
-  const favorites = new Set(favoriteIds || []);
-  return [...items].sort((a, b) => {
-    const aFav = favorites.has(a.id);
-    const bFav = favorites.has(b.id);
-    if (aFav !== bFav) return aFav ? -1 : 1;
-    return tieBreaker ? tieBreaker(a, b) : 0;
-  });
-};

--- a/client/src/utils/homePage.js
+++ b/client/src/utils/homePage.js
@@ -9,7 +9,7 @@
  * document title and bookmarks always agree with what is on screen.
  */
 
-import { sortFavoritesFirst } from './favoriteItems';
+import { rankAppShortcuts, readAppShortcutConfig } from './appShortcuts';
 
 /** The start page — greeting, chat input and featured apps. */
 export const START_PAGE_PATH = '/start';
@@ -53,8 +53,12 @@ const isChatApp = app => (app?.type || 'chat') === 'chat';
 /**
  * The app whose chat input the start page shows: the admin-configured
  * `startPage.defaultAppId` when the viewer may use it, otherwise the
- * top-ranked chat app (favorites first, then the admin-defined `order`).
+ * top-ranked chat app — favorites first, then the admin's default apps
+ * (`startPage.featuredAppIds`), then the app's `order`.
  * Only chat apps qualify — an iframe/redirect app has no chat to send to.
+ *
+ * The fallback deliberately ignores `startPage.appsMode`: with `recent` the
+ * chat input would swap apps every time the user opened a different one.
  *
  * @param {Array} apps - Apps the current user may access.
  * @param {string[]} favoriteAppIds - Locally favorited app ids.
@@ -68,10 +72,11 @@ export const pickDefaultChatApp = (apps, favoriteAppIds, uiConfig) => {
     const found = list.find(app => app.id === configuredId);
     if (found && isChatApp(found)) return found;
   }
-  const ranked = sortFavoritesFirst(
-    list,
+  const { featuredAppIds } = readAppShortcutConfig(uiConfig);
+  const ranked = rankAppShortcuts(list, {
     favoriteAppIds,
-    (a, b) => (a.order ?? Infinity) - (b.order ?? Infinity)
-  );
+    featuredAppIds,
+    mode: 'order'
+  });
   return ranked.find(isChatApp) || null;
 };

--- a/docs/apps.md
+++ b/docs/apps.md
@@ -473,7 +473,7 @@ These optional fields work for all app types:
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `enabled` | Boolean | `true` | Whether the app is enabled |
-| `order` | Number | - | Display order in app list |
+| `order` | Number | - | Display order in the apps browser, the start page and the sidebar. Editable by drag and drop under Admin → Apps → Reorder |
 | `category` | String | - | App category for grouping |
 
 ### Chat-Specific Fields Not Used in Redirect/Iframe Apps
@@ -528,7 +528,7 @@ Each app is defined with the following essential properties:
 | `icon`                  | String  | **Required.** Icon identifier for the app (see [Available Icons](#available-icons))                                      |
 | `system`                | Object  | **Required for chat type.** Localized system prompts/instructions for the AI model                                       |
 | `type`                  | String  | Optional. App type: `"chat"` (default), `"redirect"`, or `"iframe"`                                                     |
-| `order`                 | Number  | Optional. Display order in the app list                                                                                  |
+| `order`                 | Number  | Optional. Display order in the apps browser, the start page and the sidebar. Editable by drag and drop under Admin → Apps → Reorder |
 | `enabled`               | Boolean | Optional. Whether the app is enabled. Default: `true`                                                                    |
 | `category`              | String  | Optional. Category label for grouping apps in the UI                                                                     |
 | `preferredModel`        | String  | Optional. Default AI model to use with this app. If omitted, uses the model marked as default in `models.json`          |

--- a/docs/releases/5.5.0/features.md
+++ b/docs/releases/5.5.0/features.md
@@ -1385,3 +1385,25 @@ signs in or clicks the logo goes there.
   access-denied screen, so pick a target everyone reaching `/` can open.
 - Existing installations keep the start page as home; a configuration migration writes that
   choice so nothing changes until an admin picks something else.
+
+## Configure Which Apps the Start Page and Sidebar Show, and in What Order
+
+The start-page grid and the sidebar's Apps section used to be fixed at four and five apps ranked
+by favorites and the app's `order`. Both lists are now configurable under **UI Customization →
+Start Page**, and the order apps appear in can be set by drag and drop in **Admin → Apps**.
+
+- **Default apps.** Pick the apps that lead both lists and drag them into the order you want. A
+  user's own favorites always stay above them, and users who cannot access an app never see it.
+- **Separate counts.** "Apps on the start page" and "Apps in the sidebar" are set independently
+  (0–12 each). Set one to 0 to hide that list.
+- **Ranking mode.** Everything after the favorites and the default apps follows either the
+  configured order (the app's `order` field) or **Recently used first** — the same ranking the
+  apps browser offers, now available on the start page and in the sidebar.
+- **Reorder apps.** **Admin → Apps** has a new **Reorder** button: drag a row, or use the up/down
+  arrows, then choose **Save order**. It writes each app's `order` field, so the new order also
+  applies to the apps browser. Every app is listed, so search and filters do not apply while
+  reordering, and nothing is saved until you confirm.
+- The collapsed icon rail now shows the same ranked apps instead of favorites only, so a user with
+  no favorites still gets app shortcuts there.
+- Existing installations receive the current behaviour as explicit defaults through a configuration
+  migration — nothing changes on screen until an admin edits the settings.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -407,8 +407,8 @@ The same `categories` structure is also available under `promptsList.categories`
 ### Start Page Configuration
 
 The start page at `/start` is a personalized landing view: a time-based greeting, the chat input
-of a default app so users can start a conversation immediately, up to four featured apps
-(favorites first, then by `order`) and a link to the full apps browser at `/apps`. It is where
+of a default app so users can start a conversation immediately, a grid of app shortcuts and a
+link to the full apps browser at `/apps`. It is where
 `/` sends users by default, and where the sidebar's **New chat** button always goes. Messages
 typed on the start page open the app at `/apps/{appId}` and are sent right away; attachments
 added on the start page are carried into the chat. The input follows the default app's model settings: the
@@ -427,7 +427,11 @@ Start Page**; existing installations receive the defaults through a configuratio
   "subtitle": {
     "en": "How can I help you today?",
     "de": "Wie kann ich Ihnen heute helfen?"
-  }
+  },
+  "appsMode": "order",
+  "appsCount": 4,
+  "sidebarAppsCount": 5,
+  "featuredAppIds": ["chat", "translator"]
 }
 ```
 
@@ -439,6 +443,40 @@ Start Page**; existing installations receive the defaults through a configuratio
 | `showDefaultApp`   | Boolean | Show the default app's chat input on the start page (default: `true`). When `false`, the page shows the greeting and the featured apps only.                            |
 | `defaultAppId`     | String  | ID of the app whose chat input is shown. When unset — or when the current user cannot access that app — the first app the user can access is used instead.              |
 | `subtitle`         | Object  | Localized line shown under the greeting (overrides the translation value).                                                                                             |
+| `appsMode`         | String  | How apps that are neither favorites nor default apps rank in both app-shortcut lists: `order` (default) or `recent`. See [App shortcuts](#app-shortcuts).               |
+| `appsCount`        | Number  | How many apps the start-page grid shows (0–12, default `4`). `0` hides the grid.                                                                                        |
+| `sidebarAppsCount` | Number  | How many apps the sidebar's Apps section shows (0–12, default `5`). `0` hides the list.                                                                                 |
+| `featuredAppIds`   | Array   | Ids of the default apps, shown in this order right after each user's favorites. Empty by default.                                                                       |
+
+#### App shortcuts
+
+The start-page grid and the sidebar's **Apps** section are the same list of shortcuts in two
+places, so they share one ranking and one set of settings. The ranking is always:
+
+1. **The user's favorites** — the apps they starred, which no configuration can push off the list.
+2. **The default apps** — `featuredAppIds`, in exactly the order the array holds them.
+3. **Everything else** — by `appsMode`: `order` uses each app's `order` field (see
+   [Apps](apps.md)), `recent` puts each user's most recently used apps first, the same way the
+   apps browser's *Relevance* sorting does.
+
+Ties fall back to the app's localized name, so the lists never reshuffle between renders. Apps a
+user may not access are filtered out before ranking, so a default app that is disabled or outside
+the user's groups is simply skipped.
+
+`appsCount` and `sidebarAppsCount` then cut the ranked list to length; because they are separate,
+the start page can show a wide grid while the sidebar stays short. Setting either to `0` hides
+that list. The collapsed sidebar rail shows the same ranking, trimmed to the icons that fit.
+
+Two related settings live elsewhere:
+
+- **The order of the apps themselves** is edited in **Admin → Apps → Reorder** — drag a row or use
+  the up/down arrows, then **Save order**. That writes each app's `order` field, so it also
+  changes the apps browser. All apps are always listed there, so search and filters do not apply
+  while reordering.
+- **The default chat app** (`defaultAppId`, the chat input on the start page) is separate from the
+  default apps above. When it is unset, the top-ranked chat app is used — favorites first, then
+  the default apps, then `order`. `appsMode` deliberately does not apply here: with `recent`, the
+  chat input would change app every time the user opened a different one.
 
 #### Choosing the home page
 

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "test:personal-api-keys": "node server/tests/personalApiKeys.test.js",
     "test:temporal": "node server/tests/agent-temporal-context.test.js && node server/tests/chat-temporal-context.test.js",
     "test:prompts": "node server/tests/promptService.test.js && node server/tests/auto-source-addition.test.js && node server/tests/empty-prompt-bug-validation.test.js",
-    "test:migrations": "node --test server/tests/migration-v086.test.js server/tests/migration-v087.test.js server/tests/migration-v088.test.js server/tests/migration-v089.test.js server/tests/migration-v090.test.js server/tests/migration-v091.test.js",
+    "test:migrations": "node --test server/tests/migration-v086.test.js server/tests/migration-v087.test.js server/tests/migration-v088.test.js server/tests/migration-v089.test.js server/tests/migration-v090.test.js server/tests/migration-v091.test.js server/tests/migration-v092.test.js",
     "test:loop": "node --test server/tests/loop/*.test.js",
     "test:outbound-http": "node --test server/tests/dnsGuard.test.js server/tests/modelDiscoveryCache.test.js",
     "test:auth-routes": "cd server && node --experimental-vm-modules node_modules/jest/bin/jest.js tests/oidc-logout.test.js tests/rateLimiting-auth-readonly-exempt.test.js",

--- a/server/defaults/config/ui.json
+++ b/server/defaults/config/ui.json
@@ -261,7 +261,11 @@
     "subtitle": {
       "en": "How can I help you today?",
       "de": "Wie kann ich Ihnen heute helfen?"
-    }
+    },
+    "appsMode": "order",
+    "appsCount": 4,
+    "sidebarAppsCount": 5,
+    "featuredAppIds": []
   },
   "promptsList": {
     "sort": {

--- a/server/migrations/V092__add_app_shortcut_config.js
+++ b/server/migrations/V092__add_app_shortcut_config.js
@@ -1,0 +1,40 @@
+/**
+ * Migration V092 — Make the app shortcuts configurable in ui.json
+ *
+ * The start page's app grid and the sidebar's Apps section used to be
+ * hard-coded: four apps on the start page, five in the sidebar, ranked
+ * favorites-first and then by the app's `order`. Admins can now configure both
+ * lists under Admin → UI Customization → Start Page, through new fields in the
+ * `startPage` section of ui.json:
+ *
+ * - `appsMode`         — how apps that are neither favorites nor default apps
+ *                        rank: `order` (the app's `order` field) or `recent`
+ *                        (each user's most recently used apps first).
+ * - `appsCount`        — how many apps the start page grid shows.
+ * - `sidebarAppsCount` — how many apps the sidebar's Apps section shows.
+ * - `featuredAppIds`   — the default apps, shown in this order right after
+ *                        each user's favorites.
+ *
+ * The seeded values are exactly the behaviour installs already have, so
+ * upgrading changes nothing on screen. `featuredAppIds` is seeded as an empty
+ * list: with no default apps picked, both lists keep following `appsMode`.
+ */
+
+export const version = '092';
+export const description = 'Make the app shortcuts configurable in ui.json';
+
+export async function precondition(ctx) {
+  return await ctx.fileExists('config/ui.json');
+}
+
+export async function up(ctx) {
+  const ui = await ctx.readJson('config/ui.json');
+
+  ctx.setDefault(ui, 'startPage.appsMode', 'order');
+  ctx.setDefault(ui, 'startPage.appsCount', 4);
+  ctx.setDefault(ui, 'startPage.sidebarAppsCount', 5);
+  ctx.setDefault(ui, 'startPage.featuredAppIds', []);
+
+  await ctx.writeJson('config/ui.json', ui);
+  ctx.log('Applied app-shortcut defaults (startPage.appsMode, counts, featuredAppIds)');
+}

--- a/server/routes/admin/apps.js
+++ b/server/routes/admin/apps.js
@@ -861,6 +861,128 @@ export default function registerAdminAppsRoutes(app) {
 
   /**
    * @swagger
+   * /api/admin/apps/_reorder:
+   *   post:
+   *     summary: Set the display order of applications
+   *     description: |
+   *       Rewrites the `order` field of the given applications so it matches the
+   *       order the ids are sent in: the first id gets `order: 1`, the second
+   *       `order: 2`, and so on. This is what the reorder view in
+   *       **Admin → Apps** saves, and what the apps browser, the start page and
+   *       the sidebar rank by.
+   *
+   *       Only the `order` field of each app's own configuration file is
+   *       touched; apps that are not listed keep the order they have.
+   *     tags:
+   *       - Admin
+   *       - Applications
+   *     security:
+   *       - adminAuth: []
+   *     requestBody:
+   *       required: true
+   *       content:
+   *         application/json:
+   *           schema:
+   *             type: object
+   *             required:
+   *               - ids
+   *             properties:
+   *               ids:
+   *                 type: array
+   *                 items:
+   *                   type: string
+   *                 description: App ids, in the order they should appear
+   *           example:
+   *             ids: ["chat-assistant", "translator", "code-reviewer"]
+   *     responses:
+   *       200:
+   *         description: Order successfully applied
+   *         content:
+   *           application/json:
+   *             schema:
+   *               type: object
+   *               properties:
+   *                 message:
+   *                   type: string
+   *                 ids:
+   *                   type: array
+   *                   items:
+   *                     type: string
+   *                 updated:
+   *                   type: array
+   *                   items:
+   *                     type: string
+   *                   description: Apps whose file actually changed
+   *             example:
+   *               message: "App order updated successfully"
+   *               ids: ["chat-assistant", "translator"]
+   *               updated: ["translator"]
+   *       400:
+   *         description: Bad request - missing, duplicated or unknown ids
+   *       500:
+   *         description: Internal server error
+   */
+  app.post(buildServerPath('/api/admin/apps/_reorder'), contentAdminAuth, async (req, res) => {
+    try {
+      const { ids: requestedIds } = req.body || {};
+      if (!Array.isArray(requestedIds) || requestedIds.length === 0) {
+        return sendBadRequest(res, 'ids must be a non-empty array of app ids');
+      }
+      if (new Set(requestedIds).size !== requestedIds.length) {
+        return sendBadRequest(res, 'ids must not contain duplicates');
+      }
+
+      // Same id validation as every other app route — these reach the filesystem.
+      const ids = validateIdsForPath(requestedIds, 'app', res);
+      if (!ids) {
+        return;
+      }
+
+      const { data: apps } = configCache.getApps(true);
+      const known = new Set(apps.map(a => a.id));
+      const unknown = ids.filter(id => !known.has(id));
+      if (unknown.length > 0) {
+        return sendBadRequest(res, `Unknown app ids: ${unknown.join(', ')}`);
+      }
+
+      const appsDir = join(getRootDir(), 'contents', 'apps');
+      const updated = [];
+
+      for (const [index, id] of ids.entries()) {
+        const order = index + 1;
+        const filename = await findAppFile(id, appsDir);
+        if (!filename) {
+          logger.warn('App file not found', { component: 'AdminApps', id });
+          continue;
+        }
+        const appFilePath = join(appsDir, filename);
+        // Read the file, not the cached entry: the cache holds inheritance
+        // already merged in, and writing that back would freeze a child app's
+        // inherited fields into its own config.
+        const stored = JSON.parse(await fs.readFile(appFilePath, 'utf8'));
+        if (stored.order === order) continue;
+        stored.order = order;
+        await atomicWriteJSON(appFilePath, stored);
+        updated.push(id);
+      }
+
+      await configCache.refreshAppsCache();
+      await logAudit({
+        req,
+        action: 'update',
+        resource: 'app',
+        resourceId: updated.join(','),
+        summary: `Reordered ${ids.length} apps (${updated.length} changed)`
+      });
+
+      res.json({ message: 'App order updated successfully', ids, updated });
+    } catch (error) {
+      return sendInternalError(res, error, 'reorder apps');
+    }
+  });
+
+  /**
+   * @swagger
    * /api/admin/apps/{appIds}/_toggle:
    *   post:
    *     summary: Batch toggle applications enabled/disabled status

--- a/server/routes/admin/ui.js
+++ b/server/routes/admin/ui.js
@@ -22,6 +22,18 @@ import { APP_ID_PATTERN, APP_ID_MAX_LENGTH } from '../../../shared/validationPat
  */
 const VALID_DEFAULT_PAGES = ['start', 'apps', 'page', 'app'];
 
+/**
+ * How the start page and the sidebar rank the apps that are neither favorites
+ * nor admin-picked defaults. Mirrored on the client in utils/appShortcuts.js.
+ */
+const VALID_APP_SHORTCUT_MODES = ['order', 'recent'];
+
+/** Upper bound for `startPage.appsCount` / `startPage.sidebarAppsCount`. */
+const MAX_APP_SHORTCUTS = 12;
+
+/** Nobody curates more default apps than this; the counts cap the lists anyway. */
+const MAX_FEATURED_APPS = 50;
+
 export default function registerAdminUIRoutes(app) {
   // Configure multer for file uploads
   const storage = multer.diskStorage({
@@ -483,6 +495,50 @@ export default function registerAdminUIRoutes(app) {
           !APP_ID_PATTERN.test(value)
         ) {
           throw new Error(`startPage.${field} must be a valid id`);
+        }
+      }
+      // App shortcuts: which apps lead the start-page grid and the sidebar's
+      // Apps section, how the rest rank, and how many each list shows.
+      if (
+        startPage.appsMode !== undefined &&
+        startPage.appsMode !== null &&
+        startPage.appsMode !== ''
+      ) {
+        if (!VALID_APP_SHORTCUT_MODES.includes(startPage.appsMode)) {
+          throw new Error(
+            `startPage.appsMode must be one of: ${VALID_APP_SHORTCUT_MODES.join(', ')}`
+          );
+        }
+      }
+      for (const field of ['appsCount', 'sidebarAppsCount']) {
+        const value = startPage[field];
+        // Unset means "use the built-in default", which the client applies.
+        if (value === undefined || value === null || value === '') continue;
+        if (!Number.isInteger(value) || value < 0 || value > MAX_APP_SHORTCUTS) {
+          throw new Error(
+            `startPage.${field} must be an integer between 0 and ${MAX_APP_SHORTCUTS}`
+          );
+        }
+      }
+      if (startPage.featuredAppIds !== undefined && startPage.featuredAppIds !== null) {
+        const { featuredAppIds } = startPage;
+        if (!Array.isArray(featuredAppIds)) {
+          throw new Error('startPage.featuredAppIds must be an array of app ids');
+        }
+        if (featuredAppIds.length > MAX_FEATURED_APPS) {
+          throw new Error(
+            `startPage.featuredAppIds must not hold more than ${MAX_FEATURED_APPS} ids`
+          );
+        }
+        // These ids end up in /apps/<id> links on the client, so they get the
+        // same treatment as every other app id in this config.
+        for (const id of featuredAppIds) {
+          if (typeof id !== 'string' || id.length > APP_ID_MAX_LENGTH || !APP_ID_PATTERN.test(id)) {
+            throw new Error('startPage.featuredAppIds must only contain valid app ids');
+          }
+        }
+        if (new Set(featuredAppIds).size !== featuredAppIds.length) {
+          throw new Error('startPage.featuredAppIds must not contain duplicates');
         }
       }
     }

--- a/server/tests/migration-v092.test.js
+++ b/server/tests/migration-v092.test.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+
+/**
+ * Migration V092 specs — seeding the app-shortcut settings in ui.json.
+ *
+ * The start-page grid and the sidebar's Apps section are now configurable.
+ * The migration writes the behaviour installs already have (four apps on the
+ * start page, five in the sidebar, ranked by `order`, no curated defaults), so
+ * upgrading changes nothing on screen — and it must never overwrite a value an
+ * admin has already set.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { up, precondition, version } from '../migrations/V092__add_app_shortcut_config.js';
+import { setDefault } from '../migrations/utils.js';
+
+function fakeCtx(files) {
+  const logs = [];
+  return {
+    files,
+    logs,
+    fileExists: async p => p in files,
+    readJson: async p => JSON.parse(JSON.stringify(files[p])),
+    writeJson: async (p, d) => {
+      files[p] = d;
+    },
+    setDefault,
+    log: m => logs.push(m),
+    warn: m => logs.push(m)
+  };
+}
+
+test('version is the next unused number', () => {
+  assert.equal(version, '092');
+});
+
+test('precondition is false when ui.json does not exist', async () => {
+  assert.equal(await precondition(fakeCtx({})), false);
+  assert.equal(await precondition(fakeCtx({ 'config/ui.json': {} })), true);
+});
+
+test('an install without the settings gets the current behaviour spelled out', async () => {
+  const ctx = fakeCtx({
+    'config/ui.json': {
+      title: { en: 'iHub Apps' },
+      startPage: { defaultPage: 'start', showDefaultApp: true }
+    }
+  });
+
+  await up(ctx);
+
+  const { startPage } = ctx.files['config/ui.json'];
+  assert.equal(startPage.appsMode, 'order');
+  assert.equal(startPage.appsCount, 4);
+  assert.equal(startPage.sidebarAppsCount, 5);
+  assert.deepEqual(startPage.featuredAppIds, []);
+
+  // Untouched: everything the earlier migrations seeded.
+  assert.equal(startPage.defaultPage, 'start');
+  assert.equal(startPage.showDefaultApp, true);
+  assert.deepEqual(ctx.files['config/ui.json'].title, { en: 'iHub Apps' });
+});
+
+test('a ui.json without a startPage section gets the whole block', async () => {
+  const ctx = fakeCtx({ 'config/ui.json': {} });
+
+  await up(ctx);
+
+  assert.deepEqual(ctx.files['config/ui.json'].startPage, {
+    appsMode: 'order',
+    appsCount: 4,
+    sidebarAppsCount: 5,
+    featuredAppIds: []
+  });
+});
+
+test('values an admin already configured are preserved', async () => {
+  const ctx = fakeCtx({
+    'config/ui.json': {
+      startPage: {
+        appsMode: 'recent',
+        appsCount: 8,
+        sidebarAppsCount: 0,
+        featuredAppIds: ['chat', 'translate']
+      }
+    }
+  });
+
+  await up(ctx);
+
+  const { startPage } = ctx.files['config/ui.json'];
+  assert.equal(startPage.appsMode, 'recent');
+  assert.equal(startPage.appsCount, 8);
+  assert.equal(startPage.sidebarAppsCount, 0);
+  assert.deepEqual(startPage.featuredAppIds, ['chat', 'translate']);
+});
+
+test('a zero count is a real choice, not a missing value', async () => {
+  // `setDefault` must treat 0 as set — otherwise "hide this list" would be
+  // silently reverted to the default on every upgrade.
+  const ctx = fakeCtx({ 'config/ui.json': { startPage: { appsCount: 0 } } });
+
+  await up(ctx);
+
+  assert.equal(ctx.files['config/ui.json'].startPage.appsCount, 0);
+});
+
+test('the migration reports what it did', async () => {
+  const ctx = fakeCtx({ 'config/ui.json': {} });
+  await up(ctx);
+  assert.ok(ctx.logs.some(l => l.includes('startPage.appsMode')));
+});

--- a/shared/i18n/de.json
+++ b/shared/i18n/de.json
@@ -1915,6 +1915,13 @@
         "appsAsToolsNoResults": "Keine Apps entsprechen Ihrer Suche",
         "appsAsToolsNoApps": "Keine Apps verfügbar",
         "removeAppTool": "{{name}} entfernen"
+      },
+      "reorder": "Reihenfolge",
+      "reorderHelp": "Ziehen Sie eine Zeile oder nutzen Sie die Pfeile, um die Reihenfolge festzulegen, in der Apps für Benutzer erscheinen – in der App-Übersicht, auf der Startseite und in der Seitenleiste. Es werden immer alle Apps aufgelistet, Suche und Filter gelten hier nicht. Gespeichert wird erst mit „Reihenfolge speichern“.",
+      "saveOrder": "Reihenfolge speichern",
+      "savingOrder": "Reihenfolge wird gespeichert...",
+      "status": {
+        "disabled": "Deaktiviert"
       }
     },
     "features": {
@@ -2040,7 +2047,21 @@
         "showDefaultAppHelp": "Wenn deaktiviert, zeigt die Startseite die Begrüßung und Apps, aber keine Chat-Eingabe.",
         "subtitle": "Untertitel",
         "subtitleHelp": "Wird unter der Begrüßung angezeigt. Leer lassen, um den Standardtext zu verwenden.",
-        "unknownApp": "nicht gefunden"
+        "unknownApp": "nicht gefunden",
+        "shortcuts": "App-Verknüpfungen",
+        "shortcutsHelp": "Die kurzen App-Listen auf der Startseite und in der Seitenleiste. Die Favoriten eines Benutzers stehen immer zuerst, dann die unten festgelegten Standard-Apps, danach alle übrigen in der gewählten Reihenfolge.",
+        "appsMode": "Reihenfolge der übrigen Apps",
+        "appsModeOrder": "Konfigurierte Reihenfolge (Feld „order“ der App)",
+        "appsModeRecent": "Zuletzt verwendete zuerst",
+        "appsModeHelp": "Gilt für beide Listen. „Zuletzt verwendete“ sortiert die Apps nach der letzten Nutzung durch den jeweiligen Benutzer, genauso wie in der App-Übersicht; die Standard-Apps stehen weiterhin vorn.",
+        "appsCount": "Apps auf der Startseite",
+        "sidebarAppsCount": "Apps in der Seitenleiste",
+        "appsCountHelp": "Jeweils zwischen 0 und {{max}}. Mit 0 wird die Liste ausgeblendet.",
+        "featuredApps": "Standard-Apps",
+        "featuredAppsEmpty": "Noch keine Standard-Apps – beide Listen folgen der Reihenfolge oben.",
+        "featuredAppsHelp": "Werden in dieser Reihenfolge direkt nach den Favoriten des Benutzers angezeigt. Benutzer ohne Zugriff auf eine App sehen sie nicht. Zum Sortieren ziehen oder die Pfeile verwenden.",
+        "addFeaturedApp": "Standard-App hinzufügen",
+        "removeFeaturedApp": "{{name}} entfernen"
       },
       "header": {
         "colorHint": "Verwenden Sie Hex-Farben (#4f46e5) oder RGB-Werte (rgb(79, 70, 229)). Die Farbe gilt für die klassische Kopfzeile (Teams-, Office- und Nextcloud-Einbettungen, ?sidebar=false); das Seitenleisten-Layout verwendet sie nicht."
@@ -2193,6 +2214,11 @@
         "noMatches": "Keine passenden Werte",
         "noOptions": "Keine Werte"
       }
+    },
+    "reorder": {
+      "dragHandle": "Zum Sortieren ziehen",
+      "moveUp": "{{name}} nach oben verschieben",
+      "moveDown": "{{name}} nach unten verschieben"
     }
   },
   "cloudStorage": {

--- a/shared/i18n/en.json
+++ b/shared/i18n/en.json
@@ -1656,6 +1656,13 @@
         "appsAsToolsNoResults": "No apps match your search",
         "appsAsToolsNoApps": "No apps available",
         "removeAppTool": "Remove {{name}}"
+      },
+      "reorder": "Reorder",
+      "reorderHelp": "Drag a row or use the arrows to set the order apps appear in for users — in the apps browser, on the start page and in the sidebar. Every app is listed, so search and filters do not apply here. Nothing is saved until you choose \"Save order\".",
+      "saveOrder": "Save order",
+      "savingOrder": "Saving order...",
+      "status": {
+        "disabled": "Disabled"
       }
     },
     "features": {
@@ -1781,7 +1788,21 @@
         "showDefaultAppHelp": "When off, the start page shows the greeting and apps but no chat input.",
         "subtitle": "Subtitle",
         "subtitleHelp": "Shown under the greeting. Leave empty to use the built-in text.",
-        "unknownApp": "not found"
+        "unknownApp": "not found",
+        "shortcuts": "App shortcuts",
+        "shortcutsHelp": "The short app lists on the start page and in the sidebar. A user’s favorites always come first, then the default apps below, then everything else in the order you pick.",
+        "appsMode": "Order of the remaining apps",
+        "appsModeOrder": "Configured order (the app’s order field)",
+        "appsModeRecent": "Recently used first",
+        "appsModeHelp": "Applies to both lists. \"Recently used\" ranks the apps each user opened most recently, the same way the apps browser does; the default apps below still lead the list.",
+        "appsCount": "Apps on the start page",
+        "sidebarAppsCount": "Apps in the sidebar",
+        "appsCountHelp": "Between 0 and {{max}} each. Set 0 to hide a list.",
+        "featuredApps": "Default apps",
+        "featuredAppsEmpty": "No default apps yet — both lists follow the order above.",
+        "featuredAppsHelp": "Shown in this order, right after each user’s favorites. Users who cannot access an app never see it. Drag a row or use the arrows to reorder.",
+        "addFeaturedApp": "Add a default app",
+        "removeFeaturedApp": "Remove {{name}}"
       },
       "header": {
         "colorHint": "Use hex colors (#4f46e5) or rgb values (rgb(79, 70, 229)). The colour applies to the classic top header (Teams, Office and Nextcloud embeds, ?sidebar=false); the sidebar layout does not use it."
@@ -1934,6 +1955,11 @@
         "noMatches": "No matching values",
         "noOptions": "No values"
       }
+    },
+    "reorder": {
+      "dragHandle": "Drag to reorder",
+      "moveUp": "Move {{name}} up",
+      "moveDown": "Move {{name}} down"
     }
   },
   "cloudStorage": {

--- a/tests/unit/client/app-shortcuts.test.jsx
+++ b/tests/unit/client/app-shortcuts.test.jsx
@@ -1,0 +1,174 @@
+import {
+  APP_SHORTCUT_MODES,
+  DEFAULT_APP_SHORTCUT_MODE,
+  DEFAULT_SIDEBAR_APPS_COUNT,
+  DEFAULT_START_PAGE_APPS_COUNT,
+  MAX_APP_SHORTCUTS,
+  rankAppShortcuts,
+  readAppShortcutConfig
+} from '../../../client/src/utils/appShortcuts';
+
+/**
+ * The start page grid and the sidebar's Apps section show the same short list
+ * of apps, so they share one ranking and one piece of config. Two promises
+ * hold everywhere: a user's own favorites are never pushed off the list by
+ * configuration, and a hand-edited ui.json can never produce a broken list.
+ */
+
+const ui = startPage => ({ startPage });
+
+describe('readAppShortcutConfig', () => {
+  test('falls back to the built-in defaults', () => {
+    for (const config of [undefined, {}, ui(undefined), ui({})]) {
+      expect(readAppShortcutConfig(config)).toEqual({
+        mode: DEFAULT_APP_SHORTCUT_MODE,
+        featuredAppIds: [],
+        startPageCount: DEFAULT_START_PAGE_APPS_COUNT,
+        sidebarCount: DEFAULT_SIDEBAR_APPS_COUNT
+      });
+    }
+  });
+
+  test('reads what the admin configured', () => {
+    expect(
+      readAppShortcutConfig(
+        ui({
+          appsMode: 'recent',
+          appsCount: 6,
+          sidebarAppsCount: 3,
+          featuredAppIds: ['chat', 'translate']
+        })
+      )
+    ).toEqual({
+      mode: 'recent',
+      featuredAppIds: ['chat', 'translate'],
+      startPageCount: 6,
+      sidebarCount: 3
+    });
+  });
+
+  test('0 hides a list and is not mistaken for "unset"', () => {
+    const config = readAppShortcutConfig(ui({ appsCount: 0, sidebarAppsCount: 0 }));
+    expect(config.startPageCount).toBe(0);
+    expect(config.sidebarCount).toBe(0);
+  });
+
+  test('clamps and repairs values a hand-edited config could hold', () => {
+    const config = readAppShortcutConfig(
+      ui({
+        appsMode: 'nonsense',
+        appsCount: 999,
+        sidebarAppsCount: -4,
+        featuredAppIds: ['chat', '', 'chat', null, 'translate', 7]
+      })
+    );
+    expect(config.mode).toBe(DEFAULT_APP_SHORTCUT_MODE);
+    expect(config.startPageCount).toBe(MAX_APP_SHORTCUTS);
+    expect(config.sidebarCount).toBe(0);
+    // Blanks, duplicates and non-strings cannot claim a slot.
+    expect(config.featuredAppIds).toEqual(['chat', 'translate']);
+  });
+
+  test('a non-numeric or non-array value falls back instead of throwing', () => {
+    const config = readAppShortcutConfig(
+      ui({ appsCount: 'four', sidebarAppsCount: null, featuredAppIds: 'chat' })
+    );
+    expect(config.startPageCount).toBe(DEFAULT_START_PAGE_APPS_COUNT);
+    expect(config.sidebarCount).toBe(DEFAULT_SIDEBAR_APPS_COUNT);
+    expect(config.featuredAppIds).toEqual([]);
+  });
+
+  test('the accepted modes are the two the admin UI offers', () => {
+    expect(APP_SHORTCUT_MODES).toEqual(['order', 'recent']);
+  });
+});
+
+describe('rankAppShortcuts', () => {
+  const apps = [
+    { id: 'alpha', order: 3, name: { en: 'Alpha' } },
+    { id: 'beta', order: 1, name: { en: 'Beta' } },
+    { id: 'gamma', order: 2, name: { en: 'Gamma' } },
+    { id: 'delta', name: { en: 'Delta' } }
+  ];
+  const ids = list => list.map(app => app.id);
+
+  test('ranks by the configured order, apps without one last', () => {
+    expect(ids(rankAppShortcuts(apps))).toEqual(['beta', 'gamma', 'alpha', 'delta']);
+  });
+
+  test('leaves the input array alone', () => {
+    const input = [...apps];
+    rankAppShortcuts(input, { favoriteAppIds: ['delta'] });
+    expect(input).toEqual(apps);
+  });
+
+  test('favorites come first, in the configured order among themselves', () => {
+    expect(ids(rankAppShortcuts(apps, { favoriteAppIds: ['delta', 'alpha'] }))).toEqual([
+      'alpha',
+      'delta',
+      'beta',
+      'gamma'
+    ]);
+  });
+
+  test('the admin default apps follow the favorites, in the admin order', () => {
+    expect(ids(rankAppShortcuts(apps, { featuredAppIds: ['delta', 'gamma'] }))).toEqual([
+      'delta',
+      'gamma',
+      'beta',
+      'alpha'
+    ]);
+  });
+
+  test('a favorite outranks the admin default apps', () => {
+    // `alpha` sorts last on order and is not a default app — being a favorite
+    // still puts it on top, which is the promise the sidebar and start page make.
+    expect(
+      ids(
+        rankAppShortcuts(apps, {
+          favoriteAppIds: ['alpha'],
+          featuredAppIds: ['delta', 'gamma']
+        })
+      )
+    ).toEqual(['alpha', 'delta', 'gamma', 'beta']);
+  });
+
+  test('recent mode ranks the most recently used first', () => {
+    expect(
+      ids(rankAppShortcuts(apps, { mode: 'recent', recentAppIds: ['delta', 'alpha'] }))
+    ).toEqual(['delta', 'alpha', 'beta', 'gamma']);
+  });
+
+  test('recent mode still keeps favorites and default apps in front', () => {
+    expect(
+      ids(
+        rankAppShortcuts(apps, {
+          mode: 'recent',
+          recentAppIds: ['alpha', 'gamma'],
+          favoriteAppIds: ['beta'],
+          featuredAppIds: ['delta']
+        })
+      )
+    ).toEqual(['beta', 'delta', 'alpha', 'gamma']);
+  });
+
+  test('recent ids that are not accessible apps are simply ignored', () => {
+    expect(
+      ids(rankAppShortcuts(apps, { mode: 'recent', recentAppIds: ['deleted', 'gamma'] }))
+    ).toEqual(['gamma', 'beta', 'alpha', 'delta']);
+  });
+
+  test('apps that tie on everything fall back to their localized name', () => {
+    const untidy = [
+      { id: 'b', name: { en: 'Second' } },
+      { id: 'a', name: { en: 'First' } }
+    ];
+    expect(ids(rankAppShortcuts(untidy, { currentLanguage: 'en' }))).toEqual(['a', 'b']);
+  });
+
+  test('survives apps without a name and a missing list', () => {
+    expect(ids(rankAppShortcuts([{ id: 'b' }, { id: 'a' }]))).toEqual(['a', 'b']);
+    expect(rankAppShortcuts(undefined)).toEqual([]);
+    expect(rankAppShortcuts(null, { favoriteAppIds: null, featuredAppIds: null })).toEqual([]);
+  });
+});

--- a/tests/unit/client/reorderable-list.test.jsx
+++ b/tests/unit/client/reorderable-list.test.jsx
@@ -1,0 +1,150 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * ReorderableList — the admin control behind "Reorder" in Admin → Apps and the
+ * default-app list under UI Customization → Start Page (issue #2297).
+ *
+ * Pointer drag has no keyboard equivalent, so the up/down buttons are the
+ * accessible path and must produce exactly the same order as a drag. The
+ * component owns no copy of the list: every move reports the whole new order
+ * back to the parent.
+ */
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, defaultValue, opts) => {
+      let str = defaultValue ?? key;
+      if (opts && typeof str === 'string') {
+        for (const [k, v] of Object.entries(opts)) {
+          str = str.replace(new RegExp(`{{${k}}}`, 'g'), v);
+        }
+      }
+      return str;
+    },
+    i18n: { language: 'en' }
+  })
+}));
+
+jest.mock('../../../client/src/shared/components/Icon', () => {
+  return function Icon({ name }) {
+    return <span data-testid={`icon-${name}`}>{name}</span>;
+  };
+});
+
+import ReorderableList from '../../../client/src/features/admin/components/ReorderableList';
+
+const ITEMS = [
+  { id: 'a', label: 'Alpha' },
+  { id: 'b', label: 'Beta' },
+  { id: 'c', label: 'Gamma' }
+];
+
+const renderList = (props = {}) => {
+  const onReorder = jest.fn();
+  const utils = render(
+    <ReorderableList
+      items={ITEMS}
+      onReorder={onReorder}
+      getKey={item => item.id}
+      getLabel={item => item.label}
+      renderItem={item => <span>{item.label}</span>}
+      {...props}
+    />
+  );
+  return { onReorder, ...utils };
+};
+
+const dragTo = (from, to) => {
+  const rows = screen.getAllByRole('listitem');
+  const data = {};
+  const dataTransfer = {
+    setData: (type, value) => {
+      data[type] = value;
+    },
+    getData: type => data[type]
+  };
+  fireEvent.dragStart(rows[from], { dataTransfer });
+  fireEvent.dragOver(rows[to], { dataTransfer });
+  fireEvent.drop(rows[to], { dataTransfer });
+};
+
+describe('ReorderableList', () => {
+  test('renders every item with both move buttons', () => {
+    renderList();
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    expect(screen.getByLabelText('Move Alpha down')).toBeInTheDocument();
+    expect(screen.getByLabelText('Move Gamma up')).toBeInTheDocument();
+  });
+
+  test('the arrow buttons report the whole reordered list', () => {
+    const { onReorder } = renderList();
+
+    fireEvent.click(screen.getByLabelText('Move Gamma up'));
+
+    expect(onReorder).toHaveBeenCalledTimes(1);
+    expect(onReorder.mock.calls[0][0].map(item => item.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  test('moving down is the mirror of moving up', () => {
+    const { onReorder } = renderList();
+
+    fireEvent.click(screen.getByLabelText('Move Alpha down'));
+
+    expect(onReorder.mock.calls[0][0].map(item => item.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  test('the list stays put until the parent re-renders it', () => {
+    // The component holds no copy of the order, so one click can never move an
+    // item twice — the parent is the single source of truth.
+    const { onReorder } = renderList();
+
+    fireEvent.click(screen.getByLabelText('Move Gamma up'));
+    fireEvent.click(screen.getByLabelText('Move Gamma up'));
+
+    expect(onReorder).toHaveBeenCalledTimes(2);
+    expect(onReorder.mock.calls[1][0].map(item => item.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  test('the ends cannot be moved off the list', () => {
+    const { onReorder } = renderList();
+
+    expect(screen.getByLabelText('Move Alpha up')).toBeDisabled();
+    expect(screen.getByLabelText('Move Gamma down')).toBeDisabled();
+
+    fireEvent.click(screen.getByLabelText('Move Alpha up'));
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  test('dragging a row onto another lands it in that position', () => {
+    const { onReorder } = renderList();
+
+    dragTo(2, 0);
+
+    expect(onReorder).toHaveBeenCalledTimes(1);
+    expect(onReorder.mock.calls[0][0].map(item => item.id)).toEqual(['c', 'a', 'b']);
+  });
+
+  test('dropping a row on itself changes nothing', () => {
+    const { onReorder } = renderList();
+
+    dragTo(1, 1);
+
+    expect(onReorder).not.toHaveBeenCalled();
+  });
+
+  test('trailing actions render next to each row', () => {
+    renderList({
+      renderActions: item => <button aria-label={`Remove ${item.label}`} />
+    });
+
+    expect(screen.getByLabelText('Remove Beta')).toBeInTheDocument();
+  });
+
+  test('disabled drops every reordering affordance', () => {
+    renderList({ disabled: true });
+
+    expect(screen.queryByLabelText('Move Alpha down')).not.toBeInTheDocument();
+    expect(screen.getAllByRole('listitem')[0]).not.toHaveAttribute('draggable', 'true');
+  });
+});


### PR DESCRIPTION
Closes #2297.

The start-page grid and the sidebar's Apps section were hard-coded at four and five apps, ranked favorites-first then by the app's `order`. Both are now admin-configurable, and the app order itself is editable by drag and drop.

## What admins get

**UI Customization → Start Page** gains an *App shortcuts* section, backed by four new `ui.json → startPage` fields:

| Field | What it does |
| --- | --- |
| `featuredAppIds` | The **default apps** — shown in this order right after each user's favorites. Reorderable by drag or arrow buttons, removable, added from a searchable select. |
| `appsMode` | How everything else ranks: `order` (the app's `order` field, default) or `recent` (each user's most recently used apps first — the ranking the apps browser already offered). |
| `appsCount` | How many apps the start-page grid shows (0–12, default 4). |
| `sidebarAppsCount` | How many apps the sidebar's Apps section shows (0–12, default 5). `0` hides a list. |

**Admin → Apps** gains a **Reorder** button: a draggable list with up/down arrows, then *Save order* / *Cancel*. It writes each app's `order` field, so the new order also applies to the apps browser.

## How the ranking works

Both surfaces now share one helper (`client/src/utils/appShortcuts.js`):

1. **The user's favorites** — configuration can never push a user's own picks off the list.
2. **The default apps** — in exactly the order the admin set.
3. **Everything else** — by `appsMode`, with the localized name as a stable tie-breaker so the lists never reshuffle between renders.

Every value is normalized on read (unknown mode → default, counts clamped to 0–12, blank/duplicate/non-string ids dropped), so a hand-edited `ui.json` cannot produce a broken list. `null`/`''` mean "unset" and fall back to the built-in default; a written `0` is a real choice and hides the list.

Two deliberate decisions worth reviewing:

- **The default chat app keeps ignoring `appsMode`.** Under `recent`, the start page's chat input would swap apps every time a user opened a different one. Its fallback stays favorites → default apps → `order`.
- **Reorder mode ignores search and filters.** It renumbers every app, so saving a filtered subset would leave the apps outside it with stale numbers. The hint text says so.

The collapsed sidebar rail now shows the same ranked apps instead of favorites only, so a user with no favorites still gets shortcuts there.

## Server

New `POST /api/admin/apps/_reorder` (`{ ids: [...] }`) renumbers `order` to 1..n in the order sent. It rejects empty/duplicate/unknown/malformed ids (same `validateIdsForPath` check as every other app route), and writes each app's **own file** rather than the cached entry — the cache holds inheritance already merged in, and writing that back would freeze a child app's inherited fields into its own config. Apps not listed keep the order they have.

`validateUIConfig` validates the four new `startPage` fields (mode allow-list, integer 0–12 counts, and app-id-shaped, duplicate-free `featuredAppIds` — those ids reach `/apps/<id>` links on the client).

## Notes

- **Migration V092** seeds the current behaviour as explicit defaults (`order`, 4, 5, `[]`), so upgrading changes nothing on screen. `server/defaults/config/ui.json` carries the same values for fresh installs.
- Removes `sortFavoritesFirst` from `utils/favoriteItems.js` — the new ranking replaced its last two callers, leaving it unreferenced.
- New i18n keys added to both `en.json` and `de.json`.
- Docs: `docs/ui.md` (new *App shortcuts* subsection + field table), `docs/apps.md` (`order` now points at the reorder view), and a changelog entry in `docs/releases/5.5.0/features.md`.

## Testing

- `tests/unit/client/app-shortcuts.test.jsx` — 15 tests over the ranking and config normalization (favorites outrank default apps, recent mode, clamping, hand-edited values, input not mutated).
- `tests/unit/client/reorderable-list.test.jsx` — 9 tests over the reorder control (arrows and drag produce the same order, ends disabled, no internal copy of the list, `disabled` drops every affordance).
- `server/tests/migration-v092.test.js` — 7 tests, registered in `npm run test:migrations`.
- `npm run test:unit` (64 suites / 762 tests) and `npm run test:migrations` (47 tests) pass; ESLint reports 0 errors on the changed files; client build succeeds.
- Verified end-to-end against a freshly booted dev server: the reorder endpoint (success + every rejection path + 401 unauthenticated), the UI-config validation (valid save + six invalid payloads), and in the browser — start-page grid honouring `appsCount: 6` with the favorite first and the default app second, the sidebar honouring `sidebarAppsCount: 3`, and Admin → Apps reorder renumbering correctly after a move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DiZeGDyEtNi2khXdzPcwr9

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiZeGDyEtNi2khXdzPcwr9)_