### PR TITLE
fix(start-page): offer the app's chat features in the + menu (#2322)

### DIFF
--- a/client/src/features/apps/pages/AppChat.jsx
+++ b/client/src/features/apps/pages/AppChat.jsx
@@ -354,16 +354,37 @@ function AppChat({ preloadedApp = null }) {
   );
   useNextcloudEmbedAttachments(fileUploadHandler, app, currentModelObject);
 
-  // Consume any attachments handed off from the start page. The message text
-  // and auto-send still arrive via the `prefill` / `send=true` query params;
-  // here we only restore the already-processed file payload so the auto-send
-  // includes it.
+  // Consume the start-page handoff: the already-processed file payload plus the
+  // feature toggles the user picked in that page's actions menu (web search,
+  // tools, image settings, transcription — issue #2322). The message text and
+  // auto-send still arrive via the `prefill` / `send=true` query params.
+  //
+  // Gated on `app && !modelsLoading` on purpose: `useAppSettings` seeds those
+  // same values from the app config on exactly that gate, and its effect is
+  // registered before this one, so applying here reliably lands *after* the
+  // seeding instead of being overwritten by it.
+  const handoffAppliedRef = useRef(false);
   useEffect(() => {
+    handoffAppliedRef.current = false;
+  }, [appId]);
+  useEffect(() => {
+    if (handoffAppliedRef.current || !app || modelsLoading) return;
     const handoff = consumePendingChatStart(appId);
-    if (handoff?.files) {
+    handoffAppliedRef.current = true;
+    if (!handoff) return;
+    if (handoff.files) {
       fileUploadHandler.setSelectedFile(handoff.files);
     }
-  }, [appId]); // eslint-disable-line @eslint-react/exhaustive-deps
+    const settings = handoff.settings;
+    if (!settings) return;
+    if (Array.isArray(settings.enabledTools)) setEnabledTools(settings.enabledTools);
+    if (typeof settings.websearchEnabled === 'boolean')
+      setWebsearchEnabled(settings.websearchEnabled);
+    if (typeof settings.transcriptionEnabled === 'boolean')
+      setTranscriptionEnabled(settings.transcriptionEnabled);
+    if (settings.imageAspectRatio) setImageAspectRatio(settings.imageAspectRatio);
+    if (settings.imageQuality) setImageQuality(settings.imageQuality);
+  }, [app, appId, modelsLoading]); // eslint-disable-line @eslint-react/exhaustive-deps
 
   // Check document token size against model context window and warn user if needed
   useEffect(() => {

--- a/client/src/features/apps/pages/StartPage.jsx
+++ b/client/src/features/apps/pages/StartPage.jsx
@@ -21,8 +21,10 @@ import { buildAssetUrl } from '../../../utils/runtimeBasePath';
 import ChatInput from '../../chat/components/ChatInput';
 import useFileUploadHandler from '../../../shared/hooks/useFileUploadHandler';
 import useVoiceCommands from '../../voice/hooks/useVoiceCommands';
+import useMagicPrompt from '../../../shared/hooks/useMagicPrompt';
 import { setPendingChatStart } from '../../chat/startChatHandoff';
 import { buildStartPageGreeting } from '../../../utils/startPageGreeting';
+import { loadAppSettings } from '../../../utils/appSettings';
 
 export default function StartPage() {
   const { t, i18n } = useTranslation();
@@ -41,6 +43,18 @@ export default function StartPage() {
   // Models the viewer may use, tagged with the identity they were loaded for.
   const [modelsState, setModelsState] = useState({ key: null, models: [], loaded: false });
   const [selectedModel, setSelectedModel] = useState(null);
+
+  // Per-chat feature toggles offered by the input's actions menu (the `+`).
+  // The start page renders the default app's real chat input, so it has to
+  // own this state too — otherwise the menu shows the app's tools with no way
+  // to toggle them and hides web search entirely (issue #2322). `null` for
+  // the tools means "not resolved yet", matching AppChat's convention of
+  // passing `null` to hide the tools section outright.
+  const [enabledTools, setEnabledTools] = useState(null);
+  const [websearchEnabled, setWebsearchEnabled] = useState(false);
+  const [transcriptionEnabled, setTranscriptionEnabled] = useState(true);
+  const [imageAspectRatio, setImageAspectRatio] = useState('1:1');
+  const [imageQuality, setImageQuality] = useState('Medium');
 
   const inputRef = useRef(null);
   const formRef = useRef(null);
@@ -178,6 +192,54 @@ export default function StartPage() {
     });
   }, [defaultAppDetails, compatibleModels]);
 
+  // Seed the actions-menu toggles from the app config, then let anything the
+  // user already chose for this app in the current session win — the same
+  // precedence `useAppSettings` applies inside the app, so the `+` menu shows
+  // the same state on both surfaces.
+  useEffect(() => {
+    if (!defaultAppDetails) {
+      setEnabledTools(null);
+      return;
+    }
+    const saved = loadAppSettings(defaultAppDetails.id) || {};
+    setEnabledTools(
+      Array.isArray(saved.enabledTools) ? saved.enabledTools : defaultAppDetails.tools || []
+    );
+    setWebsearchEnabled(
+      saved.websearchEnabled ?? defaultAppDetails.websearch?.enabledByDefault ?? false
+    );
+    setTranscriptionEnabled(defaultAppDetails.transcription?.defaultEnabled !== false);
+    setImageAspectRatio(
+      saved.imageAspectRatio || defaultAppDetails.imageGeneration?.aspectRatio || '1:1'
+    );
+    setImageQuality(saved.imageQuality || defaultAppDetails.imageGeneration?.quality || 'Medium');
+  }, [defaultAppDetails]);
+
+  // Platform-wide kill switch for tools, mirroring AppChat: `null` keeps the
+  // tools section out of the actions menu entirely.
+  const toolsFeatureEnabled = featureFlags.isEnabled('tools', true);
+  const effectiveEnabledTools = toolsFeatureEnabled ? enabledTools : null;
+
+  // Magic prompt rewrites the draft in place, exactly as it does in the app.
+  const magicPromptHandler = useMagicPrompt();
+  const magicPromptEnabled = featureFlags.isAppFeatureEnabled(
+    defaultAppDetails,
+    'magicPrompt.enabled',
+    false
+  );
+  const handleMagicPrompt = useCallback(async () => {
+    const enhanced = await magicPromptHandler.handleMagicPrompt(
+      draft,
+      defaultAppDetails,
+      defaultAppDetails?.id
+    );
+    if (enhanced) setDraft(enhanced);
+  }, [draft, defaultAppDetails, magicPromptHandler]);
+  const handleUndoMagicPrompt = useCallback(() => {
+    const restored = magicPromptHandler.handleUndoMagicPrompt();
+    if (restored !== null) setDraft(restored);
+  }, [magicPromptHandler]);
+
   // Same rule as the in-app chat; ChatInput shows its "No models available"
   // notice when the list is empty, so a misconfigured group is visible rather
   // than silently hiding the selector. Kept hidden until the list has loaded.
@@ -198,10 +260,19 @@ export default function StartPage() {
 
   const recentChats = chatHistoryEnabled ? MOCK_CHATS.slice(0, 3) : [];
 
+  // The model object (not just its id) drives the image-generation controls and
+  // the upload config's vision/audio gating, same as in the app chat.
+  const selectedModelObject = useMemo(
+    () => compatibleModels.find(m => m.id === selectedModel) || null,
+    [compatibleModels, selectedModel]
+  );
+
   const uploadConfig = useMemo(
     () =>
-      defaultAppDetails ? fileUploadHandler.createUploadConfig(defaultAppDetails, null) : undefined,
-    [defaultAppDetails, fileUploadHandler]
+      defaultAppDetails
+        ? fileUploadHandler.createUploadConfig(defaultAppDetails, selectedModelObject)
+        : undefined,
+    [defaultAppDetails, fileUploadHandler, selectedModelObject]
   );
 
   // Start the chat: carry the message via prefill+send (so refresh/shared links
@@ -214,9 +285,20 @@ export default function StartPage() {
       const hasFile = fileUploadHandler.selectedFile != null;
       if (!text && !hasFile && !defaultAppDetails?.allowEmptyContent) return;
 
-      if (hasFile) {
-        setPendingChatStart({ appId: defaultApp.id, files: fileUploadHandler.selectedFile });
-      }
+      // Hand the app the toggles picked here (and any processed attachment) so
+      // the auto-sent first message runs with the same features the user saw
+      // in the `+` menu — issue #2322.
+      setPendingChatStart({
+        appId: defaultApp.id,
+        ...(hasFile ? { files: fileUploadHandler.selectedFile } : {}),
+        settings: {
+          ...(effectiveEnabledTools !== null ? { enabledTools: effectiveEnabledTools } : {}),
+          websearchEnabled,
+          transcriptionEnabled,
+          imageAspectRatio,
+          imageQuality
+        }
+      });
 
       const params = new URLSearchParams();
       if (text) {
@@ -230,7 +312,19 @@ export default function StartPage() {
       const qs = params.toString();
       navigate(`/apps/${defaultApp.id}${qs ? `?${qs}` : ''}`);
     },
-    [draft, defaultApp, defaultAppDetails, fileUploadHandler, navigate, selectedModel]
+    [
+      draft,
+      defaultApp,
+      defaultAppDetails,
+      fileUploadHandler,
+      navigate,
+      selectedModel,
+      effectiveEnabledTools,
+      websearchEnabled,
+      transcriptionEnabled,
+      imageAspectRatio,
+      imageQuality
+    ]
   );
 
   const logoSrc = uiConfig?.header?.logo?.url ? buildAssetUrl(uiConfig.header.logo.url) : null;
@@ -309,6 +403,29 @@ export default function StartPage() {
                 }
                 onVoiceInput={micEnabled ? handleVoiceInput : undefined}
                 onVoiceCommand={micEnabled ? handleVoiceCommand : undefined}
+                magicPromptEnabled={magicPromptEnabled}
+                onMagicPrompt={handleMagicPrompt}
+                showUndoMagicPrompt={magicPromptHandler.showUndoMagicPrompt}
+                onUndoMagicPrompt={handleUndoMagicPrompt}
+                magicPromptLoading={magicPromptHandler.magicLoading}
+                enabledTools={effectiveEnabledTools}
+                onEnabledToolsChange={toolsFeatureEnabled ? setEnabledTools : undefined}
+                websearchEnabled={websearchEnabled}
+                onWebsearchEnabledChange={
+                  defaultAppDetails?.websearch?.enabled ? setWebsearchEnabled : undefined
+                }
+                transcriptionAvailable={defaultAppDetails?.transcription?.enabled === true}
+                transcriptionEnabled={transcriptionEnabled}
+                onTranscriptionEnabledChange={
+                  defaultAppDetails?.transcription?.enabled === true
+                    ? setTranscriptionEnabled
+                    : undefined
+                }
+                model={selectedModelObject}
+                imageAspectRatio={imageAspectRatio}
+                imageQuality={imageQuality}
+                onImageAspectRatioChange={setImageAspectRatio}
+                onImageQualityChange={setImageQuality}
                 models={compatibleModels}
                 selectedModel={selectedModel}
                 onModelChange={setSelectedModel}

--- a/client/src/features/chat/startChatHandoff.js
+++ b/client/src/features/chat/startChatHandoff.js
@@ -4,12 +4,24 @@
 // upload payload here and let AppChat consume it on mount. The text + auto-send
 // still flow through the `prefill` / `send=true` query params so a refresh or a
 // shared link keeps working without relying on this volatile state.
+//
+// The same channel carries the feature toggles the user picked in the start
+// page's actions menu (web search, tools, image settings, transcription).
+// Those are per-chat choices rather than shareable link state, so they ride
+// along here instead of bloating the query string — AppChat applies them once
+// its own settings have been seeded from the app config.
 
 let pending = null;
 
 /**
  * Store a pending handoff for a specific app.
- * @param {{ appId: string, files?: any }} data
+ * @param {{ appId: string, files?: any, settings?: {
+ *   enabledTools?: string[],
+ *   websearchEnabled?: boolean,
+ *   transcriptionEnabled?: boolean,
+ *   imageAspectRatio?: string,
+ *   imageQuality?: string
+ * } }} data
  */
 export function setPendingChatStart(data) {
   pending = data || null;
@@ -18,7 +30,7 @@ export function setPendingChatStart(data) {
 /**
  * Consume (and clear) the pending handoff if it matches the given app.
  * @param {string} appId
- * @returns {{ appId: string, files?: any } | null}
+ * @returns {{ appId: string, files?: any, settings?: Object } | null}
  */
 export function consumePendingChatStart(appId) {
   if (pending && pending.appId === appId) {

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -566,3 +566,21 @@ OpenAI-compatible servers are the usual culprits.
   sent again.
 - The wait *before* the first piece of an answer is unchanged, so a model that
   thinks for a long time before it starts writing is not cut off.
+
+## Web Search and Tools Are Available From the Start Page
+
+The chat box on the start page hid most of the app's per-chat features. Opening
+the **+** menu there showed no web search toggle at all, and the app's tools were
+listed with every one switched off and no way to turn any of them on — so a
+question that needed a web lookup or a tool had to be re-typed inside the app.
+
+- The **+** menu on the start page now offers the same controls as the app it
+  starts: web search, the app's tools (pre-selected exactly as the app
+  configures them), the transcription toggle and the image-generation settings.
+- Magic Prompt now works from the start page too.
+- Whatever is picked there applies to the first message, which is sent
+  automatically on arrival in the app — the choice is no longer lost in the jump.
+- The toggles open in the state already chosen for that app in the current
+  session, so the start page and the app agree.
+- Upload options now follow the model selected on the start page, so image or
+  audio attachments are offered based on the model that will actually answer.

--- a/docs/ui.md
+++ b/docs/ui.md
@@ -416,6 +416,12 @@ model selector appears unless the app disables it, lists the models the current 
 with that app, and shows the same "No models available" notice as the chat when the user's
 groups permit none.
 
+The input is the default app's real chat input, so its **+** menu offers the same per-chat
+features the app itself offers — web search, the app's tools, the transcription toggle, the
+image-generation settings and Magic Prompt — each shown only when the app (and the platform
+feature flag) enables it. The toggles open in the state already chosen for that app in the
+current session, and whatever is picked applies to the first message when it is sent in the app.
+
 The `startPage` section configures it. It can be edited under **Admin → UI Customization →
 Start Page**; existing installations receive the defaults through a configuration migration.
 

--- a/tests/unit/client/start-page-chat-features.test.jsx
+++ b/tests/unit/client/start-page-chat-features.test.jsx
@@ -1,0 +1,189 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * Regression coverage for issue #2322: the start page renders the default
+ * app's real chat input, but it never passed the per-chat feature props, so
+ * the `+` menu hid web search entirely and listed the app's tools with every
+ * one switched off and no working toggle. The picks also have to reach the
+ * app, because the first message is auto-sent there.
+ */
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key, defaultValue) => defaultValue ?? key,
+    i18n: { language: 'en' }
+  })
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => mockNavigate
+}));
+
+const mockApp = {
+  id: 'chat',
+  name: { en: 'Chat' },
+  description: { en: 'General chat' },
+  color: '#4f46e5',
+  icon: 'chat',
+  tools: ['braveSearch', 'jira'],
+  websearch: { enabled: true, enabledByDefault: false },
+  transcription: { enabled: true, defaultEnabled: true },
+  features: { magicPrompt: { enabled: true } }
+};
+
+const mockModelList = [{ id: 'gpt', name: { en: 'GPT' } }];
+
+jest.mock('../../../client/src/api', () => ({
+  fetchAppDetails: jest.fn(() => Promise.resolve(mockApp)),
+  fetchModels: jest.fn(() => Promise.resolve(mockModelList)),
+  // The server localizes tool metadata, so names arrive as plain strings.
+  fetchToolsBasic: jest.fn(() =>
+    Promise.resolve([
+      { id: 'braveSearch', name: 'Brave Search' },
+      { id: 'jira', name: 'Jira' }
+    ])
+  ),
+  generateMagicPrompt: jest.fn(() => Promise.resolve({ prompt: 'enhanced' }))
+}));
+
+jest.mock('../../../client/src/shared/contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { id: 'u1', name: 'Ada' } })
+}));
+
+jest.mock('../../../client/src/shared/contexts/UIConfigContext', () => ({
+  useUIConfig: () => ({ uiConfig: {}, resetHeaderColor: jest.fn(), setHeaderColor: jest.fn() })
+}));
+
+jest.mock('../../../client/src/shared/contexts/PlatformConfigContext', () => ({
+  usePlatformConfig: () => ({ platformConfig: { features: {} } })
+}));
+
+jest.mock('../../../client/src/shared/hooks/useApps', () => ({
+  __esModule: true,
+  default: () => ({ apps: [{ id: 'chat', name: { en: 'Chat' }, icon: 'chat' }], loading: false })
+}));
+
+jest.mock('../../../client/src/shared/hooks/useAuthKey', () => ({
+  __esModule: true,
+  default: () => 'anon'
+}));
+
+jest.mock('../../../client/src/shared/hooks/useFavorites', () => ({
+  __esModule: true,
+  default: () => ({ favorites: [] })
+}));
+
+// `runtimeBasePath` reads `import.meta.env`, which the CJS test transform
+// cannot parse.
+jest.mock('../../../client/src/utils/runtimeBasePath', () => ({
+  buildAssetUrl: path => path,
+  getBasePath: () => '',
+  KNOWN_ROUTES: []
+}));
+
+// Leaf components that reach for browser APIs jsdom does not provide.
+jest.mock('../../../client/src/features/voice/components', () => ({
+  VoiceInputComponent: () => null
+}));
+jest.mock('../../../client/src/features/prompts/components/PromptSearch', () => () => null);
+jest.mock('../../../client/src/features/chat/components/WorkflowMentionSearch', () => () => null);
+jest.mock('../../../client/src/features/upload/components', () => ({
+  UnifiedUploader: () => null,
+  CloudStoragePicker: () => null,
+  AttachedFilesList: () => null
+}));
+
+const StartPage = require('../../../client/src/features/apps/pages/StartPage').default;
+const { consumePendingChatStart } = require('../../../client/src/features/chat/startChatHandoff');
+
+/** Render the page and wait for the default app's config + models to land. */
+async function renderStartPage() {
+  const utils = render(<StartPage />);
+  await waitFor(() => expect(screen.getByRole('textbox')).toBeInTheDocument());
+  return utils;
+}
+
+/** Open the chat input's `+` actions menu. */
+function openActionsMenu() {
+  fireEvent.click(screen.getByTitle('Actions menu'));
+  return screen.getByRole('menu');
+}
+
+/** The switch belonging to the menu row labelled `text`. */
+function switchFor(text) {
+  let node = screen.getByText(text);
+  while (node && !node.querySelector?.('input[type="checkbox"]')) node = node.parentElement;
+  return node?.querySelector('input[type="checkbox"]');
+}
+
+/** The tool row labelled `text` (role=menuitemcheckbox carries its state). */
+function toolRow(text) {
+  return screen.getByText(text).closest('[role="menuitemcheckbox"]');
+}
+
+describe('start page chat input features', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    sessionStorage.clear();
+    consumePendingChatStart('chat'); // drop any handoff a previous case left
+  });
+
+  it('offers the web search and transcription toggles', async () => {
+    await renderStartPage();
+    openActionsMenu();
+
+    expect(switchFor('Web Search')).not.toBeChecked();
+    expect(switchFor('Transcription')).toBeChecked();
+
+    fireEvent.click(switchFor('Web Search'));
+    expect(switchFor('Web Search')).toBeChecked();
+  });
+
+  it("starts the app's tools switched on and lets them be toggled", async () => {
+    await renderStartPage();
+    openActionsMenu();
+
+    await screen.findByText('Brave Search');
+    expect(toolRow('Brave Search')).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(toolRow('Brave Search'));
+    expect(toolRow('Brave Search')).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('carries the picked features into the app when the chat starts', async () => {
+    await renderStartPage();
+    openActionsMenu();
+    fireEvent.click(switchFor('Web Search'));
+
+    await screen.findByText('Jira');
+    fireEvent.click(toolRow('Jira'));
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'hello' } });
+    await act(async () => {
+      fireEvent.submit(screen.getByRole('textbox').closest('form'));
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith(expect.stringContaining('/apps/chat?prefill=hello'));
+    expect(consumePendingChatStart('chat')).toMatchObject({
+      appId: 'chat',
+      settings: { websearchEnabled: true, enabledTools: ['braveSearch'] }
+    });
+  });
+
+  it('seeds the toggles from settings the viewer already chose for the app', async () => {
+    sessionStorage.setItem(
+      'ai_hub_app_settings_chat',
+      JSON.stringify({ websearchEnabled: true, enabledTools: ['jira'] })
+    );
+
+    await renderStartPage();
+    openActionsMenu();
+
+    expect(switchFor('Web Search')).toBeChecked();
+    await screen.findByText('Brave Search');
+    expect(toolRow('Brave Search')).toHaveAttribute('aria-checked', 'false');
+    expect(toolRow('Jira')).toHaveAttribute('aria-checked', 'true');
+  });
+});


### PR DESCRIPTION
Fixes #2322.

## The problem

The start page renders the default app's **real** `ChatInput`, but it never passed any of the per-chat feature props. So in the `+` menu there:

- **Web search was missing entirely** — `ChatInputActionsMenu` renders it only when `onWebsearchEnabledChange !== null`, and nothing was passed.
- **Tools were worse than missing** — `hasTools` only requires `enabledTools !== null`, and `ChatInput`'s default is `[]`. The app's tools were listed with *every one switched off* (plus the red "some tools are off" dot), and clicking a row called `onEnabledToolsChange?.(…)` on `null`, so nothing happened.
- Magic Prompt, the transcription toggle and the image-generation settings were absent too.

A question that needed a web lookup or a tool therefore had to be re-typed inside the app.

## The fix

`StartPage` now owns that state and wires it up the way `AppChat` does:

- Web search, the app's tools (seeded from `app.tools`, gated by the platform `tools` feature flag with the same `null` convention `AppChat` uses), the transcription toggle, the image-generation settings and Magic Prompt — each rendered only when the app enables it.
- Toggles are seeded from the app config, then from anything the viewer already chose for that app in the current session (the same precedence `useAppSettings` applies), so both surfaces agree.
- The upload config now gets the selected model object instead of `null`, so image/audio attachments are gated on the model that will actually answer.

Carrying the picks into the chat reuses the existing start-chat handoff, which now takes a `settings` payload alongside the processed attachment. `AppChat` applies it once `useAppSettings` has seeded from the app config: that hook's effect is registered first and runs on the same `app && !modelsLoading` gate, so the handoff reliably lands *after* the seeding rather than being overwritten by it — and before the auto-send fires.

## Changes

| File | What |
| --- | --- |
| `client/src/features/apps/pages/StartPage.jsx` | Feature state, seeding, magic-prompt handlers, props to `ChatInput`, handoff payload |
| `client/src/features/apps/pages/AppChat.jsx` | Consume the handoff `settings` after `useAppSettings` seeding |
| `client/src/features/chat/startChatHandoff.js` | `settings` in the handoff contract |
| `tests/unit/client/start-page-chat-features.test.jsx` | New regression coverage |
| `docs/ui.md`, `docs/releases/5.5.0/fixes.md` | Docs + changelog |

## Testing

- New `tests/unit/client/start-page-chat-features.test.jsx` renders the real `StartPage` and asserts: the web search and transcription toggles appear and flip; the app's tools start switched on and are toggleable; the picks reach the handoff on submit; and the toggles seed from settings already chosen for the app.
- `npx jest --config tests/config/jest.config.js tests/unit/client` → 49 suites / 474 tests pass.
- `npx vite build` in `client/` succeeds; server starts cleanly.
- ESLint and Prettier clean on all changed files (no new warnings beyond the pre-existing `set-state-in-effect` style warnings that already blanket both pages).

## Notes

The handoff is in-memory, so a reload between the start page and the auto-send would drop the toggles — the same, pre-existing limitation the attachment payload already documents in that module, and the auto-send is stripped from the URL on arrival anyway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EpoxXWAj8vFHB5EiUviCox

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpoxXWAj8vFHB5EiUviCox)_