### PR TITLE
Fix sidebar and home redirect to refresh without page reload

### DIFF
--- a/client/src/api/endpoints/config.js
+++ b/client/src/api/endpoints/config.js
@@ -1,6 +1,6 @@
 import { apiClient } from '../client';
 import { handleApiResponse } from '../utils/requestHandler';
-import { CACHE_KEYS, DEFAULT_CACHE_TTL, buildCacheKey } from '../../utils/cache';
+import cache, { CACHE_KEYS, DEFAULT_CACHE_TTL, buildCacheKey } from '../../utils/cache';
 
 // UI Configuration
 export const fetchUIConfig = async (options = {}) => {
@@ -37,3 +37,25 @@ export const fetchMimetypesConfig = async (options = {}) => {
     DEFAULT_CACHE_TTL.LONG
   );
 };
+
+/**
+ * Drop every cached UI-config response, including the per-language variants.
+ *
+ * Responses are kept in memory for 30 minutes, so a plain refetch after an
+ * admin save was answered from the cache and left the sidebar and the "/"
+ * redirect on the old configuration until a full page reload. Invalidate
+ * first and then fetch normally: the request repopulates the cache, so every
+ * other consumer sees the new configuration too.
+ *
+ * @returns {number} How many cache entries were dropped
+ */
+export const invalidateUIConfigCache = () => cache.invalidateByPattern(CACHE_KEYS.UI_CONFIG);
+
+/**
+ * Drop the cached platform-config response. Same reasoning as
+ * `invalidateUIConfigCache`.
+ *
+ * @returns {number} How many cache entries were dropped
+ */
+export const invalidatePlatformConfigCache = () =>
+  cache.invalidateByPattern(CACHE_KEYS.PLATFORM_CONFIG);

--- a/client/src/api/endpoints/misc.js
+++ b/client/src/api/endpoints/misc.js
@@ -1,6 +1,6 @@
 import { apiClient } from '../client';
 import { handleApiResponse } from '../utils/requestHandler';
-import { CACHE_KEYS, DEFAULT_CACHE_TTL, buildCacheKey } from '../../utils/cache';
+import cache, { CACHE_KEYS, DEFAULT_CACHE_TTL, buildCacheKey } from '../../utils/cache';
 
 // Styles
 export const fetchStyles = async (options = {}) => {
@@ -80,3 +80,11 @@ export const fetchAuthStatus = async (options = {}) => {
 
   return handleApiResponse(() => apiClient.get('/auth/status'), cacheKey, DEFAULT_CACHE_TTL.MEDIUM);
 };
+
+/**
+ * Drop the cached auth-status response so the next fetch reaches the server
+ * and repopulates the cache for every other consumer.
+ *
+ * @returns {number} How many cache entries were dropped
+ */
+export const invalidateAuthStatusCache = () => cache.invalidateByPattern(CACHE_KEYS.AUTH_STATUS);

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -4,6 +4,12 @@ import App from './App';
 import './App.css';
 // Import the i18n instance before rendering the app
 import './i18n/i18n';
+import { exposeCacheForDebugging } from './utils/cache';
+
+// Dev builds put the API cache on `window.appCache` for devtools inspection.
+if (import.meta.env.DEV) {
+  exposeCacheForDebugging();
+}
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>

--- a/client/src/shared/components/AppSidebar.jsx
+++ b/client/src/shared/components/AppSidebar.jsx
@@ -9,7 +9,7 @@ import Icon from './Icon';
 import IHubLogo from './IHubLogo';
 import { getLocalizedContent } from '../../utils/localizeContent';
 import { rankAppShortcuts, readAppShortcutConfig } from '../../utils/appShortcuts';
-import { getRecentAppIds } from '../../utils/recentApps';
+import useRecentAppIds from '../hooks/useRecentAppIds';
 import { START_PAGE_PATH } from '../../utils/homePage';
 import useMediaQuery from '../hooks/useMediaQuery';
 import BrandTitle from './BrandTitle';
@@ -229,9 +229,12 @@ export default function AppSidebar({ mobileOpen = false, onMobileClose = () => {
     [uiConfig]
   );
 
-  // Read once per mount: re-reading on every render would reorder the list
-  // while the user is aiming at it. Only the `recent` mode needs it.
-  const recentAppIds = useMemo(() => (mode === 'recent' ? getRecentAppIds() : []), [mode]);
+  // Only the `recent` mode needs the list, and it has to stay live: this
+  // sidebar is mounted once in the Layout, so a read on mount would keep the
+  // ranking it had when the app booted no matter how many apps were opened
+  // since. Usage is recorded on navigation, so the list only ever reorders
+  // right after the user left it.
+  const recentAppIds = useRecentAppIds(mode === 'recent');
 
   // Favorites first, then the admin's default apps, then the rest by mode.
   const rankedApps = useMemo(

--- a/client/src/shared/contexts/PlatformConfigContext.jsx
+++ b/client/src/shared/contexts/PlatformConfigContext.jsx
@@ -1,5 +1,12 @@
 import { createContext, useContext, useEffect, useState } from 'react';
-import { fetchAuthStatus, fetchUIConfig, fetchPlatformConfig } from '../../api';
+import {
+  fetchAuthStatus,
+  fetchUIConfig,
+  fetchPlatformConfig,
+  invalidateAuthStatusCache,
+  invalidatePlatformConfigCache,
+  invalidateUIConfigCache
+} from '../../api';
 
 const PlatformConfigContext = createContext({
   platformConfig: null,
@@ -17,13 +24,21 @@ export function PlatformConfigProvider({ children }) {
     try {
       setIsLoading(true);
 
+      // On refresh (not initial load) drop the cached responses first instead
+      // of bypassing the cache: bypassing left the stale entries in place for
+      // every other consumer, so a refresh here did not help the sidebar or
+      // the "/" redirect. Refetching normally repopulates them.
+      if (platformConfig !== null) {
+        invalidateAuthStatusCache();
+        invalidateUIConfigCache();
+        invalidatePlatformConfigCache();
+      }
+
       // Fetch auth status, UI config, and platform config in parallel
-      // On refresh (not initial load), skip cache to get fresh data
-      const skipCache = platformConfig !== null;
       const [authStatus, uiConfig, platformCfg] = await Promise.all([
-        fetchAuthStatus({ skipCache }),
-        fetchUIConfig({ skipCache }),
-        fetchPlatformConfig({ skipCache })
+        fetchAuthStatus(),
+        fetchUIConfig(),
+        fetchPlatformConfig()
       ]);
 
       // Combine all configs into a single object that matches the previous platform config structure

--- a/client/src/shared/contexts/UIConfigContext.jsx
+++ b/client/src/shared/contexts/UIConfigContext.jsx
@@ -1,5 +1,5 @@
-import { createContext, useState, useContext, useEffect } from 'react';
-import { fetchUIConfig } from '../../api';
+import { createContext, useState, useContext, useEffect, useCallback } from 'react';
+import { fetchUIConfig, invalidateUIConfigCache } from '../../api';
 import { buildPath, buildAssetUrl } from '../../utils/runtimeBasePath';
 import { cacheErrorPagesConfig } from '../../utils/errorPagesCache';
 
@@ -26,10 +26,21 @@ export function UIConfigProvider({ children }) {
   const [headerColor, setHeaderColor] = useState(FALLBACK_COLOR);
   const [defaultHeaderColor, setDefaultHeaderColor] = useState(FALLBACK_COLOR);
 
-  // Fetch UI config function
-  const fetchUiConfig = async () => {
+  // Fetch UI config function.
+  //
+  // `refresh` is what an admin save needs: API responses are cached in memory
+  // for 30 minutes, so a plain refetch was answered from that cache and every
+  // consumer of this context — the sidebar's app shortcuts, the "/" redirect —
+  // kept the configuration it had until a full page reload. Dropping the entry
+  // first sends the request to the server and repopulates the cache with the
+  // saved configuration.
+  const loadUiConfig = useCallback(async ({ refresh = false } = {}) => {
     try {
-      setIsLoading(true);
+      // A refresh keeps the current config on screen while it runs: flipping
+      // `isLoading` would swap live UI (language selector, "/" redirect) for a
+      // loading state we already have an answer for.
+      if (!refresh) setIsLoading(true);
+      if (refresh) invalidateUIConfigCache();
       // Using the exported fetchUIConfig function that uses apiClient
       const data = await fetchUIConfig();
       setUiConfig(data);
@@ -40,12 +51,14 @@ export function UIConfigProvider({ children }) {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, []);
+
+  const refreshUIConfig = useCallback(() => loadUiConfig({ refresh: true }), [loadUiConfig]);
 
   // Initial UI config fetch
   useEffect(() => {
-    fetchUiConfig();
-  }, []);
+    loadUiConfig();
+  }, [loadUiConfig]);
 
   // Cache error-page messages so the context-less generic ErrorBoundary
   // (mounted above this provider) can still render admin-configured text.
@@ -189,7 +202,7 @@ export function UIConfigProvider({ children }) {
         headerColor,
         setHeaderColor,
         resetHeaderColor,
-        refreshUIConfig: fetchUiConfig
+        refreshUIConfig
       }}
     >
       {children}

--- a/client/src/shared/hooks/useRecentAppIds.js
+++ b/client/src/shared/hooks/useRecentAppIds.js
@@ -1,0 +1,38 @@
+import { useSyncExternalStore } from 'react';
+import { getRecentAppIds, subscribeToRecentApps } from '../../utils/recentApps';
+
+const EMPTY = [];
+
+const sameOrder = (a, b) => a.length === b.length && a.every((id, index) => id === b[index]);
+
+// `useSyncExternalStore` re-renders whenever the snapshot changes identity, so
+// the array has to be cached and only replaced when the order actually moved.
+let snapshot = EMPTY;
+
+const getSnapshot = () => {
+  const next = getRecentAppIds();
+  if (!sameOrder(snapshot, next)) snapshot = next;
+  return snapshot;
+};
+
+const getEmpty = () => EMPTY;
+const noSubscription = () => () => {};
+
+/**
+ * Recently used app ids, most recent first, kept live.
+ *
+ * The sidebar is mounted once in the Layout and never unmounts, so reading
+ * localStorage on mount left its `recent` ranking frozen at whatever it was
+ * when the app booted. Subscribing instead keeps it current — including when
+ * the app was opened in another tab.
+ *
+ * @param {boolean} [enabled=true] - Pass `false` when the caller does not rank
+ *   by recent use; the hook then reports an empty list and does not subscribe.
+ * @returns {string[]} The recently used app ids.
+ */
+export default function useRecentAppIds(enabled = true) {
+  return useSyncExternalStore(
+    enabled ? subscribeToRecentApps : noSubscription,
+    enabled ? getSnapshot : getEmpty
+  );
+}

--- a/client/src/utils/cache.js
+++ b/client/src/utils/cache.js
@@ -113,6 +113,29 @@ class Cache {
   }
 
   /**
+   * Remove every entry whose key matches `pattern`.
+   *
+   * A string matches by prefix, so one call drops every variant of a
+   * parameterized key — `'ui-config'` clears `ui-config` together with
+   * `ui-config?language=de` (the shape `buildCacheKey` produces). A RegExp is
+   * tested against the whole key.
+   *
+   * @param {string|RegExp} pattern - Key prefix or expression to match
+   * @returns {number} How many entries were removed
+   */
+  invalidateByPattern(pattern) {
+    if (!pattern) return 0;
+    const matches =
+      pattern instanceof RegExp ? key => pattern.test(key) : key => key.startsWith(pattern);
+
+    let count = 0;
+    for (const key of [...this.store.keys()]) {
+      if (matches(key) && this.delete(key)) count++;
+    }
+    return count;
+  }
+
+  /**
    * Clear the entire cache
    */
   clear() {
@@ -254,9 +277,16 @@ const cache = new Cache({
   storageType: 'session'
 });
 
-// Add global access in development for debugging
-if (import.meta.env.DEV) {
-  window.appCache = cache;
-}
+/**
+ * Expose the cache as `window.appCache` so it can be inspected from the
+ * devtools console. Called from the app entry point, which is where the
+ * dev-mode flag lives: keeping `import.meta` out of this module is what lets
+ * it be unit-tested, since the Jest transform cannot parse it.
+ */
+export const exposeCacheForDebugging = () => {
+  if (typeof window !== 'undefined') {
+    window.appCache = cache;
+  }
+};
 
 export default cache;

--- a/client/src/utils/recentApps.js
+++ b/client/src/utils/recentApps.js
@@ -1,6 +1,10 @@
 import { createRecentItemHelpers } from './recentItems.js';
 
-const { recordUsage: recordAppUsage, getIds: getRecentAppIds } = createRecentItemHelpers({
+const {
+  recordUsage: recordAppUsage,
+  getIds: getRecentAppIds,
+  subscribe: subscribeToRecentApps
+} = createRecentItemHelpers({
   prefix: 'ihub_recent_apps_'
 });
-export { recordAppUsage, getRecentAppIds };
+export { recordAppUsage, getRecentAppIds, subscribeToRecentApps };

--- a/client/src/utils/recentItems.js
+++ b/client/src/utils/recentItems.js
@@ -1,3 +1,11 @@
+/**
+ * Same-tab notification that one of these lists changed. Mirrors the
+ * `ihub:favorites-changed` event favorites use: a `storage` event only fires
+ * in *other* tabs, so long-lived components in this one (the sidebar, mounted
+ * once in the Layout) would otherwise keep the order they read at boot.
+ */
+const CHANGE_EVENT = 'ihub:recent-items-changed';
+
 const getCurrentUsername = () => {
   try {
     return localStorage.getItem('ihub_username') || 'default';
@@ -32,6 +40,14 @@ export function createRecentItemHelpers({
     }
   };
 
+  const notifyChanged = () => {
+    try {
+      window.dispatchEvent(new CustomEvent(CHANGE_EVENT, { detail: { prefix } }));
+    } catch {
+      // Ignore environments without window/CustomEvent (e.g. SSR)
+    }
+  };
+
   const recordUsage = id => {
     if (!id) return;
     try {
@@ -47,9 +63,34 @@ export function createRecentItemHelpers({
         .sort((a, b) => b[1] - a[1])
         .slice(0, max);
       localStorage.setItem(getStorageKey(), JSON.stringify(Object.fromEntries(entries)));
+      notifyChanged();
     } catch (err) {
       console.error('Error recording recent item usage:', err);
     }
+  };
+
+  /**
+   * Subscribe to changes of this list — usage recorded in this tab (custom
+   * event) and in other tabs (native `storage` event).
+   *
+   * @param {() => void} listener - Called after the list changed.
+   * @returns {() => void} Unsubscribe.
+   */
+  const subscribe = listener => {
+    const handler = event => {
+      // Same-tab custom event carries the prefix; ignore the other lists.
+      if (event?.detail?.prefix && event.detail.prefix !== prefix) return;
+      // Cross-tab storage event carries `key`; it is prefixed with the
+      // username, so match on the prefix rather than the full key.
+      if (event?.type === 'storage' && event.key && !event.key.startsWith(prefix)) return;
+      listener();
+    };
+    window.addEventListener(CHANGE_EVENT, handler);
+    window.addEventListener('storage', handler);
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, handler);
+      window.removeEventListener('storage', handler);
+    };
   };
 
   const getIds = () => {
@@ -61,5 +102,5 @@ export function createRecentItemHelpers({
       .map(([id]) => id);
   };
 
-  return { recordUsage, getIds };
+  return { recordUsage, getIds, subscribe };
 }

--- a/concepts/2026-09-10 Sidebar and Home Redirect Refresh Fix.md
+++ b/concepts/2026-09-10 Sidebar and Home Redirect Refresh Fix.md
@@ -1,0 +1,124 @@
+# Sidebar and Home Redirect Refresh Fix
+
+Issue: [#2320](https://github.com/intrafind/ihub-apps/issues/2320) — "Sidebar does not refresh as well as home redirect"
+
+## Symptoms
+
+Three reports, one page:
+
+1. Changing which apps the sidebar shows (**UI Customization → Start Page**) did
+   nothing until a full browser reload.
+2. With app shortcuts set to rank **by recent use**, the sidebar's Apps section
+   kept its boot order no matter how many apps were opened.
+3. Changing what "/" opens — from a specific app to "All apps" or the start
+   page — kept redirecting to the old target until a full reload.
+
+## Root causes
+
+### 1 and 3: the refresh after an admin save was answered from the client cache
+
+`handleApiResponse` keeps every cacheable API response in an in-memory `Cache`
+for its TTL — `DEFAULT_CACHE_TTL.LONG`, 30 minutes, for the UI config.
+
+`AdminUICustomization.handleSave()` already called `refreshUIConfig()` after a
+successful save, and `UIConfigContext` already refetched. But it refetched with
+`fetchUIConfig()`, i.e. *with* the cache key, so the request never left the
+browser: the context set state to the very same object it already held, React
+bailed out of the re-render, and every consumer — `AppSidebar`'s app shortcuts,
+`HomeRoute`'s `resolveHomePath(uiConfig)` — kept the configuration the page had
+booted with.
+
+Two details made it look stranger than it was:
+
+- Reproducing it showed the *previous* save applying on the next save. With the
+  30-minute TTL, whatever full page load happened in between seeded the cache,
+  so each save was one step behind.
+- `PlatformConfigContext` did refetch on refresh (`skipCache: true`), but
+  `skipCache` sets the cache key to `null`, which suppresses the *write* as
+  well as the read. So its refresh left the stale entries in place for every
+  other consumer instead of replacing them.
+
+### 2: the sidebar is mounted once and read `localStorage` once
+
+`AppSidebar` lives in `Layout`, above the router outlet, so it mounts once per
+page load. Its recent-app ranking came from `useMemo(() => getRecentAppIds(),
+[mode])` — a single read, deliberately, to avoid reshuffling the list under the
+user's cursor. `recordAppUsage()` (called from `AppChat`) wrote to
+`localStorage` and told nobody, so nothing re-read it.
+
+The start page was never affected: it is a route, so it remounts on every visit
+and re-reads the list.
+
+## The fix
+
+**Invalidate, then refetch through the cache.** `Cache` gained the
+`invalidateByPattern()` it always advertised in its class docs (and that
+`api/utils/cache.js → invalidateCacheByPattern` already called — it threw,
+because the method did not exist). A string matches by prefix, so one call
+drops a resource together with its `buildCacheKey` variants
+(`ui-config`, `ui-config?language=de`, …).
+
+`invalidateUIConfigCache()`, `invalidatePlatformConfigCache()` and
+`invalidateAuthStatusCache()` sit next to the fetchers that own those keys.
+`UIConfigContext.refreshUIConfig()` and `PlatformConfigContext.refreshConfig()`
+call them and then fetch *normally*, so the fresh response repopulates the
+cache for everyone rather than bypassing it.
+
+A refresh also no longer flips `isLoading`. With a config already on screen,
+flipping it swapped live UI for a loading state (`LanguageSelector` renders
+"Loading…", `HomeRoute` renders a spinner) while an answer was already
+available.
+
+**Subscribe to recent-app usage.** `createRecentItemHelpers` now dispatches an
+`ihub:recent-items-changed` event on write and exposes `subscribe()`, matching
+the `ihub:favorites-changed` pattern favorites already use — same-tab custom
+event plus the native `storage` event for other tabs. `useRecentAppIds` wraps
+it in `useSyncExternalStore` with a cached snapshot, so the sidebar re-renders
+only when the order actually moved. The original concern (reshuffling under the
+cursor) does not apply: usage is recorded on navigation *into* an app, when the
+user has already left the list.
+
+`import.meta.env.DEV` moved out of `client/src/utils/cache.js` into
+`client/src/index.jsx` (`exposeCacheForDebugging()`). The Jest transform cannot
+parse `import.meta`, so that one line was all that kept the cache untestable.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `client/src/utils/cache.js` | `invalidateByPattern()`; dev hook moved out |
+| `client/src/index.jsx` | calls `exposeCacheForDebugging()` in dev |
+| `client/src/api/endpoints/config.js` | `invalidateUIConfigCache`, `invalidatePlatformConfigCache` |
+| `client/src/api/endpoints/misc.js` | `invalidateAuthStatusCache` |
+| `client/src/shared/contexts/UIConfigContext.jsx` | refresh invalidates first; no loading flip |
+| `client/src/shared/contexts/PlatformConfigContext.jsx` | refresh invalidates instead of bypassing |
+| `client/src/utils/recentItems.js` | change event + `subscribe()` |
+| `client/src/utils/recentApps.js` | exports `subscribeToRecentApps` |
+| `client/src/shared/hooks/useRecentAppIds.js` | new — live recent-app ids |
+| `client/src/shared/components/AppSidebar.jsx` | uses the hook |
+
+## Verification
+
+Unit tests (`npm run test:unit`, 68 suites / 794 tests):
+
+- `tests/unit/client/api-cache-invalidation.test.jsx` — prefix and RegExp
+  matching, parameterized-key families, empty pattern is not a full flush.
+- `tests/unit/client/ui-config-refresh.test.jsx` — a refresh invalidates before
+  it fetches, the saved config reaches `resolveHomePath` and
+  `readAppShortcutConfig`, `isLoading` stays false mid-refresh, a failed
+  refresh keeps the last good config.
+- `tests/unit/client/recent-apps-live-order.test.jsx` — notification on write,
+  per-list isolation, cross-tab `storage` events, stable snapshot when the
+  order did not change.
+
+End-to-end, against a booted dev server logged in as the bundled local admin,
+driving the real admin UI and leaving it through the admin sidebar's "Back to
+iHub" link (a client-side navigation — a full reload would hide the bug). Every
+row failed before the change and passes after it:
+
+| Scenario | Before | After |
+| --- | --- | --- |
+| `sidebarAppsCount` 5 → 2, then leave admin | 5 apps | 2 apps |
+| "/" target: specific app → All apps | `/apps/{app}` | `/apps` |
+| "/" target: All apps → start page | `/apps` (the previous save) | `/start` |
+| `appsMode: recent`, open the last app in the list | order unchanged | that app first |

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -566,3 +566,17 @@ OpenAI-compatible servers are the usual culprits.
   sent again.
 - The wait *before* the first piece of an answer is unchanged, so a model that
   thinks for a long time before it starts writing is not cut off.
+
+## Start Page and Sidebar Settings Take Effect Without a Page Reload
+
+Changes saved under **UI Customization → Start Page** did not reach the running
+app: the sidebar kept the app shortcuts it had loaded with, and "/" kept
+opening whatever view it opened before. Only a full browser reload picked up
+the change. Configuration responses are held in memory for 30 minutes, and the
+refresh that follows a save was answered out of that cache instead of from the
+server — so a second save appeared to apply the *previous* one.
+
+- Saving now refreshes the sidebar's app list and count, the featured apps, the
+  heading and the view "/" redirects to, straight away.
+- With app shortcuts set to rank **by recent use**, the sidebar also reorders as
+  soon as an app is opened, in this tab and in any other tab that is open.

--- a/tests/unit/client/api-cache-invalidation.test.jsx
+++ b/tests/unit/client/api-cache-invalidation.test.jsx
@@ -1,0 +1,71 @@
+import cache, { CACHE_KEYS, buildCacheKey } from '../../../client/src/utils/cache';
+import { invalidateCacheByPattern, clearApiCache } from '../../../client/src/api/utils/cache';
+
+/**
+ * API responses are held in memory for up to 30 minutes, so anything that
+ * changes server-side configuration has to drop the matching entries or every
+ * consumer keeps serving the old answer until a full page reload (#2320).
+ * `buildCacheKey` appends parameters to the base key, so dropping one resource
+ * means dropping a family of keys — that is what prefix matching is for.
+ */
+
+beforeEach(() => {
+  cache.clear();
+});
+
+describe('cache.invalidateByPattern', () => {
+  test('a string drops the base key and every parameterized variant', () => {
+    cache.set(CACHE_KEYS.UI_CONFIG, { data: 'plain' });
+    cache.set(buildCacheKey(CACHE_KEYS.UI_CONFIG, { language: 'de' }), { data: 'de' });
+    cache.set(buildCacheKey(CACHE_KEYS.UI_CONFIG, { language: 'en' }), { data: 'en' });
+    cache.set(CACHE_KEYS.APPS_LIST, { data: 'apps' });
+
+    expect(cache.invalidateByPattern(CACHE_KEYS.UI_CONFIG)).toBe(3);
+    expect(cache.get(CACHE_KEYS.UI_CONFIG)).toBeNull();
+    expect(cache.get('ui-config?language=de')).toBeNull();
+    // Unrelated resources are left alone.
+    expect(cache.get(CACHE_KEYS.APPS_LIST)).toEqual({ data: 'apps' });
+  });
+
+  test('a RegExp is tested against the whole key', () => {
+    cache.set('ui-config?language=de', { data: 'de' });
+    cache.set('ui-config?language=en', { data: 'en' });
+
+    expect(cache.invalidateByPattern(/language=de$/)).toBe(1);
+    expect(cache.get('ui-config?language=de')).toBeNull();
+    expect(cache.get('ui-config?language=en')).toEqual({ data: 'en' });
+  });
+
+  test('an empty pattern is a no-op rather than a full flush', () => {
+    cache.set(CACHE_KEYS.UI_CONFIG, { data: 'plain' });
+
+    expect(cache.invalidateByPattern('')).toBe(0);
+    expect(cache.invalidateByPattern(null)).toBe(0);
+    expect(cache.invalidateByPattern(undefined)).toBe(0);
+    expect(cache.get(CACHE_KEYS.UI_CONFIG)).toEqual({ data: 'plain' });
+  });
+});
+
+describe('api cache helpers', () => {
+  // This one called a method the cache never had, so it threw instead of
+  // invalidating anything.
+  test('invalidateCacheByPattern reports how many entries it dropped', () => {
+    cache.set(CACHE_KEYS.UI_CONFIG, { data: 'plain' });
+    cache.set('ui-config?language=de', { data: 'de' });
+
+    expect(invalidateCacheByPattern(CACHE_KEYS.UI_CONFIG)).toBe(2);
+    expect(cache.size).toBe(0);
+  });
+
+  test('clearApiCache drops one key or everything', () => {
+    cache.set(CACHE_KEYS.UI_CONFIG, { data: 'plain' });
+    cache.set(CACHE_KEYS.APPS_LIST, { data: 'apps' });
+
+    clearApiCache(CACHE_KEYS.UI_CONFIG);
+    expect(cache.get(CACHE_KEYS.UI_CONFIG)).toBeNull();
+    expect(cache.get(CACHE_KEYS.APPS_LIST)).toEqual({ data: 'apps' });
+
+    clearApiCache();
+    expect(cache.size).toBe(0);
+  });
+});

--- a/tests/unit/client/recent-apps-live-order.test.jsx
+++ b/tests/unit/client/recent-apps-live-order.test.jsx
@@ -1,0 +1,115 @@
+import { renderHook, act } from '@testing-library/react';
+
+import { createRecentItemHelpers } from '../../../client/src/utils/recentItems';
+import {
+  getRecentAppIds,
+  recordAppUsage,
+  subscribeToRecentApps
+} from '../../../client/src/utils/recentApps';
+import { recordPromptUsage } from '../../../client/src/utils/recentPrompts';
+import useRecentAppIds from '../../../client/src/shared/hooks/useRecentAppIds';
+
+/**
+ * With the app shortcuts set to rank by recent use, the sidebar's Apps section
+ * has to reorder as soon as an app is opened. The sidebar is mounted once in
+ * the Layout and never unmounts, so a read on mount froze its ranking at
+ * whatever it was when the page loaded (#2320) — it needs a subscription.
+ */
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('recent item helpers', () => {
+  test('recording usage notifies subscribers of this list only', () => {
+    const onAppsChanged = jest.fn();
+    const unsubscribe = subscribeToRecentApps(onAppsChanged);
+
+    recordAppUsage('chat');
+    expect(onAppsChanged).toHaveBeenCalledTimes(1);
+    expect(getRecentAppIds()).toEqual(['chat']);
+
+    // A different list (recent prompts) must not wake the apps subscribers.
+    recordPromptUsage('summarize');
+    expect(onAppsChanged).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    recordAppUsage('translator');
+    expect(onAppsChanged).toHaveBeenCalledTimes(1);
+  });
+
+  test('a write from another tab reaches subscribers', () => {
+    const listener = jest.fn();
+    const unsubscribe = subscribeToRecentApps(listener);
+
+    window.dispatchEvent(new StorageEvent('storage', { key: 'ihub_recent_apps_default' }));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    // Another key's storage event is not ours.
+    window.dispatchEvent(new StorageEvent('storage', { key: 'ihub_favorite_apps' }));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+  });
+
+  test('a subscriber never sees an id it did not record', () => {
+    const helpers = createRecentItemHelpers({ prefix: 'test_recent_' });
+    const listener = jest.fn();
+    const unsubscribe = helpers.subscribe(listener);
+
+    // No id means no write and no notification.
+    helpers.recordUsage('');
+    expect(listener).not.toHaveBeenCalled();
+    expect(helpers.getIds()).toEqual([]);
+
+    unsubscribe();
+  });
+});
+
+describe('useRecentAppIds', () => {
+  test('reorders as apps are opened', () => {
+    recordAppUsage('chat');
+    const { result } = renderHook(() => useRecentAppIds(true));
+    expect(result.current).toEqual(['chat']);
+
+    act(() => recordAppUsage('translator'));
+    expect(result.current).toEqual(['translator', 'chat']);
+
+    act(() => recordAppUsage('chat'));
+    expect(result.current).toEqual(['chat', 'translator']);
+  });
+
+  test('keeps the same array when the order did not change', () => {
+    recordAppUsage('chat');
+    const { result } = renderHook(() => useRecentAppIds(true));
+    const first = result.current;
+
+    // Re-opening the only app leaves the ranking untouched; handing back a new
+    // array would re-sort the sidebar list on every navigation for nothing.
+    act(() => recordAppUsage('chat'));
+    expect(result.current).toBe(first);
+  });
+
+  test('reports nothing while the caller does not rank by recent use', () => {
+    recordAppUsage('chat');
+    const { result, rerender } = renderHook(({ enabled }) => useRecentAppIds(enabled), {
+      initialProps: { enabled: false }
+    });
+    expect(result.current).toEqual([]);
+
+    act(() => recordAppUsage('translator'));
+    expect(result.current).toEqual([]);
+
+    // Switching the mode on (the admin saved `appsMode: 'recent'`) picks the
+    // list up without a reload.
+    rerender({ enabled: true });
+    expect(result.current).toEqual(['translator', 'chat']);
+  });
+
+  test('stops listening once unmounted', () => {
+    const { unmount } = renderHook(() => useRecentAppIds(true));
+    unmount();
+    // A write after unmount must not touch React state.
+    expect(() => recordAppUsage('chat')).not.toThrow();
+  });
+});

--- a/tests/unit/client/recent-apps-live-order.test.jsx
+++ b/tests/unit/client/recent-apps-live-order.test.jsx
@@ -16,8 +16,32 @@ import useRecentAppIds from '../../../client/src/shared/hooks/useRecentAppIds';
  * whatever it was when the page loaded (#2320) — it needs a subscription.
  */
 
+// A cross-tab write, as the listener sees it: only `type` and `key` are read.
+// Built on a plain Event rather than `new StorageEvent('storage', { key })` —
+// the two-argument constructor is standard, but CodeQL's bundled DOM externs
+// declare the pre-EventInit single-argument form and flag the init object as a
+// superfluous trailing argument. This also keeps the test independent of
+// jsdom's StorageEvent implementation.
+const storageEvent = key => {
+  const event = new Event('storage');
+  Object.defineProperty(event, 'key', { value: key, configurable: true });
+  return event;
+};
+
 beforeEach(() => {
   localStorage.clear();
+  // Recency is ordered by millisecond timestamps, so two ids recorded in the
+  // same millisecond tie and fall back to insertion order — which turns any
+  // "most recent first" assertion into a race against the clock, passing only
+  // while the work between two writes happens to cross a millisecond
+  // boundary. Hand out a distinct, increasing time per call so the expected
+  // order is the only possible order.
+  let clock = 1_700_000_000_000;
+  jest.spyOn(Date, 'now').mockImplementation(() => (clock += 1000));
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
 });
 
 describe('recent item helpers', () => {
@@ -42,11 +66,11 @@ describe('recent item helpers', () => {
     const listener = jest.fn();
     const unsubscribe = subscribeToRecentApps(listener);
 
-    window.dispatchEvent(new StorageEvent('storage', { key: 'ihub_recent_apps_default' }));
+    window.dispatchEvent(storageEvent('ihub_recent_apps_default'));
     expect(listener).toHaveBeenCalledTimes(1);
 
     // Another key's storage event is not ours.
-    window.dispatchEvent(new StorageEvent('storage', { key: 'ihub_favorite_apps' }));
+    window.dispatchEvent(storageEvent('ihub_favorite_apps'));
     expect(listener).toHaveBeenCalledTimes(1);
 
     unsubscribe();

--- a/tests/unit/client/ui-config-refresh.test.jsx
+++ b/tests/unit/client/ui-config-refresh.test.jsx
@@ -1,0 +1,134 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('../../../client/src/api', () => ({
+  fetchUIConfig: jest.fn(),
+  invalidateUIConfigCache: jest.fn()
+}));
+// runtimeBasePath uses `import.meta`, which the Jest transform cannot parse.
+jest.mock('../../../client/src/utils/runtimeBasePath', () => ({
+  buildPath: path => path,
+  buildAssetUrl: path => path
+}));
+
+import { fetchUIConfig, invalidateUIConfigCache } from '../../../client/src/api';
+import { UIConfigProvider, useUIConfig } from '../../../client/src/shared/contexts/UIConfigContext';
+import { resolveHomePath } from '../../../client/src/utils/homePage';
+import { readAppShortcutConfig } from '../../../client/src/utils/appShortcuts';
+
+/**
+ * Everything an admin changes under UI Customization reaches the running app
+ * through this context: the sidebar's app shortcuts and the view "/" redirects
+ * to both read it. API responses are cached in memory for 30 minutes, so a
+ * refresh that goes through the cache hands back the configuration the page
+ * booted with and the change only shows after a full reload (#2320).
+ */
+
+const APP_HOME = {
+  startPage: { defaultPage: 'app', defaultPageAppId: 'translator', sidebarAppsCount: 2 }
+};
+const APPS_HOME = {
+  startPage: { defaultPage: 'apps', sidebarAppsCount: 7, featuredAppIds: ['chat'] }
+};
+
+function Probe() {
+  const { uiConfig, isLoading, refreshUIConfig } = useUIConfig();
+  const { sidebarCount, featuredAppIds } = readAppShortcutConfig(uiConfig);
+  return (
+    <div>
+      <span data-testid="loading">{String(isLoading)}</span>
+      <span data-testid="home">{resolveHomePath(uiConfig)}</span>
+      <span data-testid="sidebar-count">{sidebarCount}</span>
+      <span data-testid="featured">{featuredAppIds.join(',')}</span>
+      <button onClick={refreshUIConfig}>refresh</button>
+    </div>
+  );
+}
+
+const renderProbe = async () => {
+  const utils = render(
+    <UIConfigProvider>
+      <Probe />
+    </UIConfigProvider>
+  );
+  await waitFor(() => expect(screen.getByTestId('loading')).toHaveTextContent('false'));
+  return utils;
+};
+
+beforeEach(() => {
+  fetchUIConfig.mockReset();
+  invalidateUIConfigCache.mockReset();
+});
+
+test('a refresh drops the cached response before refetching', async () => {
+  fetchUIConfig.mockResolvedValueOnce(APP_HOME).mockResolvedValueOnce(APPS_HOME);
+  await renderProbe();
+
+  // The initial load may be served from the cache — nothing has changed yet.
+  expect(invalidateUIConfigCache).not.toHaveBeenCalled();
+
+  await act(async () => {
+    screen.getByText('refresh').click();
+  });
+
+  expect(invalidateUIConfigCache).toHaveBeenCalledTimes(1);
+  expect(fetchUIConfig).toHaveBeenCalledTimes(2);
+  // Invalidation has to happen first, or the refetch is answered from the cache.
+  expect(invalidateUIConfigCache.mock.invocationCallOrder[0]).toBeLessThan(
+    fetchUIConfig.mock.invocationCallOrder[1]
+  );
+});
+
+test('the saved configuration reaches the "/" redirect and the sidebar shortcuts', async () => {
+  fetchUIConfig.mockResolvedValueOnce(APP_HOME).mockResolvedValueOnce(APPS_HOME);
+  await renderProbe();
+
+  expect(screen.getByTestId('home')).toHaveTextContent('/apps/translator');
+  expect(screen.getByTestId('sidebar-count')).toHaveTextContent('2');
+  expect(screen.getByTestId('featured')).toHaveTextContent('');
+
+  await act(async () => {
+    screen.getByText('refresh').click();
+  });
+
+  expect(screen.getByTestId('home')).toHaveTextContent('/apps');
+  expect(screen.getByTestId('sidebar-count')).toHaveTextContent('7');
+  expect(screen.getByTestId('featured')).toHaveTextContent('chat');
+});
+
+test('a refresh keeps the current config on screen instead of flipping to loading', async () => {
+  let resolveRefresh;
+  fetchUIConfig
+    .mockResolvedValueOnce(APP_HOME)
+    .mockImplementationOnce(() => new Promise(resolve => (resolveRefresh = resolve)));
+  await renderProbe();
+
+  await act(async () => {
+    screen.getByText('refresh').click();
+  });
+
+  // Still in flight: `isLoading` must stay false so the language selector and
+  // the "/" redirect keep rendering the answer we already have.
+  expect(screen.getByTestId('loading')).toHaveTextContent('false');
+  expect(screen.getByTestId('home')).toHaveTextContent('/apps/translator');
+
+  await act(async () => {
+    resolveRefresh(APPS_HOME);
+  });
+  expect(screen.getByTestId('home')).toHaveTextContent('/apps');
+});
+
+test('a failed refresh reports the error and keeps the last good config', async () => {
+  const logged = jest.spyOn(console, 'error').mockImplementation(() => {});
+  fetchUIConfig.mockResolvedValueOnce(APP_HOME).mockRejectedValueOnce(new Error('boom'));
+  await renderProbe();
+
+  await act(async () => {
+    screen.getByText('refresh').click();
+  });
+
+  expect(screen.getByTestId('home')).toHaveTextContent('/apps/translator');
+  expect(screen.getByTestId('loading')).toHaveTextContent('false');
+  expect(logged).toHaveBeenCalled();
+  logged.mockRestore();
+});


### PR DESCRIPTION
## Summary

Fixes issue #2320 where changes to UI customization (sidebar app shortcuts, home redirect target) did not take effect until a full page reload. The root cause was that configuration refreshes were answered from the 30-minute in-memory API cache instead of fetching fresh data from the server.

Two details made it look stranger than it was:

- Each save appeared to apply the *previous* one — with a 30-minute TTL, whatever full page load happened in between seeded the cache.
- `PlatformConfigContext` did refetch on refresh (`skipCache: true`), but `skipCache` sets the cache key to `null`, which suppresses the **write** as well as the read. Its refresh left the stale entries in place for every other consumer instead of replacing them.

The recent-use symptom has a separate cause: `AppSidebar` lives in `Layout`, above the router outlet, so it mounts once per page load and read `localStorage` once. `recordAppUsage()` wrote and told nobody. The start page was never affected — it is a route, so it remounts on every visit and re-reads the list. That asymmetry is left as it is: a live grid there would only ever be reordered by *another* tab, which is exactly the reshuffle the existing comment guards against.

## Key Changes

**Cache Invalidation System**
- Added `cache.invalidateByPattern()` method to drop cached entries by prefix or RegExp, supporting parameterized cache keys (e.g., `ui-config?language=de`). The class docs already advertised it, and `api/utils/cache.js → invalidateCacheByPattern` already called it — it threw, because the method did not exist.
- Exported `invalidateUIConfigCache()`, `invalidatePlatformConfigCache()`, and `invalidateAuthStatusCache()` functions that invalidate before refetching
- Moved `import.meta.env.DEV` check out of cache.js into index.jsx via `exposeCacheForDebugging()` to enable cache testing

**UI Config Refresh**
- `UIConfigContext.refreshUIConfig()` now invalidates the cache before refetching, ensuring the server response repopulates the cache for all consumers
- Refresh no longer sets `isLoading = true`, keeping the current config on screen while the request is in flight (prevents language selector and "/" redirect from showing loading state)

**Platform Config Refresh**
- Changed from `skipCache: true` (which bypassed the cache entirely) to explicit invalidation followed by normal fetch
- This ensures the fresh response repopulates the cache for other consumers like the sidebar and home redirect

**Live Recent App Ranking**
- Added `subscribe()` method to `createRecentItemHelpers()` that dispatches `ihub:recent-items-changed` custom events on write and listens for cross-tab `storage` events — mirroring the `ihub:favorites-changed` pattern favorites already use
- Created `useRecentAppIds` hook using `useSyncExternalStore` to keep the sidebar's recent-app ranking live without re-rendering on every navigation
- Updated `AppSidebar` to use the hook instead of reading localStorage once on mount
- Maintains stable array identity when order doesn't change to prevent unnecessary re-renders

No config schema change, so no migration.

## Testing

Unit tests — `npm run test:unit` is 68 suites / 794 tests green; `npm run lint:fix` and `npm run format:fix` clean (0 errors); `vite build` succeeds.

- `api-cache-invalidation.test.jsx`: Prefix/RegExp matching, parameterized keys, empty pattern safety
- `ui-config-refresh.test.jsx`: Invalidation before fetch, config reaches consumers, loading state behavior, error handling
- `recent-apps-live-order.test.jsx`: Subscription notifications, per-list isolation, cross-tab events, stable snapshots

These pin the seams; they do not by themselves prove the reload is gone. That was verified separately in a browser against a booted dev server (local admin), driving the real admin UI and leaving it through the admin sidebar's **Back to iHub** link — a client-side navigation, since a full reload would hide the bug. Each run asserted the document was not reloaded. Every row fails before the change and passes after it:

| Scenario | Before | After |
| --- | --- | --- |
| `sidebarAppsCount` 5 → 2, then leave admin | 5 apps | 2 apps |
| `/` target: specific app → All apps | `/apps/{app}` | `/apps` |
| `/` target: All apps → start page | `/apps` (the *previous* save) | `/start` |
| `appsMode: recent`, open the last app in the list | order unchanged | that app first |

Root-cause write-up: `concepts/2026-09-10 Sidebar and Home Redirect Refresh Fix.md`. Changelog entry: `docs/releases/5.5.0/fixes.md`.

https://claude.ai/code/session_016JG4io54YfC1qCDd8UreMJ