### PR TITLE
docs(concepts): knowledge layer &amp; LLM wiki design (RAGFlow-inspired)

### DIFF
--- a/concepts/knowledge-layer-wiki/2026-09-10 Knowledge Layer and LLM Wiki Design.md
+++ b/concepts/knowledge-layer-wiki/2026-09-10 Knowledge Layer and LLM Wiki Design.md
@@ -1,0 +1,258 @@
+# Knowledge Layer & LLM Wiki — Design
+
+**Date:** 2026-09-10
+**Status:** Draft for review — open decisions in §2 need answers before an issue stack
+**Author:** Daniel Manzke / Claude
+**Input:** [RAGFlow Capability Analysis](./2026-09-10%20RAGFlow%20Capability%20Analysis.md)
+**Depends on:** [Storage Provider & Durable Chats Design](../persistence-layer/2026-09-09%20Storage%20Provider%20and%20Durable%20Chats%20Design.md) (approved)
+
+---
+
+## 1. Summary
+
+iHub Apps gains a **Knowledge Layer**: derived, persisted knowledge *about* source documents — summaries, typed metadata, keywords, reference questions, entities, relations and topic articles — produced by LLM enrichment passes at ingest time, stored on the StorageProvider, browsable as an **LLM wiki**, and fed back into retrieval.
+
+The framing decision is what iHub does *not* build. RAGFlow is a complete RAG engine: parser, chunker, embedder, vector store, graph builder, retriever. iHub is deliberately not that — retrieval belongs to iFinder, and iHub's sources are whole-document prompt context. Reimplementing RAGFlow's stack inside iHub would ship a second, weaker retrieval engine alongside IntraFind's actual product.
+
+What is genuinely missing, portable, and valuable is the **derivation layer**. Today every LLM insight iHub produces about a document is computed inside one workflow run and thrown away when the run ends. There is no answer to "what do we already know about this document?" The Knowledge Layer makes those insights durable, cumulative, readable by humans, and reusable by retrieval — while retrieval engines stay pluggable underneath.
+
+The phasing is driven by cost. A per-document enrichment tier costs ~1–2% of a per-chunk tier on the same corpus (§11) and delivers a large share of the benefit, so it ships first and alone.
+
+---
+
+## 2. Open decisions
+
+These change the design materially and are not mine to pick. Everything after §3 assumes the **recommendation** column; flag any you want changed.
+
+| # | Decision | Options | Recommendation |
+|---|----------|---------|----------------|
+| 1 | Does iHub get its own index? | (a) lexical-only over the knowledge store; (b) optional embedding facet on the OpenSearch storage provider; (c) full vector store | **(a) for phases 0–1, (b) opt-in from phase 2.** Never (c) — see §1. |
+| 2 | iFinder ingest API | Is IntraFind willing to expose a write/metadata-update endpoint? | Design assumes **no** (verified read-only today, §3). A yes simplifies phases 1–2 substantially and should reopen this doc. |
+| 3 | Which source types get enriched | `ifinder` / `filesystem` / `url` / `page`, any subset | **All four.** The enrichment contract is "text + a stable key"; all four handlers already provide that. |
+| 4 | ACL model for synthesised articles | (a) knowledge space with a declared ACL up front; (b) per-read filtering of contributing documents; (c) regenerate per audience | **(a).** The only option that is safe *and* simple. See §8. |
+| 5 | Enrichment model | Reuse app `preferredModel` / a dedicated indexing model | **Dedicated `indexingModel` per space.** Bulk, latency-insensitive, budget-sensitive work must not be pinned to the interactive chat model. |
+| 6 | Wiki audience in v1 | Admin-only / all authenticated users / per-space permission | **Per-space permission**, defaulting to the contributing sources' groups. |
+| 7 | Keyword vocabulary | Open-ended generation / controlled taxonomy (RAGFlow tag sets) / both | **Both, taxonomy preferred where one exists** — enterprise deployments already have taxonomies, and classification is cheaper than generation. |
+| 8 | Graph scope | Ship phases 2–3 at all, or stop after chunk-level Q&A? | **Decide after phase 1 ships**, on real corpora. The graph is where the cost is and it is the least certain win. |
+
+---
+
+## 3. Current state (verified 2026-09-10 on `main`)
+
+From a full read of the source tree — this is what the design builds on, and the gaps it fills.
+
+**Sources are whole documents, and there is no index.**
+
+- Four handlers: `FileSystemHandler`, `URLHandler`, `IFinderHandler`, `PageHandler` behind `SourceManager` (`server/sources/`). Type union `filesystem | url | ifinder | page` (`server/validators/sourceConfigSchema.js`).
+- `exposeAs: 'prompt' | 'tool'` — content is either injected as prompt context or exposed as a callable tool. Caching is TTL-based (`static | refresh`).
+- **No chunking, no embeddings, no vector store anywhere in the server.** Grepping the whole server tree: `embedding` appears exactly once, as the string constant `embeddings: 'embeddings'` in `server/telemetry/attributes.js`. The 65 `chunk` hits are SSE stream chunks, not retrieval chunks. `rerank` and `knowledgeGraph`: zero hits.
+- Retrieval is **entirely delegated to iFinder**. `iFinderService` (`server/services/integrations/iFinderService.js`) exposes `search`, `getContent`, `getMetadata`, `discover` (with facets), `download`, `resolveDocumentLink` — **all read paths, no write-back or ingest**. Derived artifacts cannot be pushed into iFinder's index today.
+
+**The pipeline machinery already exists — and is already doing a crude version of this.**
+
+The workflow engine (`server/services/workflow/`) has the node executors an enrichment pipeline needs:
+
+| Executor | Role in enrichment |
+|----------|--------------------|
+| `CorpusSearchNodeExecutor` | Pages iFinder queries, dedupes by `docId`, pre-fetches fulltext into `_corpus` |
+| `LoopNodeExecutor` | Per-document / per-chunk iteration |
+| `PromptNodeExecutor` | The extraction passes |
+| `StructuredRecordNodeExecutor` | Collects typed records across iterations |
+| `QuoteValidatorNodeExecutor` | Grounding check — quotes must exist in the source |
+| `QueryPlanNodeExecutor` | Query decomposition and expansion |
+| `TemplateRenderNodeExecutor` | Composes the final document |
+| `CodeNodeExecutor` / `TransformNodeExecutor` | Mechanical steps (clustering, dedup) without an LLM |
+
+`corpus-analysis-decomposed-v2.json` already chains exactly these: `query-plan → loop(corpus-search) → loop(prompt → structured-record) → quote-validator → prompt → template-render`. That is a document-analysis pipeline in production use.
+
+**The gap is durability, not capability.** Everything that pipeline derives lives in workflow state (`contents/data/workflow-state/<executionId>/latest.json`) and dies with the run. Nothing accumulates; nothing is queryable; nothing is readable by a human afterwards; the next run re-pays the full token cost. Making derived knowledge a **first-class stored resource** is the whole of this design.
+
+**Storage is arriving.** The approved StorageProvider design gives a two-facet provider (`documents` + `logs`, plus `notifier` and `locks`), `ownerId` as first-class document metadata, cursor paging, a ~40-test conformance suite, and a provider lineup of filesystem (default), SQLite, PostgreSQL and **OpenSearch**. The Knowledge Layer is a consumer of that abstraction and must not predate it — its namespaces are additive and its OpenSearch provider is the natural home for decision #1(b).
+
+**Other relevant facts:** run ledger `RunLog` exists behind the dark `runLog` feature flag; workflow triggers exist (`server/services/workflow/triggers`) for scheduling; feature flags live in `server/featureRegistry.js` with a `preview` category; config migrations are Flyway-style and currently at `V093`.
+
+---
+
+## 4. Architecture
+
+```
+   sources (existing)                knowledge layer (new)              consumers
+ ┌──────────────────┐         ┌────────────────────────────────┐   ┌──────────────────┐
+ │ filesystem / url │  text   │  Enrichment pipeline           │   │ /wiki  (browse)  │
+ │ page / ifinder   │ ──────▶ │  (workflows, existing engine)  │   │ document dossier │
+ └──────────────────┘  + key  │    ↓ derived artifacts         │   │ entity / topic   │
+        │                     │  KnowledgeStore                │──▶│ articles         │
+        │                     │  (StorageProvider documents)   │   └──────────────────┘
+        │                     └────────────────────────────────┘   ┌──────────────────┐
+        │                                    │                     │ retrieval hooks  │
+        │                                    └────────────────────▶│ query expansion  │
+        │                                                          │ question match   │
+        └─────────────────── retrieval (iFinder, unchanged) ───────▶│ graph expansion  │
+                                                                   └──────────────────┘
+```
+
+Three rules keep this from becoming a second RAG engine:
+
+1. **The Knowledge Layer never becomes the primary retriever.** iFinder (or whatever the source's engine is) still finds documents. The knowledge layer *improves the query* and *adds context*; it does not replace the search.
+2. **Enrichment is a workflow, not new bespoke orchestration.** Reuse the engine, its checkpointing, its resume-on-boot, its triggers, its cost accounting. New code is limited to a handful of node executors and the store.
+3. **Every artifact carries provenance and a content hash.** Re-enrichment is idempotent and incremental; an artifact whose `contentHash` still matches is never recomputed.
+
+---
+
+## 5. Data model
+
+New StorageProvider namespaces. All documents carry `spaceId`, `lang`, `contentHash` and a `provenance` block (`{ model, promptVersion, runId, tokensIn, tokensOut, costEstimate, createdAt }`) so cost is attributable and stale artifacts are detectable.
+
+| Namespace | Key | Contents |
+|-----------|-----|----------|
+| `knowledge-spaces` | `spaceId` | Space config: contributing source ids, declared ACL (§8), `indexingModel`, enabled tiers, taxonomy ref, schedule |
+| `knowledge-docs` | `docKey` | The **document dossier**: source ref, title, summaries (short/long), typed auto-metadata, keywords, taxonomy tags, reference questions, entity refs, enrichment status |
+| `knowledge-chunks` | `docKey:ordinal` | Chunk text (or an offset range into the source), per-chunk keywords, generated questions, entity refs, optional embedding ref |
+| `knowledge-entities` | `entityKey` | Canonical name, type, aliases, LLM-merged description, mention refs, degree/PageRank |
+| `knowledge-relations` | `relKey` | `from`/`to` entity, type, description, evidence refs (`docKey:ordinal`), weight |
+| `knowledge-topics` | `topicKey` | Cluster article: title, summary, findings, impact rating, member entities, hierarchy level |
+| `knowledge-questions` | `questionKey` | Reference question → answering chunk refs. The FAQ index (§7.2) |
+
+**`docKey`** is a stable hash of `(sourceId, documentId)` — not of content — so a document's dossier survives edits and accumulates history. **`contentHash`** gates recomputation.
+
+**Language is a first-class dimension.** iHub is bilingual throughout (localized names, `system` prompts, pages under `contents/pages/{lang}/`). A dossier for a German document with English keywords is useless for a German query. Artifacts are keyed per `lang`; the pragmatic default is to enrich in the document's detected language and generate reference questions in every configured UI language, since question matching is exactly where cross-language mismatch hurts most.
+
+---
+
+## 6. The enrichment pipeline
+
+Expressed as workflows, one per tier, so each is inspectable and editable by admins like any other workflow.
+
+```
+knowledge-enrich-documents  (tier 0)
+  start → resolve-space → loop(documents)
+            ├ skip-if-unchanged   (code: compare contentHash)
+            ├ fetch-content       (source handler / corpus-search)
+            ├ extract-dossier     (prompt → structured output: summary, metadata, keywords, questions)
+            ├ tag-taxonomy        (code/prompt: classify against the space's taxonomy)
+            └ knowledge-write     (NEW executor: persist dossier + provenance)
+          → end
+
+knowledge-enrich-chunks     (tier 1)   adds: chunk → per-chunk prompt → knowledge-write
+knowledge-build-graph       (tier 2)   adds: extract-entities → resolve-entities → knowledge-write
+knowledge-build-topics      (tier 3)   adds: cluster-entities → summarise-community → knowledge-write
+```
+
+**New node executors** — deliberately few:
+
+- **`chunk`** — deterministic, no LLM. Structure-aware splitting (headings, then paragraphs, then a token budget with overlap). Chunk quality bounds every derived artifact (§2.7 of the analysis doc), so this deserves real care and real unit tests, not a naive character split.
+- **`knowledge-write`** — the only path into the store. Validates against the artifact schema, computes `contentHash`, writes provenance, is idempotent on re-run.
+- **`knowledge-query`** — read side, used by retrieval hooks and by the wiki.
+
+Entity resolution and clustering start as `code` nodes (connected-components merge over normalised names + alias table; agglomerative clustering over co-occurrence) and only graduate to LLM-assisted passes if the cheap version measurably underperforms. RAGFlow's resolution pass is LLM-driven over batched candidate pairs; that is a large token line item and should be earned, not assumed.
+
+**Scheduling** uses existing workflow triggers: on-demand from the admin UI, on a schedule per space, and — later — on source-change notification via the StorageProvider's `notifier` facet.
+
+---
+
+## 7. Retrieval integration
+
+Three hooks, cheapest first. Each is independently useful and independently shippable.
+
+### 7.1 Query expansion (phase 0, no index needed)
+
+`QueryPlanNodeExecutor` and the iFinder tool consult the knowledge layer for keywords, taxonomy tags and entity aliases matching the user's question, and widen the iFinder query with them. This is the RAGFlow auto-keyword benefit — fixing vocabulary mismatch — delivered without iHub owning an index, because iFinder still does the searching.
+
+### 7.2 Question matching (phase 1)
+
+The user's question is matched against stored reference questions; hits resolve to their answering chunks, which enter the context directly. Question-to-question matching beats question-to-prose matching because the two sides have the same shape — this is the highest-leverage feature in the whole design and it works with a purely lexical index.
+
+Matching starts lexical (normalised token overlap + iFinder's own text matching over questions fed back as a synthetic source). Decision #1(b) upgrades it to embeddings when the OpenSearch provider lands.
+
+### 7.3 Graph expansion (phase 2–3)
+
+Entity candidates from the query → N-hop expansion over `knowledge-relations` → contributing documents added to the candidate set, with topic articles supplied as context. This is RAGFlow's `KGSearch` shape, and it is the part to build last and judge hardest.
+
+**A note on grounding.** `QuoteValidatorNodeExecutor` already exists and enforces that quoted evidence appears in the source. Every synthesised artifact — dossier summary, topic article — must pass through it. A wiki of confidently wrong summaries is worse than no wiki, and the existing validator is the cheapest available defence.
+
+---
+
+## 8. Permissions — the part with no RAGFlow analogue
+
+A RAGFlow dataset is effectively single-tenant, so synthesising a community report across all its documents raises no access question. iHub is group-permissioned per source and per app. **A topic article synthesised from documents with different ACLs is a data-leak vector**: the article's prose can carry facts from a document the reader may not open, and no read-time filter can un-say them.
+
+The recommended rule (decision #4a):
+
+> A **knowledge space** declares its ACL up front. Only documents whose own permissions are satisfied by that ACL are enriched into it. Every artifact in the space inherits the space's ACL. Cross-document synthesis is therefore always within one access class, by construction.
+
+Consequences, stated plainly:
+- A source whose documents span access classes must be split across spaces, or enriched into the most restrictive one.
+- Per-document dossiers may additionally be filtered at read time to the reader's own document permissions — that is defence in depth, not the primary control.
+- For iFinder sources, per-document ACLs live in iFinder and are enforced per user at search time. The space ACL must be set to match the search profile's audience; getting this wrong is the single most damaging misconfiguration in this design, so the admin UI must state the rule at the point of configuration and the validator must reject a space with no declared ACL.
+
+---
+
+## 9. Configuration, flags and migration
+
+- **Feature flag** `knowledgeLayer` in `server/featureRegistry.js`, `category: 'preview'`, `default: false`, `preview: true` — same posture as `runLog`.
+- **Space configs** as individual files under `contents/knowledge/<spaceId>.json`, following the established one-file-per-resource pattern (`contents/apps/*.json`, `contents/models/*.json`), with a Zod schema in `server/validators/knowledgeSpaceSchema.js`.
+- **Migration** `V094__add_knowledge_layer_config.js` seeds platform defaults (global enrichment budget ceiling, default `indexingModel`, retention). Additive only — `setDefault` never overwrites admin values.
+- **Sources** gain an optional `knowledge` block (`{ spaceId, tiers, schedule }`). Additive and optional, so no existing `sources.json` breaks and no compatibility shim is needed.
+
+## 10. UI surface
+
+- New top-level route **`/wiki`**: space index → document dossiers → entity pages → topic articles, plus a search box over the knowledge store.
+- Admin: space CRUD, per-space enrichment status and cost, "re-enrich" actions, stale-artifact counts.
+
+⚠️ **Adding `/wiki` requires updating both route lists** — `KNOWN_ROUTES` in `client/src/utils/runtimeBasePath.js` *and* the inline `knownRoutes` array in `client/index.html`. `tests/unit/client/known-routes-sync.test.jsx` fails if they drift, and missing the `index.html` copy breaks **cold loads** of `/wiki` on subpath deployments with "Unable to connect to the server" while client-side navigation still appears to work.
+
+---
+
+## 11. Cost, and why the phasing is what it is
+
+Per the analysis doc, for *D* documents at *C* chunks each:
+
+| Tier | LLM calls | 500 docs × 40 chunks |
+|------|-----------|----------------------|
+| 0 — document dossiers | ~*D* | ~500 |
+| 1 — chunk keywords + questions | ~2·*D·C* | ~40,000 |
+| 2 — graph extraction + resolution | ~*D·C* + pair batches | ~20,000+ |
+| 3 — topic articles | ~communities | ~hundreds |
+
+Tier 0 is **~1–2% of tier 1** on the same corpus and already delivers document dossiers, retrieval filters, query expansion, and a readable wiki page per document. That asymmetry is the entire argument for shipping it alone and measuring before spending two orders of magnitude more.
+
+Controls that ship with tier 0, not after it: a per-space token budget with hard stop, a dedicated cheap `indexingModel`, `contentHash` skip-if-unchanged, dry-run cost estimation before a bulk run, and per-space cost reporting in the admin UI. Enrichment is the first feature in iHub that can spend a large budget with no user watching, so the guardrails are part of the minimum viable version.
+
+---
+
+## 12. Phased plan
+
+Each phase ships user-visible value on its own and is independently abandonable.
+
+| Phase | Ships | Depends on |
+|-------|-------|-----------|
+| **0** | `KnowledgeStore` + `knowledge-write`/`knowledge-query` executors, document dossiers, `/wiki` browse, query expansion (§7.1), budget controls, feature flag | StorageProvider step 1 |
+| **1** | `chunk` executor, per-chunk keywords + reference questions, question matching (§7.2) | Phase 0 |
+| **2** | Entity + relation extraction, mechanical resolution, entity pages, graph expansion (§7.3) | Phase 1 + decision #8 |
+| **3** | Clustering + topic articles — the LLM wiki proper | Phase 2 |
+| **4** | Change-driven incremental re-enrichment via the `notifier` facet; optional embedding facet (decision #1b) | Phases 0–3 |
+
+**Phase 0 is the whole recommendation.** Phases 2–3 should be re-argued against real phase-1 data rather than pre-approved here; that is where RAGFlow's own documentation warns the cost lives, and where the benefit is least certain for iHub's corpora.
+
+---
+
+## 13. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| **ACL leakage through synthesised prose** | Space-declared ACL (§8); validator rejects undeclared; admin UI states the rule inline |
+| **Runaway enrichment cost** | Per-space budget with hard stop, dry-run estimate, cheap `indexingModel`, content-hash skip — all in phase 0 |
+| **Confidently wrong summaries** | Mandatory `quote-validator` pass; dossiers link to source; wiki marks every artifact as generated, with model and date |
+| **Becoming a second RAG engine** | Architecture rule #1 (§4): the knowledge layer improves queries and adds context, never replaces search. Decision #1 caps this explicitly |
+| **Stale knowledge** | `contentHash` per artifact; stale counts surfaced in admin; phase 4 makes re-enrichment change-driven |
+| **Poor chunk boundaries poisoning everything downstream** | `chunk` is deterministic and unit-tested; structure-aware before token-budget fallback |
+| **Bilingual mismatch** | `lang` is a first-class key; reference questions generated per configured UI language |
+| **iFinder gains an ingest API and invalidates the design** | Decision #2 is called out as a reopen trigger, not an assumption buried in code |
+
+---
+
+## 14. Follow-ups when implementation starts
+
+- `docs/knowledge-layer.md` (new, added to `docs/SUMMARY.md`) and a cross-reference from `docs/sources.md`.
+- A changelog entry in `docs/releases/` via the `document-feature` skill — this is admin- and user-visible.
+- Conformance tests for the new namespaces against the StorageProvider suite.

--- a/concepts/knowledge-layer-wiki/2026-09-10 RAGFlow Capability Analysis.md
+++ b/concepts/knowledge-layer-wiki/2026-09-10 RAGFlow Capability Analysis.md
@@ -1,0 +1,129 @@
+# RAGFlow Capability Analysis — What It Actually Builds
+
+**Date:** 2026-09-10
+**Status:** Research input for the [Knowledge Layer design](./2026-09-10%20Knowledge%20Layer%20and%20LLM%20Wiki%20Design.md)
+**Purpose:** Establish precisely what RAGFlow's document-analysis features do, so the iHub design copies the *ideas* that transfer and not the architecture that doesn't.
+
+---
+
+## 1. Why this document exists
+
+"RAGFlow can build a knowledge graph and extract concepts" is easy to say and easy to get wrong. RAGFlow's document intelligence is five separate features with different costs, different outputs, and different retrieval behaviour. Two of them are cheap and high value; one of them is expensive enough that RAGFlow's own documentation warns you off it. Any iHub design that treats them as one switch will mis-budget by an order of magnitude.
+
+Everything below is a per-dataset (knowledge base) setting in RAGFlow, applied at parse time. RAGFlow requires you to pick an **indexing model** per dataset — the chat model used to generate the knowledge graph, RAPTOR, auto-metadata, auto-keyword and auto-question artifacts. That single fact is the most important structural point: **all of these features are LLM passes over content at ingest time**, not query-time behaviour.
+
+---
+
+## 2. The five features
+
+### 2.1 Auto-keyword
+
+A chat model generates *N* keywords or synonyms from each chunk. Configured as a slider (an integer; a non-integer like `1.7` rounds down). The stated purpose is to "correct errors and enhance retrieval accuracy" — i.e. it patches vocabulary mismatch between how a document phrases something and how a user asks about it.
+
+- **Granularity:** per chunk.
+- **Cost:** one LLM call per chunk, at ingest.
+- **Retrieval effect:** keywords are indexed alongside the chunk, so a query matching a synonym matches the chunk.
+
+### 2.2 Auto-question
+
+A chat model generates *N* questions (who/what/why) that each chunk answers. Documented as improving "the matching of user queries", and explicitly aimed at "FAQ retrieval scenarios involving product manuals or policy documents".
+
+- **Granularity:** per chunk.
+- **Cost:** one LLM call per chunk, at ingest.
+- **Retrieval effect:** this is query-to-query matching rather than query-to-document matching. A user question is compared against generated questions, which are far closer in form to a query than prose is. This is the single highest-leverage trick in the list.
+
+### 2.3 Auto-metadata
+
+An LLM pass extracts document-level metadata fields, which then become retrieval filters.
+
+- **Granularity:** per document.
+- **Cost:** roughly one LLM call per document — the cheapest feature per unit of value.
+
+### 2.4 Tag sets
+
+A *tag set* is a dataset whose only job is to hold tags. Auto-tagging maps tags from user-defined tag sets onto chunks **by similarity with each chunk**. You configure which tag set(s) a dataset uses, then re-parse to trigger tagging.
+
+The important distinction: this is **classification against a controlled vocabulary**, not open-ended extraction. Auto-keyword invents vocabulary; tag sets constrain it. For enterprise use — where taxonomies already exist and matter — the constrained version is usually the one you want, and it is notably cheaper because similarity matching, not generation, does the work.
+
+### 2.5 Knowledge graph (GraphRAG)
+
+RAGFlow inserts a graph-construction step between extraction and indexing, creating **additional chunks** from the ones the chunking method produced. From the implementation:
+
+| Stage | Mechanism |
+|-------|-----------|
+| Entity + relation extraction | Two strategies: a standard extractor asking for "richer typed entities, relations, and iterative gleanings", and a `light` variant that trims scope to cut cost and latency |
+| Entity resolution | An LLM-assisted equivalence pass that "batches candidate pairs, checkpoints progress, merges nodes and edges by connected components, and recomputes PageRank after the merge" |
+| Community detection | Leiden clustering over the graph |
+| Community reports | Structured JSON per community: **title, summary, impact rating, and findings** |
+| Storage | Artifacts live *in the document store itself* — the global graph, per-document subgraphs, entity chunks and relation chunks — with entities and relations embedded for vector search |
+| Retrieval (`KGSearch`) | Rewrites the question into keywords → finds entity candidates via keyword *and* embedding signals → expands N-hop paths → folds in community reports → normalises everything into chunk-shaped bundles |
+
+RAGFlow's documentation is blunt about the trade-off: constructing a knowledge graph "requires significant memory, computational resources, and tokens", and is worth it for "multi-hop question-answering involving nested logic", books, and "works with complex entities and relationships".
+
+Two details deserve emphasis because they are the parts most re-implementations get wrong:
+
+1. **Entity resolution is not optional.** Without the merge pass, "Dr. Meier", "Meier, A." and "Andreas Meier" are three nodes and the graph is worthless. The merge is itself LLM-driven over candidate pairs, which is where a large slice of the token cost lives.
+2. **Community reports are the actual product.** The graph enables them; the reports are what retrieval consumes. A title + summary + findings per cluster *is* an auto-generated wiki article. This is the mechanism behind "something like an LLM wiki".
+
+### 2.6 RAPTOR (adjacent, same budget)
+
+RAPTOR — Recursive Abstractive Processing for Tree Organized Retrieval — recursively clusters and summarises chunks into a hierarchical tree, so retrieval can hit a summary node instead of scattered leaves. Also aimed at multi-hop QA and long documents.
+
+- `use_raptor` defaults to `false`.
+- **Threshold** sets the minimum similarity for chunks to cluster together: default `0.1`, max `1`. Higher threshold → fewer chunks per cluster.
+- Available when the chunk method is one of `qa`, `manual`, `paper`, `book`, `laws`, `presentation`.
+
+RAPTOR and the knowledge graph solve overlapping problems by different means: RAPTOR builds hierarchy over *text*, GraphRAG builds structure over *entities*. RAPTOR is materially cheaper — clustering is mechanical and only summarisation costs tokens, with no O(pairs) resolution step.
+
+### 2.7 Chunking as the foundation
+
+All of the above sit on RAGFlow's layout-aware chunking templates (`naive`, `qa`, `paper`, `book`, `laws`, `presentation`, `table`, `picture`, `resume`, `one`). Chunk quality bounds every derived artifact: keywords, questions, entities and clusters are all only as good as the chunk boundaries they were computed over. RAGFlow's differentiator is arguably this parsing layer rather than the LLM passes on top of it.
+
+---
+
+## 3. Cost model, made explicit
+
+Let *D* = documents, *C* = chunks per document, *E* = entities extracted.
+
+| Feature | LLM calls at ingest | Scales with |
+|---------|--------------------|-------------|
+| Auto-metadata | ~*D* | documents |
+| Auto-keyword | ~*D·C* | chunks |
+| Auto-question | ~*D·C* | chunks |
+| Tag sets | 0 generative (similarity matching) | chunks (embedding only) |
+| RAPTOR | ~clusters per level × levels | chunks, sub-linear |
+| Knowledge graph | ~*D·C* (extraction) + candidate-pair batches (resolution) + communities (reports) | chunks **and** entity pairs |
+
+A 500-document corpus at 40 chunks per document is 20,000 chunks. Auto-keyword *and* auto-question on that corpus is ~40,000 LLM calls before a single user question is asked. Graph construction on the same corpus adds another 20,000 extraction calls plus resolution and report passes. This is the number that decides the phasing in the iHub design: the per-document tier costs ~500 calls for the same corpus — roughly 1–2% of the chunk-level tier — and delivers a large share of the practical benefit.
+
+---
+
+## 4. What transfers to iHub Apps, and what does not
+
+**Transfers well** — these are ideas, not infrastructure:
+
+- **Reference questions per unit of content.** Cheap, provider-agnostic, and the best matching trick available. Works with a purely lexical index.
+- **Document-level dossiers** (summary + keywords + typed metadata). Nearly free per document; immediately useful as prompt context, as retrieval filters, and as human-readable pages.
+- **Controlled-vocabulary tagging** over open-ended keyword generation. iHub's enterprise deployments already have taxonomies.
+- **Community/cluster reports as generated articles.** This is the "LLM wiki" and it is worth building — but as the *last* phase, since it depends on everything above it.
+- **A separate indexing model.** Enrichment is bulk, latency-insensitive and budget-sensitive; it should never be pinned to the interactive chat model. iHub's per-app `preferredModel` has no equivalent notion of a cheap bulk-processing model.
+
+**Does not transfer** — this is where copying RAGFlow would be a mistake:
+
+- **Owning the parser, chunker, embedder and vector store.** RAGFlow is a complete RAG engine. iHub deliberately is not: retrieval is delegated to iFinder (`CorpusSearchNodeExecutor`, `iFinderService.search`), and non-iFinder sources are whole-file prompt context with no chunk identity at all. Rebuilding RAGFlow's stack inside iHub means shipping a second, weaker retrieval engine next to IntraFind's actual product.
+- **Dataset-scoped permissions.** A RAGFlow dataset is effectively single-tenant, so a community report synthesised across all its documents raises no access question. iHub is group-permissioned per source and per app, so a single article synthesised from documents with differing ACLs is a data-leak vector. This has no RAGFlow analogue and needs a first-class answer.
+- **Storing graph artifacts as embedded chunks in the search index.** That only works if you control the index. iHub cannot: `iFinderService` exposes `search`, `getContent`, `getMetadata`, `discover`, `download` and `resolveDocumentLink` — all read paths. There is **no write-back or ingest API**, so derived artifacts cannot be pushed into iFinder's index from iHub as things stand. The knowledge layer must own its own store.
+
+---
+
+## 5. Sources
+
+- [Auto-keyword Auto-question | RAGFlow](https://ragflow.io/docs/autokeyword_autoquestion)
+- [Auto-Extract Metadata | RAGFlow](https://ragflow.io/docs/auto_metadata)
+- [Use tag set | RAGFlow](https://ragflow.io/docs/use_tag_sets)
+- [Construct knowledge graph | RAGFlow](https://ragflow.io/docs/dev/construct_knowledge_graph)
+- [Enable RAPTOR | RAGFlow](https://ragflow.io/docs/dev/enable_raptor)
+- [GraphRAG implementation walkthrough — RAGFlow Field Guide](https://doc.holiday/library/ragflow/graphrag/)
+- [Introduction to RAGFlow: Open-Source RAG Engine with Deep Document Understanding](https://www.pondhouse-data.com/blog/introduction-to-ragflow)
+- [infiniflow/ragflow — `rag/raptor.py`](https://github.com/infiniflow/ragflow/blob/main/rag/raptor.py)
+- [infiniflow/ragflow — `docs/guides/dataset/use_tag_sets.md`](https://github.com/infiniflow/ragflow/blob/main/docs/guides/dataset/use_tag_sets.md)

--- a/concepts/knowledge-layer-wiki/README.md
+++ b/concepts/knowledge-layer-wiki/README.md
@@ -1,0 +1,20 @@
+# Knowledge Layer & LLM Wiki — Concept Documents
+
+Design documents for giving iHub Apps a derived-knowledge layer over its sources — document dossiers, reference questions, an entity graph and generated topic articles — inspired by RAGFlow's document-analysis features.
+
+## Documents
+
+- **[2026-09-10 Knowledge Layer and LLM Wiki Design](./2026-09-10%20Knowledge%20Layer%20and%20LLM%20Wiki%20Design.md)** — **Current.** The design: `KnowledgeStore` namespaces on the approved StorageProvider, enrichment expressed as workflows over the existing node executors, three retrieval hooks (query expansion, question matching, graph expansion), the knowledge-space ACL model, cost model and a five-phase plan. Contains eight open decisions that need answers before an issue stack.
+- **[2026-09-10 RAGFlow Capability Analysis](./2026-09-10%20RAGFlow%20Capability%20Analysis.md)** — Research input. What RAGFlow's auto-keyword, auto-question, auto-metadata, tag sets, knowledge graph and RAPTOR features actually do, their relative token costs, and an explicit split of what transfers to iHub versus what would be a mistake to copy.
+
+## Context
+
+iHub Apps has no index of its own. Sources (`filesystem`, `url`, `ifinder`, `page`) are whole-document prompt context, and retrieval is delegated to iFinder — there is no chunking, no embeddings and no vector store in the server. That is a deliberate boundary: IntraFind's search engine is the retriever, and iHub should not ship a second one.
+
+What is missing is durability of insight. The workflow engine already runs sophisticated document analysis (`corpus-analysis-decomposed-v2` chains query planning, per-document evidence extraction, quote validation and synthesis), but everything it derives lives in workflow state and dies with the run. Nothing accumulates, nothing is queryable, nothing is readable afterwards, and the next run re-pays the full token cost.
+
+The Knowledge Layer makes derived knowledge a first-class stored resource: cumulative, browsable as a wiki, and reusable by retrieval — while retrieval engines stay pluggable underneath.
+
+## Status
+
+Draft, pending review. The cost asymmetry in the design (§11) is the key point for the review: the per-document tier costs roughly 1–2% of the per-chunk tier on the same corpus, so phase 0 is the recommendation and the graph phases should be re-argued against real data rather than pre-approved.


### PR DESCRIPTION
## What

Two concept documents in `concepts/knowledge-layer-wiki/`, responding to the observation that RAGFlow can generate graphs, extract concepts, store keyword metadata and attach reference questions to chunks to build something like an LLM wiki.

- `2026-09-10 RAGFlow Capability Analysis.md` — what those features actually do, per feature: auto-keyword and auto-question (per chunk), auto-metadata (per document), tag sets (classification against a controlled vocabulary, not generation), the knowledge graph (typed extraction → LLM entity resolution over batched candidate pairs → Leiden clustering → community reports with title/summary/impact rating/findings → `KGSearch` with N-hop expansion), and RAPTOR. Includes an explicit token-cost model and a split between the ideas that transfer to iHub and the architecture that would be a mistake to copy.
- `2026-09-10 Knowledge Layer and LLM Wiki Design.md` — the design for iHub: `KnowledgeStore` namespaces on the approved StorageProvider, enrichment expressed as workflows over the existing node executors, three retrieval hooks, the knowledge-space ACL model, cost model, five-phase plan and risks.
- `README.md` — folder index and context.

Docs only — no code, config or behaviour changes. `concepts/` is prettier-ignored, so no formatting pass applies.

## Framing

The central decision is what iHub does *not* build. Verified against `main`:

- There is **no index infrastructure in the server** — `embedding` appears exactly once (a telemetry string constant), and `rerank`/`knowledgeGraph` not at all. The 65 `chunk` hits are SSE stream chunks.
- Retrieval is **entirely delegated to iFinder**, and `iFinderService` exposes only read paths (`search`, `getContent`, `getMetadata`, `discover`, `download`, `resolveDocumentLink`) — **no write-back or ingest API**, so derived artifacts cannot be pushed into iFinder's index today.

Reimplementing RAGFlow's stack (parser, chunker, embedder, vector store, retriever) would ship a second, weaker retriever next to IntraFind's actual product. What is genuinely missing is **durability of insight**: `corpus-analysis-decomposed-v2` already chains query planning, per-document evidence extraction, quote validation and synthesis — but everything it derives lives in workflow state and dies with the run. Nothing accumulates, nothing is queryable, nothing is readable afterwards, and the next run re-pays the full token cost.

So the design makes derived knowledge a first-class stored resource and keeps retrieval engines pluggable underneath. Enrichment reuses the existing workflow engine (loop, prompt, structured-record, quote-validator, template-render, triggers); new code is limited to three node executors (`chunk`, `knowledge-write`, `knowledge-query`) and the store.

## Recommendation

**Phase 0 only** — document dossiers (summary, typed metadata, keywords, reference questions), a `/wiki` browse surface, and query expansion into iFinder. On a 500-document corpus at 40 chunks each, the per-document tier is ~500 LLM calls against ~40,000 for the per-chunk tier: **~1–2% of the cost** for a large share of the practical benefit. The graph phases are where RAGFlow's own docs warn the cost lives, so they should be re-argued against real phase-1 data rather than pre-approved here.

Budget guardrails ship *with* phase 0, not after it — enrichment is the first iHub feature that can spend a large budget with no user watching.

## Two points worth reviewer attention

- **ACL leakage has no RAGFlow analogue.** A RAGFlow dataset is effectively single-tenant, so synthesising a community report across all its documents raises no access question. iHub is group-permissioned per source, and a topic article synthesised from documents with differing ACLs can carry facts from a document the reader may not open — which no read-time filter can un-say. The proposed rule: a knowledge space declares its ACL up front, only documents satisfying it are enriched into the space, and all artifacts inherit it, so cross-document synthesis is always within one access class by construction.
- **`/wiki` is a new top-level route**, so it needs adding to `KNOWN_ROUTES` in `client/src/utils/runtimeBasePath.js` *and* the inline `knownRoutes` array in `client/index.html` — flagged in the design because missing the `index.html` copy breaks cold loads on subpath deployments while client-side navigation still appears to work.

## Open decisions

Eight decisions are listed in §2 of the design and need answers before an issue stack — notably whether iHub ever gets its own embedding index (recommendation: lexical-only for phases 0–1, an optional OpenSearch embedding facet later, never a standalone vector store), and whether IntraFind might expose an iFinder ingest API, which is called out as a reopen trigger since it would simplify phases 1–2 substantially.

## Test plan

Not applicable — documentation only. Claims about the codebase were verified by reading the referenced files; external RAGFlow claims are sourced in §5 of the analysis document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014wN64AboKnpvnADKEBA7QR