### PR TITLE
fix(auth): make username and email matching case-insensitive

### DIFF
--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -632,3 +632,11 @@ request:
 
 When the ceiling does fire, the error names the setting to raise, and the server log records the
 endpoint that was tried (with URL secrets redacted) next to the model and provider.
+
+## Logging In No Longer Depends on Username Capitalization
+
+A user whose username was created as `Daniel.Manzke` could not log in by typing `daniel.manzke` —
+username and email lookups compared strings exactly, so any difference in capitalization was
+treated as a different account. Login, admin user creation, and duplicate-username checks now all
+match usernames and emails case-insensitively, and the same fix applies to how OIDC, LDAP, NTLM,
+and Teams sign-ins are matched against previously persisted accounts.

--- a/server/middleware/jwtAuth.js
+++ b/server/middleware/jwtAuth.js
@@ -5,7 +5,7 @@ import {
 } from '../utils/oauthClientManager.js';
 import { isPersonalKeyExpired, isPersonalKeysEnabled } from '../utils/personalApiKeyManager.js';
 import { isCurrentKeyGeneration } from '../utils/oauthTokenService.js';
-import { loadUsers, isUserActive } from '../utils/userManager.js';
+import { loadUsers, isUserActive, equalsIgnoreCase } from '../utils/userManager.js';
 import { verifyJwt, decodeJwt } from '../utils/tokenService.js';
 import { recordAuthEvent } from '../telemetry/metrics.js';
 import configCache from '../configCache.js';
@@ -560,7 +560,7 @@ export default function jwtAuthMiddleware(req, res, next) {
         // If not found by ID, try to find by email (OIDC users may have different IDs)
         if (!userRecord && decoded.email) {
           userRecord = Object.values(usersConfig.users || {}).find(
-            u => u.email === decoded.email && u.authMethods?.includes('oidc')
+            u => equalsIgnoreCase(u.email, decoded.email) && u.authMethods?.includes('oidc')
           );
         }
 
@@ -610,13 +610,15 @@ export default function jwtAuthMiddleware(req, res, next) {
 
         if (!userRecord && decoded.email) {
           userRecord = Object.values(usersConfig.users || {}).find(
-            u => u.email === decoded.email && u.authMethods?.includes('ldap')
+            u => equalsIgnoreCase(u.email, decoded.email) && u.authMethods?.includes('ldap')
           );
         }
 
         if (!userRecord && decoded.username) {
           userRecord = Object.values(usersConfig.users || {}).find(
-            u => u.ldapData?.username === decoded.username && u.authMethods?.includes('ldap')
+            u =>
+              equalsIgnoreCase(u.ldapData?.username, decoded.username) &&
+              u.authMethods?.includes('ldap')
           );
         }
 
@@ -663,7 +665,7 @@ export default function jwtAuthMiddleware(req, res, next) {
         // If not found by ID, try to find by email
         if (!userRecord && decoded.email) {
           userRecord = Object.values(usersConfig.users || {}).find(
-            u => u.email === decoded.email && u.authMethods?.includes('teams')
+            u => equalsIgnoreCase(u.email, decoded.email) && u.authMethods?.includes('teams')
           );
         }
 
@@ -712,7 +714,9 @@ export default function jwtAuthMiddleware(req, res, next) {
           userRecord = Object.values(usersConfig.users || {}).find(
             u =>
               (u.ntlmData?.subject === userId && u.authMethods?.includes('ntlm')) ||
-              (decoded.email && u.email === decoded.email && u.authMethods?.includes('ntlm'))
+              (decoded.email &&
+                equalsIgnoreCase(u.email, decoded.email) &&
+                u.authMethods?.includes('ntlm'))
           );
         }
 

--- a/server/middleware/localAuth.js
+++ b/server/middleware/localAuth.js
@@ -5,7 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { enhanceUserGroups } from '../utils/authorization.js';
 import { generateJwt } from '../utils/tokenService.js';
-import { hashPasswordWithUserId, loadUsers } from '../utils/userManager.js';
+import { equalsIgnoreCase, hashPasswordWithUserId, loadUsers } from '../utils/userManager.js';
 import configCache from '../configCache.js';
 import { ensureFirstUserIsAdmin } from '../utils/adminRescue.js';
 
@@ -55,8 +55,10 @@ export async function loginUser(username, password, localAuthConfig) {
   const usersConfig = loadUsers(localAuthConfig.usersFile || 'contents/config/users.json');
   const users = usersConfig.users || {};
 
-  // Find user by username or email
-  const user = Object.values(users).find(u => u.username === username || u.email === username);
+  // Find user by username or email (case-insensitive)
+  const user = Object.values(users).find(
+    u => equalsIgnoreCase(u.username, username) || equalsIgnoreCase(u.email, username)
+  );
 
   if (!user) {
     await verifyPasswordWithUserId(password, DUMMY_USER_ID, DUMMY_PASSWORD_HASH);
@@ -125,8 +127,10 @@ export async function createUser(userData, usersFilePath) {
   const usersConfig = loadUsers(usersFilePath);
   const users = usersConfig.users || {};
 
-  // Check if user already exists
-  const existingUser = Object.values(users).find(u => u.username === username || u.email === email);
+  // Check if user already exists (case-insensitive)
+  const existingUser = Object.values(users).find(
+    u => equalsIgnoreCase(u.username, username) || equalsIgnoreCase(u.email, email)
+  );
 
   if (existingUser) {
     throw new Error('User with this username or email already exists');

--- a/server/routes/admin/auth.js
+++ b/server/routes/admin/auth.js
@@ -5,7 +5,7 @@ import { atomicWriteJSON } from '../../utils/atomicWrite.js';
 import configCache from '../../configCache.js';
 import { adminAuth, isAdminAuthRequired } from '../../middleware/adminAuth.js';
 import { isContentAdminAuthRequired } from '../../middleware/contentAdminAuth.js';
-import { hashPasswordWithUserId } from '../../utils/userManager.js';
+import { equalsIgnoreCase, hashPasswordWithUserId } from '../../utils/userManager.js';
 import { v4 as uuidv4 } from 'uuid';
 import { buildServerPath } from '../../utils/basePath.js';
 import { validateIdForPath } from '../../utils/pathSecurity.js';
@@ -397,8 +397,10 @@ export default function registerAdminAuthRoutes(app) {
         };
       }
 
-      // Check if username already exists
-      const existingUser = Object.values(usersData.users).find(user => user.username === username);
+      // Check if username already exists (case-insensitive)
+      const existingUser = Object.values(usersData.users).find(user =>
+        equalsIgnoreCase(user.username, username)
+      );
       if (existingUser) {
         return sendErrorResponse(res, 409, 'Username already exists');
       }

--- a/server/tests/localAuth.test.js
+++ b/server/tests/localAuth.test.js
@@ -3,8 +3,29 @@ import fs from 'fs/promises';
 import { jest } from '@jest/globals';
 import os from 'os';
 import path from 'path';
-import { loginUser } from '../middleware/localAuth.js';
-import { hashPasswordWithUserId } from '../utils/userManager.js';
+
+// Successful logins also go through JWT signing and the first-user-admin-rescue
+// check; neither is relevant to username matching, so keep them out of the way
+// with lightweight, deterministic stand-ins.
+jest.unstable_mockModule('../configCache.js', () => ({
+  __esModule: true,
+  default: {
+    getPlatform: () => ({
+      jwt: { algorithm: 'HS256' },
+      auth: { jwtSecret: 'test-secret-key' },
+      localAuth: { enabled: true }
+    }),
+    get: () => ({ data: null, etag: null }),
+    setCacheEntry: () => {}
+  }
+}));
+jest.unstable_mockModule('../utils/adminRescue.js', () => ({
+  __esModule: true,
+  ensureFirstUserIsAdmin: async user => user
+}));
+
+const { loginUser, createUser } = await import('../middleware/localAuth.js');
+const { hashPasswordWithUserId } = await import('../utils/userManager.js');
 
 describe('localAuth loginUser timing protections', () => {
   const expectedDummyHash = '$2a$12$n6wyln4ERyOHBD6UAx2fAOkt0F7nX0x6X2ZiYAbBVvK7i7diOaJjG';
@@ -58,5 +79,118 @@ describe('localAuth loginUser timing protections', () => {
     );
     expect(compareSpy).toHaveBeenNthCalledWith(2, 'user_1:wrong-password', storedPasswordHash);
     compareSpy.mockRestore();
+  });
+});
+
+describe('localAuth loginUser case-insensitive matching', () => {
+  let testDir;
+  let usersFilePath;
+  let localAuthConfig;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'local-auth-test-'));
+    usersFilePath = path.join(testDir, 'users.json');
+
+    const storedPasswordHash = await hashPasswordWithUserId('correct-password', 'user_1');
+    const usersConfig = {
+      users: {
+        user_1: {
+          id: 'user_1',
+          username: 'Daniel.Manzke',
+          email: 'Daniel.Manzke@example.com',
+          name: 'Daniel Manzke',
+          active: true,
+          passwordHash: storedPasswordHash,
+          internalGroups: ['user']
+        }
+      }
+    };
+
+    await fs.writeFile(usersFilePath, JSON.stringify(usersConfig, null, 2), 'utf8');
+    localAuthConfig = { usersFile: usersFilePath, sessionTimeoutMinutes: 480 };
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  test('logs in when the typed username differs in case from the stored username', async () => {
+    const result = await loginUser('daniel.manzke', 'correct-password', localAuthConfig);
+    expect(result.user.id).toBe('user_1');
+    expect(result.user.username).toBe('Daniel.Manzke');
+    expect(result.token).toBeDefined();
+  });
+
+  test('logs in when the typed email differs in case from the stored email', async () => {
+    const result = await loginUser(
+      'DANIEL.MANZKE@EXAMPLE.COM',
+      'correct-password',
+      localAuthConfig
+    );
+    expect(result.user.id).toBe('user_1');
+  });
+
+  test('still rejects an unrelated username regardless of case', async () => {
+    await expect(loginUser('someone.else', 'correct-password', localAuthConfig)).rejects.toThrow(
+      'Invalid credentials'
+    );
+  });
+});
+
+describe('localAuth createUser case-insensitive uniqueness', () => {
+  let testDir;
+  let usersFilePath;
+
+  beforeEach(async () => {
+    testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'local-auth-create-test-'));
+    usersFilePath = path.join(testDir, 'users.json');
+
+    const usersConfig = {
+      users: {
+        user_1: {
+          id: 'user_1',
+          username: 'Daniel.Manzke',
+          email: 'Daniel.Manzke@example.com',
+          name: 'Daniel Manzke',
+          active: true,
+          passwordHash: 'irrelevant-for-this-test',
+          internalGroups: ['user']
+        }
+      }
+    };
+
+    await fs.writeFile(usersFilePath, JSON.stringify(usersConfig, null, 2), 'utf8');
+  });
+
+  afterEach(async () => {
+    await fs.rm(testDir, { recursive: true, force: true });
+  });
+
+  test('rejects a new username that differs only in case from an existing one', async () => {
+    await expect(
+      createUser(
+        {
+          username: 'daniel.manzke',
+          email: 'other@example.com',
+          password: 'password123',
+          name: 'Someone Else'
+        },
+        usersFilePath
+      )
+    ).rejects.toThrow('User with this username or email already exists');
+  });
+
+  test('rejects a new email that differs only in case from an existing one', async () => {
+    await expect(
+      createUser(
+        {
+          username: 'someone-else',
+          email: 'daniel.manzke@example.com',
+          password: 'password123',
+          name: 'Someone Else'
+        },
+        usersFilePath
+      )
+    ).rejects.toThrow('User with this username or email already exists');
   });
 });

--- a/server/tests/userManager.test.js
+++ b/server/tests/userManager.test.js
@@ -1,0 +1,46 @@
+import { equalsIgnoreCase, findUserByIdentifier } from '../utils/userManager.js';
+
+describe('equalsIgnoreCase', () => {
+  test('matches strings that differ only in case', () => {
+    expect(equalsIgnoreCase('Daniel.Manzke', 'daniel.manzke')).toBe(true);
+    expect(equalsIgnoreCase('ADMIN', 'admin')).toBe(true);
+    expect(equalsIgnoreCase('same', 'same')).toBe(true);
+  });
+
+  test('rejects genuinely different strings', () => {
+    expect(equalsIgnoreCase('daniel.manzke', 'daniel.mueller')).toBe(false);
+  });
+
+  test('returns false for non-string or missing values', () => {
+    expect(equalsIgnoreCase(undefined, 'admin')).toBe(false);
+    expect(equalsIgnoreCase('admin', undefined)).toBe(false);
+    expect(equalsIgnoreCase(null, null)).toBe(false);
+  });
+});
+
+describe('findUserByIdentifier case-insensitivity', () => {
+  const usersConfig = {
+    users: {
+      user_1: {
+        id: 'user_1',
+        username: 'Daniel.Manzke',
+        email: 'Daniel.Manzke@example.com',
+        authMethods: ['local']
+      }
+    }
+  };
+
+  test('finds user by username regardless of case', () => {
+    const user = findUserByIdentifier(usersConfig, 'daniel.manzke');
+    expect(user?.id).toBe('user_1');
+  });
+
+  test('finds user by email regardless of case', () => {
+    const user = findUserByIdentifier(usersConfig, 'daniel.manzke@example.com');
+    expect(user?.id).toBe('user_1');
+  });
+
+  test('does not match an unrelated identifier', () => {
+    expect(findUserByIdentifier(usersConfig, 'someone.else')).toBeNull();
+  });
+});

--- a/server/utils/userManager.js
+++ b/server/utils/userManager.js
@@ -174,6 +174,18 @@ export async function saveUsers(usersConfig, usersFilePath) {
 }
 
 /**
+ * Case-insensitively compare two identifier strings (username/email).
+ * Login-facing identifiers must not be treated as distinct just because
+ * they differ in case (e.g. "Daniel.Manzke" vs "daniel.manzke").
+ * @param {string} a
+ * @param {string} b
+ * @returns {boolean} True if both are strings and equal ignoring case
+ */
+export function equalsIgnoreCase(a, b) {
+  return typeof a === 'string' && typeof b === 'string' && a.toLowerCase() === b.toLowerCase();
+}
+
+/**
  * Find user by various identifiers (username, email, oidcSubject)
  * @param {Object} usersConfig - Users configuration
  * @param {string} identifier - Username, email, or OIDC subject ID
@@ -191,10 +203,11 @@ export function findUserByIdentifier(usersConfig, identifier, authMethod = null)
       continue;
     }
 
-    // Match by username, email, or auth-specific subject
+    // Match by username, email (both case-insensitive), or auth-specific subject
+    // (provider subject IDs are opaque and compared exactly)
     if (
-      user.username === identifier ||
-      (identifier && user.email === identifier) ||
+      equalsIgnoreCase(user.username, identifier) ||
+      (identifier && equalsIgnoreCase(user.email, identifier)) ||
       (user.oidcData && user.oidcData.subject === identifier) ||
       (user.proxyData && user.proxyData.subject === identifier) ||
       (user.teamsData && user.teamsData.subject === identifier) ||


### PR DESCRIPTION
## Summary

Fixes https://github.com/intrafind/ihub-apps/issues/2326 — local login was case-sensitive, so a user created as `Daniel.Manzke` could not log in by typing `daniel.manzke`.

Username and email comparisons now go through a shared `equalsIgnoreCase()` helper instead of strict `===`, applied everywhere an identifier is looked up or checked for uniqueness:

- `server/middleware/localAuth.js` — `loginUser()` lookup and `createUser()` duplicate check
- `server/routes/admin/auth.js` — admin "create user" duplicate-username check
- `server/utils/userManager.js` — `findUserByIdentifier()` (shared by OIDC/proxy/LDAP/NTLM/Teams persistence), which now exports `equalsIgnoreCase`
- `server/middleware/jwtAuth.js` — the OIDC/LDAP/Teams/NTLM JWT re-validation fallbacks that match a token's `email`/`username` claims against persisted users

Provider-specific subject IDs (`oidcData.subject`, `ldapData.subject`, etc.) are intentionally left as exact matches — those are opaque IdP-issued identifiers, not something a person types in.

## Test plan

- [x] Added `server/tests/userManager.test.js` — unit tests for `equalsIgnoreCase()` and case-insensitive `findUserByIdentifier()` matching
- [x] Extended `server/tests/localAuth.test.js` — `loginUser()` now succeeds when the typed username/email differs only in case from the stored value, and `createUser()` now rejects a new username/email that differs only in case from an existing one
- [x] `npx eslint` and `npx prettier --check` clean on all changed files
- [x] Ran the full server Jest suite and confirmed via `git stash` that all pre-existing failures (many suites fail even on a fresh, unmodified checkout — unrelated to this change) are unchanged before/after this fix; none of the passing suites regressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqqvWGCANdoanNvkVX3DfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01DqqvWGCANdoanNvkVX3DfD)_