### PR TITLE
fix(auth): resolve model/app/workflow ids case-insensitively

### DIFF
--- a/client/src/features/apps/components/AppCreationWizard.jsx
+++ b/client/src/features/apps/components/AppCreationWizard.jsx
@@ -1003,7 +1003,7 @@ function BasicInfoStep({
           required
           title={t(
             'admin.apps.wizard.basic.appIdTitle',
-            'Only letters, numbers, dots (.), underscores (_), and hyphens (-) allowed'
+            'Only lowercase letters, numbers, dots (.), underscores (_), and hyphens (-) allowed'
           )}
         />
         {fieldErrors.id ? (
@@ -1016,7 +1016,7 @@ function BasicInfoStep({
           <p className="mt-1 text-sm text-gray-500">
             {t(
               'admin.apps.wizard.basic.appIdHelp',
-              `Use only letters, numbers, dots (.), underscores (_), and hyphens (-). Max ${APP_ID_MAX_LENGTH} characters.`
+              `Use only lowercase letters, numbers, dots (.), underscores (_), and hyphens (-). Max ${APP_ID_MAX_LENGTH} characters.`
             )}
           </p>
         )}

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -632,3 +632,17 @@ request:
 
 When the ceiling does fire, the error names the setting to raise, and the server log records the
 endpoint that was tried (with URL secrets redacted) next to the model and provider.
+
+## Model, App, and Workflow IDs Are No Longer Case-Sensitive
+
+Calling a model, app, or workflow by id with different casing than it was configured with — for
+example through the OpenAI-compatible inference API, an MCP tool call, or a public `GET` endpoint —
+failed with a "not found" or "access denied" error even though the resource existed and the caller
+had permission to use it.
+
+- Model, app, and workflow lookups now match ids case-insensitively, so `GPT-4o` resolves the same
+  model as `gpt-4o`.
+- The app/model access check applied to every chat request now compares ids case-insensitively
+  too, so a differently-cased id is no longer rejected as access-denied right after being found.
+- New app and workflow ids must now be lowercase when created or edited, matching the existing rule
+  for model and prompt ids.

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "test:migrations": "node --test server/tests/migration-v086.test.js server/tests/migration-v087.test.js server/tests/migration-v088.test.js server/tests/migration-v089.test.js server/tests/migration-v090.test.js server/tests/migration-v091.test.js server/tests/migration-v092.test.js server/tests/migration-v093.test.js server/tests/migration-v094.test.js",
     "test:loop": "node --test server/tests/loop/*.test.js",
     "test:outbound-http": "node --test server/tests/dnsGuard.test.js server/tests/modelDiscoveryCache.test.js",
-    "test:auth-routes": "cd server && node --experimental-vm-modules node_modules/jest/bin/jest.js tests/oidc-logout.test.js tests/rateLimiting-auth-readonly-exempt.test.js",
+    "test:auth-routes": "cd server && node --experimental-vm-modules node_modules/jest/bin/jest.js tests/oidc-logout.test.js tests/rateLimiting-auth-readonly-exempt.test.js tests/case-insensitive-resource-access.test.js",
     "test:tool-calling": "cd server && node tests/toolCalling.test.js",
     "test:tool-integration": "cd server && node tests/toolCallingIntegration.test.js",
     "test:real-llm": "cd server && node tests/real-llm-integration.test.js",

--- a/server/configCache.js
+++ b/server/configCache.js
@@ -20,6 +20,7 @@ import tokenStorageService from './services/TokenStorageService.js';
 import { SECRET_FIELDS_BY_TYPE } from './validators/credentialSchema.js';
 import logger from './utils/logger.js';
 import { getLocalizedString } from './utils/localize.js';
+import { findByIdCaseInsensitive } from './utils/resourceLookup.js';
 
 /**
  * Resolve environment variables in a string
@@ -1029,7 +1030,7 @@ class ConfigCache {
    */
   getWorkflowById(id) {
     const { data } = this.getWorkflows(true);
-    return data.find(workflow => workflow.id === id) || null;
+    return findByIdCaseInsensitive(data, id) || null;
   }
 
   /**

--- a/server/middleware/authRequired.js
+++ b/server/middleware/authRequired.js
@@ -4,6 +4,7 @@
 import { isAnonymousAccessAllowed, enhanceUserWithPermissions } from '../utils/authorization.js';
 import authDebugService from '../utils/authDebugService.js';
 import configCache from '../configCache.js';
+import { hasIdCaseInsensitive } from '../utils/resourceLookup.js';
 
 /**
  * Middleware that requires authentication when anonymousAuth is disabled
@@ -98,8 +99,10 @@ function resourceAccessRequired(resourceType) {
     if (req.user && req.user.permissions) {
       const allowedResources = req.user.permissions[permissionsKey] || new Set();
 
-      // Check if user has wildcard access or specific resource access
-      if (!allowedResources.has('*') && !allowedResources.has(resourceId)) {
+      // Check if user has wildcard access or specific resource access.
+      // Resource ids arriving from outside (e.g. the OpenAI-compatible
+      // inference API) may not match the configured casing exactly.
+      if (!allowedResources.has('*') && !hasIdCaseInsensitive(allowedResources, resourceId)) {
         return res.status(403).json({
           error: 'Access denied',
           code: `${resourceType.toUpperCase()}_ACCESS_DENIED`,

--- a/server/routes/chat/conversationRoutes.js
+++ b/server/routes/chat/conversationRoutes.js
@@ -8,6 +8,7 @@ import conversationApiService from '../../services/integrations/ConversationApiS
 import iAssistantService from '../../services/integrations/iAssistantService.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import { sendInternalError, sendNotFound, sendBadRequest } from '../../utils/responseHelpers.js';
+import { findByIdCaseInsensitive } from '../../utils/resourceLookup.js';
 
 /**
  * Resolve the iAssistant base URL for an app's conversation API calls.
@@ -21,7 +22,7 @@ function resolveBaseUrl(app) {
   const modelId = app?.preferredModel;
   if (modelId) {
     const { data: models = [] } = configCache.getModels() || {};
-    const model = models.find(m => m.id === modelId);
+    const model = findByIdCaseInsensitive(models, modelId);
     if (model?.config?.baseUrl) return model.config.baseUrl;
   }
 
@@ -102,7 +103,7 @@ export default function registerConversationRoutes(app) {
 
         // Load app config to get baseUrl
         const { data: apps = [] } = configCache.getApps() || {};
-        const appConfig = apps.find(a => a.id === appId);
+        const appConfig = findByIdCaseInsensitive(apps, appId);
         if (!appConfig) {
           return sendNotFound(res, 'App');
         }
@@ -177,7 +178,7 @@ export default function registerConversationRoutes(app) {
         const user = req.user;
 
         const { data: apps = [] } = configCache.getApps() || {};
-        const appConfig = apps.find(a => a.id === appId);
+        const appConfig = findByIdCaseInsensitive(apps, appId);
         if (!appConfig) {
           return sendNotFound(res, 'App');
         }
@@ -244,7 +245,7 @@ export default function registerConversationRoutes(app) {
         const user = req.user;
 
         const { data: apps = [] } = configCache.getApps() || {};
-        const appConfig = apps.find(a => a.id === appId);
+        const appConfig = findByIdCaseInsensitive(apps, appId);
         if (!appConfig) {
           return sendNotFound(res, 'App');
         }

--- a/server/routes/chat/sessionRoutes.js
+++ b/server/routes/chat/sessionRoutes.js
@@ -31,6 +31,7 @@ import validate from '../../validators/validate.js';
 import { chatTestSchema, chatPostSchema, chatConnectSchema } from '../../validators/index.js';
 import { buildServerPath } from '../../utils/basePath.js';
 import logger from '../../utils/logger.js';
+import { findByIdCaseInsensitive } from '../../utils/resourceLookup.js';
 import {
   sendNotFound,
   sendFailedOperationError,
@@ -266,7 +267,7 @@ export default function registerSessionRoutes(app, { getLocalizedError, DEFAULT_
             new Error('models is null')
           );
         }
-        const model = models.find(m => m.id === modelId);
+        const model = findByIdCaseInsensitive(models, modelId);
         if (!model) {
           return sendNotFound(res, 'Model');
         }

--- a/server/routes/generalRoutes.js
+++ b/server/routes/generalRoutes.js
@@ -2,6 +2,7 @@ import configCache from '../configCache.js';
 import { enhanceUserWithPermissions, isAnonymousAccessAllowed } from '../utils/authorization.js';
 import { authRequired, appAccessRequired } from '../middleware/authRequired.js';
 import { buildServerPath, getRelativeRequestPath } from '../utils/basePath.js';
+import { findByIdCaseInsensitive } from '../utils/resourceLookup.js';
 import {
   sendInternalError,
   sendFailedOperationError,
@@ -341,7 +342,7 @@ export default function registerGeneralRoutes(app, { getLocalizedError }) {
             new Error('apps is null')
           );
         }
-        const appData = apps.find(a => a.id === appId);
+        const appData = findByIdCaseInsensitive(apps, appId);
         if (!appData) {
           const errorMessage = await getLocalizedError('appNotFound', {}, language);
           return sendErrorResponse(res, 404, errorMessage);
@@ -350,7 +351,7 @@ export default function registerGeneralRoutes(app, { getLocalizedError }) {
         // Check if user has permission to access this app
         if (req.user && req.user.permissions) {
           const allowedApps = req.user.permissions.apps || new Set();
-          if (!allowedApps.has('*') && !allowedApps.has(appId)) {
+          if (!allowedApps.has('*') && !allowedApps.has(appData.id)) {
             const errorMessage = await getLocalizedError('appNotFound', {}, language);
             return sendErrorResponse(res, 404, errorMessage);
           }

--- a/server/routes/modelRoutes.js
+++ b/server/routes/modelRoutes.js
@@ -8,6 +8,7 @@ import {
 } from '../utils/responseHelpers.js';
 import { buildServerPath } from '../utils/basePath.js';
 import { validateIdForPath } from '../utils/pathSecurity.js';
+import { findByIdCaseInsensitive } from '../utils/resourceLookup.js';
 
 /**
  * Strip server-side secrets before a model is sent to the browser.
@@ -169,7 +170,7 @@ export default function registerModelRoutes(app, { getLocalizedError }) {
         if (!models) {
           return sendFailedOperationError(res, 'load models configuration');
         }
-        const model = models.find(m => m.id === modelId);
+        const model = findByIdCaseInsensitive(models, modelId);
         // Transcription models are not exposed through this public chat-model
         // route (G9); their internal ws:// url / apiKey must never reach the
         // browser. Treat them as not-found here.
@@ -181,7 +182,7 @@ export default function registerModelRoutes(app, { getLocalizedError }) {
         // Check if user has permission to access this model
         if (req.user && req.user.permissions) {
           const allowedModels = req.user.permissions.models || new Set();
-          if (!allowedModels.has('*') && !allowedModels.has(modelId)) {
+          if (!allowedModels.has('*') && !allowedModels.has(model.id)) {
             const errorMessage = await getLocalizedError('modelNotFound', {}, language);
             return sendNotFound(res, errorMessage);
           }

--- a/server/routes/openaiProxy.js
+++ b/server/routes/openaiProxy.js
@@ -265,7 +265,9 @@ export default function registerOpenAIProxyRoutes(app, { llmClient = defaultLlmC
     }
     if (req.user && req.user.permissions) {
       const allowed = req.user.permissions.models || new Set();
-      if (!allowed.has('*') && !allowed.has(modelId)) {
+      // Check against the resolved model's canonical id, not the raw
+      // (possibly differently-cased) id the caller sent.
+      if (!allowed.has('*') && !allowed.has(model.id)) {
         const msg = await getLocalizedError('modelAccessDenied', {}, lang);
         return res.status(403).json({ error: msg });
       }

--- a/server/routes/workflow/workflowRoutes.js
+++ b/server/routes/workflow/workflowRoutes.js
@@ -43,6 +43,7 @@ import {
 import { filterResourcesByPermissions } from '../../utils/authorization.js';
 import logger from '../../utils/logger.js';
 import configCache from '../../configCache.js';
+import { findByIdCaseInsensitive } from '../../utils/resourceLookup.js';
 import { requireFeature } from '../../featureRegistry.js';
 import { removeMarketplaceInstallation } from '../../utils/installationCleanup.js';
 
@@ -525,7 +526,7 @@ export default function registerWorkflowRoutes(app, deps = {}) {
         }
 
         const workflows = await loadWorkflows();
-        const workflow = workflows.find(w => w.id === id);
+        const workflow = findByIdCaseInsensitive(workflows, id);
 
         if (!workflow) {
           return sendNotFound(res, 'Workflow');
@@ -894,7 +895,7 @@ export default function registerWorkflowRoutes(app, deps = {}) {
 
         // Load and validate workflow access
         const workflows = await loadWorkflows();
-        const workflow = workflows.find(w => w.id === id);
+        const workflow = findByIdCaseInsensitive(workflows, id);
 
         if (!workflow) {
           return sendNotFound(res, 'Workflow');

--- a/server/server.js
+++ b/server/server.js
@@ -11,6 +11,7 @@ import { loadJson } from './configLoader.js';
 import { getRootDir } from './pathUtils.js';
 import configCache from './configCache.js';
 import logger from './utils/logger.js';
+import { findByIdCaseInsensitive } from './utils/resourceLookup.js';
 import { startStickyPrimary, attachStickyWorker, logStickyRoutingCaveat } from './clusterSticky.js';
 import { initPrimaryBus, initWorkerBus } from './clusterBus.js';
 import { registerConfigReloadHooks } from './configReloadHooks.js';
@@ -847,7 +848,7 @@ if (cluster.isPrimary && workerCount > 1) {
         return { definition, options: { user: principal, timeout: RESUME_NODE_TIMEOUT_MS } };
       }
       const workflows = await loadWorkflows(false);
-      const definition = workflows.find(w => w.id === state.workflowId);
+      const definition = findByIdCaseInsensitive(workflows, state.workflowId);
       if (!definition) return null;
       return {
         definition,

--- a/server/services/chat/RequestBuilder.js
+++ b/server/services/chat/RequestBuilder.js
@@ -4,6 +4,7 @@ import { getToolsForApp, resolveAppNativeWebSearch } from '../../toolLoader.js';
 import ErrorHandler from '../../utils/ErrorHandler.js';
 import ApiKeyVerifier from '../../utils/ApiKeyVerifier.js';
 import logger from '../../utils/logger.js';
+import { findByIdCaseInsensitive } from '../../utils/resourceLookup.js';
 
 function preprocessMessagesWithFileData(messages) {
   return messages.map(msg => {
@@ -202,7 +203,7 @@ class RequestBuilder {
         return { success: false, error };
       }
 
-      const app = apps.find(a => a.id === appId);
+      const app = findByIdCaseInsensitive(apps, appId);
       if (!app) {
         const error = await this.errorHandler.createModelError(appId, 'unknown', language);
         error.code = 'APP_NOT_FOUND';
@@ -267,6 +268,13 @@ class RequestBuilder {
       // route and the MCP gateway — without changing the app-default path when
       // no model is requested.
       let requestedModelId = modelId;
+      if (requestedModelId) {
+        // Normalize to the configured casing up front so the permission
+        // check and every downstream `id === requestedModelId` comparison
+        // line up regardless of how the caller cased the model id.
+        const matchedModel = findByIdCaseInsensitive(models, requestedModelId);
+        if (matchedModel) requestedModelId = matchedModel.id;
+      }
       if (requestedModelId && !isModelPermittedForUser(user, requestedModelId)) {
         logger.warn('Requested model not permitted for user; falling back to app default', {
           component: 'RequestBuilder',

--- a/server/services/chat/appToolsGateway.js
+++ b/server/services/chat/appToolsGateway.js
@@ -34,13 +34,14 @@ import logger from '../../utils/logger.js';
 import ChatService from './ChatService.js';
 import { getLocalizedString } from '../../utils/localize.js';
 import { canUserAccessResource } from '../../utils/authorization.js';
+import { findByIdCaseInsensitive } from '../../utils/resourceLookup.js';
 
 const chatService = new ChatService();
 
 function getAppById(appId) {
   const apps = configCache.getApps(true);
   if (!apps?.data) return null;
-  return apps.data.find(a => a.id === appId) || null;
+  return findByIdCaseInsensitive(apps.data, appId) || null;
 }
 
 function buildToolParameters(app) {
@@ -121,10 +122,10 @@ export async function getAppAsTools(appIds, language = 'en', { user } = {}) {
       continue;
     }
     if (app.enabled === false) continue;
-    if (user && !isAppInvocationAllowed(user, appId)) {
+    if (user && !isAppInvocationAllowed(user, app.id)) {
       logger.info('App-as-tool: app filtered by user permissions', {
         component: 'AppToolsGateway',
-        appId,
+        appId: app.id,
         userId: user.id
       });
       continue;
@@ -135,12 +136,12 @@ export async function getAppAsTools(appIds, language = 'en', { user } = {}) {
     // locale here, do NOT re-wrap as a localized object.
     const appName = getLocalizedString(app.name, language, undefined, app.id);
     tools.push({
-      id: `app__${appId}`,
+      id: `app__${app.id}`,
       name: `App: ${appName}`,
       description: localizedDescription(app, language),
       parameters: buildToolParameters(app),
       isAppAsTool: true,
-      _appId: appId
+      _appId: app.id
     });
   }
   return tools;
@@ -225,8 +226,8 @@ export async function invokeAppTool({
 
   // Enforce the calling user's app permissions — invoking an app through a
   // tool must not grant more access than opening it directly would.
-  if (!isAppInvocationAllowed(user, appId)) {
-    return { error: true, message: `You do not have permission to access app ${appId}` };
+  if (!isAppInvocationAllowed(user, app.id)) {
+    return { error: true, message: `You do not have permission to access app ${app.id}` };
   }
 
   const messageBody = args.message || JSON.stringify(args);
@@ -248,7 +249,7 @@ export async function invokeAppTool({
 
   try {
     const result = await chatService.invokeAppInternal({
-      appId,
+      appId: app.id,
       user: nestedUser,
       messages,
       variables,

--- a/server/services/loop/LLMClient.js
+++ b/server/services/loop/LLMClient.js
@@ -41,6 +41,7 @@ import { httpFetch, redactUrlSecrets } from '../../utils/httpConfig.js';
 import { isDnsFailure } from '../../utils/dnsGuard.js';
 import configCache from '../../configCache.js';
 import config from '../../config.js';
+import { findByIdCaseInsensitive } from '../../utils/resourceLookup.js';
 import ApiKeyVerifier from '../../utils/ApiKeyVerifier.js';
 import ErrorHandler from '../../utils/ErrorHandler.js';
 import logger from '../../utils/logger.js';
@@ -508,7 +509,7 @@ export class LLMClient {
    */
   findModel(modelId, { includeDisabled = false } = {}) {
     if (!modelId) return null;
-    return this.listModels(includeDisabled).find(m => m.id === modelId) || null;
+    return findByIdCaseInsensitive(this.listModels(includeDisabled), modelId) || null;
   }
 
   /**
@@ -539,7 +540,7 @@ export class LLMClient {
     if (pool.length === 0) return null;
     for (const id of [modelId, ...preferredIds]) {
       if (!id) continue;
-      const found = pool.find(m => m.id === id);
+      const found = findByIdCaseInsensitive(pool, id);
       if (found) return found;
     }
     if (!fallbackToDefault) return null;

--- a/server/services/mcp/appInvoker.js
+++ b/server/services/mcp/appInvoker.js
@@ -3,6 +3,7 @@ import ChatService from '../chat/ChatService.js';
 import { isValidId } from '../../utils/pathSecurity.js';
 import configCache from '../../configCache.js';
 import logger from '../../utils/logger.js';
+import { findByIdCaseInsensitive } from '../../utils/resourceLookup.js';
 
 const chatService = new ChatService();
 
@@ -52,7 +53,7 @@ export async function invokeAppNonStreaming({ appId, args, user, language, timeo
   // Look up the app against configCache; pass only the trusted app.id
   // back downstream so the user-controlled appId stops here.
   const { data: apps = [] } = configCache.getApps();
-  const app = apps.find(a => a.id === safeAppId);
+  const app = findByIdCaseInsensitive(apps, safeAppId);
   if (!app) {
     throw new Error(`App not found: ${safeAppId}`);
   }

--- a/server/services/workflow/executors/BaseNodeExecutor.js
+++ b/server/services/workflow/executors/BaseNodeExecutor.js
@@ -13,6 +13,7 @@
 
 import logger from '../../../utils/logger.js';
 import promptService from '../../PromptService.js';
+import { findByIdCaseInsensitive } from '../../../utils/resourceLookup.js';
 
 /**
  * Execution result returned by node executors
@@ -393,7 +394,7 @@ export class BaseNodeExecutor {
    */
   resolveModel(models, config = {}, context = {}, state = null, nodeId = undefined) {
     if (!Array.isArray(models) || models.length === 0) return null;
-    const byId = id => (id ? models.find(m => m.id === id) : undefined);
+    const byId = id => (id ? findByIdCaseInsensitive(models, id) : undefined);
 
     // 1. Node-level model: explicit config.modelId, else the durable per-node
     //    agent model. `config.modelId || …` matches the prompt node — a set-but-

--- a/server/services/workflow/executors/VerifierNodeExecutor.js
+++ b/server/services/workflow/executors/VerifierNodeExecutor.js
@@ -25,6 +25,7 @@ import { thinkingConfigToOptions } from '../thinkingOptions.js';
 import configCache from '../../../configCache.js';
 import logger from '../../../utils/logger.js';
 import { actionTracker } from '../../../actionTracker.js';
+import { findByIdCaseInsensitive } from '../../../utils/resourceLookup.js';
 
 export class VerifierNodeExecutor extends BaseNodeExecutor {
   /**
@@ -476,7 +477,7 @@ export class VerifierNodeExecutor extends BaseNodeExecutor {
    */
   resolveModel(models, config = {}, context = {}, state = null, nodeId = undefined) {
     if (!Array.isArray(models) || models.length === 0) return null;
-    const byId = id => (id ? models.find(m => m.id === id) : null);
+    const byId = id => (id ? findByIdCaseInsensitive(models, id) : null);
     return (
       byId(config.modelId) ||
       byId(context?.workflow?.config?.defaultModelId) ||

--- a/server/services/workflow/triggers/TriggerManager.js
+++ b/server/services/workflow/triggers/TriggerManager.js
@@ -18,6 +18,7 @@ import {
   isSchedulerOwner
 } from './schedulerLock.js';
 import logger from '../../../utils/logger.js';
+import { findByIdCaseInsensitive } from '../../../utils/resourceLookup.js';
 
 /** @type {TriggerManager|null} */
 let triggerManagerInstance = null;
@@ -234,7 +235,7 @@ export class TriggerManager {
       let workflow;
       if (this.workflowLoader) {
         const workflows = await this.workflowLoader(false);
-        workflow = workflows.find(w => w.id === workflowId);
+        workflow = findByIdCaseInsensitive(workflows, workflowId);
       }
 
       if (!workflow) {

--- a/server/tests/case-insensitive-resource-access.test.js
+++ b/server/tests/case-insensitive-resource-access.test.js
@@ -1,0 +1,103 @@
+/**
+ * Regression tests for https://github.com/intrafind/ihub-apps/issues/2327:
+ * model/app/prompt/workflow ids supplied by external callers (e.g. the
+ * OpenAI-compatible inference API) must resolve and pass permission checks
+ * regardless of casing.
+ *
+ * Runs under the server's own native-ESM jest (see the `test:auth-routes` npm
+ * script, which `test:quick` — and therefore CI — chains in). It cannot live
+ * under tests/unit/server/: the root jest config transforms `.js` to CJS, and
+ * middleware/authRequired.js reaches utils/authorization.js, which uses
+ * `import.meta.url`.
+ */
+import { describe, it, expect, jest } from '@jest/globals';
+import {
+  filterResourcesByPermissions,
+  canUserAccessResource,
+  intersectWithClientAllowList
+} from '../utils/authorization.js';
+import { appAccessRequired, modelAccessRequired } from '../middleware/authRequired.js';
+
+describe('filterResourcesByPermissions (case-insensitive)', () => {
+  it('matches a resource whose id differs only in case from the permission list', () => {
+    const resources = [{ id: 'Translator' }, { id: 'summarizer' }];
+    const allowed = new Set(['translator']);
+    expect(filterResourcesByPermissions(resources, allowed)).toEqual([{ id: 'Translator' }]);
+  });
+
+  it('still honors the wildcard', () => {
+    const resources = [{ id: 'a' }, { id: 'b' }];
+    expect(filterResourcesByPermissions(resources, new Set(['*']))).toEqual(resources);
+  });
+});
+
+describe('canUserAccessResource (case-insensitive)', () => {
+  it('allows access when only casing differs', () => {
+    const user = { permissions: { apps: new Set(['translator']) } };
+    expect(canUserAccessResource(user, 'apps', 'Translator')).toBe(true);
+  });
+
+  it('denies access for an unrelated id', () => {
+    const user = { permissions: { apps: new Set(['translator']) } };
+    expect(canUserAccessResource(user, 'apps', 'summarizer')).toBe(false);
+  });
+});
+
+describe('intersectWithClientAllowList (case-insensitive)', () => {
+  it('keeps a user-permitted id whose case differs from the client allow-list entry', () => {
+    const result = intersectWithClientAllowList(new Set(['gpt-4o']), ['GPT-4O']);
+    expect(result.has('gpt-4o')).toBe(true);
+  });
+});
+
+function createMockReqRes(user, params) {
+  const req = { user, params };
+  const res = {
+    statusCode: null,
+    body: null,
+    status(code) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data) {
+      this.body = data;
+      return this;
+    }
+  };
+  return { req, res };
+}
+
+describe('appAccessRequired / modelAccessRequired (case-insensitive gate)', () => {
+  it('allows a request whose app id differs in case from the granted permission', () => {
+    const { req, res } = createMockReqRes(
+      { id: 'u1', permissions: { apps: new Set(['translator']) } },
+      { appId: 'Translator' }
+    );
+    const next = jest.fn();
+    appAccessRequired(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBeNull();
+  });
+
+  it('allows an inference-API-style request whose model id differs in case', () => {
+    const { req, res } = createMockReqRes(
+      { id: 'u1', permissions: { models: new Set(['gpt-4o']) } },
+      { modelId: 'GPT-4O' }
+    );
+    const next = jest.fn();
+    modelAccessRequired(req, res, next);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.statusCode).toBeNull();
+  });
+
+  it('still denies access to a genuinely different model id', () => {
+    const { req, res } = createMockReqRes(
+      { id: 'u1', permissions: { models: new Set(['gpt-4o']) } },
+      { modelId: 'claude-sonnet' }
+    );
+    const next = jest.fn();
+    modelAccessRequired(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+  });
+});

--- a/server/utils.js
+++ b/server/utils.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'url';
 import configCache from './configCache.js';
 import tokenStorageService from './services/TokenStorageService.js';
 import logger from './utils/logger.js';
+import { findByIdCaseInsensitive } from './utils/resourceLookup.js';
 
 /**
  * Sanitize user-provided input for logging to prevent log injection
@@ -45,7 +46,7 @@ export async function getApiKeyForModel(modelId) {
     }
 
     // Find the model by ID
-    const model = models.find(m => m.id === modelId);
+    const model = findByIdCaseInsensitive(models, modelId);
     if (!model) {
       logger.error(`Model not found: ${sanitizeForLog(modelId)}`, { component: 'Utils' });
       return null;

--- a/server/utils/authorization.js
+++ b/server/utils/authorization.js
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'url';
 import { sendAuthRequired, sendInsufficientPermissions } from './responseHelpers.js';
 import logger from './logger.js';
 import configCache from '../configCache.js';
+import { hasIdCaseInsensitive } from './resourceLookup.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -425,7 +426,7 @@ export function intersectWithClientAllowList(userAllowed, clientAllowed) {
   const result = new Set();
   const clientSet = new Set(clientAllowed);
   for (const id of userAllowed || []) {
-    if (clientSet.has(id)) {
+    if (hasIdCaseInsensitive(clientSet, id)) {
       result.add(id);
     }
   }
@@ -471,7 +472,7 @@ export function filterResourcesByPermissions(resources, allowedResources) {
   // Filter resources based on allowed IDs
   return resources.filter(resource => {
     const resourceId = resource.id || resource.modelId || resource.name;
-    return allowedResources.has(resourceId);
+    return hasIdCaseInsensitive(allowedResources, resourceId);
   });
 }
 
@@ -724,7 +725,7 @@ export function canUserAccessResource(user, resourceType, resourceId) {
   const allowedResources = user.permissions[resourceType];
   if (!allowedResources) return false;
 
-  return allowedResources.has('*') || allowedResources.has(resourceId);
+  return allowedResources.has('*') || hasIdCaseInsensitive(allowedResources, resourceId);
 }
 
 /**

--- a/server/utils/resourceLookup.js
+++ b/server/utils/resourceLookup.js
@@ -1,0 +1,37 @@
+/**
+ * Case-insensitive lookup helpers for resources identified by an `id` field
+ * (models, apps, prompts, workflows).
+ *
+ * External callers — the OpenAI-compatible inference API, MCP tools, chat
+ * requests — may send an id in any casing, while configured resource ids are
+ * conventionally lowercase. These helpers let lookups and permission checks
+ * treat casing as insignificant without requiring stored ids to be rewritten.
+ */
+
+/**
+ * Find an item in a list by its `id` field, ignoring case.
+ * @param {Array<{id?: string}>} list
+ * @param {string} id
+ * @returns {Object|undefined}
+ */
+export function findByIdCaseInsensitive(list, id) {
+  if (!Array.isArray(list) || typeof id !== 'string') return undefined;
+  const target = id.toLowerCase();
+  return list.find(item => typeof item?.id === 'string' && item.id.toLowerCase() === target);
+}
+
+/**
+ * Check whether a Set of ids contains the given id, ignoring case.
+ * @param {Set<string>} set
+ * @param {string} id
+ * @returns {boolean}
+ */
+export function hasIdCaseInsensitive(set, id) {
+  if (!set || typeof id !== 'string') return false;
+  if (set.has(id)) return true;
+  const target = id.toLowerCase();
+  for (const entry of set) {
+    if (typeof entry === 'string' && entry.toLowerCase() === target) return true;
+  }
+  return false;
+}

--- a/server/validators/appConfigSchema.js
+++ b/server/validators/appConfigSchema.js
@@ -354,7 +354,7 @@ const baseAppConfigSchema = z.object({
     .string()
     .regex(
       APP_ID_PATTERN,
-      'ID must contain only alphanumeric characters, underscores, dots, and hyphens'
+      'ID must contain only lowercase alphanumeric characters, underscores, dots, and hyphens'
     )
     .min(1, 'ID cannot be empty')
     .max(APP_ID_MAX_LENGTH, `ID cannot exceed ${APP_ID_MAX_LENGTH} characters`),

--- a/server/validators/workflowConfigSchema.js
+++ b/server/validators/workflowConfigSchema.js
@@ -478,7 +478,7 @@ const baseWorkflowConfigSchema = z.object({
     .string()
     .regex(
       APP_ID_PATTERN,
-      'ID must contain only alphanumeric characters, underscores, dots, and hyphens'
+      'ID must contain only lowercase alphanumeric characters, underscores, dots, and hyphens'
     )
     .min(1, 'ID cannot be empty')
     .max(APP_ID_MAX_LENGTH, `ID cannot exceed ${APP_ID_MAX_LENGTH} characters`),

--- a/shared/validationPatterns.js
+++ b/shared/validationPatterns.js
@@ -5,14 +5,15 @@
 
 /**
  * App ID validation
- * Must contain only alphanumeric characters, underscores, dots, and hyphens
+ * Must contain only lowercase alphanumeric characters, underscores, dots, and hyphens
+ * (lowercase-only so ids stay unambiguous now that lookups are case-insensitive)
  * Length: 1-50 characters
  */
-export const APP_ID_PATTERN = /^[a-zA-Z0-9._-]+$/;
+export const APP_ID_PATTERN = /^[a-z0-9._-]+$/;
 export const APP_ID_MIN_LENGTH = 1;
 export const APP_ID_MAX_LENGTH = 50;
 export const APP_ID_ERROR_MESSAGE =
-  'App ID can only contain letters, numbers, dots (.), underscores (_), and hyphens (-)';
+  'App ID can only contain lowercase letters, numbers, dots (.), underscores (_), and hyphens (-)';
 
 /**
  * Model ID validation

--- a/tests/unit/server/resourceLookup.test.js
+++ b/tests/unit/server/resourceLookup.test.js
@@ -1,0 +1,61 @@
+import { describe, it, expect } from '@jest/globals';
+import {
+  findByIdCaseInsensitive,
+  hasIdCaseInsensitive
+} from '../../../server/utils/resourceLookup.js';
+
+describe('findByIdCaseInsensitive', () => {
+  const list = [{ id: 'gpt-4o' }, { id: 'claude-sonnet' }];
+
+  it('finds an exact-case match', () => {
+    expect(findByIdCaseInsensitive(list, 'gpt-4o')).toBe(list[0]);
+  });
+
+  it('finds a match regardless of casing', () => {
+    expect(findByIdCaseInsensitive(list, 'GPT-4O')).toBe(list[0]);
+    expect(findByIdCaseInsensitive(list, 'Claude-Sonnet')).toBe(list[1]);
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(findByIdCaseInsensitive(list, 'unknown')).toBeUndefined();
+  });
+
+  it('returns undefined for non-array input', () => {
+    expect(findByIdCaseInsensitive(null, 'gpt-4o')).toBeUndefined();
+    expect(findByIdCaseInsensitive(undefined, 'gpt-4o')).toBeUndefined();
+  });
+
+  it('returns undefined for a non-string id', () => {
+    expect(findByIdCaseInsensitive(list, undefined)).toBeUndefined();
+    expect(findByIdCaseInsensitive(list, 42)).toBeUndefined();
+  });
+
+  it('ignores items without a string id', () => {
+    const mixedList = [{ id: 42 }, { name: 'no id' }, { id: 'valid-id' }];
+    expect(findByIdCaseInsensitive(mixedList, 'VALID-ID')).toBe(mixedList[2]);
+  });
+});
+
+describe('hasIdCaseInsensitive', () => {
+  it('matches exact case', () => {
+    expect(hasIdCaseInsensitive(new Set(['gpt-4o']), 'gpt-4o')).toBe(true);
+  });
+
+  it('matches regardless of casing', () => {
+    expect(hasIdCaseInsensitive(new Set(['gpt-4o']), 'GPT-4O')).toBe(true);
+    expect(hasIdCaseInsensitive(new Set(['Translator']), 'translator')).toBe(true);
+  });
+
+  it('returns false when the set does not contain the id', () => {
+    expect(hasIdCaseInsensitive(new Set(['gpt-4o']), 'claude')).toBe(false);
+  });
+
+  it('returns false for a missing set or non-string id', () => {
+    expect(hasIdCaseInsensitive(null, 'gpt-4o')).toBe(false);
+    expect(hasIdCaseInsensitive(new Set(['gpt-4o']), undefined)).toBe(false);
+  });
+
+  it('ignores non-string entries in the set', () => {
+    expect(hasIdCaseInsensitive(new Set([42, 'gpt-4o']), 'GPT-4O')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [#2327](https://github.com/intrafind/ihub-apps/issues/2327): model names (and app/workflow ids) were case-sensitive when called from outside — e.g. the OpenAI-compatible inference API — so a request using different casing than the configured id got a false "not found" or "access denied" response even though the resource existed and the caller had permission to use it.

- Added `server/utils/resourceLookup.js` (`findByIdCaseInsensitive`, `hasIdCaseInsensitive`) and used it at every id-lookup and permission-set check for **models**, **apps**, and **workflows** — including `resourceAccessRequired` (the shared middleware behind `appAccessRequired`/`modelAccessRequired`, which gates every chat request), the OpenAI-compatible inference API, public `GET /api/apps/:appId` / `GET /api/models/:modelId` / `GET /api/workflows/:id` routes, the MCP app-invocation gateway, and workflow-node model resolution.
- Where a raw request id was compared against a permission set *after* the resource was already resolved (`openaiProxy.js`, `appToolsGateway.js`), switched the check to the resolved object's canonical id instead of layering on a second case-insensitive comparison.
- `filterResourcesByPermissions`, `canUserAccessResource`, and `intersectWithClientAllowList` in `server/utils/authorization.js` now compare permission-list entries case-insensitively too, so a casing mismatch between a configured permission list and a resource id can no longer cause a false denial.
- Tightened `APP_ID_PATTERN` (`shared/validationPatterns.js`, used by `appConfigSchema.js` and `workflowConfigSchema.js`) to lowercase-only, matching the rule model and prompt ids already enforce — new app/workflow ids can no longer introduce the casing ambiguity that case-insensitive lookup would otherwise have to arbitrate. This only affects newly created/edited apps and workflows; existing configs still load (schema validation on load only warns, never rejects).
- Prompt ids were already schema-locked to lowercase and have no public by-id lookup route, so no runtime change was needed there.

## Test plan

- [x] New unit tests: `tests/unit/server/resourceLookup.test.js` (pure helper functions) and `server/tests/case-insensitive-resource-access.test.js` (regression tests for `appAccessRequired`/`modelAccessRequired` and the `authorization.js` permission helpers), wired into `npm run test:auth-routes` → `test:quick` → CI.
- [x] `npm run test:quick` (the full CI unit/adapter/auth/migration/loop suite) passes with no regressions.
- [x] `npm run lint:fix` / `npm run format:fix` — no new warnings or errors introduced.
- [x] Manually traced every touched call site to confirm downstream code uses the resolved resource's canonical id (not the raw request string) for subsequent permission checks and file-path construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CrGWtStje4Q7cq2UeyzGfD

---
_Generated by [Claude Code](https://claude.ai/code/session_01CrGWtStje4Q7cq2UeyzGfD)_