### PR TITLE
fix(admin): send FormData uploads as multipart instead of JSON

### DIFF
--- a/client/src/api/adminApi.js
+++ b/client/src/api/adminApi.js
@@ -50,12 +50,22 @@ export const makeAdminApiCall = async (url, options = {}) => {
 
     axiosConfig.data = body;
     if (isFormData) {
-      // Let axios/browser set the multipart boundary for FormData bodies
+      // Let axios/browser set the multipart boundary for FormData bodies.
+      //
+      // Deleting the key from this per-request object is NOT enough: the shared
+      // axios instance declares `Content-Type: application/json` as an *instance
+      // default* (see api/client.js), and that default still applies to a request
+      // whose own headers simply omit the key. Axios' default transformRequest
+      // then sees a JSON content type on a FormData payload and serialises the
+      // form to JSON (`{"backup":{}}`), so the file never leaves the browser and
+      // the server reports a missing upload. Setting the header to `undefined`
+      // overrides the instance default and tells axios to omit it entirely.
       Object.keys(axiosConfig.headers).forEach(headerKey => {
         if (headerKey.toLowerCase() === 'content-type') {
           delete axiosConfig.headers[headerKey];
         }
       });
+      axiosConfig.headers['Content-Type'] = undefined;
     } else {
       axiosConfig.headers = {
         'Content-Type': 'application/json',

--- a/docs/releases/5.5.0/fixes.md
+++ b/docs/releases/5.5.0/fixes.md
@@ -661,3 +661,17 @@ Once a conversation had more than one exchange, editing an earlier message updat
 resend it — the edited text was left sitting in the input box, and the only way to actually send it
 was to press Send again by hand. Editing a message now reliably resends it and continues the
 conversation from that point, no matter how long the conversation already is.
+
+## Configuration Import and Other Admin File Uploads Work Again
+
+Importing a configuration backup failed immediately with "Failed to import configuration: HTTP 400"
+and the server log showed only "Starting configuration import" with no further detail. The selected
+file was never actually sent: the admin API helper left a JSON content type on the request, so the
+browser's HTTP client converted the upload into a short JSON object and discarded the file. The
+server correctly reported that no ZIP had arrived.
+
+- Affects every admin file upload, not just backup import: **System → Configuration Backup &
+  Import**, the UI **asset upload**, and **skill import** from a `.zip`.
+- Exporting a backup was never affected, and no backup created with an earlier version is damaged —
+  re-importing a previously exported ZIP now works.
+- No configuration change or admin action is required.

--- a/tests/unit/client/admin-api-call-formdata.test.jsx
+++ b/tests/unit/client/admin-api-call-formdata.test.jsx
@@ -1,0 +1,134 @@
+/**
+ * Regression test for issue #2334.
+ *
+ * Admin uploads (backup import, UI asset upload, skill import) send a FormData
+ * body through `makeAdminApiCall`. The shared axios instance in api/client.js
+ * declares `Content-Type: application/json` as an INSTANCE DEFAULT, which still
+ * applies to a request whose own headers merely omit the key. Axios' default
+ * `transformRequest` then sees a JSON content type on a FormData payload and
+ * serialises the form to JSON (`{"backup":{}}`), so the file never leaves the
+ * browser and the server answers `400 No ZIP file uploaded`.
+ *
+ * These tests drive the real helper against a real axios instance and assert on
+ * what the adapter would actually put on the wire — a source-text check cannot
+ * catch this, because the buggy code *looked* correct.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+// The real api/client.js reads `import.meta.env`, which the Jest CJS transform
+// cannot parse. Stand in a real axios instance configured the same way — the
+// JSON instance default is the whole point of this regression, and the
+// premise test below asserts the real module still declares it.
+jest.mock('../../../client/src/api/client.js', () => {
+  const realAxios = jest.requireActual('axios');
+  return {
+    apiClient: realAxios.create({
+      baseURL: '/api',
+      headers: { 'Content-Type': 'application/json' },
+      withCredentials: true
+    })
+  };
+});
+
+// runtimeBasePath also uses `import.meta`.
+jest.mock('../../../client/src/utils/runtimeBasePath', () => ({
+  buildApiUrl: p => `/api/${p}`,
+  buildPath: p => p,
+  buildAssetUrl: p => p
+}));
+
+import { apiClient } from '../../../client/src/api/client.js';
+import { makeAdminApiCall } from '../../../client/src/api/adminApi.js';
+
+/**
+ * Swaps in an adapter that resolves immediately and records the request exactly
+ * as axios hands it over — after transformRequest has run, which is where the
+ * FormData payload was being destroyed.
+ */
+function captureOutgoingRequest() {
+  const captured = {};
+  const originalAdapter = apiClient.defaults.adapter;
+
+  apiClient.defaults.adapter = config => {
+    captured.data = config.data;
+    captured.contentType = config.headers.getContentType();
+    return Promise.resolve({ data: { ok: true }, status: 200, headers: {}, config });
+  };
+
+  return {
+    captured,
+    restore: () => {
+      apiClient.defaults.adapter = originalAdapter;
+    }
+  };
+}
+
+describe('makeAdminApiCall FormData handling (issue #2334)', () => {
+  let harness;
+
+  beforeEach(() => {
+    harness = captureOutgoingRequest();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    harness.restore();
+  });
+
+  test('premise: the shared axios instance still declares a JSON content type default', () => {
+    // If this default is ever dropped, the FormData workaround below is no
+    // longer load-bearing — but until then, removing it silently breaks uploads.
+    const source = fs.readFileSync(path.join(process.cwd(), 'client/src/api/client.js'), 'utf8');
+    expect(source).toMatch(/'Content-Type':\s*'application\/json'/);
+  });
+
+  test('sends a FormData body untouched instead of serialising it to JSON', async () => {
+    const formData = new FormData();
+    formData.append('backup', new Blob(['PK'], { type: 'application/zip' }), 'b.zip');
+
+    await makeAdminApiCall('/admin/backup/import', { method: 'POST', body: formData });
+
+    // The payload must still be the FormData instance. Before the fix this was
+    // the string '{"backup":{}}' and the uploaded file was silently dropped.
+    expect(harness.captured.data).toBe(formData);
+    expect(typeof harness.captured.data).not.toBe('string');
+  });
+
+  test('does not put a JSON content type on a FormData request', async () => {
+    const formData = new FormData();
+    formData.append('asset', new Blob(['x'], { type: 'image/png' }), 'logo.png');
+
+    await makeAdminApiCall('/admin/ui/upload-asset', { method: 'POST', body: formData });
+
+    // A JSON content type is what triggers axios' formToJSON serialisation. Any
+    // other value (or none) is fine: for a FormData body the browser adapter
+    // unsets Content-Type so the browser can add the multipart boundary.
+    expect(harness.captured.contentType ?? '').not.toContain('application/json');
+  });
+
+  test('still sends plain object bodies as JSON', async () => {
+    await makeAdminApiCall('/admin/apps/test-app', {
+      method: 'PUT',
+      body: { id: 'test-app', enabled: true }
+    });
+
+    expect(harness.captured.contentType).toContain('application/json');
+    expect(JSON.parse(harness.captured.data)).toEqual({ id: 'test-app', enabled: true });
+  });
+
+  test('a caller-supplied Content-Type does not reintroduce JSON serialisation', async () => {
+    const formData = new FormData();
+    formData.append('skill', new Blob(['PK'], { type: 'application/zip' }), 's.zip');
+
+    await makeAdminApiCall('/admin/skills/import', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: formData
+    });
+
+    expect(harness.captured.data).toBe(formData);
+    expect(harness.captured.contentType ?? '').not.toContain('application/json');
+  });
+});


### PR DESCRIPTION
Fixes #2334.

## Symptom

Admin → System → Configuration Backup & Import fails immediately with `HTTP 400` / "No ZIP file uploaded". The server log shows only:

```
{"component":"AdminBackup","level":"info","message":"Starting configuration import"}
```

and nothing after it. The selected ZIP is valid; it is simply never transmitted.

## Root cause

`makeAdminApiCall` stripped `Content-Type` for FormData bodies by deleting the key from the **per-request** headers object, which is normally empty:

```js
Object.keys(axiosConfig.headers).forEach(headerKey => {
  if (headerKey.toLowerCase() === 'content-type') delete axiosConfig.headers[headerKey];
});
```

There is nothing to delete. The shared axios instance in `client/src/api/client.js` declares `Content-Type: application/json` as an **instance-level default**, and that default still applies to a request whose own headers merely omit the key. Axios' default `transformRequest` then sees a JSON content type on a FormData payload and serialises the form with `formToJSON`, so the body becomes the literal string `{"backup":{}}`. `multer` never sees `multipart/form-data`, leaves `req.file` undefined, and the route correctly reports a missing upload.

This is confirmed empirically rather than by inspection — driving the real helper through a real axios instance and capturing what the adapter receives:

```
--- before ---
outgoing Content-Type : application/json
outgoing body type    : [object String]
outgoing body preview : {"backup":{}}

--- after ---
outgoing body type    : [object FormData]
```

In a browser, once the payload is still FormData at adapter time, axios' `resolveConfig` calls `headers.setContentType(undefined)` so the browser supplies `multipart/form-data; boundary=…`. The bug was that `transformRequest` had already destroyed the payload before that point.

## Fix

Set the header to `undefined` rather than deleting a key that is not there. `undefined` overrides the instance default and tells axios to omit the header entirely. The existing delete loop is kept so a caller-supplied `content-type` (in any casing) collapses to a single canonical key.

## Scope

Every FormData upload routed through `makeAdminApiCall` was affected, not only backup import:

| Endpoint | Caller |
| --- | --- |
| `POST /admin/backup/import` | `AdminBackupPage.jsx` |
| `POST /admin/ui/upload-asset` | `AssetManager.jsx` |
| `POST /admin/skills/import` | `AdminSkillsPage.jsx` via `adminApi.importSkill` |

**Export was never broken.** Verified against a running server with the local admin account: `GET /api/admin/backup/export` returns `200` with a valid 219 KB ZIP (120 files, correct `Content-Type` and `Content-Disposition`). It is a GET with no body, so the header handling above never applies to it.

## Verification

Against a freshly booted dev server:

```
# what the client actually sent (reproduces the report exactly)
POST /api/admin/backup/import  -H 'Content-Type: application/json' -d '{"backup":{}}'
  → 400 {"error":"No ZIP file uploaded"}

# what it sends after the fix
POST /api/admin/backup/import  -F "backup=@export.zip;type=application/zip"
  → 200 {"success":true,"importedFiles":119,"backupPath":"contents-backup-…"}
```

The server side of both export and import is healthy; the defect was entirely client-side.

## Tests

`tests/unit/client/admin-api-call-body-conventions.test.jsx` only greps source text, which is why this regressed unnoticed — the buggy code *looked* correct. The new `tests/unit/client/admin-api-call-formdata.test.jsx` drives the real helper through a real axios instance and asserts on what the adapter would put on the wire:

- a FormData body reaches the adapter as FormData, not a JSON string
- no JSON content type on a FormData request
- plain object bodies are still sent as JSON (no regression)
- a caller-supplied `content-type: application/json` does not reintroduce the serialisation

Reverting the one-line fix fails three of these assertions. Full unit suite: **815 passed, 72 suites**. `npm run lint:fix` and `npm run format:fix` clean (0 errors).

## Note (out of scope)

The export ZIP includes `contents/.encryption-key`, `contents/.jwt-private-key.pem` and `contents/.jwt-secret`. That is pre-existing behaviour and unchanged here, but worth a separate look at whether secrets belong in an admin-downloadable backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MHq5Z86uFHszNWmq1zKrU6

---
_Generated by [Claude Code](https://claude.ai/code/session_01MHq5Z86uFHszNWmq1zKrU6)_