### PR TITLE
fix(admin): clear axios default Content-Type for FormData uploads

### DIFF
--- a/client/src/api/adminApi.js
+++ b/client/src/api/adminApi.js
@@ -56,6 +56,12 @@ export const makeAdminApiCall = async (url, options = {}) => {
           delete axiosConfig.headers[headerKey];
         }
       });
+      // Deleting the key above only clears this per-request headers object, not
+      // apiClient's axios-instance default (Content-Type: application/json, set in
+      // client.js) — axios still merges that in and JSON-serializes the FormData
+      // instead of sending it as multipart. Set it to undefined to override the
+      // instance default and let axios/browser set the multipart boundary.
+      axiosConfig.headers['Content-Type'] = undefined;
     } else {
       axiosConfig.headers = {
         'Content-Type': 'application/json',


### PR DESCRIPTION
Fixes #2334.

`makeAdminApiCall` only deleted `Content-Type` from the per-request headers object, which is normally empty. That left `apiClient`'s axios-instance default (`Content-Type: application/json`, set in `client.js`) in place, so axios's default `transformRequest` JSON-serialized `FormData` bodies instead of sending them as `multipart/form-data` — breaking backup import and any other admin `FormData` upload.

Explicitly set the header to `undefined` so it overrides the instance default regardless of what the per-request headers object contains.